### PR TITLE
Support HEALTHCHECK

### DIFF
--- a/config.go
+++ b/config.go
@@ -543,3 +543,37 @@ func (b *Builder) SetStopSignal(stopSignal string) {
 	b.OCIv1.Config.StopSignal = stopSignal
 	b.Docker.Config.StopSignal = stopSignal
 }
+
+// Healthcheck returns information that recommends how a container engine
+// should check if a running container is "healthy".
+func (b *Builder) Healthcheck() *docker.HealthConfig {
+	if b.Docker.Config.Healthcheck == nil {
+		return nil
+	}
+	return &docker.HealthConfig{
+		Test:        copyStringSlice(b.Docker.Config.Healthcheck.Test),
+		Interval:    b.Docker.Config.Healthcheck.Interval,
+		Timeout:     b.Docker.Config.Healthcheck.Timeout,
+		StartPeriod: b.Docker.Config.Healthcheck.StartPeriod,
+		Retries:     b.Docker.Config.Healthcheck.Retries,
+	}
+}
+
+// SetHealthcheck sets recommended commands to run in order to verify that a
+// running container based on this image is "healthy", along with information
+// specifying how often that test should be run, and how many times the test
+// should fail before the container should be considered unhealthy.
+// Note: this setting is not present in the OCIv1 image format, so it is
+// discarded when writing images using OCIv1 formats.
+func (b *Builder) SetHealthcheck(config *docker.HealthConfig) {
+	b.Docker.Config.Healthcheck = nil
+	if config != nil {
+		b.Docker.Config.Healthcheck = &docker.HealthConfig{
+			Test:        copyStringSlice(config.Test),
+			Interval:    config.Interval,
+			Timeout:     config.Timeout,
+			StartPeriod: config.StartPeriod,
+			Retries:     config.Retries,
+		}
+	}
+}

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -274,6 +274,11 @@ return 1
        --entrypoint
        --env
        -e
+       --healthcheck
+       --healthcheck-interval
+       --healthcheck-retries
+       --healthcheck-start-period
+       --healthcheck-timeout
        --history-comment
        --hostname
        --label

