### PR TITLE
Change gofmt so it runs on all but 1.10

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -80,7 +80,6 @@ env:
 tests:
     - mkdir -p $GOSRC && ln -s /var/tmp/checkout $GOSRC/buildah
     - cd $GOSRC/buildah && make darwin
-    - cd $GOSRC/buildah && GOOS=darwin GOPATH=/go sh ./tests/validate/gofmt.sh
 
 artifacts:
     - test-suite.log

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ BINDIR := $(PREFIX)/bin
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 BUILDFLAGS := -tags "$(AUTOTAGS) $(TAGS)"
 GO := go
-GO111 := 1.11
-GOVERSION := $(findstring $(GO111),$(shell go version))
+GO110 := 1.10
+GOVERSION := $(findstring $(GO110),$(shell go version))
 
 
 GIT_COMMIT := $(if $(shell git rev-parse --short HEAD),$(shell git rev-parse --short HEAD),$(error "git failed"))
@@ -53,7 +53,7 @@ deps: gopath
 validate:
 	# Run gofmt only on version 1.11
 	
-ifeq ($(GO111),$(GOVERSION))
+ifneq ($(GO110),$(GOVERSION))
 	@./tests/validate/gofmt.sh
 endif
 	@./tests/validate/whitespace.sh


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Flip the logic from #1110.  Rather than running gofmt only on 1.11, run on any version that is not 1.10.  gofmt should run on version 1.11 and higher and we currently only have 1.10 and higher in the Test CI system.

Also remove the gofmt for the Darwin CI which was failing and in truth superfluous.