### PR TITLE
Add a few debug messages to pull

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -3,6 +3,7 @@ package buildah
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -179,6 +180,12 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 	case signature.PolicyRequirementError:
 		logrus.Debugf("PolicyRequirementError raised")
 		return nil, err
+	case *url.Error:
+		logrus.Debugf("URL Error raised, tranport: [%v]", options.Transport)
+		if options.Transport == "" {
+			// Not using localhost, a url error that's a problem
+			return nil, err
+		}
 	default:
 		logrus.Debugf("Generic Error raised [%v] [%v]", err, reflect.TypeOf(err))
 	}
@@ -187,13 +194,16 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 	registryPath := sysregistries.RegistriesConfPath(sc)
 	searchRegistries, err := getRegistries(sc)
 	if err != nil {
+		logrus.Debugf("getRegistries Error for image [%s] [%v] [%v]", imageName, err, reflect.TypeOf(err))
 		return nil, err
 	}
 	hasRegistryInName, err := hasRegistry(imageName)
 	if err != nil {
+		logrus.Debugf("hasRegistry Error for image [%s] [%v] [%v]", imageName, err, reflect.TypeOf(err))
 		return nil, err
 	}
 	if !hasRegistryInName && len(searchRegistries) == 0 {
+		logrus.Debugf("No registry in name for image [%s] [%v] [%v]", imageName, err, reflect.TypeOf(err))
 		return nil, errors.Errorf("image name provided is a short name and no search registries are defined in %s.", registryPath)
 	}
 	return nil, NewGenericPullError(fmt.Sprintf("unable to find image in the registries defined in %q", registryPath))


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add a few debug statements to find out why a pull failed.  Also if we encounter a URL error, handle it rather than checking for the registry which will cause "invalid reference format" errors.

Testing: 
=====
```
# ./buildah from docker://registry1.fedoraproject.org/fedora-minimal
Get https://registry1.fedoraproject.org/v2/: dial tcp: lookup registry1.fedoraproject.org on 192.168.122.1:53: no such host
```