### PR TITLE
Get rid of dangling whitespace in markdown files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ deps: gopath
 .PHONY: validate
 validate:
 	@./tests/validate/gofmt.sh
+	@./tests/validate/whitespace.sh
 	@./tests/validate/govet.sh
 	@./tests/validate/git-validation.sh
 	@./tests/validate/gometalinter.sh . cmd/buildah

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ storage differences, you can not see Podman containers from within Buildah or vi
 
 In short Buildah is an efficient way to create OCI images  while Podman allows
 you to manage and maintain those images and containers in a production environment using
-familiar container cli commands.  For more details, see the 
+familiar container cli commands.  For more details, see the
 [Container Tools Guide](https://github.com/containers/buildah/tree/master/docs/containertools).
 
 ## Example

--- a/demos/README.md
+++ b/demos/README.md
@@ -7,7 +7,7 @@ The purpose of these demonstrations is twofold:
 1. To help automate some of the tutorial material so that Buildah newcomers can walk through some of the concepts.
 2. For Buildah enthusiasts and practitioners to use for demos at educational presentations - college classes, Meetups etc.
 
-It is assumed that you have installed Buildah and Podman on your machine. 
+It is assumed that you have installed Buildah and Podman on your machine.
 
     $ sudo yum -y install podman buildah
 
@@ -17,7 +17,7 @@ For the Docker compatibility demo you will also need to install Docker.
 
 Replace `yum` with `dnf` if required.
 
-## Building from scratch demo 
+## Building from scratch demo
 
 filename: [`buildah-scratch-demo.sh`](buildah-scratch-demo.sh)
 
@@ -33,34 +33,34 @@ There are several variables you will want to set that are listed at the top of t
     quayuser=UserNameHere
     myname=YourNameHere
     distrorelease=28
-    pkgmgr=dnf   # switch to yum if using yum 
+    pkgmgr=dnf   # switch to yum if using yum
 
 ## Buildah and Docker compatibility demo
 
 filename: [`docker-compatibility-demo.sh`](docker-compatibility-demo.sh)
 
-This demo builds an nginx container image using Buildah. It modifies the homepage and commits the image. The container is tested using `podman run` and then stopped. The Docker daemon is then started and the image is pushed to the Docker repository. The container is started using `docker run` and tested. 
+This demo builds an nginx container image using Buildah. It modifies the homepage and commits the image. The container is tested using `podman run` and then stopped. The Docker daemon is then started and the image is pushed to the Docker repository. The container is started using `docker run` and tested.
 
 There are several variables you will want to set that are listed at the top of the script. The name for the container image, your quay.io username, your name, and the Fedora release number:
 
     demoimg=dockercompatibilitydemo
-    quayuser=UsernameHere  
+    quayuser=UsernameHere
     myname=YourNameHear
     distro=fedora
     distrorelease=28
-    pkgmgr=dnf   # switch to yum if using yum 
+    pkgmgr=dnf   # switch to yum if using yum
 
 ## Buildah build using Docker demo
 
 filename: [`docker-bud-demo.sh`](buildah-bud-demo.sh)
 
-This demo builds an nginx container image using Buildah with. Buildah's `buildah-using-docker`, or `bud` option, provides a mechanism for using existing Dockerfiles to build the container image. This image is the same as the image in the Docker compatibility demo (at time of creating this README). The container is tested using `podman run` and then stopped. The Docker daemon is then started and the image is pushed to the Docker repository. The container is started using `docker run` and tested. 
+This demo builds an nginx container image using Buildah with. Buildah's `buildah-using-docker`, or `bud` option, provides a mechanism for using existing Dockerfiles to build the container image. This image is the same as the image in the Docker compatibility demo (at time of creating this README). The container is tested using `podman run` and then stopped. The Docker daemon is then started and the image is pushed to the Docker repository. The container is started using `docker run` and tested.
 
 There are several variables you will want to set that are listed at the top of the script. The name for the container image, your quay.io username, your name, and the Fedora release number:
 
     demoimg=buildahbuddemo
-    quayuser=UsernameHere  
+    quayuser=UsernameHere
     myname=YourNameHear
     distro=fedora
     distrorelease=28
-    pkgmgr=dnf   # switch to yum if using yum 
+    pkgmgr=dnf   # switch to yum if using yum

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -172,7 +172,7 @@ value can be entered.  The password is entered without echo.
 
 **--disable-content-trust**
 
-This is a Docker specific option to disable image verification to a Docker 
+This is a Docker specific option to disable image verification to a Docker
 registry and is not supported by Buildah.  This flag is a NOOP and provided
 soley for scripting compatibility.
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -430,7 +430,7 @@ Only the current container can use a private volume.
 
 By default bind mounted volumes are `private`. That means any mounts done
 inside container will not be visible on the host and vice versa. This behavior can
-be changed by specifying a volume mount propagation property. 
+be changed by specifying a volume mount propagation property.
 
 When the mount propagation policy is set to `shared`, any mounts completed inside
 the container on that volume will be visible to both the host and container. When
@@ -475,7 +475,7 @@ buildah from --name mycontainer dir:directoryname
 
 buildah from --signature-policy /etc/containers/policy.json imagename
 
-buildah from --pull-always --name "mycontainer" docker://myregistry.example.com/imagename 
+buildah from --pull-always --name "mycontainer" docker://myregistry.example.com/imagename
 
 buildah from --tls-verify=false myregistry/myrepository/imagename:imagetag
 

--- a/docs/buildah-inspect.md
+++ b/docs/buildah-inspect.md
@@ -8,7 +8,7 @@ buildah\-inspect - Display information about working containers or images.
 
 ## DESCRIPTION
 Prints the low-level information on Buildah object(s) (e.g. container, images) identified by name or ID. By default, this will render all results in a
-JSON array. If the container and image have the same name, this will return container JSON for unspecified type. If a format is specified, 
+JSON array. If the container and image have the same name, this will return container JSON for unspecified type. If a format is specified,
 the given template will be executed for each result.
 
 ## OPTIONS

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -174,7 +174,7 @@ Only the current container can use a private volume.
 
 By default bind mounted volumes are `private`. That means any mounts done
 inside container will not be visible on the host and vice versa. This behavior can
-be changed by specifying a volume mount propagation property. 
+be changed by specifying a volume mount propagation property.
 
 When the mount propagation policy is set to `shared`, any mounts completed inside
 the container on that volume will be visible to both the host and container. When

--- a/docs/containertools/README.md
+++ b/docs/containertools/README.md
@@ -8,7 +8,7 @@ on [GitHub.com](https://github.com) that operate on
 guide will give a high level explanation of the related container tools and will explain a bit
 on how they interact amongst each other.
 
-The tools are:  
+The tools are:
 
 * [Buildah](https://github.com/containers/buildah)
 * [CRI-O](https://github.com/kubernetes-sigs/cri-o)
@@ -45,11 +45,11 @@ and image verification when pulling images along with resource isolation of cont
 ## Skopeo
 
 Skopeo is a command line tool that performs a variety of operations on container images and image repositories.
-Skopeo can work on either OCI or Docker images.  Skopeo can be used to copy images from and to various 
+Skopeo can work on either OCI or Docker images.  Skopeo can be used to copy images from and to various
 container storage mehchanisms including container registries.  Skopeo also allows you to inspect an image
 showing its layers without requiring that the image be pulled.  Skopeo also allows you to delete an image
 from a repository.  When required by the repository, Skopeo can pass appropriate certificates and credentials
-for authentication. 
+for authentication.
 
 
 ## Buildah and Podman relationship
@@ -86,18 +86,18 @@ familiar container cli commands.
 Some of the commands between the projects overlap:
 
 * build
-The `podman build` and `buildah bud` commands have significant overlap as Podman borrows large pieces of the `podman build` implementation from Buildah. 
+The `podman build` and `buildah bud` commands have significant overlap as Podman borrows large pieces of the `podman build` implementation from Buildah.
 
 * run
 The `buildah run` and `podman run` commands are similar but different.  As explained above Podman and Buildah have a different concept of a container.  An easy way to think of it is the `buildah run` command emulates the RUN command in a Dockerfile while the `podman run` command emulates the `docker run` command in functionality.  As Buildah and Podman have some what different concepts of containers, you can not see Podman containers from within Buildah or vice versa.
 
-* pull, push 
+* pull, push
 These commands are basically the same between the two and either could be used.
 
 * commit
 Commit works differently because of the differences in `containers`.  You cannot commit a Podman container from Buildah nor a Buildah container from Podman.
 
-* tag, rmi, images 
+* tag, rmi, images
 These commands are basically the same between the two and either could be used.
 
 * rm
@@ -105,7 +105,7 @@ This command appears to be equivalent on the surface, but they differ due to the
 between the two projects.  Given that, Buildah containers can not be removed with a Podman command and Podman containers
 can not be removed with a Buildah command.
 
-* mount 
+* mount
 Mount command is similar for both in that you can mount the container image and modify content in it, which will be saved to an image when you commit.
 
 In short Buildah is an efficient way to create OCI images  while Podman allows

--- a/docs/release-announcements/v0.16.md
+++ b/docs/release-announcements/v0.16.md
@@ -4,7 +4,7 @@
 
 We're pleased to announce the release of Buildah Alpha version 0.16 which is now available from GitHub for any Linux distro.  We will be shipping this release on Fedora, CentOS and Ubuntu in the near future.
 
-The Buildah project has continued to grow over the past several weeks, welcoming several new contributors to the mix, launching new functionality and creating a number of improvements and bug fixes.  
+The Buildah project has continued to grow over the past several weeks, welcoming several new contributors to the mix, launching new functionality and creating a number of improvements and bug fixes.
 
 ## The major highlights for this release are:
 

--- a/docs/release-announcements/v1.1.md
+++ b/docs/release-announcements/v1.1.md
@@ -4,7 +4,7 @@
 
 We're pleased to announce the release of Buildah version 1.1 which is now available from GitHub for any Linux distro.  We are shipping this release on Fedora, RHEL 7, CentOS and Ubuntu in the near future.
 
-The Buildah project has continued to grow over the past several weeks, welcoming several new contributors to the mix, launching new functionality and creating a number of improvements and bug fixes.  
+The Buildah project has continued to grow over the past several weeks, welcoming several new contributors to the mix, launching new functionality and creating a number of improvements and bug fixes.
 
 ## The major highlights for this release are:
 
@@ -44,7 +44,7 @@ The Buildah project has continued to grow over the past several weeks, welcoming
  * Touchup man page short options across man pages
  * Demo Changes
    * Added demo dir and a demo.
-   * Added Docker compatibility demo 
+   * Added Docker compatibility demo
    * Added a bud demo and tidied up
    * Update buildah scratch demo to support el7
    * Quick fix on demo readme
@@ -71,7 +71,7 @@ The Buildah project has continued to grow over the past several weeks, welcoming
    * Update github.com/containers/libpod
    * Vendor in latest containers/image
  * Plus a number of smaller fixes.
- 
+
 ## Try it Out.
 
 If you haven’t yet, install Buildah from the Fedora repo or GitHub and give it a spin.  We’re betting you'll find it’s an easy and quick way to build containers in your environment without a daemon being involved!

--- a/docs/release-announcements/v1.2.md
+++ b/docs/release-announcements/v1.2.md
@@ -2,17 +2,17 @@
 
 ![buildah logo](https://cdn.rawgit.com/containers/buildah/master/logos/buildah-logo_large.png)
 
-We're pleased to announce the release of Buildah version 1.2 which is now available from GitHub for any Linux distro.  We are shipping this release on Fedora, RHEL 7, CentOS and Ubuntu in the near future.  
+We're pleased to announce the release of Buildah version 1.2 which is now available from GitHub for any Linux distro.  We are shipping this release on Fedora, RHEL 7, CentOS and Ubuntu in the near future.
 
 The Buildah project has continued to grow over the past several weeks, welcoming several new contributors to the mix.  The highlights of this release are the added ability to control image layers when building an image, CVE’s Fixes, the initial support for user namespace handling and several other enhancements and bug fixes.
 
 ## The major highlights for this release are:
 
-### Allow the user to control the layers of the image when the image is built with the ‘buildah bud’ command. 
+### Allow the user to control the layers of the image when the image is built with the ‘buildah bud’ command.
 
 A container is comprised of a final readable/writeable layer and when the layers are cached, a number of intermediate read only layers.  The read only layers are created with each step in the Dockerfile and the final readable/writeable layer contains the intermediate layers.  Prior to these changes Buildah did not cache these intermediate read only layers.
 
-This release has a new environment variable ‘BUILDAH_LAYERS’ and a new ‘buildah bud’ --layers parameter.  When either is set to true, the image layers are cached during the ‘buildah bud’ processing and not discarded.  The disadvantage to retaining layers is the space that they use.  The advantage to retaining them is if you make a change to your Dockerfile, only the layers for that change and the ones following it will need to be regenerated.  
+This release has a new environment variable ‘BUILDAH_LAYERS’ and a new ‘buildah bud’ --layers parameter.  When either is set to true, the image layers are cached during the ‘buildah bud’ processing and not discarded.  The disadvantage to retaining layers is the space that they use.  The advantage to retaining them is if you make a change to your Dockerfile, only the layers for that change and the ones following it will need to be regenerated.
 
 The --nocache parameter has also been added to the ‘buildah bud’ command.  When this parameter is set to true the ‘buildah bud’ command ignores any existing layers and creates all of the image layers anew.
 

--- a/docs/tutorials/01-intro.md
+++ b/docs/tutorials/01-intro.md
@@ -5,7 +5,7 @@
 
 The purpose of this tutorial is to demonstrate how Buildah can be used to build container images compliant with the [Open Container Initiative](https://www.opencontainers.org/) (OCI) [image specification](https://github.com/opencontainers/image-spec). Images can be built from existing images, from scratch, and using Dockerfiles. OCI images built using the Buildah command line tool (CLI) and the underlying OCI based technologies (e.g. [containers/image](https://github.com/containers/image) and [containers/storage](https://github.com/containers/storage)) are portable and can therefore run in a Docker environment.
 
-In brief the `containers/image` project provides mechanisms to copy, push, pull, inspect and sign container images. The `containers/storage` project provides mechanisms for storing filesystem layers, container images, and containers. Buildah is a CLI that takes advantage of these underlying projects and therefore allows you to build, move, and manage container images and containers.  
+In brief the `containers/image` project provides mechanisms to copy, push, pull, inspect and sign container images. The `containers/storage` project provides mechanisms for storing filesystem layers, container images, and containers. Buildah is a CLI that takes advantage of these underlying projects and therefore allows you to build, move, and manage container images and containers.
 
 First step is to install Buildah. Run as root because you will need to be root for running Buildah commands:
 
@@ -22,7 +22,7 @@ After installing Buildah we can see there are no images installed. The `buildah 
 We can also see that there are also no containers by running:
 
     # buildah containers
-  
+
 When you build a working container from an existing image, Buildah defaults to appending '-working-container' to the image's name to construct a name for the container. The Buildah CLI conveniently returns the name of the new container. You can take advantage of this by assigning the returned value to a shell varible using standard shell assignment :
 
     # container=$(buildah from fedora)
@@ -34,7 +34,7 @@ It is not required to assign a shell variable. Running `buildah from fedora` is 
 What can we do with this new container? Let's try running bash:
 
     # buildah run $container bash
-    
+
 Notice we get a new shell prompt because we are running a bash shell inside of the container. It should be noted that `buildah run` is primarily intended for helping debug during the build process. A runtime like runc or a container interface like [CRI-O](https://github.com/kubernetes-sigs/cri-o) is more suited for starting containers in production.
 
 Be sure to `exit` out of the container and let's try running something else:
@@ -44,27 +44,27 @@ Be sure to `exit` out of the container and let's try running something else:
 Oops. Java is not installed. A message containing something like the following was returned.
 
     container_linux.go:274: starting container process caused "exec: \"java\": executable file not found in $PATH"
-    
+
 Lets try installing it using:
-    
+
     # buildah run $container -- dnf -y install java
 
-The `--` syntax basically tells Buildah: there are no more `buildah run` command options after this point. The options after this point are for inside the containers shell. It is required if the command we specify includes command line options which are not meant for Buildah. 
+The `--` syntax basically tells Buildah: there are no more `buildah run` command options after this point. The options after this point are for inside the containers shell. It is required if the command we specify includes command line options which are not meant for Buildah.
 
 Now running `buildah run $container java` will show that Java has been installed. It will return the standard Java `Usage` output.
 
 ## Building a container from scratch
 
-One of the advantages of using `buildah` to build OCI compliant container images is that you can easily build a container image from scratch and therefore exclude unnecessary packages from your image. E.g. most final container images for production probably don't need a package manager like `dnf`. 
+One of the advantages of using `buildah` to build OCI compliant container images is that you can easily build a container image from scratch and therefore exclude unnecessary packages from your image. E.g. most final container images for production probably don't need a package manager like `dnf`.
 
-Let's build a container from scratch. The special "image" name "scratch" tells Buildah to create an empty container.  The container has a small amount of metadata about the container but no real Linux content. 
+Let's build a container from scratch. The special "image" name "scratch" tells Buildah to create an empty container.  The container has a small amount of metadata about the container but no real Linux content.
 
     # newcontainer=$(buildah from scratch)
-  
+
 You can see this new empty container by running:
 
     # buildah containers
-  
+
 You should see output similar to the following:
 
     CONTAINER ID  BUILDER  IMAGE ID     IMAGE NAME                       CONTAINER NAME
@@ -74,23 +74,23 @@ You should see output similar to the following:
 Its container name is working-container by default and it's stored in the `$newcontainer` variable. Notice the image name (IMAGE NAME) is "scratch". This just indicates that there is no real image yet. i.e. It is containers/storage but there is no representation in containers/image. So when we run:
 
     # buildah images
-  
+
 We don't see the image listed. There is no corresponding scratch image. It is an empty container.
 
 So does this container actually do anything? Let's see.
 
     # buildah run $newcontainer bash
-    
+
 Nope. This really is empty. The package installer `dnf` is not even inside this container. It's essentially an empty layer on top of the kernel. So what can be done with that?  Thankfully there is a `buildah mount` command.
 
     # scratchmnt=$(buildah mount $newcontainer)
-    
+
 By echoing `$scratchmnt` we can see the path for the [overlay image](https://wiki.archlinux.org/index.php/Overlay_filesystem), which gives you a link directly to the root file system of the container.
 
     # echo $scratchmnt
-    /var/lib/containers/storage/overlay/b78d0e11957d15b5d1fe776293bd40a36c28825fb6cf76f407b4d0a95b2a200d/diff  
-    
-Notice that the overlay image is under `/var/lib/containers/storage` as one would expect. (See above on `containers/storage` or for more information see [containers/storage](https://github.com/containers/storage).) 
+    /var/lib/containers/storage/overlay/b78d0e11957d15b5d1fe776293bd40a36c28825fb6cf76f407b4d0a95b2a200d/diff
+
+Notice that the overlay image is under `/var/lib/containers/storage` as one would expect. (See above on `containers/storage` or for more information see [containers/storage](https://github.com/containers/storage).)
 
 Now that we have a new empty container we can install or remove software packages or simply copy content into that container. So let's install `bash` and `coreutils` so that we can run bash scripts. This could easily be `nginx` or other packages needed for your container.
 
@@ -114,15 +114,15 @@ Notice we have a `/usr/bin` directory in the newcontainer's image layer. Let's f
 Change the permissions on the file so that it can be run:
 
     # chmod +x runecho.sh
-    
 
-With `buildah` files can be copied into the new image.  We can then use `buildah run` to run that command within the container by specifying the command.  We can also configure the image to run the command directly using [Podman](https://github.com/containers/libpod) and its `podman run` command. In short the `buildah run` command is equivalent to the "RUN" command in a Dockerfile, whereas `podman run` is equivalent to the `docker run` command.  Now let's copy this new command into the container's `/usr/bin` directory and configure the container to run the command when the container is run via podman: 
+
+With `buildah` files can be copied into the new image.  We can then use `buildah run` to run that command within the container by specifying the command.  We can also configure the image to run the command directly using [Podman](https://github.com/containers/libpod) and its `podman run` command. In short the `buildah run` command is equivalent to the "RUN" command in a Dockerfile, whereas `podman run` is equivalent to the `docker run` command.  Now let's copy this new command into the container's `/usr/bin` directory and configure the container to run the command when the container is run via podman:
 
     # To test with Podman, first install via:
     # dnf -y install podman
     # buildah copy $newcontainer ./runecho.sh /usr/bin
     # buildah config --cmd /usr/bin/runecho.sh $newcontainer
-    
+
 Now run the command in the container with Buildah specifying the command to run in the container:
 
     # buildah run $newcontainer /usr/bin/runecho.sh
@@ -157,9 +157,9 @@ Back to Buildah, let's add some more configuration information.
 
     # buildah config --created-by "ipbabble"  $newcontainer
     # buildah config --author "wgh at redhat.com @ipbabble" --label name=fedora26-bashecho $newcontainer
- 
+
 We can inspect the container's metadata using the `inspect` command:
- 
+
     # buildah inspect $newcontainer
 
 We should probably unmount and commit the image:
@@ -167,12 +167,12 @@ We should probably unmount and commit the image:
      # buildah unmount $newcontainer
      # buildah commit $newcontainer fedora-bashecho
      # buildah images
-     
+
 And you can see there is a new image called `fedora-bashecho:latest`. You can inspect the new image using:
 
     # buildah inspect --type=image fedora-bashecho
 
-Later when you want to create a new container or containers from this image, you simply need need to do `buildah from fedora-bashecho`. This will create a new containers based on this image for you. 
+Later when you want to create a new container or containers from this image, you simply need need to do `buildah from fedora-bashecho`. This will create a new containers based on this image for you.
 
 Now that you have the new image you can remove the scratch container called working-container:
 
@@ -188,14 +188,14 @@ Let's test if this new OCI image is really portable to another OCI technology li
 
     # dnf -y install docker
     # systemctl start docker
-    
+
 Let's copy that image from where containers/storage stores it to where the Docker daemon stores its images, so that we can run it using Docker. We can achieve this using `buildah push`. This copies the image to Docker's repository area which is located under `/var/lib/docker`. Docker's repository is managed by the Docker daemon. This needs to be explicitly stated by telling Buildah to push to the Docker repository protocol using `docker-daemon:`.
 
     # buildah push fedora-bashecho docker-daemon:fedora-bashecho:latest
 
 Under the covers, the containers/image library calls into the containers/storage library to read the image's contents, and sends them to the local Docker daemon. This can take a little while. And usually you won't need to do this. If you're using `buildah` you are probably not using Docker. This is just for demo purposes. Let's try it:
 
-    # docker run fedora-bashecho 
+    # docker run fedora-bashecho
     This is a new container from ipbabble [ 0 ]
     This is a new container from ipbabble [ 1 ]
     This is a new container from ipbabble [ 2 ]
@@ -206,7 +206,7 @@ Under the covers, the containers/image library calls into the containers/storage
     This is a new container from ipbabble [ 7 ]
     This is a new container from ipbabble [ 8 ]
     This is a new container from ipbabble [ 9 ]
-    
+
 OCI container images built with `buildah` are completely standard as expected. So now it might be time to run:
 
     # dnf -y remove docker
@@ -224,7 +224,7 @@ Find one of your Dockerfiles or create a file called Dockerfile. Use the followi
     # Update image and install httpd
     RUN echo "Updating all fedora packages"; dnf -y update; dnf -y clean all
     RUN echo "Installing httpd"; dnf -y install httpd
- 
+
     # Expose the default httpd port 80
     EXPOSE 80
 
@@ -243,14 +243,14 @@ You will see all the steps of the Dockerfile executing. Afterwards `buildah imag
 
     # httpcontainer=$(buildah from fedora-httpd)
     # buildah run $httpcontainer
-    
+
 While that container is running, in another shell run:
 
     # curl localhost
-    
+
 You will see the standard Apache webpage.
 
-Why not try and modify the Dockerfile. Do not install httpd, but instead ADD the runecho.sh file and have it run as the CMD. 
+Why not try and modify the Dockerfile. Do not install httpd, but instead ADD the runecho.sh file and have it run as the CMD.
 
 ## Congratulations
 

--- a/docs/tutorials/02-registries-repositories.md
+++ b/docs/tutorials/02-registries-repositories.md
@@ -3,7 +3,7 @@
 # Buildah Tutorial 2
 ## Using Buildah with container registries
 
-The purpose of this tutorial is to demonstrate how Buildah can be used to move OCI compliant images in and out of private or public registries. 
+The purpose of this tutorial is to demonstrate how Buildah can be used to move OCI compliant images in and out of private or public registries.
 
 In the [first tutorial](https://github.com/containers/buildah/blob/master/docs/tutorials/01-intro.md) we built an image from scratch that we called `fedora-bashecho` and we pushed it to a local Docker repository using the `docker-daemon` protocol. We are going to use the same image to push to a private Docker registry.
 
@@ -18,12 +18,12 @@ It is worth pointing out that the `from` command can also use other protocols be
 Then we need to start the registry. You should start the registry in a separate shell and leave it running there:
 
     # buildah run $registry
-    
+
 If you would like to see more details as to what is going on inside the registry, especially if you are having problems with the registry, you can run the registry container in debug mode as follows:
 
     # buildah --debug run $registry
 
-You can use `--debug` on any Buildah command. 
+You can use `--debug` on any Buildah command.
 
 The registry is running and is waiting for requests to process. Notice that this registry is a Docker registry that we pulled from Docker hub and we are running it for this example using `buildah run`. There is no Docker daemon running at this time.
 
@@ -32,7 +32,7 @@ Let's push our image to the private registry. By default, Buildah is set up to e
     # buildah push --tls-verify=false fedora-bashecho docker://localhost:5000/ipbabble/fedora-bashecho:latest
 
 [Skopeo](https://github.com/containers/skopeo) is a containers tool that was created to inspect images in registries without having to pull the image from the registry. It has grown to have many other uses. We will verify that the image has been stored by using Skopeo to inspect the image in the registry:
- 
+
     # skopeo inspect --tls-verify=false docker://localhost:5000/ipbabble/fedora-bashecho:latest
     {
         "Name": "localhost:5000/ipbabble/fedora-bashecho",
@@ -57,9 +57,9 @@ We can verify that it is still portable with Docker by starting Docker again, as
     # systemctl start docker
     # docker pull localhost:5000/ipbabble/fedora-bashecho
     Using default tag: latest
-    Trying to pull repository localhost:5000/ipbabble/fedora-bashecho ... 
+    Trying to pull repository localhost:5000/ipbabble/fedora-bashecho ...
     sha256:6806f9385f97bc09f54b5c0ef583e58c3bc906c8c0b3e693d8782d0a0acf2137: Pulling from localhost:5000/ipbabble/fedora-bashecho
-    0cb7556c7147: Pull complete 
+    0cb7556c7147: Pull complete
     Digest: sha256:6806f9385f97bc09f54b5c0ef583e58c3bc906c8c0b3e693d8782d0a0acf2137
     Status: Downloaded newer image for localhost:5000/ipbabble/fedora-bashecho:latest
 
@@ -103,20 +103,20 @@ And let's inspect that with Skopeo:
 
 We can use Buildah to pull down the image using the `buildah from` command. But before we do let's clean up our local containers-storage so that we don't have an existing fedora-bashecho - otherwise Buildah will know it already exists and not bother pulling it down.
 
-    #  buildah images 
+    #  buildah images
     IMAGE ID             IMAGE NAME                                               CREATED AT             SIZE
     d4cd7d73ee42         docker.io/library/registry:latest                        Dec 1, 2017 22:15      31.74 MB
     e31b0f0b0a63         docker.io/library/fedora-bashecho:latest                 Dec 5, 2017 21:38      772 B
     # buildah rmi fedora-bashecho
     untagged: docker.io/library/fedora-bashecho:latest
     e31b0f0b0a63e94c5a558d438d7490fab930a282a4736364360ab9b92cb25f3a
-    #  buildah images 
+    #  buildah images
     IMAGE ID             IMAGE NAME                                               CREATED AT             SIZE
     d4cd7d73ee42         docker.io/library/registry:latest                        Dec 1, 2017 22:15      31.74 MB
 
 Okay, so we don't have a fedora-bashecho anymore. Let's pull the image from Docker hub:
 
-    # buildah from ipbabble/fedora-bashecho 
+    # buildah from ipbabble/fedora-bashecho
 
 If you don't want to bother doing the remove image step (`rmi`) you can use the flag `--pull-always` to force the image to be pulled again and overwrite any corresponding local image.
 
@@ -126,7 +126,7 @@ Now check that image is in the local containers-storage:
     IMAGE ID             IMAGE NAME                                               CREATED AT             SIZE
     d4cd7d73ee42         docker.io/library/registry:latest                        Dec 1, 2017 22:15      31.74 MB
     864871ac1c45         docker.io/ipbabble/fedora-bashecho:latest                Dec 5, 2017 21:38      315.4 MB
-    
+
 Success!
 
 If you have any suggestions or issues please post them at the [Containers Buildah Issues page](https://github.com/containers/buildah/issues).

--- a/docs/tutorials/03-on-build.md
+++ b/docs/tutorials/03-on-build.md
@@ -1,18 +1,18 @@
 ![buildah logo](../../logos/buildah-logo_large.png)
 
-# Buildah Tutorial 3 
-## Using ONBUILD in Buildah 
+# Buildah Tutorial 3
+## Using ONBUILD in Buildah
 
 The purpose of this tutorial is to demonstrate how Buildah can use a Dockerfile with the ONBUILD instruction within it or how the ONBUILD instruction can be used with the `buildah config` command.  The ONBUILD instruction stores a command in the meta data of a container image which is then invoked when a secondary container image is created.  The image can have multiple ONBUILD instructions.  Note: The ONBUILD instructions do not change the content of the image that contain the instructions, only the container images that are created from this image are changed based on the FROM command.
 
-Container images that are compliant with the [Open Container Initiative][] (OCI) [image specification][] do not support the ONBUILD instruction.  Images that are created by Buildah are OCI compliant by default.  Therefore only containers that are created by Buildah that use the Docker format can use the ONBUILD instruction.  The OCI format can be overridden in Buildah by specifying the Docker format with the `--format=docker` option or by setting the BUILDAH_FORMAT environment variable to 'docker'.  Regardless of the format selected, Buildah is capable of working seamlessly with either OCI or Docker compliant images and containers. 
+Container images that are compliant with the [Open Container Initiative][] (OCI) [image specification][] do not support the ONBUILD instruction.  Images that are created by Buildah are OCI compliant by default.  Therefore only containers that are created by Buildah that use the Docker format can use the ONBUILD instruction.  The OCI format can be overridden in Buildah by specifying the Docker format with the `--format=docker` option or by setting the BUILDAH_FORMAT environment variable to 'docker'.  Regardless of the format selected, Buildah is capable of working seamlessly with either OCI or Docker compliant images and containers.
 
 On to the tutorial.  The first step is to install Buildah.  In short, the `buildah run` command emulates the RUN command that is found in a Dockerfile while the `podman run` command emulates the `docker run` command.  For the purpose of this tutorial Buildah's run command will be used.  As an aside, Podman is aimed at managing containers, images, and pods while Buildah focuses on the building of containers.  For more info on Podman, please go to [GitHub][].
 
 ## Setup
 
 The following assumes installation on Fedora.
- 
+
 Run as root because you will need to be root for running Buildah commands (at the time of this writing work is underway to allow non-root access):
 
     $ sudo -s
@@ -28,10 +28,10 @@ After installing Buildah check to see that there are no images installed. The `b
 We can also see that there are also no containers by running:
 
     # buildah containers
-  
+
 ## Examples
 
-The two examples that will be shown are relatively simple, but they illustrate how a command or a number of commands can be setup in a master image such that they will be added to a secondary container image that is created from it.  This is extremely useful if you need to setup an environment where your containers have 75% of the same content, but need a few individual tweaks.  This can be helpful in setting up a environment for maven or java development containers for instance.  In this way you can create a single Dockerfile with all the common setup steps as ONBUILD commands and then really minimize the buildah commands or instructions in a second Dockerfile that would be necessary to complete the creation of the container image.  
+The two examples that will be shown are relatively simple, but they illustrate how a command or a number of commands can be setup in a master image such that they will be added to a secondary container image that is created from it.  This is extremely useful if you need to setup an environment where your containers have 75% of the same content, but need a few individual tweaks.  This can be helpful in setting up a environment for maven or java development containers for instance.  In this way you can create a single Dockerfile with all the common setup steps as ONBUILD commands and then really minimize the buildah commands or instructions in a second Dockerfile that would be necessary to complete the creation of the container image.
 
 ## ONBUILD in a Dockerfile - Example 1
 
@@ -113,7 +113,7 @@ result-container
 /bar  /baz  /foo
 ```
 
-## ONBUILD via `buildah config` - Example 2 
+## ONBUILD via `buildah config` - Example 2
 
 For this example the ONBUILD instructions in the primary container image will be used to copy a shell script and then run it in the secondary container image.  For the script, we'll make use of the shell script from the [Introduction Tutorial][].  First create a file in the local directory called `runecho.sh` containing the following:
 
@@ -124,7 +124,7 @@ for i in `seq 0 9`;
 do
 	echo "This is a new container from ipbabble [" $i "]"
 done
-``` 
+```
 Change the permissions on the file so that it can be run:
 
 ```
@@ -176,7 +176,7 @@ This is a new container pull ipbabble [ 8 ]
 This is a new container pull ipbabble [ 9 ]
 
 ```
-Again these aren't the most extensive examples, but they both illustrate how a master image can be setup and then a secondary container image can then be created with just a few steps.  This way the steps that are set up with the ONBUILD instructions don't have to be typed in each and every time that you need to setup your container. 
+Again these aren't the most extensive examples, but they both illustrate how a master image can be setup and then a secondary container image can then be created with just a few steps.  This way the steps that are set up with the ONBUILD instructions don't have to be typed in each and every time that you need to setup your container.
 
 ## Congratulations
 

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -17,7 +17,7 @@ The dependencies for comformance testing include two parts:
 ### Install Buildah
 
 Install Buildah using dnf, yum or apt-get, based on your distribution.  Buildah can also be cloned and installed from [GitHub](https://github.com/containers/buildah/blob/master/install.md).
- 
+
 ### Install Docker CE
 
 Conformance tests use Docker CE to check the images built with Buildah. Install Docker CE with dnf, yum or apt-get, based on your distribution and verify that the Docker service is started as the default. In Fedora, RHEL and CentOS Docker rather than Docker CE may be installed by default, please verify that you install the correct variant of Docker.

--- a/tests/validate/whitespace.sh
+++ b/tests/validate/whitespace.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+#  Check for one or more whitespace characters at the end of a line in a markdown or text file.
+#  gofmt is already going to be doing the same for source code.
+#
+status=0
+if find * -name '*.md' -o -name "*.txt" | grep -v ^vendor | xargs egrep -q '[[:space:]]+$' ; then
+	echo "** ERROR: dangling whitespace found in these files: **"
+	find * -name '*.md' -o -name "*.txt" | grep -v ^vendor | xargs egrep -n '[[:space:]]+$'
+	echo "** ERROR: try running \"sed -i -E -e 's,[[:space:]]+$,,'\" on the affected files **"
+	status=1
+fi
+exit $status


### PR DESCRIPTION
Get rid of dangling whitespace in markdown files, and add a quick validation check to error out if we try to add any new ones.