### PR TITLE
Update rmi man for prune changes

### DIFF
--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -4,7 +4,7 @@
 buildah\-rmi - Removes one or more images.
 
 ## SYNOPSIS
-**buildah rmi** *image* ...
+**buildah rmi** [*image*] ...
 
 ## DESCRIPTION
 Removes one or more locally stored images.
@@ -20,10 +20,12 @@ If _imageID_ is a name, but does not include a registry name, buildah will attem
 **--all, -a**
 
 All local images will be removed from the system that do not have containers using the image as a reference image.
+An image name or id cannot be provided when this option is used.
 
 **--prune, -p**
 
 All local images will be removed from the system that do not have a tag and do not have a child image pointing to them.
+An image name or id cannot be provided when this option is used.
 
 **--force, -f**
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Update the rmi man page to let the user know that when using the --prune option, an image id/name cannot be provided.  I made the similar change to the --all option as that holds there too and noted that the image argument can be optional in the synopsis.