### PR TITLE
Clear intermediate container IDs after each stage

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -751,6 +751,7 @@ func (b *Executor) Execute(ctx context.Context, ib *imagebuilder.Builder, node *
 	checkForLayers := true
 	children := node.Children
 	commitName := b.output
+	b.containerIDs = nil
 	for i, node := range node.Children {
 		step := ib.Step()
 		if err := step.Resolve(node); err != nil {


### PR DESCRIPTION
Since we delete intermediate containers at the end of the whole build
process, we keep track of the intermediate container IDs.
In the case of a multi stage build, we need to clear the container IDs
before each stage to ensure we don't have a container ID repeated.
Before this, the container IDs were repeated and when we delete them
an error would be thrown as it would try to delete a container that
was already deleted.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>