### PR TITLE
Add --isolation rootless

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -39,3 +39,4 @@ go get github.com/onsi/gomega/...
 export GITVALIDATE_TIP=$(cd $GOSRC; git log -2 --pretty='%H' | tail -n 1)
 make -C $GOSRC install.tools runc all validate test-unit test-integration TAGS="seccomp"
 env BUILDAH_ISOLATION=chroot make -C $GOSRC test-integration TAGS="seccomp"
+env BUILDAH_ISOLATION=rootless make -C $GOSRC test-integration TAGS="seccomp"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go:
 env:
     - BUILDAH_ISOLATION=oci
     - BUILDAH_ISOLATION=chroot
+    - BUILDAH_ISOLATION=rootless
 
 matrix:
   # If the latest unstable development version of go fails, that's OK.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_COMMIT := $(if $(shell git rev-parse --short HEAD),$(shell git rev-parse --s
 BUILD_INFO := $(if $(shell date +%s),$(shell date +%s),$(error "date failed"))
 CNI_COMMIT := $(if $(shell sed -e '\,github.com/containernetworking/cni, !d' -e 's,.* ,,g' vendor.conf),$(shell sed -e '\,github.com/containernetworking/cni, !d' -e 's,.* ,,g' vendor.conf),$(error "sed failed"))
 
