### PR TITLE
Attempt to log or return every error

### DIFF
--- a/config.go
+++ b/config.go
@@ -44,7 +44,7 @@ func unmarshalConvertedConfig(ctx context.Context, dest interface{}, img types.I
 		return errors.Wrapf(err, "error reading %s config from %q", wantedManifestMIMEType, transports.ImageName(img.Reference()))
 	}
 	if err := json.Unmarshal(config, dest); err != nil {
-		return errors.Wrapf(err, "error parsing %s configuration from %q", wantedManifestMIMEType, transports.ImageName(img.Reference()))
+		return errors.Wrapf(err, "error parsing %s configuration %q from %q", wantedManifestMIMEType, string(config), transports.ImageName(img.Reference()))
 	}
 	return nil
 }
@@ -78,7 +78,7 @@ func (b *Builder) initConfig(ctx context.Context, img types.Image) error {
 			// Attempt to recover format-specific data from the manifest.
 			v1Manifest := ociv1.Manifest{}
 			if err := json.Unmarshal(b.Manifest, &v1Manifest); err != nil {
-				return errors.Wrapf(err, "error parsing OCI manifest")
+				return errors.Wrapf(err, "error parsing OCI manifest %q", string(b.Manifest))
 			}
 			b.ImageAnnotations = v1Manifest.Annotations
 		}
