### PR TITLE
unshare: keep the additional groups of the user

### DIFF
--- a/unshare/unshare.c
+++ b/unshare/unshare.c
@@ -31,7 +31,7 @@ static int _buildah_unshare_parse_envint(const char *envname) {
 
 void _buildah_unshare(void)
 {
-	int flags, pidfd, continuefd, n, pgrp, sid, ctty, allow_setgroups;
+	int flags, pidfd, continuefd, n, pgrp, sid, ctty;
 	char buf[2048];
 
 	flags = _buildah_unshare_parse_envint("_Buildah-unshare");
@@ -83,14 +83,7 @@ void _buildah_unshare(void)
 			_exit(1);
 		}
 	}
-	allow_setgroups = _buildah_unshare_parse_envint("_Buildah-allow-setgroups");
 	if ((flags & CLONE_NEWUSER) != 0) {
-		if (allow_setgroups == 1) {
-			if (setgroups(0, NULL) != 0) {
-				fprintf(stderr, "Error during setgroups(0, NULL): %m\n");
-				_exit(1);
-			}
-		}
 		if (setresgid(0, 0, 0) != 0) {
 			fprintf(stderr, "Error during setresgid(0): %m\n");
 			_exit(1);

--- a/unshare/unshare.go
+++ b/unshare/unshare.go
@@ -84,11 +84,6 @@ func (c *Cmd) Start() error {
 		c.Env = append(c.Env, fmt.Sprintf("_Buildah-ctty=%d", len(c.ExtraFiles)+3))
 		c.ExtraFiles = append(c.ExtraFiles, c.Ctty)
 	}
-	if c.GidMappingsEnableSetgroups {
-		c.Env = append(c.Env, "_Buildah-allow-setgroups=1")
-	} else {
-		c.Env = append(c.Env, "_Buildah-allow-setgroups=0")
-	}
 
 	// Make sure we clean up our pipes.
 	defer func() {


### PR DESCRIPTION
Do not reset the additional groups for a rootless user when creating a
new user namespace.  In this way, users of the "docker" group are
still able to use the docker-deamon: destination.

Closes: https://github.com/projectatomic/buildah/issues/978

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>