### PR TITLE
Check for empty buildTime in version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ deps: gopath
 
 .PHONY: validate
 validate:
-	# Run gofmt only on version 1.11
+	# Run gofmt on version 1.11 and higher
 	
 ifneq ($(GO110),$(GOVERSION))
 	@./tests/validate/gofmt.sh

--- a/chroot/run.go
+++ b/chroot/run.go
@@ -1147,7 +1147,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 		}
 		if uintptr(fs.Flags)&expectedFlags != expectedFlags {
 			if err := unix.Mount(target, target, "bind", requestFlags|unix.MS_REMOUNT, ""); err != nil {
-				return undoBinds, errors.Wrapf(err, "error remounting %q in mount namespace with expected flags")
+				return undoBinds, errors.Wrapf(err, "error remounting %q in mount namespace with expected flags", target)
 			}
 		}
 	}

--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -27,10 +27,14 @@ func versionCmd(c *cli.Context) error {
 		return errors.New("'buildah version' does not accept arguments")
 	}
 
-	//converting unix time from string to int64
-	buildTime, err := strconv.ParseInt(buildInfo, 10, 64)
-	if err != nil {
-		return err
+	var err error
+	buildTime := int64(0)
+	if buildInfo != "" {
+		//converting unix time from string to int64
+		buildTime, err = strconv.ParseInt(buildInfo, 10, 64)
+		if err != nil {
+			return err
+		}
 	}
 
 	fmt.Println("Version:        ", buildah.Version)

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -764,7 +764,7 @@ func (b *Executor) resolveNameToImageRef() (types.ImageReference, error) {
 		if err != nil {
 			candidates, _, err := util.ResolveName(b.output, "", b.systemContext, b.store)
 			if err != nil {
-				return nil, errors.Wrapf(err, "error parsing target image name %q: %v", b.output)
+				return nil, errors.Wrapf(err, "error parsing target image name %q", b.output)
 			}
 			if len(candidates) == 0 {
 				return nil, errors.Errorf("error parsing target image name %q", b.output)

--- a/run.go
+++ b/run.go
@@ -1956,7 +1956,7 @@ func runAcceptTerminal(consoleListener *net.UnixListener, terminalSize *specs.Bo
 	for i := range scm {
 		fds, err := unix.ParseUnixRights(&scm[i])
 		if err != nil {
-			return -1, errors.Wrapf(err, "error parsing unix rights control message: %v")
+			return -1, errors.Wrapf(err, "error parsing unix rights control message: %v", &scm[i])
 		}
 		logrus.Debugf("fds: %v", fds)
 		if len(fds) == 0 {


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add a guard to make sure the the buildInfo variable from the make process is not blank.  This will cause a segv if it is blank and ParseInt tries to do it's thing.

At least partially addresses: #1106

Also added a fix few fixes to Wrapf calls with missing variables so it can pass recent go vetting changes in go 1.11 