### PR TITLE
Restore rootless isolation test for from volume ro test

### DIFF
--- a/tests/from.bats
+++ b/tests/from.bats
@@ -295,7 +295,7 @@ load helpers
 }
 
 @test "from volume ro test" {
-  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
+  if "$BUILDAH_ISOLATION" = "chroot" ; then
     skip
   fi
   if ! which runc ; then


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

When rushing around recently to get the papr tests back and working, I removed the "from volume ro test" from the rootless isolation streams of tests when I should not have.  Adding it back in.