### PR TITLE
Update copy chown test

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -859,12 +859,13 @@ load helpers
   [[ "${output}" =~ "must be lower" ]]
 }
 
-@test "bud with chmod copy" {
+@test "bud with chown copy" {
   imgName=alpine-image
   ctrName=alpine-chown
-  run buildah --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-chown
+  run buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-chown
   echo "$output"
   [ "$status" -eq 0 ]
+  [[ "$output" =~ user:2367[[:space:]]group:3267 ]]
   run buildah --debug=false from --name ${ctrName} ${imgName}
   echo "$output"
   [ "$status" -eq 0 ] 

--- a/tests/bud/copy-chown/Dockerfile
+++ b/tests/bud/copy-chown/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine
 
 COPY --chown=2367:3267 copychown.txt /tmp 
+RUN stat -c "user:%u group:%g" /tmp/copychown.txt 
 CMD /bin/sh
 


### PR DESCRIPTION
Update the test case to check the file owner and group during build. And also update the test case name.