### PR TITLE
Correctly follow "insecure" and "blocked" settings when pulling images

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -92,6 +92,15 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 	var imgID string
 
 	systemContext := getSystemContext(options.SystemContext, options.SignaturePolicyPath)
+
+	blocked, err := isReferenceBlocked(dest, systemContext)
+	if err != nil {
+		return "", errors.Wrapf(err, "error checking if committing to registry for %q is blocked", transports.ImageName(dest))
+	}
+	if blocked {
+		return "", errors.Errorf("commit access to registry for %q is blocked by configuration", transports.ImageName(dest))
+	}
+
 	policy, err := signature.DefaultPolicy(systemContext)
 	if err != nil {
 		return imgID, errors.Wrapf(err, "error obtaining default signature policy")
@@ -162,6 +171,15 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 // Push copies the contents of the image to a new location.
 func Push(ctx context.Context, image string, dest types.ImageReference, options PushOptions) error {
 	systemContext := getSystemContext(options.SystemContext, options.SignaturePolicyPath)
+
+	blocked, err := isReferenceBlocked(dest, systemContext)
+	if err != nil {
+		return errors.Wrapf(err, "error checking if pushing to registry for %q is blocked", transports.ImageName(dest))
+	}
+	if blocked {
+		return errors.Errorf("push access to registry for %q is blocked by configuration", transports.ImageName(dest))
+	}
+
 	policy, err := signature.DefaultPolicy(systemContext)
 	if err != nil {
 		return errors.Wrapf(err, "error obtaining default signature policy")

--- a/commit.go
+++ b/commit.go
@@ -120,7 +120,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 		return imgID, errors.Wrapf(err, "error computing layer digests and building metadata")
 	}
 	// "Copy" our image to where it needs to be.
-	err = cp.Image(ctx, policyContext, dest, src, getCopyOptions(options.ReportWriter, nil, systemContext, ""))
+	err = cp.Image(ctx, policyContext, dest, src, getCopyOptions(options.ReportWriter, src, nil, dest, systemContext, ""))
 	if err != nil {
 		return imgID, errors.Wrapf(err, "error copying layers and metadata")
 	}
@@ -176,7 +176,7 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 		return err
 	}
 	// Copy everything.
-	err = cp.Image(ctx, policyContext, dest, src, getCopyOptions(options.ReportWriter, nil, systemContext, options.ManifestType))
+	err = cp.Image(ctx, policyContext, dest, src, getCopyOptions(options.ReportWriter, src, nil, dest, systemContext, options.ManifestType))
 	if err != nil {
 		return errors.Wrapf(err, "error copying layers and metadata")
 	}

--- a/common.go
+++ b/common.go
@@ -3,7 +3,10 @@ package buildah
 import (
 	"io"
 
+	"github.com/sirupsen/logrus"
+
 	cp "github.com/containers/image/copy"
+	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 )
 
@@ -14,11 +17,35 @@ const (
 	DOCKER = "docker"
 )
 
-func getCopyOptions(reportWriter io.Writer, sourceSystemContext *types.SystemContext, destinationSystemContext *types.SystemContext, manifestType string) *cp.Options {
+func getCopyOptions(reportWriter io.Writer, sourceReference types.ImageReference, sourceSystemContext *types.SystemContext, destinationReference types.ImageReference, destinationSystemContext *types.SystemContext, manifestType string) *cp.Options {
+	sourceCtx := &types.SystemContext{}
+	if sourceSystemContext != nil {
+		*sourceCtx = *sourceSystemContext
+	}
+	sourceInsecure, err := isReferenceInsecure(sourceReference, sourceCtx)
+	if err != nil {
+		logrus.Debugf("error determining if registry for %q is insecure: %v", transports.ImageName(sourceReference), err)
+	} else if sourceInsecure {
+		sourceCtx.DockerInsecureSkipTLSVerify = true
+		sourceCtx.OCIInsecureSkipTLSVerify = true
+	}
+
+	destinationCtx := &types.SystemContext{}
+	if destinationSystemContext != nil {
+		*destinationCtx = *destinationSystemContext
+	}
+	destinationInsecure, err := isReferenceInsecure(destinationReference, destinationCtx)
+	if err != nil {
+		logrus.Debugf("error determining if registry for %q is insecure: %v", transports.ImageName(destinationReference), err)
+	} else if destinationInsecure {
+		destinationCtx.DockerInsecureSkipTLSVerify = true
+		destinationCtx.OCIInsecureSkipTLSVerify = true
+	}
+
 	return &cp.Options{
 		ReportWriter:          reportWriter,
-		SourceCtx:             sourceSystemContext,
-		DestinationCtx:        destinationSystemContext,
+		SourceCtx:             sourceCtx,
+		DestinationCtx:        destinationCtx,
 		ForceManifestMIMEType: manifestType,
 	}
 }

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1131,6 +1131,7 @@ func (b *Executor) Commit(ctx context.Context, ib *imagebuilder.Builder, created
 		AdditionalTags:        b.additionalTags,
 		ReportWriter:          writer,
 		PreferredManifestType: b.outputFormat,
+		SystemContext:         b.systemContext,
 		IIDFile:               b.iidfile,
 		Squash:                b.squash,
 		Parent:                b.builder.FromImageID,

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -283,6 +283,8 @@ func SystemContextFromOptions(c *cli.Context) (*types.SystemContext, error) {
 	}
 	if c.IsSet("tls-verify") {
 		ctx.DockerInsecureSkipTLSVerify = !c.BoolT("tls-verify")
+		ctx.OCIInsecureSkipTLSVerify = !c.BoolT("tls-verify")
+		ctx.DockerDaemonInsecureSkipTLSVerify = !c.BoolT("tls-verify")
 	}
 	if c.IsSet("creds") {
 		var err error

--- a/pull.go
+++ b/pull.go
@@ -190,7 +190,7 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 	}()
 
 	logrus.Debugf("copying %q to %q", spec, destName)
-	pullError := cp.Image(ctx, policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter, sc, nil, ""))
+	pullError := cp.Image(ctx, policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter, srcRef, sc, destRef, nil, ""))
 	if pullError == nil {
 		return destRef, nil
 	}

--- a/pull.go
+++ b/pull.go
@@ -160,6 +160,14 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 		srcRef = srcRef2
 	}
 
