### PR TITLE
Add the --no-pivot flag to the run command

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -43,6 +43,10 @@ var (
 			Name:  "runtime-flag",
 			Usage: "add global flags for the container runtime",
 		},
+		cli.BoolFlag{
+			Name:  "no-pivot",
+			Usage: "do not use pivot root to jail process inside rootfs",
+		},
 		cli.StringSliceFlag{
 			Name:  "security-opt",
 			Usage: "security options (default [])",
@@ -108,6 +112,8 @@ func runCmd(c *cli.Context) error {
 		runtimeFlags = append(runtimeFlags, "--"+arg)
 	}
 
+	noPivot := c.Bool("no-pivot")
+
 	namespaceOptions, networkPolicy, err := parse.NamespaceOptions(c)
 	if err != nil {
 		return errors.Wrapf(err, "error parsing namespace-related options")
@@ -117,6 +123,7 @@ func runCmd(c *cli.Context) error {
 		Hostname:         c.String("hostname"),
 		Runtime:          c.String("runtime"),
 		Args:             runtimeFlags,
+		NoPivot:          noPivot,
 		User:             c.String("user"),
 		Isolation:        isolation,
 		NamespaceOptions: namespaceOptions,

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -112,7 +112,7 @@ func runCmd(c *cli.Context) error {
 		runtimeFlags = append(runtimeFlags, "--"+arg)
 	}
 
-	noPivot := c.Bool("no-pivot")
+	noPivot := c.Bool("no-pivot") || (os.Getenv("BUILDAH_NOPIVOT") != "")
 
 	namespaceOptions, networkPolicy, err := parse.NamespaceOptions(c)
 	if err != nil {

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -397,6 +397,7 @@ return 1
      --memory-swap
      --net
      --network
+     --no-pivot
      --pid
      --runtime
      --runtime-flag

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -111,6 +111,11 @@ runtime, the manpage to consult is `runc(8)`).
 Note: Do not pass the leading `--` to the flag. To pass the runc flag `--log-format json`
 to buildah run, the option given would be `--runtime-flag log-format=json`.
 
+**--no-pivot**
+
+Do not use pivot root to jail process inside rootfs. This should be used
+whenever the rootfs is on top of a ramdisk.
+
 **-t**, **--tty**, **--terminal**
 
 By default a pseudo-TTY is allocated only when buildah's standard input is

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -116,6 +116,9 @@ to buildah run, the option given would be `--runtime-flag log-format=json`.
 Do not use pivot root to jail process inside rootfs. This should be used
 whenever the rootfs is on top of a ramdisk.
 
+Note: You can make this option the default by setting the BUILDAH\_NOPIVOT
+environment variable.  `export BUILDAH_NOPIVOT=true`
+
 **-t**, **--tty**, **--terminal**
 
 By default a pseudo-TTY is allocated only when buildah's standard input is

--- a/run.go
+++ b/run.go
@@ -146,6 +146,8 @@ type RunOptions struct {
 	Runtime string
 	// Args adds global arguments for the runtime.
 	Args []string
+	// NoPivot adds the --no-pivot runtime flag.
+	NoPivot bool
 	// Mounts are additional mount points which we want to provide.
 	Mounts []specs.Mount
 	// Env is additional environment variables to set.
@@ -1091,7 +1093,13 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		// 	}
 		// }
 		// options.Args = append(options.Args, rootlessFlag...)
-		err = b.runUsingRuntimeSubproc(options, configureNetwork, configureNetworks, nil, spec, mountPoint, path, Package+"-"+filepath.Base(path))
+		var moreCreateArgs []string
+		if options.NoPivot {
+			moreCreateArgs = []string{"--no-pivot"}
+		} else {
+			moreCreateArgs = nil
+		}
+		err = b.runUsingRuntimeSubproc(options, configureNetwork, configureNetworks, moreCreateArgs, spec, mountPoint, path, Package+"-"+filepath.Base(path))
 	case IsolationChroot:
 		err = chroot.RunUsingChroot(spec, path, options.Stdin, options.Stdout, options.Stderr)
 	case IsolationOCIRootless:


### PR DESCRIPTION
--no-pivot: "do not use pivot root to jail process inside rootfs.
  This should be used whenever the rootfs is on top of a ramdisk"

This is used in minikube, currently with $DOCKER_RAMDISK
(but I'm not sure if this clients wants to honor that env variable...)