### PR TITLE
parse: fix IsolationOption function

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -568,7 +568,7 @@ func IsolationOption(c *cli.Context) (buildah.Isolation, error) {
 		case "chroot":
 			return buildah.IsolationChroot, nil
 		default:
-			return buildah.IsolationDefault, errors.Errorf("unrecognized isolation type %q", c.String("isolation"))
+			return 0, errors.Errorf("unrecognized isolation type %q", c.String("isolation"))
 		}
 	}
 	return defaultIsolation()

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -543,14 +543,16 @@ func NamespaceOptions(c *cli.Context) (namespaceOptions buildah.NamespaceOptions
 func defaultIsolation() (buildah.Isolation, error) {
 	isolation, isSet := os.LookupEnv("BUILDAH_ISOLATION")
 	if isSet {
-		if strings.HasPrefix(strings.ToLower(isolation), "oci") {
+		switch strings.ToLower(isolation) {
+		case "oci":
 			return buildah.IsolationOCI, nil
-		} else if strings.HasPrefix(strings.ToLower(isolation), "rootless") {
+		case "rootless":
 			return buildah.IsolationOCIRootless, nil
-		} else if strings.HasPrefix(strings.ToLower(isolation), "chroot") {
+		case "chroot":
 			return buildah.IsolationChroot, nil
+		default:
+			return 0, errors.Errorf("unrecognized $BUILDAH_ISOLATION value %q", isolation)
 		}
-		return 0, errors.Errorf("unrecognized $BUILDAH_ISOLATION value %q", isolation)
 	}
 	return buildah.IsolationDefault, nil
 }
@@ -558,13 +560,14 @@ func defaultIsolation() (buildah.Isolation, error) {
 // IsolationOption parses the --isolation flag.
 func IsolationOption(c *cli.Context) (buildah.Isolation, error) {
 	if c.String("isolation") != "" {
-		if strings.HasPrefix(strings.ToLower(c.String("isolation")), "oci") {
+		switch strings.ToLower(c.String("isolation")) {
+		case "oci":
 			return buildah.IsolationOCI, nil
-		} else if strings.HasPrefix(strings.ToLower(c.String("isolation")), "rootless") {
+		case "rootless":
 			return buildah.IsolationOCIRootless, nil
-		} else if strings.HasPrefix(strings.ToLower(c.String("isolation")), "chroot") {
+		case "chroot":
 			return buildah.IsolationChroot, nil
-		} else {
+		default:
 			return buildah.IsolationDefault, errors.Errorf("unrecognized isolation type %q", c.String("isolation"))
 		}
 	}


### PR DESCRIPTION
1.parse: modify the verification of the isolation value

To verify the value of the isolation, verify that all strings are the same, not just the beginning of the string.
Avoid users mistakenly thinking that the wrong value entered is also a correct value.

```
➜  buildah git:(isolation-fix) ✗ buildah from --isolation chrootcc cc510acfcd70
fedora-working-container-7
```

After Change:
```
➜  buildah git:(isolation-fix) ✗ ./buildah from --isolation chrootcc cc510acfcd70
unrecognized isolation type "chrootcc"
ERRO[0000] exit status 1
```

2.parse: Modify the return value

Code optimization and modification of return values.


Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>