### PR TITLE
Copy ExposedPorts from base image into the config

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -648,20 +648,25 @@ func (b *Executor) Prepare(ctx context.Context, ib *imagebuilder.Builder, node *
 	for _, v := range builder.Volumes() {
 		volumes[v] = struct{}{}
 	}
+	ports := map[docker.Port]struct{}{}
+	for _, p := range builder.Ports() {
+		ports[docker.Port(p)] = struct{}{}
+	}
 	dConfig := docker.Config{
-		Hostname:   builder.Hostname(),
-		Domainname: builder.Domainname(),
-		User:       builder.User(),
-		Env:        builder.Env(),
-		Cmd:        builder.Cmd(),
-		Image:      from,
-		Volumes:    volumes,
-		WorkingDir: builder.WorkDir(),
-		Entrypoint: builder.Entrypoint(),
-		Labels:     builder.Labels(),
-		Shell:      builder.Shell(),
-		StopSignal: builder.StopSignal(),
-		OnBuild:    builder.OnBuild(),
+		Hostname:     builder.Hostname(),
+		Domainname:   builder.Domainname(),
+		User:         builder.User(),
+		Env:          builder.Env(),
+		Cmd:          builder.Cmd(),
+		Image:        from,
+		Volumes:      volumes,
+		WorkingDir:   builder.WorkDir(),
+		Entrypoint:   builder.Entrypoint(),
+		Labels:       builder.Labels(),
+		Shell:        builder.Shell(),
+		StopSignal:   builder.StopSignal(),
+		OnBuild:      builder.OnBuild(),
+		ExposedPorts: ports,
 	}
 	var rootfs *docker.RootFS
 	if builder.Docker.RootFS != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -19,36 +19,40 @@ load helpers
 @test "bud with --layers and --no-cache flags" {
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 7 ]
+  [ $(wc -l <<< "$output") -eq 8 ]
   [ "${status}" -eq 0 ]
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 9 ]
+  [ $(wc -l <<< "$output") -eq 10 ]
   [ "${status}" -eq 0 ]
   run buildah inspect --format "{{.Docker.ContainerConfig.Env}}" test2
   echo "$output"
   [ "$status" -eq 0 ]
   [[ $output =~ "foo=bar" ]]
+  run buildah inspect --format "{{.Docker.ContainerConfig.ExposedPorts}}" test2
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [[ $output =~ "8080" ]]
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 11 ]
+  [ $(wc -l <<< "$output") -eq 12 ]
   [ "${status}" -eq 0 ]
 
   mkdir -p ${TESTSDIR}/bud/use-layers/mount/subdir
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test4 -f Dockerfile.3 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 13 ]
+  [ $(wc -l <<< "$output") -eq 14 ]
   [ "${status}" -eq 0 ]
   touch ${TESTSDIR}/bud/use-layers/mount/subdir/file.txt
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test5 -f Dockerfile.3 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 15 ]
+  [ $(wc -l <<< "$output") -eq 16 ]
   [ "${status}" -eq 0 ]
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --no-cache -t test6 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 18 ]
+  [ $(wc -l <<< "$output") -eq 19 ]
   [ "${status}" -eq 0 ]
 
   buildah rmi -a -f
@@ -63,7 +67,7 @@ load helpers
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --rm=false --layers -t test2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false containers
-  [ $(wc -l <<< "$output") -eq 6 ]
+  [ $(wc -l <<< "$output") -eq 7 ]
   [ "${status}" -eq 0 ]
 
   buildah rm -a

--- a/tests/bud/use-layers/Dockerfile
+++ b/tests/bud/use-layers/Dockerfile
@@ -2,5 +2,6 @@ FROM alpine
 RUN mkdir /hello
 VOLUME /var/lib/testdata
 RUN touch file.txt
+EXPOSE 8080
 ADD https://github.com/containers/buildah/blob/master/README.md /tmp/
 ENV foo=bar

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -32,7 +32,7 @@ load helpers
   [ $(wc -l <<< "$output") -eq 3 ]
   [ "${status}" -eq 0 ]
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 7 ]
+  [ $(wc -l <<< "$output") -eq 8 ]
 
   # create a no name image which should show up when doing buildah images without the --all flag
   buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/use-layers

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -154,19 +154,19 @@ load helpers
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a -q
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 6 ]
+  [ $(wc -l <<< "$output") -eq 7 ]
   [ "${status}" -eq 0 ]
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a -q
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 8 ]
+  [ $(wc -l <<< "$output") -eq 9 ]
   [ "${status}" -eq 0 ]
   run buildah --debug=false rmi test2
   echo "$output"
   [ "${status}" -eq 0 ]
   run buildah --debug=false images -a -q
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 6 ]
+  [ $(wc -l <<< "$output") -eq 7 ]
   [ "${status}" -eq 0 ]
   run buildah --debug=false rmi test1
   echo "$output"


### PR DESCRIPTION
This ensures that we pass the ports to the imagebuilder and
are not lost during the build process when using --layers.

Fixes https://github.com/containers/buildah/issues/1037

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>