+	blocked, err := isReferenceBlocked(srcRef, sc)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error checking if pulling from registry for %q is blocked", transports.ImageName(srcRef))
+	}
+	if blocked {
+		return nil, errors.Errorf("pull access to registry for %q is blocked by configuration", transports.ImageName(srcRef))
+	}
+
 	destName, err := localImageNameForReference(ctx, store, srcRef, spec)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error computing local image name for %q", transports.ImageName(srcRef))

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -4,11 +4,24 @@ load helpers
 
 @test "pull-flags-order-verification" {
   run buildah pull image1 --tls-verify
+  echo "$output"
   check_options_flag_err "--tls-verify"
 
   run buildah pull image1 --authfile=/tmp/somefile
+  echo "$output"
   check_options_flag_err "--authfile=/tmp/somefile"
 
   run buildah pull image1 -q --cred bla:bla --authfile=/tmp/somefile
+  echo "$output"
   check_options_flag_err "-q"
+}
+
+@test "pull-blocked" {
+  run buildah --registries-conf ${TESTSDIR}/registries.conf.block pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
+  echo "$output"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "is blocked by configuration" ]]
+  run buildah --registries-conf ${TESTSDIR}/registries.conf       pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
+  echo "$output"
+  [ "$status" -eq 0 ]
 }

--- a/tests/registries.conf.block
+++ b/tests/registries.conf.block
@@ -1,0 +1,25 @@
+# This is a system-wide configuration file used to
+# keep track of registries for various container backends.
+# It adheres to TOML format and does not support recursive
+# lists of registries.
+
+# The default location for this configuration file is /etc/containers/registries.conf.
+
+# The only valid categories are: 'registries.search', 'registries.insecure', 
+# and 'registries.block'.
+
+[registries.search]
+registries = ['docker.io', 'registry.fedoraproject.org', 'registry.access.redhat.com']
+
+# If you need to access insecure registries, add the registry's fully-qualified name.
+# An insecure registry is one that does not have a valid SSL certificate or only does HTTP.
+[registries.insecure]
+registries = []
+
+
+# If you need to block pull access from a registry, uncomment the section below
+# and add the registries fully-qualified name.
+#
+# Docker only
+[registries.block]
+registries = ['docker.io', 'registry.fedoraproject.org', 'registry.access.redhat.com']

