### PR TITLE
chroot: use user namespaces only when necessary, check if they're enabled on error

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -27,6 +27,8 @@ tests:
   - podman run -d -p 5000:5000 --name registry -v /home/travis/auth:/home/travis/auth:Z -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH=/home/travis/auth/htpasswd -e REGISTRY_HTTP_TLS_CERTIFICATE=/home/travis/auth/domain.crt -e REGISTRY_HTTP_TLS_KEY=/home/travis/auth/domain.key registry:2
 
 # Test Podman setup
+  - podman version
+  - podman info
   - podman ps --all
   - podman images
   - ls -alF /home/travis/auth

--- a/chroot/run.go
+++ b/chroot/run.go
@@ -848,7 +848,11 @@ func setApparmorProfile(spec *specs.Spec) error {
 }
 
 // setCapabilities sets capabilities for ourselves, to be more or less inherited by any processes that we'll start.
-func setCapabilities(spec *specs.Spec) error {
+func setCapabilities(spec *specs.Spec, keepCaps ...string) error {
+	currentCaps, err := capability.NewPid(0)
+	if err != nil {
+		return errors.Wrapf(err, "error reading capabilities of current process")
+	}
 	caps, err := capability.NewPid(0)
 	if err != nil {
 		return errors.Wrapf(err, "error reading capabilities of current process")
@@ -861,8 +865,8 @@ func setCapabilities(spec *specs.Spec) error {
 		capability.AMBIENT:     spec.Process.Capabilities.Ambient,
 	}
 	knownCaps := capability.List()
+	caps.Clear(capability.CAPS | capability.BOUNDS | capability.AMBS)
 	for capType, capList := range capMap {
-		caps.Clear(capType)
 		for _, capToSet := range capList {
 			cap := capability.CAP_LAST_CAP
 			for _, c := range knownCaps {
@@ -876,11 +880,24 @@ func setCapabilities(spec *specs.Spec) error {
 			}
 			caps.Set(capType, cap)
 		}
-	}
-	for capType := range capMap {
-		if err = caps.Apply(capType); err != nil {
-			return errors.Wrapf(err, "error setting %s capabilities to %#v", capType.String(), capMap[capType])
+		for _, capToSet := range keepCaps {
+			cap := capability.CAP_LAST_CAP
+			for _, c := range knownCaps {
+				if strings.EqualFold("CAP_"+c.String(), capToSet) {
+					cap = c
+					break
+				}
+			}
+			if cap == capability.CAP_LAST_CAP {
+				return errors.Errorf("error mapping capability %q to a number", capToSet)
+			}
+			if currentCaps.Get(capType, cap) {
+				caps.Set(capType, cap)
+			}
 		}
+	}
+	if err = caps.Apply(capability.CAPS | capability.BOUNDS | capability.AMBS); err != nil {
+		return errors.Wrapf(err, "error setting capabilities")
 	}
 	return nil
 }

--- a/unshare/unshare.go
+++ b/unshare/unshare.go
@@ -191,8 +191,8 @@ func (c *Cmd) Start() error {
 				}
 				defer gidmap.Close()
 				if _, err := fmt.Fprintf(gidmap, "%s", g.String()); err != nil {
-					fmt.Fprintf(continueWrite, "error writing /proc/%s/gid_map: %v", pidString, err)
-					return errors.Wrapf(err, "error writing /proc/%s/gid_map", pidString)
+					fmt.Fprintf(continueWrite, "error writing %q to /proc/%s/gid_map: %v", g.String(), pidString, err)
+					return errors.Wrapf(err, "error writing %q to /proc/%s/gid_map", g.String(), pidString)
 				}
 			}
 		}
@@ -222,8 +222,8 @@ func (c *Cmd) Start() error {
 				}
 				defer uidmap.Close()
 				if _, err := fmt.Fprintf(uidmap, "%s", u.String()); err != nil {
-					fmt.Fprintf(continueWrite, "error writing /proc/%s/uid_map: %v", pidString, err)
-					return errors.Wrapf(err, "error writing /proc/%s/uid_map", pidString)
+					fmt.Fprintf(continueWrite, "error writing %q to /proc/%s/uid_map: %v", u.String(), pidString, err)
+					return errors.Wrapf(err, "error writing %q to /proc/%s/uid_map", u.String(), pidString)
 				}
 			}
 		}


### PR DESCRIPTION
When running with chroot isolation, only create a new user namespace when we have mappings to set.

If we get an error when trying to create a new user namespace, check `/proc/sys/user/max_user_namespaces` to verify that user namespaces are even available.
