### PR TITLE
Add builtin directory on run if non-existent

### DIFF
--- a/run.go
+++ b/run.go
@@ -512,7 +512,14 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, copyWit
 			srcPath := filepath.Join(mountPoint, volume)
 			stat, err := os.Stat(srcPath)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to stat %q for volume %q", srcPath, volume)
+				logrus.Debugf("failed to stat %q for volume %q err %v, attempting MkdirAll", srcPath, volume, err)
+				if err = os.MkdirAll(srcPath, 0755); err != nil {
+					return nil, errors.Wrapf(err, "error creating directory %q", srcPath)
+				}
+				stat, err = os.Stat(srcPath)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to stat %q for volume %q", srcPath, volume)
+				}
 			}
 			if err = os.Chmod(volumePath, stat.Mode().Perm()); err != nil {
 				return nil, errors.Wrapf(err, "failed to chmod %q for volume %q", volumePath, volume)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

I think this will most likely replace #1125, but don't want to close that quite yet.

If an image has a builtin volume attached to it like:

```
            "Volumes": {
                "/var/lib/registry": {}
            },
```
Create the directory if it doesn't exist and fails the first stat, then attempt to continue processing.  

I've one slight concern with this change.  To replicate it prior to this change:

```
registry=$(buildah from registry:2)
buildah --debug run $registry -- htpasswd -Bbn testuser testpassword > /root/auth/htpasswd   # failed
buildah --debug run $registry -- htpasswd -Bbn testuser testpassword > /root/auth/htpasswd   # completed
```

After this change both runs work.  However my concern is what's created on the host.  After the first `buildah run` I see:

```
# find /var/lib/containers/storage -name registry
/var/lib/containers/storage/overlay/1fe8be720d6e3a8540dc649be8542b5304c46a88d5dcfac49729b3e8c267b4ac/diff/bin/registry
/var/lib/containers/storage/overlay/a4c34f0c87b2563d2835c48bffe2b940fea9719850c003c314e487e6af44da53/diff/etc/docker/registry
/var/lib/containers/storage/overlay/241c7d778023cd436c1148c16af2c039c8ae9f27d79bf66ee8dc6386848c6dea/diff/var/lib/registry
```

But I was thinking I should see something under 

```
/var/lib/containers/storage/overlay/241c7d778023cd436c1148c16af2c039c8ae9f27d79bf66ee8dc6386848c6dea/merged
```

too, but I'm not.  Am I overexpecting @nalind ?  

Otherwise with this change I'm seeing the /var/lib/registry directory in the container as I'd expect.