### PR TITLE
ReserveSELinuxLabels(): handle wrapped errors from OpenBuilder()

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -457,6 +457,10 @@ func OpenBuilderByPath(store storage.Store, path string) (*Builder, error) {
 		}
 		buildstate, err := ioutil.ReadFile(filepath.Join(cdir, stateFile))
 		if err != nil {
+			if os.IsNotExist(err) {
+				logrus.Debugf("error reading %q: %v, ignoring container %q", filepath.Join(cdir, stateFile), err, container.ID)
+				continue
+			}
 			return nil, errors.Wrapf(err, "error reading %q", filepath.Join(cdir, stateFile))
 		}
 		b := &Builder{}
@@ -488,9 +492,12 @@ func OpenAllBuilders(store storage.Store) (builders []*Builder, err error) {
 			return nil, err
 		}
 		buildstate, err := ioutil.ReadFile(filepath.Join(cdir, stateFile))
-		if err != nil && os.IsNotExist(err) {
-			logrus.Debugf("error reading %q: %v", filepath.Join(cdir, stateFile), err)
-			continue
+		if err != nil {
+			if os.IsNotExist(err) {
+				logrus.Debugf("error reading %q: %v, ignoring container %q", filepath.Join(cdir, stateFile), err, container.ID)
+				continue
+			}
+			return nil, errors.Wrapf(err, "error reading %q", filepath.Join(cdir, stateFile))
 		}
 		b := &Builder{}
 		err = json.Unmarshal(buildstate, &b)

--- a/new.go
+++ b/new.go
@@ -296,7 +296,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 
 	defer func() {
 		if err != nil {
-			if err2 := store.DeleteContainer(container.ID); err != nil {
+			if err2 := store.DeleteContainer(container.ID); err2 != nil {
 				logrus.Errorf("error deleting container %q: %v", container.ID, err2)
 			}
 		}

--- a/run.go
+++ b/run.go
@@ -520,7 +520,7 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, copyWit
 			if err = os.Chown(volumePath, int(stat.Sys().(*syscall.Stat_t).Uid), int(stat.Sys().(*syscall.Stat_t).Gid)); err != nil {
 				return nil, errors.Wrapf(err, "error chowning directory %q for volume %q", volumePath, volume)
 			}
-			if err = copyWithTar(srcPath, volumePath); err != nil && !os.IsNotExist(err) {
+			if err = copyWithTar(srcPath, volumePath); err != nil && !os.IsNotExist(errors.Cause(err)) {
 				return nil, errors.Wrapf(err, "error populating directory %q for volume %q using contents of %q", volumePath, volume, srcPath)
 			}
 		}

--- a/util.go
+++ b/util.go
@@ -252,7 +252,7 @@ func ReserveSELinuxLabels(store storage.Store, id string) error {
 			} else {
 				b, err := OpenBuilder(store, c.ID)
 				if err != nil {
-					if os.IsNotExist(err) {
+					if os.IsNotExist(errors.Cause(err)) {
 						// Ignore not exist errors since containers probably created by other tool
 						// TODO, we need to read other containers json data to reserve their SELinux labels
 						continue


### PR DESCRIPTION
`ReserveSELinuxLabels()` checks if an error returned by `OpenBuilder()` is a does-not-exist error, but `OpenBuilder()` returns wrapped errors now, and it wasn't checking the root cause error.

When `newBuilder()` fails, check the right error value when deciding whether or not deleting the partially-constructed container failed.

`OpenBuildersByPath()` shouldn't choke on non-buildah containers, so have it handle does-not-exist errors the same way `OpenAllBuilders()` does.