### PR TITLE
Podman  --privileged selinux is broken

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -46,7 +46,7 @@ tests:
   - podman rmi localhost:5000/my-alpine
 
   # mount yum repos to inherit injected mirrors from PAPR
-  - podman run --net=host --privileged -v /etc/yum.repos.d:/etc/yum.repos.d.host:ro
+  - podman run --net=host --security-opt label=disable --cap-add all --security-opt seccomp=unconfined -v /etc/yum.repos.d:/etc/yum.repos.d.host:ro
     -v $PWD:/go/src/github.com/containers/buildah
     --workdir /go/src/github.com/containers/buildah
     registry.fedoraproject.org/fedora:28 bash -c sh ./.papr.sh


### PR DESCRIPTION
Current podman does not disable SELinux when running in privileged mode

This PR Should fix this until we get an updated version of podman out.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>