-RUNC_COMMIT := c5ec25487693612aed95673800863e134785f946
+RUNC_COMMIT := 2c632d1a2de0192c3f18a2542ccb6f30a8719b1f
 LIBSECCOMP_COMMIT := release-2.3
 
 LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO} -X main.cniVersion=${CNI_COMMIT}'

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -159,10 +159,10 @@ func maybeReexecUsingUserNamespace(c *cli.Context, evenForRoot bool) {
 	err = os.Setenv(startedInUserNS, "1")
 	bailOnError(err, "error setting %s=1 in environment", startedInUserNS)
 
-	// Set the default isolation type to use the "chroot" method.
-	if _, ok := os.LookupEnv("BUILDAH_ISOLATION"); !ok {
-		if err = os.Setenv("BUILDAH_ISOLATION", "chroot"); err != nil {
-			logrus.Errorf("error setting BUILDAH_ISOLATION=chroot in environment: %v", err)
+	// Set the default isolation type to use the "rootless" method.
+	if _, present := os.LookupEnv("BUILDAH_ISOLATION"); !present {
+		if err = os.Setenv("BUILDAH_ISOLATION", "rootless"); err != nil {
+			logrus.Errorf("error setting BUILDAH_ISOLATION=rootless in environment: %v", err)
 			os.Exit(1)
 		}
 	}

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -217,10 +217,14 @@ another process.
 
 **--isolation** *type*
 
-Controls what type of isolation is used when processing RUN instructions.
-Recognized types include *oci* (OCI-compatible runtime, the default) and
-*chroot* (an internal wrapper that leans more toward chroot(1) than container
-technology).
+Controls what type of isolation is used for running processes as part of `RUN`
+instructions.  Recognized types include *oci* (OCI-compatible runtime, the
+default), *rootless* (OCI-compatible runtime invoked using a modified
+configuration and its --rootless flag enabled, with *--no-new-keyring
+--no-pivot* added to its *create* invocation, with network and UTS namespaces
+disabled, and IPC, PID, and user namespaces enabled; the default for
+unprivileged users), and *chroot* (an internal wrapper that leans more toward
+chroot(1) than container technology).
 
 Note: You can also override the default isolation type by setting the
 BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -180,9 +180,13 @@ another process.
 
 **--isolation** *type*
 
-Controls what type of isolation will be used by default by `buildah run`.
-Recognized types include *oci* (OCI-compatible runtime, the default) and
-*chroot* (an internal wrapper that leans more toward chroot(1) than container
+Controls what type of isolation is used for running processes under `buildah
+run`.  Recognized types include *oci* (OCI-compatible runtime, the default),
+*rootless* (OCI-compatible runtime invoked using a modified configuration and
+its --rootless flag enabled, with *--no-new-keyring --no-pivot* added to its
+*create* invocation, with network and UTS namespaces disabled, and IPC, PID,
+and user namespaces enabled; the default for unprivileged users), and *chroot*
+(an internal wrapper that leans more toward chroot(1) than container
 technology).
 
 Note: You can also override the default isolation type by setting the

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -65,9 +65,13 @@ process.
 
 **--isolation** *type*
 
-Controls what type of isolation is used for running the process.
-Recognized types include *oci* (OCI-compatible runtime, the default) and
-*chroot* (an internal wrapper that leans more toward chroot(1) than container
+Controls what type of isolation is used for running the process.  Recognized
+types include *oci* (OCI-compatible runtime, the default), *rootless*
+(OCI-compatible runtime invoked using a modified configuration and its
+--rootless flag enabled, with *--no-new-keyring --no-pivot* added to its
+*create* invocation, with network and UTS namespaces disabled, and IPC, PID,
+and user namespaces enabled; the default for unprivileged users), and *chroot*
+(an internal wrapper that leans more toward chroot(1) than container
 technology).
 
 Note: You can also override the default isolation type by setting the

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -536,6 +536,8 @@ func defaultIsolation() (buildah.Isolation, error) {
 	if isSet {
 		if strings.HasPrefix(strings.ToLower(isolation), "oci") {
 			return buildah.IsolationOCI, nil
+		} else if strings.HasPrefix(strings.ToLower(isolation), "rootless") {
+			return buildah.IsolationOCIRootless, nil
 		} else if strings.HasPrefix(strings.ToLower(isolation), "chroot") {
 			return buildah.IsolationChroot, nil
 		}
@@ -549,6 +551,8 @@ func IsolationOption(c *cli.Context) (buildah.Isolation, error) {
 	if c.String("isolation") != "" {
 		if strings.HasPrefix(strings.ToLower(c.String("isolation")), "oci") {
 			return buildah.IsolationOCI, nil
+		} else if strings.HasPrefix(strings.ToLower(c.String("isolation")), "rootless") {
+			return buildah.IsolationOCIRootless, nil
 		} else if strings.HasPrefix(strings.ToLower(c.String("isolation")), "chroot") {
 			return buildah.IsolationChroot, nil
 		} else {

--- a/run.go
+++ b/run.go
@@ -354,6 +354,13 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 		return false
 	}
 
+	ipc := namespaceOptions.Find(string(specs.IPCNamespace))
+	hostIPC := ipc == nil || ipc.Host
+	net := namespaceOptions.Find(string(specs.NetworkNamespace))
+	hostNetwork := net == nil || net.Host
+	user := namespaceOptions.Find(string(specs.UserNamespace))
+	hostUser := user == nil || user.Host
+
 	// Copy mounts from the generated list.
 	mountCgroups := true
 	specMounts := []specs.Mount{}
@@ -361,9 +368,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 		// Override some of the mounts from the generated list if we're doing different things with namespaces.
 		if specMount.Destination == "/dev/shm" {
 			specMount.Options = []string{"nosuid", "noexec", "nodev", "mode=1777", "size=" + shmSize}
-			user := namespaceOptions.Find(string(specs.UserNamespace))
-			ipc := namespaceOptions.Find(string(specs.IPCNamespace))
-			if (ipc == nil || ipc.Host) && (user != nil && !user.Host) {
+			if hostIPC && !hostUser {
 				if _, err := os.Stat("/dev/shm"); err != nil && os.IsNotExist(err) {
 					continue
 				}
@@ -376,9 +381,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 			}
 		}
 		if specMount.Destination == "/dev/mqueue" {
-			user := namespaceOptions.Find(string(specs.UserNamespace))
-			ipc := namespaceOptions.Find(string(specs.IPCNamespace))
-			if (ipc == nil || ipc.Host) && (user != nil && !user.Host) {
+			if hostIPC && !hostUser {
 				if _, err := os.Stat("/dev/mqueue"); err != nil && os.IsNotExist(err) {
 					continue
 				}
@@ -391,9 +394,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 			}
 		}
 		if specMount.Destination == "/sys" {
-			user := namespaceOptions.Find(string(specs.UserNamespace))
-			net := namespaceOptions.Find(string(specs.NetworkNamespace))
-			if (net == nil || net.Host) && (user != nil && !user.Host) {
+			if hostNetwork && !hostUser {
 				mountCgroups = false
 				if _, err := os.Stat("/sys"); err != nil && os.IsNotExist(err) {
 					continue
@@ -719,7 +720,6 @@ func setupTerminal(g *generate.Generator, terminalPolicy TerminalPolicy, termina
 
 func setupNamespaces(g *generate.Generator, namespaceOptions NamespaceOptions, idmapOptions IDMappingOptions, policy NetworkConfigurationPolicy) (configureNetwork bool, configureNetworks []string, configureUTS bool, err error) {
 	// Set namespace options in the container configuration.
-	hostPidns := false
 	configureUserns := false
 	specifiedNetwork := false
 	for _, namespaceOption := range namespaceOptions {
@@ -729,8 +729,6 @@ func setupNamespaces(g *generate.Generator, namespaceOptions NamespaceOptions, i
 			if !namespaceOption.Host && namespaceOption.Path == "" {
 				configureUserns = true
 			}
-		case string(specs.PIDNamespace):
-			hostPidns = namespaceOption.Host
 		case string(specs.NetworkNamespace):
 			specifiedNetwork = true
 			configureNetwork = false
@@ -758,11 +756,9 @@ func setupNamespaces(g *generate.Generator, namespaceOptions NamespaceOptions, i
 			return false, nil, false, errors.Wrapf(err, "error adding %q namespace %q for run", namespaceOption.Name, namespaceOption.Path)
 		}
 	}
+
 	// If we've got mappings, we're going to have to create a user namespace.
 	if len(idmapOptions.UIDMap) > 0 || len(idmapOptions.GIDMap) > 0 || configureUserns {
-		if hostPidns {
-			return false, nil, false, errors.New("unable to mix host PID namespace with user namespace")
-		}
 		if err := g.AddOrReplaceLinuxNamespace(specs.UserNamespace, ""); err != nil {
 			return false, nil, false, errors.Wrapf(err, "error adding new %q namespace for run", string(specs.UserNamespace))
 		}
@@ -944,25 +940,25 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 			logrus.Errorf("error removing %q: %v", path, err2)
 		}
 	}()
+
 	gp, err := generate.New("linux")
 	if err != nil {
 		return err
 	}
-
 	g := &gp
 
-	b.configureEnvironment(g, options)
-
-	if os.Getuid() != 0 {
-		g.RemoveMount("/dev/pts")
-		devPts := specs.Mount{
-			Destination: "/dev/pts",
-			Type:        "devpts",
-			Source:      "devpts",
-			Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620"},
+	isolation := options.Isolation
+	if isolation == IsolationDefault {
+		isolation = b.Isolation
+		if isolation == IsolationDefault {
+			isolation = IsolationOCI
 		}
-		g.AddMount(devPts)
 	}
+	if err := checkAndOverrideIsolationOptions(isolation, &options); err != nil {
+		return err
+	}
+
+	b.configureEnvironment(g, options)
 
 	if b.CommonBuildOpts == nil {
 		return errors.Errorf("Invalid format on container you must recreate the container")
@@ -1074,22 +1070,137 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		}
 	}
 
-	isolation := options.Isolation
-	if isolation == IsolationDefault {
-		isolation = b.Isolation
-		if isolation == IsolationDefault {
-			isolation = IsolationOCI
-		}
-	}
 	switch isolation {
 	case IsolationOCI:
-		err = b.runUsingRuntimeSubproc(options, configureNetwork, configureNetworks, spec, mountPoint, path, Package+"-"+filepath.Base(path))
+		// The default is --rootless=auto, which makes troubleshooting a bit harder.
+		// rootlessFlag := []string{"--rootless=false"}
+		// for _, arg := range options.Args {
+		// 	if strings.HasPrefix(arg, "--rootless") {
+		// 		rootlessFlag = nil
+		// 	}
+		// }
+		// options.Args = append(options.Args, rootlessFlag...)
+		err = b.runUsingRuntimeSubproc(options, configureNetwork, configureNetworks, nil, spec, mountPoint, path, Package+"-"+filepath.Base(path))
 	case IsolationChroot:
 		err = chroot.RunUsingChroot(spec, path, options.Stdin, options.Stdout, options.Stderr)
+	case IsolationOCIRootless:
+		if err := setupRootlessSpecChanges(spec, path, rootUID, rootGID); err != nil {
+			return err
+		}
+		rootlessFlag := []string{"--rootless=true"}
+		for _, arg := range options.Args {
+			if strings.HasPrefix(arg, "--rootless") {
+				rootlessFlag = nil
+			}
+		}
+		options.Args = append(options.Args, rootlessFlag...)
+		err = b.runUsingRuntimeSubproc(options, configureNetwork, configureNetworks, []string{"--no-new-keyring", "--no-pivot"}, spec, mountPoint, path, Package+"-"+filepath.Base(path))
 	default:
 		err = errors.Errorf("don't know how to run this command")
 	}
 	return err
+}
+
+func checkAndOverrideIsolationOptions(isolation Isolation, options *RunOptions) error {
+	switch isolation {
+	case IsolationOCIRootless:
+		if ns := options.NamespaceOptions.Find(string(specs.IPCNamespace)); ns == nil || ns.Host {
+			logrus.Debugf("Forcing use of an IPC namespace.")
+		}
+		options.NamespaceOptions.AddOrReplace(NamespaceOption{Name: string(specs.IPCNamespace)})
+		if ns := options.NamespaceOptions.Find(string(specs.NetworkNamespace)); ns != nil && !ns.Host {
+			logrus.Debugf("Disabling network namespace.")
+		}
+		options.NamespaceOptions.AddOrReplace(NamespaceOption{Name: string(specs.NetworkNamespace), Host: true})
+		if ns := options.NamespaceOptions.Find(string(specs.PIDNamespace)); ns == nil || ns.Host {
+			logrus.Debugf("Forcing use of a PID namespace.")
+		}
+		options.NamespaceOptions.AddOrReplace(NamespaceOption{Name: string(specs.PIDNamespace), Host: false})
+		if ns := options.NamespaceOptions.Find(string(specs.UserNamespace)); ns == nil || ns.Host {
+			logrus.Debugf("Forcing use of a user namespace.")
+		}
+		options.NamespaceOptions.AddOrReplace(NamespaceOption{Name: string(specs.UserNamespace)})
+		if ns := options.NamespaceOptions.Find(string(specs.UTSNamespace)); ns != nil && !ns.Host {
+			logrus.Debugf("Disabling UTS namespace.")
+		}
+		options.NamespaceOptions.AddOrReplace(NamespaceOption{Name: string(specs.UTSNamespace), Host: true})
+	case IsolationOCI:
+		pidns := options.NamespaceOptions.Find(string(specs.PIDNamespace))
+		userns := options.NamespaceOptions.Find(string(specs.UserNamespace))
+		if (pidns == nil || pidns.Host) && (userns != nil && !userns.Host) {
+			return fmt.Errorf("not allowed to mix host PID namespace with container user namespace")
+		}
+	}
+	return nil
+}
+
+func setupRootlessSpecChanges(spec *specs.Spec, bundleDir string, rootUID, rootGID uint32) error {
+	spec.Hostname = ""
+	spec.Process.User.AdditionalGids = nil
+	spec.Linux.Resources = nil
+
+	emptyDir := filepath.Join(bundleDir, "empty")
+	if err := os.Mkdir(emptyDir, 0); err != nil {
+		return errors.Wrapf(err, "error creating %q", emptyDir)
+	}
+
+	// Replace /sys with a read-only bind mount.
+	mounts := []specs.Mount{
+		{
+			Source:      "/dev",
+			Destination: "/dev",
+			Type:        "tmpfs",
+			Options:     []string{"private", "strictatime", "noexec", "nosuid", "mode=755", "size=65536k"},
+		},
+		{
+			Source:      "mqueue",
+			Destination: "/dev/mqueue",
+			Type:        "mqueue",
+			Options:     []string{"private", "nodev", "noexec", "nosuid"},
+		},
+		{
+			Source:      "pts",
+			Destination: "/dev/pts",
+			Type:        "devpts",
+			Options:     []string{"private", "noexec", "nosuid", "newinstance", "ptmxmode=0666", "mode=0620"},
+		},
+		{
+			Source:      "shm",
+			Destination: "/dev/shm",
+			Type:        "tmpfs",
+			Options:     []string{"private", "nodev", "noexec", "nosuid", "mode=1777", "size=65536k"},
+		},
+		{
+			Source:      "/proc",
+			Destination: "/proc",
+			Type:        "proc",
+			Options:     []string{"private", "nodev", "noexec", "nosuid"},
+		},
+		{
+			Source:      "/sys",
+			Destination: "/sys",
+			Type:        "bind",
+			Options:     []string{bind.NoBindOption, "rbind", "private", "nodev", "noexec", "nosuid", "ro"},
+		},
+	}
+	// Cover up /sys/fs/cgroup and /sys/fs/selinux, if they exist in our source for /sys.
+	if _, err := os.Stat("/sys/fs/cgroup"); err == nil {
+		spec.Linux.MaskedPaths = append(spec.Linux.MaskedPaths, "/sys/fs/cgroup")
+	}
+	if _, err := os.Stat("/sys/fs/selinux"); err == nil {
+		spec.Linux.MaskedPaths = append(spec.Linux.MaskedPaths, "/sys/fs/selinux")
+	}
+	// Keep anything that isn't under /dev, /proc, or /sys.
+	for i := range spec.Mounts {
+		if spec.Mounts[i].Destination == "/dev" || strings.HasPrefix(spec.Mounts[i].Destination, "/dev/") ||
+			spec.Mounts[i].Destination == "/proc" || strings.HasPrefix(spec.Mounts[i].Destination, "/proc/") ||
+			spec.Mounts[i].Destination == "/sys" || strings.HasPrefix(spec.Mounts[i].Destination, "/sys/") {
+			continue
+		}
+		mounts = append(mounts, spec.Mounts[i])
+	}
+	spec.Mounts = mounts
+	return nil
 }
 
 type runUsingRuntimeSubprocOptions struct {
@@ -1099,10 +1210,11 @@ type runUsingRuntimeSubprocOptions struct {
 	BundlePath        string
 	ConfigureNetwork  bool
 	ConfigureNetworks []string
+	MoreCreateArgs    []string
 	ContainerName     string
 }
 
-func (b *Builder) runUsingRuntimeSubproc(options RunOptions, configureNetwork bool, configureNetworks []string, spec *specs.Spec, rootPath, bundlePath, containerName string) (err error) {
+func (b *Builder) runUsingRuntimeSubproc(options RunOptions, configureNetwork bool, configureNetworks, moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName string) (err error) {
 	var confwg sync.WaitGroup
 	config, conferr := json.Marshal(runUsingRuntimeSubprocOptions{
 		Options:           options,
@@ -1111,6 +1223,7 @@ func (b *Builder) runUsingRuntimeSubproc(options RunOptions, configureNetwork bo
 		BundlePath:        bundlePath,
 		ConfigureNetwork:  configureNetwork,
 		ConfigureNetworks: configureNetworks,
+		MoreCreateArgs:    moreCreateArgs,
 		ContainerName:     containerName,
 	})
 	if conferr != nil {
@@ -1181,7 +1294,7 @@ func runUsingRuntimeMain() {
 		os.Exit(1)
 	}
 	// Run the container, start to finish.
-	status, err := runUsingRuntime(options.Options, options.ConfigureNetwork, options.ConfigureNetworks, options.Spec, options.RootPath, options.BundlePath, options.ContainerName)
+	status, err := runUsingRuntime(options.Options, options.ConfigureNetwork, options.ConfigureNetworks, options.MoreCreateArgs, options.Spec, options.RootPath, options.BundlePath, options.ContainerName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error running container: %v\n", err)
 		os.Exit(1)
@@ -1196,7 +1309,7 @@ func runUsingRuntimeMain() {
 	os.Exit(1)
 }
 
-func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetworks []string, spec *specs.Spec, rootPath, bundlePath, containerName string) (wstatus unix.WaitStatus, err error) {
+func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetworks, moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName string) (wstatus unix.WaitStatus, err error) {
 	// Lock the caller to a single OS-level thread.
 	runtime.LockOSThread()
 
@@ -1230,8 +1343,6 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetwork
 		runtime = util.Runtime()
 	}
 
-	// Default to not specifying a console socket location.
-	var moreCreateArgs []string
 	// Default to just passing down our stdio.
 	getCreateStdio := func() (io.ReadCloser, io.WriteCloser, io.WriteCloser) {
 		return os.Stdin, os.Stdout, os.Stderr
@@ -1317,6 +1428,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetwork
 	del.Stderr = os.Stderr
 
 	// Actually create the container.
+	logrus.Debugf("Running %q", create.Args)
 	err = create.Run()
 	if err != nil {
 		return 1, errors.Wrapf(err, "error creating container for %v: %s", spec.Process.Args, runCollectOutput(errorFds, closeBeforeReadingErrorFds))
@@ -1377,6 +1489,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetwork
 	go runCopyStdio(&stdio, copyPipes, stdioPipe, copyConsole, consoleListener, finishCopy, finishedCopy, spec)
 
 	// Start the container.
+	logrus.Debugf("Running %q", start.Args)
 	err = start.Run()
 	if err != nil {
 		return 1, errors.Wrapf(err, "error starting container")

--- a/run.go
+++ b/run.go
@@ -116,6 +116,8 @@ const (
 	// IsolationChroot is a more chroot-like environment: less isolation,
 	// but with fewer requirements.
 	IsolationChroot
+	// IsolationOCIRootless is a proper OCI runtime in rootless mode.
+	IsolationOCIRootless
 )
 
 // String converts a Isolation into a string.
@@ -127,6 +129,8 @@ func (i Isolation) String() string {
 		return "IsolationOCI"
 	case IsolationChroot:
 		return "IsolationChroot"
+	case IsolationOCIRootless:
+		return "IsolationOCIRootless"
 	}
 	return fmt.Sprintf("unrecognized isolation type %d", i)
 }
@@ -135,7 +139,7 @@ func (i Isolation) String() string {
 type RunOptions struct {
 	// Hostname is the hostname we set for the running container.
 	Hostname string
-	// Isolation is either IsolationDefault, IsolationOCI, or IsolationChroot.
+	// Isolation is either IsolationDefault, IsolationOCI, IsolationChroot, or IsolationOCIRootless.
 	Isolation Isolation
 	// Runtime is the name of the runtime to run.  It should accept the
 	// same arguments that runc does, and produce similar output.

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -193,7 +193,7 @@ load helpers
 }
 
 @test "from cpu-period test" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   if ! which runc ; then
@@ -208,7 +208,7 @@ load helpers
 }
 
 @test "from cpu-quota test" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   if ! which runc ; then
@@ -223,7 +223,7 @@ load helpers
 }
 
 @test "from cpu-shares test" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   if ! which runc ; then
@@ -238,7 +238,7 @@ load helpers
 }
 
 @test "from cpuset-cpus test" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   if ! which runc ; then
@@ -253,7 +253,7 @@ load helpers
 }
 
 @test "from cpuset-mems test" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   if ! which runc ; then
@@ -268,7 +268,7 @@ load helpers
 }
 
 @test "from memory test" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   if ! which runc ; then
@@ -307,7 +307,7 @@ load helpers
 }
 
 @test "from shm-size test" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   if ! which runc ; then

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -3,7 +3,7 @@
 load helpers
 
 @test "user-and-network-namespace" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   mkdir -p $TESTDIR/no-cni-configs
@@ -173,7 +173,7 @@ load helpers
     [ "$output" != "" ]
     case x"$map" in
     x)
-      if test "$BUILDAH_ISOLATION" != "chroot" ; then
+      if test "$BUILDAH_ISOLATION" != "chroot" -a "$BUILDAH_ISOLATION" != "rootless" ; then
         [ "$output" == "$mynamespace" ]
       fi
       ;;
@@ -305,49 +305,49 @@ general_namespace() {
 }
 
 @test "ipc-namespace" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   general_namespace ipc
 }
 
 @test "net-namespace" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   general_namespace net
 }
 
 @test "network-namespace" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   general_namespace net network
 }
 
 @test "pid-namespace" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   general_namespace pid
 }
 
 @test "user-namespace" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   general_namespace user userns
 }
 
 @test "uts-namespace" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   general_namespace uts
 }
 
 @test "combination-namespaces" {
-  if test "$BUILDAH_ISOLATION" = "chroot" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip
   fi
   # mnt is always per-container, cgroup isn't a thing runc lets us configure

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -303,6 +303,9 @@ load helpers
 }
 
 @test "run --hostname" {
+	if test "$BUILDAH_ISOLATION" = "rootless" ; then
+		skip
+	fi
 	if ! which runc ; then
 		skip
 	fi

--- a/tests/selinux.bats
+++ b/tests/selinux.bats
@@ -4,7 +4,7 @@ load helpers
 
 @test "selinux test" {
   if ! which selinuxenabled > /dev/null 2> /dev/null ; then
-    skip "No selinuxenabled"
+    skip 'selinuxenabled command not found in $PATH'
   elif ! selinuxenabled ; then
     skip "selinux is disabled"
   fi


### PR DESCRIPTION
Add an isolation mode which also calls an OCI runtime, but with modified arguments, passing it a modified runtime configuration.  This mode does things which are currently not permitted for containers in SELinux policy.
We now reexec ourselves in a new user namespace — even when we're running with UID 0 — if we don't have `CAP_SYS_ADMIN`, so that we can use `unshare(2)` when setting up to run a runtime.