### PR TITLE
Allow cgroups to be passed into chroot, read/only

### DIFF
--- a/chroot/run.go
+++ b/chroot/run.go
@@ -955,6 +955,20 @@ func setRlimits(spec *specs.Spec, onlyLower, onlyRaise bool) error {
 	return nil
 }
 
+func makeReadOnly(mntpoint string, flags uintptr) error {
+	var fs unix.Statfs_t
+	// Make sure it's read-only.
+	if err := unix.Statfs(mntpoint, &fs); err != nil {
+		return errors.Wrapf(err, "error checking if directory %q was bound read-only", mntpoint)
+	}
+	if fs.Flags&unix.ST_RDONLY == 0 {
+		if err := unix.Mount(mntpoint, mntpoint, "bind", flags|unix.MS_REMOUNT, ""); err != nil {
+			return errors.Wrapf(err, "error remounting %s in mount namespace read-only", mntpoint)
+		}
+	}
+	return nil
+}
+
 // setupChrootBindMounts actually bind mounts things under the rootfs, and returns a
 // callback that will clean up its work.
 func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func() error, err error) {
@@ -976,7 +990,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	bindFlags := commonFlags | unix.MS_NODEV
 	devFlags := commonFlags | unix.MS_NOEXEC | unix.MS_NOSUID | unix.MS_RDONLY
 	procFlags := devFlags | unix.MS_NODEV
-	sysFlags := devFlags | unix.MS_NODEV | unix.MS_RDONLY
+	sysFlags := devFlags | unix.MS_NODEV
 
 	// Bind /dev read-only.
 	subDev := filepath.Join(spec.Root.Path, "/dev")
@@ -1030,13 +1044,22 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			return undoBinds, errors.Wrapf(err, "error bind mounting /sys from host into mount namespace")
 		}
 	}
-	// Make sure it's read-only.
-	if err = unix.Statfs(subSys, &fs); err != nil {
-		return undoBinds, errors.Wrapf(err, "error checking if directory %q was bound read-only", subSys)
+	if err := makeReadOnly(subSys, sysFlags); err != nil {
+		return undoBinds, err
 	}
-	if fs.Flags&unix.ST_RDONLY == 0 {
-		if err := unix.Mount(subSys, subSys, "bind", sysFlags|unix.MS_REMOUNT, ""); err != nil {
-			return undoBinds, errors.Wrapf(err, "error remounting /sys in mount namespace read-only")
+
+	mnts, _ := mount.GetMounts()
+	for _, m := range mnts {
+		if !strings.HasPrefix(m.Mountpoint, "/sys/") &&
+			m.Mountpoint != "/sys" {
+			continue
+		}
+		subSys := filepath.Join(spec.Root.Path, m.Mountpoint)
+		if err := unix.Mount(m.Mountpoint, subSys, "bind", sysFlags, ""); err != nil {
+			return undoBinds, errors.Wrapf(err, "error bind mounting /sys from host into mount namespace")
+		}
+		if err := makeReadOnly(subSys, sysFlags); err != nil {
+			return undoBinds, err
 		}
 	}
 	logrus.Debugf("bind mounted %q to %q", "/sys", filepath.Join(spec.Root.Path, "/sys"))
@@ -1044,10 +1067,6 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	// Add /sys/fs/selinux to the set of masked paths, to ensure that we don't have processes
 	// attempting to interact with labeling, when they aren't allowed to do so.
 	spec.Linux.MaskedPaths = append(spec.Linux.MaskedPaths, "/sys/fs/selinux")
-	// Add /sys/fs/cgroup to the set of masked paths, to ensure that we don't have processes
-	// attempting to mess with cgroup configuration, when they aren't allowed to do so.
-	spec.Linux.MaskedPaths = append(spec.Linux.MaskedPaths, "/sys/fs/cgroup")
-
 	// Bind mount in everything we've been asked to mount.
 	for _, m := range spec.Mounts {
 		// Skip anything that we just mounted.
@@ -1143,7 +1162,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			logrus.Debugf("mounted a tmpfs to %q", target)
 		}
 		if err = unix.Statfs(target, &fs); err != nil {
-			return undoBinds, errors.Wrapf(err, "error checking if directory %q was bound read-only", subSys)
+			return undoBinds, errors.Wrapf(err, "error checking if directory %q was bound read-only", target)
 		}
 		if uintptr(fs.Flags)&expectedFlags != expectedFlags {
 			if err := unix.Mount(target, target, "bind", requestFlags|unix.MS_REMOUNT, ""); err != nil {


### PR DESCRIPTION
Interesting finding here.  MS_REC only effects the Propagation flags, it does not apply the "ro" options to the recursive mounts.  So we need to apply them individually.


Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>