### PR TITLE
Remove no longer valid todo

### DIFF
--- a/image.go
+++ b/image.go
@@ -107,7 +107,6 @@ func expectedDockerDiffIDs(image docker.V2Image) int {
 // compression that we'll be applying.
 func (i *containerImageRef) computeLayerMIMEType(what string) (omediaType, dmediaType string, err error) {
 	omediaType = v1.MediaTypeImageLayer
-	//TODO: Convert to manifest.DockerV2Schema2LayerUncompressedMediaType once available
 	dmediaType = docker.V2S2MediaTypeUncompressedLayer
 	if i.compression != archive.Uncompressed {
 		switch i.compression {


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Remove a no longer valid TODO message.  At one point I'd planned to the define the variable in the manifest in the image code, but it was decided to leave it here in Buildah as the variable is not used elsewhere and most likely will not be.