@@ -220,7 +220,7 @@ func (b *Builder) ClearOnBuild() {
 // discarded when writing images using OCIv1 formats.
 func (b *Builder) SetOnBuild(onBuild string) {
 	if onBuild != "" && b.Format != Dockerv2ImageManifest {
-		logrus.Errorf("ONBUILD is not supported for OCI Image formats, %s will be ignored. Must use `docker` format", onBuild)
+		logrus.Errorf("ONBUILD is not supported for OCI image format, %s will be ignored. Must use `docker` format", onBuild)
 	}
 	b.Docker.Config.OnBuild = append(b.Docker.Config.OnBuild, onBuild)
 }
@@ -252,7 +252,7 @@ func (b *Builder) Shell() []string {
 // discarded when writing images using OCIv1 formats.
 func (b *Builder) SetShell(shell []string) {
 	if len(shell) > 0 && b.Format != Dockerv2ImageManifest {
-		logrus.Errorf("SHELL is not supported for OCI Image format, %s will be ignored. Must use `docker` format", shell)
+		logrus.Errorf("SHELL is not supported for OCI image format, %s will be ignored. Must use `docker` format", shell)
 	}
 
 	b.Docker.Config.Shell = copyStringSlice(shell)
@@ -475,7 +475,7 @@ func (b *Builder) Hostname() string {
 // discarded when writing images using OCIv1 formats.
 func (b *Builder) SetHostname(name string) {
 	if name != "" && b.Format != Dockerv2ImageManifest {
-		logrus.Errorf("HOSTNAME is not supported for OCI Image format, hostname %s will be ignored. Must use `docker` format", name)
+		logrus.Errorf("HOSTNAME is not supported for OCI image format, hostname %s will be ignored. Must use `docker` format", name)
 	}
 	b.Docker.Config.Hostname = name
 }
@@ -492,7 +492,7 @@ func (b *Builder) Domainname() string {
 // discarded when writing images using OCIv1 formats.
 func (b *Builder) SetDomainname(name string) {
 	if name != "" && b.Format != Dockerv2ImageManifest {
-		logrus.Errorf("DOMAINNAME is not supported for OCI Image format, domainname %s will be ignored. Must use `docker` format", name)
+		logrus.Errorf("DOMAINNAME is not supported for OCI image format, domainname %s will be ignored. Must use `docker` format", name)
 	}
 	b.Docker.Config.Domainname = name
 }
@@ -514,7 +514,7 @@ func (b *Builder) Comment() string {
 // discarded when writing images using OCIv1 formats.
 func (b *Builder) SetComment(comment string) {
 	if comment != "" && b.Format != Dockerv2ImageManifest {
-		logrus.Errorf("COMMENT is not supported for OCI Image format, comment %s will be ignored. Must use `docker` format", comment)
+		logrus.Errorf("COMMENT is not supported for OCI image format, comment %s will be ignored. Must use `docker` format", comment)
 	}
 	b.Docker.Comment = comment
 }

--- a/delete.go
+++ b/delete.go
@@ -9,7 +9,7 @@ import (
 // be used after this method is called.
 func (b *Builder) Delete() error {
 	if err := b.store.DeleteContainer(b.ContainerID); err != nil {
-		return errors.Wrapf(err, "error deleting build container")
+		return errors.Wrapf(err, "error deleting build container %q", b.ContainerID)
 	}
 	b.MountPoint = ""
 	b.Container = ""

--- a/mount.go
+++ b/mount.go
@@ -1,17 +1,21 @@
 package buildah
 
+import (
+	"github.com/pkg/errors"
+)
+
 // Mount mounts a container's root filesystem in a location which can be
 // accessed from the host, and returns the location.
 func (b *Builder) Mount(label string) (string, error) {
 	mountpoint, err := b.store.Mount(b.ContainerID, label)
 	if err != nil {
-		return "", err
+		return "", errors.Wrapf(err, "error mounting build container %q", b.ContainerID)
 	}
 	b.MountPoint = mountpoint
 
 	err = b.Save()
 	if err != nil {
-		return "", err
+		return "", errors.Wrapf(err, "error saving updated state for build container %q", b.ContainerID)
 	}
 	return mountpoint, nil
 }

--- a/pull.go
+++ b/pull.go
@@ -54,11 +54,11 @@ func localImageNameForReference(ctx context.Context, store storage.Store, srcRef
 	case util.DockerArchive:
 		tarSource, err := tarfile.NewSourceFromFile(file)
 		if err != nil {
-			return "", err
+			return "", errors.Wrapf(err, "error opening tarfile %q as a source image", file)
 		}
 		manifest, err := tarSource.LoadTarManifest()
 		if err != nil {
-			return "", errors.Errorf("error retrieving manifest.json: %v", err)
+			return "", errors.Errorf("error retrieving manifest.json from tarfile %q: %v", file, err)
 		}
 		// to pull the first image stored in the tar file
 		if len(manifest) == 0 {
@@ -82,7 +82,7 @@ func localImageNameForReference(ctx context.Context, store storage.Store, srcRef
 		// retrieve the manifest from index.json to access the image name
 		manifest, err := ociarchive.LoadManifestDescriptor(srcRef)
 		if err != nil {
-			return "", errors.Wrapf(err, "error loading manifest for %q", srcRef)
+			return "", errors.Wrapf(err, "error loading manifest for %q", transports.ImageName(srcRef))
 		}
 		// if index.json has no reference name, compute the image digest instead
 		if manifest.Annotations == nil || manifest.Annotations["org.opencontainers.image.ref.name"] == "" {
@@ -108,11 +108,12 @@ func localImageNameForReference(ctx context.Context, store storage.Store, srcRef
 			if err == nil {
 				return name, nil
 			}
+			logrus.Debugf("error parsing local storage reference %q: %v", name, err)
 			if strings.LastIndex(name, "/") != -1 {
 				name = name[strings.LastIndex(name, "/")+1:]
 				_, err = is.Transport.ParseStoreReference(store, name)
 				if err == nil {
-					return name, nil
+					return name, errors.Wrapf(err, "error parsing local storage reference %q", name)
 				}
 			}
 			return "", errors.Errorf("reference to image %q is not a named reference", transports.ImageName(srcRef))
@@ -209,13 +210,16 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 	registryPath := sysregistries.RegistriesConfPath(sc)
 	searchRegistries, err := getRegistries(sc)
 	if err != nil {
-		return nil, err
+		logrus.Debugf("error getting list of registries: %v", err)
+		return nil, errors.Wrapf(pullError, "error copying image from %q to %q", transports.ImageName(srcRef), transports.ImageName(destRef))
 	}
 	hasRegistryInName, err := hasRegistry(imageName)
 	if err != nil {
-		return nil, err
+		logrus.Debugf("error checking if image name %q includes a registry component: %v", err)
+		return nil, errors.Wrapf(pullError, "error copying image from %q to %q", transports.ImageName(srcRef), transports.ImageName(destRef))
 	}
 	if !hasRegistryInName && len(searchRegistries) == 0 {
+		logrus.Debugf("copying %q to %q failed: %v", pullError)
 		return nil, errors.Errorf("image name provided does not include a registry name and no search registries are defined in %s: %s", registryPath, pullError)
 	}
 	return nil, pullError
@@ -226,13 +230,13 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 func getImageDigest(ctx context.Context, src types.ImageReference, sc *types.SystemContext) (string, error) {
 	newImg, err := src.NewImage(ctx, sc)
 	if err != nil {
-		return "", err
+		return "", errors.Wrapf(err, "error opening image %q for reading", transports.ImageName(src))
 	}
 	defer newImg.Close()
 
 	digest := newImg.ConfigInfo().Digest
 	if err = digest.Validate(); err != nil {
-		return "", errors.Wrapf(err, "error getting config info")
+		return "", errors.Wrapf(err, "error getting config info from image %q", transports.ImageName(src))
 	}
 	return "@" + digest.Hex(), nil
 }

--- a/run.go
+++ b/run.go
@@ -213,7 +213,7 @@ func DefaultNamespaceOptions() (NamespaceOptions, error) {
 	}
 	g, err := generate.New("linux")
 	if err != nil {
-		return options, err
+		return options, errors.Wrapf(err, "error generating new 'linux' runtime spec")
 	}
 	spec := g.Config
 	if spec.Linux != nil {
@@ -295,7 +295,7 @@ func addHostsToFile(hosts []string, filename string) error {
 	}
 	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error creating hosts file %q", filename)
 	}
 	defer file.Close()
 	return addHosts(hosts, file)
@@ -370,6 +370,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 			specMount.Options = []string{"nosuid", "noexec", "nodev", "mode=1777", "size=" + shmSize}
 			if hostIPC && !hostUser {
 				if _, err := os.Stat("/dev/shm"); err != nil && os.IsNotExist(err) {
+					logrus.Debugf("/dev/shm is not present, not binding into container")
 					continue
 				}
 				specMount = specs.Mount{
@@ -383,6 +384,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 		if specMount.Destination == "/dev/mqueue" {
 			if hostIPC && !hostUser {
 				if _, err := os.Stat("/dev/mqueue"); err != nil && os.IsNotExist(err) {
+					logrus.Debugf("/dev/mqueue is not present, not binding into container")
 					continue
 				}
 				specMount = specs.Mount{
@@ -397,6 +399,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 			if hostNetwork && !hostUser {
 				mountCgroups = false
 				if _, err := os.Stat("/sys"); err != nil && os.IsNotExist(err) {
+					logrus.Debugf("/sys is not present, not binding into container")
 					continue
 				}
 				specMount = specs.Mount{
@@ -498,7 +501,8 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, copyWit
 		subdir := digest.Canonical.FromString(volume).Hex()
 		volumePath := filepath.Join(containerDir, "buildah-volumes", subdir)
 		// If we need to, initialize the volume path's initial contents.
-		if _, err := os.Stat(volumePath); os.IsNotExist(err) {
+		if _, err := os.Stat(volumePath); err != nil && os.IsNotExist(err) {
+			logrus.Debugf("setting up built-in volume at %q", volumePath)
 			if err = os.MkdirAll(volumePath, 0755); err != nil {
 				return nil, errors.Wrapf(err, "error creating directory %q for volume %q", volumePath, volume)
 			}
@@ -576,6 +580,7 @@ func runSetupVolumeMounts(mountLabel string, volumeMounts []string, optionMounts
 	}
 	// Bind mount volumes specified for this particular Run() invocation
 	for _, i := range optionMounts {
+		logrus.Debugf("setting up mounted volume at %q", i.Destination)
 		mount, err := parseMount(i.Source, i.Destination, append(i.Options, "rbind"))
 		if err != nil {
 			return nil, err
@@ -937,13 +942,13 @@ func (b *Builder) configureNamespaces(g *generate.Generator, options RunOptions)
 func (b *Builder) Run(command []string, options RunOptions) error {
 	p, err := ioutil.TempDir("", Package)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "run: error creating temporary directory under %q", os.TempDir())
 	}
 	// On some hosts like AH, /tmp is a symlink and we need an
 	// absolute path.
 	path, err := filepath.EvalSymlinks(p)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "run: error evaluating %q for symbolic links", p)
 	}
 	logrus.Debugf("using %q to hold bundle data", path)
 	defer func() {
@@ -954,7 +959,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 
 	gp, err := generate.New("linux")
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error generating new 'linux' runtime spec")
 	}
 	g := &gp
 
@@ -987,7 +992,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	setupSelinux(g, b.ProcessLabel, b.MountLabel)
 	mountPoint, err := b.Mount(b.MountLabel)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "error mounting container %q", b.ContainerID)
 	}
 	defer func() {
 		if err := b.Unmount(); err != nil {
@@ -1065,7 +1070,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	}
 	err = b.setupMounts(mountPoint, spec, path, options.Mounts, bindFiles, b.Volumes(), b.CommonBuildOpts.Volumes, b.CommonBuildOpts.ShmSize, append(b.NamespaceOptions, options.NamespaceOptions...))
 	if err != nil {
-		return errors.Wrapf(err, "error resolving mountpoints for container")
+		return errors.Wrapf(err, "error resolving mountpoints for container %q", b.ContainerID)
 	}
 
 	if options.CNIConfigDir == "" {
@@ -1262,15 +1267,24 @@ func (b *Builder) runUsingRuntimeSubproc(options RunOptions, configureNetwork bo
 	confwg.Add(1)
 	go func() {
 		_, conferr = io.Copy(pwriter, bytes.NewReader(config))
+		if conferr != nil {
+			conferr = errors.Wrapf(conferr, "error while copying configuration down pipe to child process")
+		}
 		confwg.Done()
 	}()
 	cmd.ExtraFiles = append([]*os.File{preader}, cmd.ExtraFiles...)
 	defer preader.Close()
 	defer pwriter.Close()
 	err = cmd.Run()
+	if err != nil {
+		err = errors.Wrapf(err, "error while running runtime")
+	}
 	confwg.Wait()
 	if err == nil {
 		return conferr
+	}
+	if conferr != nil {
+		logrus.Debugf("%v", conferr)
 	}
 	return err
 }
@@ -1340,10 +1354,10 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetwork
 	// Write the runtime configuration.
 	specbytes, err := json.Marshal(spec)
 	if err != nil {
-		return 1, err
+		return 1, errors.Wrapf(err, "error encoding configuration %#v as json", spec)
 	}
 	if err = ioutils.AtomicWriteFile(filepath.Join(bundlePath, "config.json"), specbytes, 0600); err != nil {
-		return 1, errors.Wrapf(err, "error storing runtime configuration")
+		return 1, errors.Wrapf(err, "error storing runtime configuration in %q", filepath.Join(bundlePath, "config.json"))
 	}
 
 	logrus.Debugf("config = %v", string(specbytes))
@@ -1378,7 +1392,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetwork
 			socketPath := filepath.Join(bundlePath, "console.sock")
 			consoleListener, err = net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
 			if err != nil {
-				return 1, errors.Wrapf(err, "error creating socket to receive terminal descriptor")
+				return 1, errors.Wrapf(err, "error creating socket %q to receive terminal descriptor", consoleListener.Addr())
 			}
 			// Add console socket arguments.
 			moreCreateArgs = append(moreCreateArgs, "--console-socket", socketPath)
@@ -1792,7 +1806,7 @@ func runCopyStdio(stdio *sync.WaitGroup, copyPipes bool, stdioPipe [][]int, copy
 				return true
 			}
 		}
-		logrus.Error(what)
+		logrus.Errorf("%s: %v", what, err)
 		return false
 	}
 	// Pass data back and forth.
@@ -1924,7 +1938,7 @@ func runAcceptTerminal(consoleListener *net.UnixListener, terminalSize *specs.Bo
 	oob := make([]byte, 8192)
 	n, oobn, _, _, err := c.ReadMsgUnix(b, oob)
 	if err != nil {
-		return -1, errors.Wrapf(err, "error reading socket descriptor: %v")
+		return -1, errors.Wrapf(err, "error reading socket descriptor")
 	}
 	if n > 0 {
 		logrus.Debugf("socket descriptor is for %q", string(b[:n]))

--- a/run_test.go
+++ b/run_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/pkg/errors"
 )
 
 func TestAddRlimits(t *testing.T) {
@@ -185,7 +186,7 @@ func TestAddHostsToNotExistFile(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected test to fail")
 	}
-	if !os.IsNotExist(err) {
+	if !os.IsNotExist(errors.Cause(err)) {
 		t.Errorf("expected error to fail because of 'no such file or directory' but got %#v", err.Error())
 	}
 }

--- a/unmount.go
+++ b/unmount.go
@@ -1,11 +1,19 @@
 package buildah
 
+import (
+	"github.com/pkg/errors"
+)
+
 // Unmount unmounts a build container.
 func (b *Builder) Unmount() error {
 	_, err := b.store.Unmount(b.ContainerID, false)
-	if err == nil {
-		b.MountPoint = ""
-		err = b.Save()
+	if err != nil {
+		return errors.Wrapf(err, "error unmounting build container %q", b.ContainerID)
 	}
-	return err
+	b.MountPoint = ""
+	err = b.Save()
+	if err != nil {
+		return errors.Wrapf(err, "error saving updated state for build container %q", b.ContainerID)
+	}
+	return nil
 }


### PR DESCRIPTION
Make sure that when attempting to diagnose an error, if we encounter an error during the diagnostic attempt, we return the original error rather than the error encountered in trying to diagnose it.  Log that one.  Try to wrap more errors, and include more information when we do.