--- a/docker/types.go
+++ b/docker/types.go
@@ -60,8 +60,9 @@ type HealthConfig struct {
 	Test []string `json:",omitempty"`
 
 	// Zero means to inherit. Durations are expressed as integer nanoseconds.
-	Interval time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
-	Timeout  time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+	StartPeriod time.Duration `json:",omitempty"` // Time to wait after the container starts before running the first check.
 
 	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -69,6 +69,46 @@ executed together.
 Add a value (e.g. name=*value*) to the environment for containers based on any
 images which will be built using the specified container. Can be used multiple times.
 
+**--healthcheck** *command*
+
+Specify a command which should be run to check if a container is running correctly.
+
+Values can be *NONE*, "*CMD* ..." (run the specified command directly), or
+"*CMD-SHELL* ..." (run the specified command using the system's shell), or the
+empty value (remove a previously-set value and related settings).
+
+Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
+
+**--healthcheck-interval** *interval*
+
+Specify how often the command specified using the *--healthcheck* option should
+be run.
+
+Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
+
+**--healthcheck-retries** *count*
+
+Specify how many times the command specified using the *--healthcheck* option
+can fail before the container is considered to be unhealthy.
+
+Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
+
+**--healthcheck-start-period** *interval*
+
+Specify how long to wait after starting a container before running the command
+specified using the *--healthcheck* option.
+
+Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
+
+**--healthcheck-timeout** *interval*
+
+Specify how long to wait after starting the command specified using the
+*--healthcheck* option to wait for the command to return its exit status.  If
+the command has not returned within this time, it should be considered to have
+failed.
+
+Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
+
 **--history-comment** *comment*
 
 Sets a comment on the topmost layer in any images which will be created
@@ -89,8 +129,9 @@ images which will be built using the specified container. Can be used multiple t
 **--onbuild** *onbuild command*
 
 Add an ONBUILD command to the image.  ONBUILD commands are automatically run
-when images are built based on the image you are creating.  ONBUILD images are
-only supported on `docker` formatted images.
+when images are built based on the image you are creating.
+
+Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
 
 **--os** *operating system*
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/containers/buildah"
+	buildahdocker "github.com/containers/buildah/docker"
 	"github.com/containers/buildah/util"
 	cp "github.com/containers/image/copy"
 	"github.com/containers/image/docker/reference"
@@ -1116,6 +1117,17 @@ func (b *Executor) Commit(ctx context.Context, ib *imagebuilder.Builder, created
 	b.builder.SetEntrypoint(config.Entrypoint)
 	b.builder.SetShell(config.Shell)
 	b.builder.SetStopSignal(config.StopSignal)
+	if config.Healthcheck != nil {
+		b.builder.SetHealthcheck(&buildahdocker.HealthConfig{
+			Test:        append([]string{}, config.Healthcheck.Test...),
+			Interval:    config.Healthcheck.Interval,
+			Timeout:     config.Healthcheck.Timeout,
+			StartPeriod: config.Healthcheck.StartPeriod,
+			Retries:     config.Healthcheck.Retries,
+		})
+	} else {
+		b.builder.SetHealthcheck(nil)
+	}
 	b.builder.ClearLabels()
 	for k, v := range config.Labels {
 		b.builder.SetLabel(k, v)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1018,3 +1018,15 @@ load helpers
   [ "$status" -eq 0 ]
 }
 
+@test "bud-with-healthcheck" {
+  target=alpine-image
+  buildah --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} --format docker ${TESTSDIR}/bud/healthcheck
+  run buildah --debug=false inspect -f '{{printf "%q" .Docker.Config.Healthcheck.Test}} {{printf "%d" .Docker.Config.Healthcheck.StartPeriod}} {{printf "%d" .Docker.Config.Healthcheck.Interval}} {{printf "%d" .Docker.Config.Healthcheck.Timeout}} {{printf "%d" .Docker.Config.Healthcheck.Retries}}' ${target}
+  echo "$output"
+  [ "$status" -eq 0 ]
+  second=1000000000
+  threeseconds=$(( 3 * $second ))
+  fiveminutes=$(( 5 * 60 * $second ))
+  tenminutes=$(( 10 * 60 * $second ))
+  [ "$output" = '["CMD-SHELL" "curl -f http://localhost/ || exit 1"]'" $tenminutes $fiveminutes $threeseconds 4" ]
+}

--- a/tests/bud/healthcheck/Dockerfile
+++ b/tests/bud/healthcheck/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+HEALTHCHECK --start-period=10m --interval=5m --timeout=3s --retries=4 \
+  CMD curl -f http://localhost/ || exit 1

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -177,6 +177,11 @@ load helpers
    --shell /bin/arbitrarysh \
    --domainname mydomain.local \
    --hostname cleverhostname \
+   --healthcheck "CMD /bin/true" \
+   --healthcheck-start-period 5s \
+   --healthcheck-interval 6s \
+   --healthcheck-timeout 7s \
+   --healthcheck-retries 8 \
   $cid
 
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
@@ -261,6 +266,16 @@ load helpers
   buildah --debug=false inspect --type=image --format '{{.Docker.Config.Hostname}}' scratch-image-docker | grep cleverhostname
   # Shell isn't part of the OCI spec, so it's discarded when we save to OCI format.
   buildah --debug=false inspect --type=image --format '{{.Docker.Config.Shell}}' scratch-image-docker | grep /bin/arbitrarysh
+  # Healthcheck command isn't part of the OCI spec, so it's discarded when we save to OCI format.
+  buildah --debug=false inspect -f '{{.Docker.Config.Healthcheck.Test}}' scratch-image-docker | grep true
+  # Healthcheck start period isn't part of the OCI spec, so it's discarded when we save to OCI format.
+  buildah --debug=false inspect -f '{{.Docker.Config.Healthcheck.StartPeriod}}' scratch-image-docker | grep 5
+  # Healthcheck interval isn't part of the OCI spec, so it's discarded when we save to OCI format.
+  buildah --debug=false inspect -f '{{.Docker.Config.Healthcheck.Interval}}' scratch-image-docker | grep 6
+  # Healthcheck timeout isn't part of the OCI spec, so it's discarded when we save to OCI format.
+  buildah --debug=false inspect -f '{{.Docker.Config.Healthcheck.Timeout}}' scratch-image-docker | grep 7
+  # Healthcheck retry count isn't part of the OCI spec, so it's discarded when we save to OCI format.
+  buildah --debug=false inspect -f '{{.Docker.Config.Healthcheck.Retries}}' scratch-image-docker | grep 8
 }
 
 @test "config env using --env expansion" {


### PR DESCRIPTION
Handle healthcheck configuration that imagebuilder picks up, and add CLI flags to `buildah config` that allow the values to be set on the command line.  We should replace the last commit with one that goes back to upstream imagebuilder after https://github.com/openshift/imagebuilder/pull/94 or an equivalent is merged.