--- a/util.go
+++ b/util.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // InitReexec is a wrapper for reexec.Init().  It should be called at
@@ -192,8 +193,14 @@ func isRegistryInsecure(registry string, sc *types.SystemContext) (bool, error) 
 		return false, errors.Wrapf(err, "unable to parse the registries configuration (%s)", sysregistries.RegistriesConfPath(sc))
 	}
 	if reginfo := sysregistriesv2.FindRegistry(registry, registries); reginfo != nil {
+		if reginfo.Insecure {
+			logrus.Debugf("registry %q is marked insecure in registries configuration %q", registry, sysregistries.RegistriesConfPath(sc))
+		} else {
+			logrus.Debugf("registry %q is not marked insecure in registries configuration %q", registry, sysregistries.RegistriesConfPath(sc))
+		}
 		return reginfo.Insecure, nil
 	}
+	logrus.Debugf("registry %q is not listed in registries configuration %q, assuming it's secure", registry, sysregistries.RegistriesConfPath(sc))
 	return false, nil
 }
 
@@ -204,8 +211,14 @@ func isRegistryBlocked(registry string, sc *types.SystemContext) (bool, error) {
 		return false, errors.Wrapf(err, "unable to parse the registries configuration (%s)", sysregistries.RegistriesConfPath(sc))
 	}
 	if reginfo := sysregistriesv2.FindRegistry(registry, registries); reginfo != nil {
+		if reginfo.Blocked {
+			logrus.Debugf("registry %q is marked as blocked in registries configuration %q", registry, sysregistries.RegistriesConfPath(sc))
+		} else {
+			logrus.Debugf("registry %q is not marked as blocked in registries configuration %q", registry, sysregistries.RegistriesConfPath(sc))
+		}
 		return reginfo.Blocked, nil
 	}
+	logrus.Debugf("registry %q is not listed in registries configuration %q, assuming it's not blocked", registry, sysregistries.RegistriesConfPath(sc))
 	return false, nil
 }
 

--- a/util.go
+++ b/util.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/pkg/sysregistries"
 	"github.com/containers/image/pkg/sysregistriesv2"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
@@ -182,6 +183,58 @@ func getRegistries(sc *types.SystemContext) ([]string, error) {
 		}
 	}
 	return searchRegistries, nil
+}
+
+// isRegistryInsecure checks if the named registry is marked as not secure
+func isRegistryInsecure(registry string, sc *types.SystemContext) (bool, error) {
+	registries, err := sysregistriesv2.GetRegistries(sc)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to parse the registries configuration (%s)", sysregistries.RegistriesConfPath(sc))
+	}
+	if reginfo := sysregistriesv2.FindRegistry(registry, registries); reginfo != nil {
+		return reginfo.Insecure, nil
+	}
+	return false, nil
+}
+
+// isRegistryBlocked checks if the named registry is marked as blocked
+func isRegistryBlocked(registry string, sc *types.SystemContext) (bool, error) {
+	registries, err := sysregistriesv2.GetRegistries(sc)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to parse the registries configuration (%s)", sysregistries.RegistriesConfPath(sc))
+	}
+	if reginfo := sysregistriesv2.FindRegistry(registry, registries); reginfo != nil {
+		return reginfo.Blocked, nil
+	}
+	return false, nil
+}
+
+// isReferenceSomething checks if the registry part of a reference is insecure or blocked
+func isReferenceSomething(ref types.ImageReference, sc *types.SystemContext, what func(string, *types.SystemContext) (bool, error)) (bool, error) {
+	if ref != nil && ref.DockerReference() != nil {
+		if named, ok := ref.DockerReference().(reference.Named); ok {
+			if domain := reference.Domain(named); domain != "" {
+				return what(domain, sc)
+			}
+		}
+	}
+	return false, nil
+}
+
+// isReferenceInsecure checks if the registry part of a reference is insecure
+func isReferenceInsecure(ref types.ImageReference, sc *types.SystemContext) (bool, error) {
+	return isReferenceSomething(ref, sc, isRegistryInsecure)
+}
+
+// isReferenceBlocked checks if the registry part of a reference is blocked
+func isReferenceBlocked(ref types.ImageReference, sc *types.SystemContext) (bool, error) {
+	if ref != nil && ref.Transport() != nil {
+		switch ref.Transport().Name() {
+		case "docker":
+			return isReferenceSomething(ref, sc, isRegistryBlocked)
+		}
+	}
+	return false, nil
 }
 
 // hasRegistry returns a bool/err response if the image has a registry in its


### PR DESCRIPTION
The image library's copy routine doesn't itself consult the registries configuration in order to decide whether or not to disable TLS verification when communicating with a registry, so it's on us to use the name of a source or destination image to decide whether to set the flag for that behavior.

While we're in here, wire up blocked registries.
