### PR TITLE
Update imagebuilder dependency to support heading ARGs in Dockerfile

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1342,7 +1342,10 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options BuildOpt
 		return "", nil, errors.Wrapf(err, "error creating build executor")
 	}
 	b := imagebuilder.NewBuilder(options.Args)
-	stages := imagebuilder.NewStages(mainNode, b)
+	stages, err := imagebuilder.NewStages(mainNode, b)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "error reading multiple stages")
+	}
 	return exec.Build(ctx, stages)
 }
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1006,3 +1006,15 @@ load helpers
   [ "$status" -ne 0 ]
 }
 
+@test "bud with ARG before FROM default value" {
+  target=leading-args-default
+  run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/leading-args/Dockerfile ${TESTSDIR}/bud/leading-args
+  [ "$status" -eq 0 ]
+}
+
+@test "bud with ARG before FROM" {
+  target=leading-args
+  run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg=VERSION=musl -f ${TESTSDIR}/bud/leading-args/Dockerfile ${TESTSDIR}/bud/leading-args
+  [ "$status" -eq 0 ]
+}
+

--- a/tests/bud/leading-args/Dockerfile
+++ b/tests/bud/leading-args/Dockerfile
@@ -1,0 +1,5 @@
+ARG VERSION=latest
+ARG FOO=bar
+FROM busybox:$VERSION
+ENV FOO $FOO
+RUN echo $FOO $VERSION

--- a/vendor/github.com/openshift/imagebuilder/evaluator.go
+++ b/vendor/github.com/openshift/imagebuilder/evaluator.go
@@ -122,8 +122,7 @@ func (b *Step) Resolve(ast *parser.Node) error {
 	envs := b.Env
 	for ast.Next != nil {
 		ast = ast.Next
-		var str string
-		str = ast.Value
+		str := ast.Value
 		if replaceEnvAllowed[cmd] {
 			var err error
 			var words []string


### PR DESCRIPTION
Add support for leading `ARG` (`ARG` before a `FROM`). 

Marking as `WIP` as it depdends on https://github.com/openshift/imagebuilder/pull/105 (Edited: Also depends on https://github.com/openshift/imagebuilder/pull/104).

/cc @rhatdan @TomSweeneyRedHat 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>