### PR TITLE
Pull Error handling: talk about search registries again, more intelligent output, cleanups

### DIFF
--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -142,7 +142,7 @@ func commitCmd(c *cli.Context) error {
 
 	dest, err := alltransports.ParseImageName(image)
 	if err != nil {
-		candidates, err := util.ResolveName(image, "", systemContext, store)
+		candidates, _, err := util.ResolveName(image, "", systemContext, store)
 		if err != nil {
 			return errors.Wrapf(err, "error parsing target image name %q", image)
 		}

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -761,7 +761,7 @@ func (b *Executor) resolveNameToImageRef() (types.ImageReference, error) {
 	if b.output != "" {
 		imageRef, err = alltransports.ParseImageName(b.output)
 		if err != nil {
-			candidates, err := util.ResolveName(b.output, "", b.systemContext, b.store)
+			candidates, _, err := util.ResolveName(b.output, "", b.systemContext, b.store)
 			if err != nil {
 				return nil, errors.Wrapf(err, "error parsing target image name %q: %v", b.output)
 			}

--- a/new.go
+++ b/new.go
@@ -203,12 +203,12 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 
 	systemContext := getSystemContext(options.SystemContext, options.SignaturePolicyPath)
 
-	if options.FromImage != "scratch" {
+	if options.FromImage != "" && options.FromImage != "scratch" {
 		ref, img, err = resolveImage(ctx, systemContext, store, options)
 		if err != nil {
 			return nil, err
 		}
-		if options.FromImage != "" && (ref == nil || img == nil) {
+		if ref == nil || img == nil {
 			// If options.FromImage is set but we ended up
 			// with nil in ref or in img then there was an error that
 			// we should return.

--- a/new.go
+++ b/new.go
@@ -106,7 +106,7 @@ func newContainerIDMappingOptions(idmapOptions *IDMappingOptions) storage.IDMapp
 }
 
 func resolveImage(ctx context.Context, systemContext *types.SystemContext, store storage.Store, options BuilderOptions) (types.ImageReference, *storage.Image, error) {
-	images, err := util.ResolveName(options.FromImage, options.Registry, systemContext, store)
+	images, _, err := util.ResolveName(options.FromImage, options.Registry, systemContext, store)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "error parsing reference to image %q", options.FromImage)
 	}

--- a/new.go
+++ b/new.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/containers/buildah/util"
-	"github.com/containers/image/pkg/sysregistries"
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/transports/alltransports"
@@ -207,12 +206,6 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		ref, img, err = resolveImage(ctx, systemContext, store, options)
 		if err != nil {
 			return nil, err
-		}
-		if ref == nil || img == nil {
-			// If options.FromImage is set but we ended up
-			// with nil in ref or in img then there was an error that
-			// we should return.
-			return nil, errors.Wrapf(storage.ErrImageUnknown, "image %q not found in %s registries", options.FromImage, sysregistries.RegistriesConfPath(systemContext))
 		}
 	}
 	image := options.FromImage

--- a/pull.go
+++ b/pull.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/image/docker/reference"
 	tarfile "github.com/containers/image/docker/tarfile"
 	ociarchive "github.com/containers/image/oci/archive"
-	"github.com/containers/image/pkg/sysregistries"
 	"github.com/containers/image/signature"
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/transports"
@@ -201,28 +200,10 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 	}()
 
 	logrus.Debugf("copying %q to %q", spec, destName)
-	pullError := cp.Image(ctx, policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter, srcRef, sc, destRef, nil, ""))
-	if pullError == nil {
-		return destRef, nil
+	if err := cp.Image(ctx, policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter, srcRef, sc, destRef, nil, "")); err != nil {
+		return nil, err
 	}
-
-	// If no image was found, we should handle.  Lets be nicer to the user and see if we can figure out why.
-	registryPath := sysregistries.RegistriesConfPath(sc)
-	searchRegistries, err := getRegistries(sc)
-	if err != nil {
-		logrus.Debugf("error getting list of registries: %v", err)
-		return nil, errors.Wrapf(pullError, "error copying image from %q to %q", transports.ImageName(srcRef), transports.ImageName(destRef))
-	}
-	hasRegistryInName, err := hasRegistry(imageName)
-	if err != nil {
-		logrus.Debugf("error checking if image name %q includes a registry component: %v", imageName, err)
-		return nil, errors.Wrapf(pullError, "error copying image from %q to %q", transports.ImageName(srcRef), transports.ImageName(destRef))
-	}
-	if !hasRegistryInName && len(searchRegistries) == 0 {
-		logrus.Debugf("copying %q to %q failed: %v", pullError)
-		return nil, errors.Errorf("image name provided does not include a registry name and no search registries are defined in %s: %s", registryPath, pullError)
-	}
-	return nil, pullError
+	return destRef, nil
 }
 
 // getImageDigest creates an image object and uses the hex value of the digest as the image ID

--- a/util.go
+++ b/util.go
@@ -173,21 +173,6 @@ func (b *Builder) tarPath() func(path string) (io.ReadCloser, error) {
 	}
 }
 
-// getRegistries obtains the list of search registries defined in the global registries file.
-func getRegistries(sc *types.SystemContext) ([]string, error) {
-	var searchRegistries []string
-	registries, err := sysregistriesv2.GetRegistries(sc)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to parse the registries.conf file")
-	}
-	for _, registry := range sysregistriesv2.FindUnqualifiedSearchRegistries(registries) {
-		if !registry.Blocked {
-			searchRegistries = append(searchRegistries, registry.URL)
-		}
-	}
-	return searchRegistries, nil
-}
-
 // isRegistryInsecure checks if the named registry is marked as not secure
 func isRegistryInsecure(registry string, sc *types.SystemContext) (bool, error) {
 	registries, err := sysregistriesv2.GetRegistries(sc)
@@ -248,20 +233,6 @@ func isReferenceBlocked(ref types.ImageReference, sc *types.SystemContext) (bool
 		case "docker":
 			return isReferenceSomething(ref, sc, isRegistryBlocked)
 		}
-	}
-	return false, nil
-}
-
-// hasRegistry returns a bool/err response if the image has a registry in its
-// name
-func hasRegistry(imageName string) (bool, error) {
-	imgRef, err := reference.Parse(imageName)
-	if err != nil {
-		return false, errors.Wrapf(err, "error parsing image name %q", imageName)
-	}
-	registry := reference.Domain(imgRef.(reference.Named))
-	if registry != "" {
-		return true, nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
<s>WIP ABSOLUTELY UNTESTED.</s>

Motivated by #907 and #908: Refactor pull error handling; instead of throwing away most errors, go to the other extreme and report all of them when searching multiple registries.

_Mostly_ this is fairly straightforward refactoring and ~simplification. The last commit, though, fairly drastically changes `resolveImage` error handling to first collect the details of all failures to pull the image, and _then_ at the end decide how to report it to the user.

**I am fairly sure the result is not good enough**, but _having that information_ at all in `resolveImage` should allow making more intelligent decisions **EDIT than trying to do the right thing deep in `pullImage` with incomplete information**.

The `resolveImage` loop body is fairly big and maybe should be split now into a separate function.

This might need at least one more step, explicitly recognizing the `localhost` case as likely-to-fail and being more silent about failures to pull it (but not other failures involving it).

See individual commits for details. This CHANGES BEHAVIOR, marked like that in the commit messages.

Feel free to reuse and/or modify all of parts of this as necessary; or tell me to throw it away.