### PR TITLE
Restore rootless isolation test for from volume ro test

### DIFF
--- a/tests/from.bats
+++ b/tests/from.bats
@@ -312,7 +312,7 @@ load helpers
 }
 
 @test "from volume ro test" {
-  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot" ; then
     skip
   fi
   if ! which runc ; then


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Remove rootless from tests.