### PR TITLE
Don't ResolveName if image is fully specified

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -201,6 +201,7 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 
 	logrus.Debugf("copying %q to %q", spec, destName)
 	if _, err := cp.Image(ctx, policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter, srcRef, sc, destRef, nil, "")); err != nil {
+		logrus.Debugf("error copying src image [%q] to dest image [%q] err: %v", spec, destiName, err)
 		return nil, err
 	}
 	return destRef, nil

--- a/util/util.go
+++ b/util/util.go
@@ -84,6 +84,12 @@ func ResolveName(name string, firstRegistry string, sc *types.SystemContext, sto
 	// If the image includes a transport's name as a prefix, use it as-is.
 	split := strings.SplitN(name, ":", 2)
 	if len(split) == 2 {
+		// If we have a '//' at the start of split[1], then they
+		// used a fully qualified image, just use the name as is.
+		// i.e. docker://centos:centos
+		if strings.HasPrefix(split[1], "//") {
+			return []string{name}, false, nil
+		}
 		if _, ok := Transports[split[0]]; ok {
 			return []string{split[1]}, false, nil
 		}


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

If the user specified a fully qualified image name, i.e. `docker://centos:centos`, then don't try to parse it, just let it try to be resolved as is.  The prior code failed the parsing due to two colons ':' in the  given name.

Addresses: #1117