### PR TITLE
Handle empty built in directory

### DIFF
--- a/run.go
+++ b/run.go
@@ -512,7 +512,8 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, copyWit
 			srcPath := filepath.Join(mountPoint, volume)
 			stat, err := os.Stat(srcPath)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to stat %q for volume %q", srcPath, volume)
+				logrus.Debugf("failed to stat %q for volume %q err %v", srcPath, volume, err)
+				continue
 			}
 			if err = os.Chmod(volumePath, stat.Mode().Perm()); err != nil {
 				return nil, errors.Wrapf(err, "failed to chmod %q for volume %q", volumePath, volume)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

For at least the registry:2 image, the volume was existent, but empty:
```
           "ArgsEscaped": true,
            "Image": "sha256:bc0d86131a2db92f18b8413a38da41718748b152024be47a8bc9413fa1d50a95",
            "Volumes": {
                "/var/lib/registry": {}
            },
```
The srcPath was never created on disk by the time the stat happened at 514, so the stat failed.  I'm not sure if this is the right approach or if we need to somehow create the srcPath, I wasn't able to see away to do that unless we move this functionality outside of this function and do the processing after the directory is created.

Prior to this fix, this would fail:
```
registry=$(buildah from registry:2)
buildah --debug run $registry -- htpasswd -Bbn testuser testpassword > /root/auth/htpasswd
```

But if you ran the run command a second time, it would succeed.
