### PR TITLE
Fix unshare gofmt issue

### DIFF
--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -151,7 +151,7 @@ func maybeReexecUsingUserNamespace(c *cli.Context, evenForRoot bool) {
 	cmd.Stderr = os.Stderr
 
 	// Set up a new user namespace with the ID mapping.
-	cmd.UnshareFlags = syscall.CLONE_NEWUSER|syscall.CLONE_NEWNS
+	cmd.UnshareFlags = syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS
 	cmd.UseNewuidmap = uidNum != 0
 	cmd.UidMappings = uidmap
 	cmd.UseNewgidmap = uidNum != 0


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Fix gofmt 1.11 issues in unshare.go which are causing build headaches.