### PR TITLE
Change rmi --prune to not accept an imageID

### DIFF
--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -61,6 +61,9 @@ func rmiCmd(c *cli.Context) error {
 	if removeAll && pruneDangling {
 		return errors.Errorf("when using the --all switch, you may not use --prune switch")
 	}
+	if len(args) > 0 && pruneDangling {
+		return errors.Errorf("when using the --prune switch, you may not pass any images names or IDs")
+	}
 
 	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
 		return err

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -112,6 +112,12 @@ load helpers
 
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
+  run buildah --debug=false rmi -p alpine
+  [ "$status" -eq 1 ]
+  [ "$output" == "when using the --prune switch, you may not pass any images names or IDs" ]
+
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  buildah rm "$cid"
   run buildah --debug=false rmi -a -p
   [ "$status" -eq 1 ]
   [ "$output" == "when using the --all switch, you may not use --prune switch" ]


### PR DESCRIPTION
You cannot enter image when using the prune option.

After change:
```
➜  buildah git:(rmi-prune-fix) ✗ sudo ./buildah rmi -p 165
when using the --prune switch, you may not pass any images names or IDs
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>