### PR TITLE
Fix From As in Dockerfile

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -219,7 +219,9 @@ type Executor struct {
 	noCache                        bool
 	removeIntermediateCtrs         bool
 	forceRmIntermediateCtrs        bool
-	containerIDs                   []string // Stores the IDs of the successful intermediate containers used during layer build
+	containerIDs                   []string          // Stores the IDs of the successful intermediate containers used during layer build
+	imageMap                       map[string]string // Used to map images that we create to handle the AS construct.
+
 }
 
 // withName creates a new child executor that will be used whenever a COPY statement uses --from=NAME.
@@ -614,7 +616,10 @@ func NewExecutor(store storage.Store, options BuildOptions) (*Executor, error) {
 
 // Prepare creates a working container based on specified image, or if one
 // isn't specified, the first FROM instruction we can find in the parsed tree.
-func (b *Executor) Prepare(ctx context.Context, ib *imagebuilder.Builder, node *parser.Node, from string) error {
+func (b *Executor) Prepare(ctx context.Context, stage imagebuilder.Stage, from string) error {
+	ib := stage.Builder
+	node := stage.Node
+
 	if from == "" {
 		base, err := ib.From(node)
 		if err != nil {
@@ -623,10 +628,22 @@ func (b *Executor) Prepare(ctx context.Context, ib *imagebuilder.Builder, node *
 		}
 		from = base
 	}
-	logrus.Debugf("FROM %#v", from)
-	if !b.quiet {
-		b.log("FROM %s", from)
+	displayFrom := from
+	// stage.Name will be a string of integers for all stages without an "AS" clause
+	asImageName := stage.Name
+	if asImageName != "" {
+		if _, err := strconv.Atoi(asImageName); err != nil {
+			displayFrom = from + " AS " + asImageName
+		} else {
+			asImageName = ""
+		}
 	}
+
+	logrus.Debugf("FROM %#v", displayFrom)
+	if !b.quiet {
+		b.log("FROM %s", displayFrom)
+	}
+
 	builderOptions := buildah.BuilderOptions{
 		Args:                  ib.Args,
 		FromImage:             from,
@@ -646,10 +663,19 @@ func (b *Executor) Prepare(ctx context.Context, ib *imagebuilder.Builder, node *
 		DefaultMountsFilePath: b.defaultMountsFilePath,
 		Format:                b.outputFormat,
 	}
-	builder, err := buildah.NewBuilder(ctx, b.store, builderOptions)
+
+	var builder *buildah.Builder
+	var err error
+	// Check and see if the image was declared previously with
+	// an AS clause in the Dockerfile.
+	if asImageFound, ok := b.imageMap[from]; ok {
+		builderOptions.FromImage = asImageFound
+	}
+	builder, err = buildah.NewBuilder(ctx, b.store, builderOptions)
 	if err != nil {
 		return errors.Wrapf(err, "error creating build container")
 	}
+
 	volumes := map[string]struct{}{}
 	for _, v := range builder.Volumes() {
 		volumes[v] = struct{}{}
@@ -758,11 +784,14 @@ func (b *Executor) resolveNameToImageRef() (types.ImageReference, error) {
 }
 
 // Execute runs each of the steps in the parsed tree, in turn.
-func (b *Executor) Execute(ctx context.Context, ib *imagebuilder.Builder, node *parser.Node) error {
+func (b *Executor) Execute(ctx context.Context, stage imagebuilder.Stage) error {
+	ib := stage.Builder
+	node := stage.Node
 	checkForLayers := true
 	children := node.Children
 	commitName := b.output
 	b.containerIDs = nil
+
 	for i, node := range node.Children {
 		step := ib.Step()
 		if err := step.Resolve(node); err != nil {
@@ -847,7 +876,7 @@ func (b *Executor) Execute(ctx context.Context, ib *imagebuilder.Builder, node *
 		b.containerIDs = append(b.containerIDs, b.builder.ContainerID)
 		// Prepare for the next step with imgID as the new base image.
 		if i != len(children)-1 {
-			if err := b.Prepare(ctx, ib, node, imgID); err != nil {
+			if err := b.Prepare(ctx, stage, imgID); err != nil {
 				return errors.Wrap(err, "error preparing container for next step")
 			}
 		}
@@ -882,7 +911,7 @@ func (b *Executor) copyExistingImage(ctx context.Context, cacheID string) error 
 }
 
 // layerExists returns true if an intermediate image of currNode exists in the image store from a previous build.
-// It verifies tihis by checking the parent of the top layer of the image and the history.
+// It verifies this by checking the parent of the top layer of the image and the history.
 func (b *Executor) layerExists(ctx context.Context, currNode *parser.Node, children []*parser.Node) (string, error) {
 	// Get the list of images available in the image store
 	images, err := b.store.Images()
@@ -1156,9 +1185,11 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) error 
 		stageExecutor *Executor
 		lastErr       error
 	)
+	b.imageMap = make(map[string]string)
+	stageCount := 0
 	for _, stage := range stages {
 		stageExecutor = b.withName(stage.Name, stage.Position)
-		if err := stageExecutor.Prepare(ctx, stage.Builder, stage.Node, ""); err != nil {
+		if err := stageExecutor.Prepare(ctx, stage, ""); err != nil {
 			return err
 		}
 		// Always remove the intermediate/build containers, even if the build was unsuccessful.
@@ -1167,7 +1198,7 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) error 
 		if b.forceRmIntermediateCtrs || (!b.layers && !b.noCache) {
 			defer stageExecutor.Delete()
 		}
-		if err := stageExecutor.Execute(ctx, stage.Builder, stage.Node); err != nil {
+		if err := stageExecutor.Execute(ctx, stage); err != nil {
 			lastErr = err
 		}
 
@@ -1180,6 +1211,18 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) error 
 			return lastErr
 		}
 		b.containerIDs = append(b.containerIDs, stageExecutor.containerIDs...)
+		// If we've a stage.Name with alpha and not numeric, we've an
+		// AS clause in play.  Create an intermediate image for this
+		// stage to be used by other FROM statements that will want
+		// to use it later in the Dockerfile.  Note the id in our map.
+		if _, err := strconv.Atoi(stage.Name); err != nil {
+			imgID, err := stageExecutor.Commit(ctx, stages[stageCount].Builder, "")
+			if err != nil {
+				return err
+			}
+			b.imageMap[stage.Name] = imgID
+		}
+		stageCount++
 	}
 
 	if !b.layers && !b.noCache {
@@ -1201,6 +1244,12 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) error 
 			return errors.Errorf("Failed to cleanup intermediate containers")
 		}
 	}
+	// Remove intermediate images that we created for AS clause handling
+	for _, value := range b.imageMap {
+		if _, err := b.store.DeleteImage(value, true); err != nil {
+			logrus.Debugf("unable to remove intermediate image %q: %v", value, err)
+		}
+	}
 	return nil
 }
 
@@ -1217,6 +1266,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options BuildOpt
 			d.Close()
 		}
 	}(dockerfiles...)
+
 	for _, dfile := range paths {
 		var data io.ReadCloser
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -898,3 +898,64 @@ load helpers
   [ "$status" -eq 0 ]
   [[ $output =~ "/var/file2" ]]
 }
+
+@test "bud with FROM AS construct" {
+  buildah bud --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
+  run buildah --debug=false images -a
+  [[ $output =~ "test1" ]]
+  [ "${status}" -eq 0 ]
+
+  ctr=$(buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json test1)
+  run buildah --debug=false containers -a
+  [[ $output =~ "test1" ]]
+  [ "${status}" -eq 0 ]
+  
+  run buildah inspect --format "{{.Docker.ContainerConfig.Env}}" --type image test1
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [[ $output =~ "LOCAL=/1" ]]
+}
+
+@test "bud with FROM AS construct with layers" {
+  buildah bud --layers --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
+  run buildah --debug=false images -a
+  [[ $output =~ "test1" ]]
+  [ "${status}" -eq 0 ]
+
+  ctr=$(buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json test1)
+  run buildah --debug=false containers -a
+  [[ $output =~ "test1" ]]
+  [ "${status}" -eq 0 ]
+  
+  run buildah inspect --format "{{.Docker.ContainerConfig.Env}}" --type image test1
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [[ $output =~ "LOCAL=/1" ]]
+}
+
+@test "bud with FROM AS skip FROM construct" {
+  run buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t test1 -f ${TESTSDIR}/bud/from-as/Dockerfile.skip ${TESTSDIR}/bud/from-as
+  [[ $output =~ "LOCAL=/1" ]]
+  [[ $output =~ "LOCAL2=/2" ]]
+  [ "${status}" -eq 0 ]
+
+  run buildah --debug=false images -a
+  [[ $output =~ "test1" ]]
+  [ "${status}" -eq 0 ]
+
+  ctr=$(buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json test1)
+  run buildah --debug=false containers -a
+  [[ $output =~ "test1" ]]
+  [ "${status}" -eq 0 ]
+
+  mnt=$(buildah mount $ctr)
+  run test -e $mnt/1
+  [ "${status}" -eq 0 ]
+  run test -e $mnt/2
+  [ "${status}" -ne 0 ]
+ 
+  run buildah --debug=false inspect --format "{{.Docker.ContainerConfig.Env}}" --type image test1
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [[ $output =~ "[PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin LOCAL=/1]" ]]
+}

--- a/tests/bud/from-as/Dockerfile
+++ b/tests/bud/from-as/Dockerfile
@@ -1,0 +1,7 @@
+FROM centos:7 AS base
+RUN touch /1
+ENV LOCAL=/1
+RUN find $LOCAL
+    	
+FROM base
+RUN find $LOCAL

--- a/tests/bud/from-as/Dockerfile.skip
+++ b/tests/bud/from-as/Dockerfile.skip
@@ -1,0 +1,14 @@
+FROM centos:7 AS base
+RUN touch /1
+ENV LOCAL=/1
+RUN find $LOCAL
+    	
+FROM base
+RUN find $LOCAL
+RUN touch /2
+ENV LOCAL2=/2
+RUN find $LOCAL2
+
+FROM base
+RUN find $LOCAL
+RUN ls / 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

This is the second stab at this.  This time without changes to imagebuilder.  I need to test more and add tests, but would appreciate reviews.  The hang up was we weren't parsing out the "AS image" part of the "FROM image AS image" command in a Dockerfile.  It was not being noted in the output and worse yet Buildah didn't know what to do with it.  Also each "FROM" in the Dockerfile causes imagebuilder to create a stage for each one.  The environment variables created in the first stage are not sent to the second or later stages.  This change creates a slice to collect and use them all.  I'm not sure if other things should or should not also be collected, happy to hear opinions.  I initially started by collecting everything in the Docker Config struct, but eventually narrowed that down just to the Env slice in that struct.  I could revert if necessary.

Test run with Conformance test Dockerfile that uncovered this issue.
```
# buildah bud -t tom -f ~/Dockerfile .
STEP 1: FROM centos:7 AS base
STEP 2: RUN touch /1
STEP 3: ENV LOCAL=/1
STEP 4: RUN find $LOCAL
/1
STEP 5: FROM base
STEP 6: RUN find $LOCAL 
/1
STEP 7: COMMIT containers-storage:[overlay@/var/lib/containers/storage+/var/run/containers/storage:overlay.override_kernel_check=true]localhost/tom:latest
Getting image source signatures
Skipping fetch of repeat blob sha256:1d31b5806ba40b5f67bde96f18a181668348934a44c9253b420d5f04cfb4e37a
Copying blob sha256:021b1264e8efc3ed17a3ec27a43d7ee8b5cd1e437860341c64f34625ab005aca
 167 B / 167 B [============================================================] 0s
Copying config sha256:30ce4fa0ea522c7115a9e3a2104bb0e12fcf01469a36fd32a167f2c6019b9521
 1.17 KiB / 1.17 KiB [======================================================] 0s
Writing manifest to image destination
Storing signatures
--> 30ce4fa0ea522c7115a9e3a2104bb0e12fcf01469a36fd32a167f2c6019b9521

# ctr=$(buildah from tom)

# buildah run $ctr /bin/bash
[root@mrsdalloway /]# echo $LOCAL
/1

```