### PR TITLE
vndr in latest containers/storage

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -5,7 +5,7 @@ github.com/containerd/continuity master
 github.com/containernetworking/cni v0.7.0-alpha1
 github.com/containers/image 5e5b67d6b1cf43cc349128ec3ed7d5283a6cc0d1
 github.com/containers/libpod f3b08379749e8d09cdec45238486ae0b91b4c6ee
-github.com/containers/storage bd5818eda84012cf1db4dafbddd4b7509bb77142
+github.com/containers/storage 09abf3a26b8a3aa69e29fd7faeb260b98d675759
 github.com/docker/distribution 5f6282db7d65e6d72ad7c2cc66310724a57be716
 github.com/docker/docker 86f080cff0914e9694068ed78d503701667c4c00
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1

--- a/vendor/github.com/containers/storage/drivers/overlay/check.go
+++ b/vendor/github.com/containers/storage/drivers/overlay/check.go
@@ -20,7 +20,7 @@ import (
 // which copies up the opaque flag when copying up an opaque
 // directory or the kernel enable CONFIG_OVERLAY_FS_REDIRECT_DIR.
 // When these exist naive diff should be used.
-func doesSupportNativeDiff(d string) error {
+func doesSupportNativeDiff(d, mountOpts string) error {
 	td, err := ioutil.TempDir(d, "opaque-bug-check")
 	if err != nil {
 		return err
@@ -57,6 +57,9 @@ func doesSupportNativeDiff(d string) error {
 	}
 
 	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", path.Join(td, "l2"), path.Join(td, "l1"), path.Join(td, "l3"), path.Join(td, "work"))
+	if mountOpts != "" {
+		opts = fmt.Sprintf("%s,%s", opts, mountOpts)
+	}
 	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", 0, opts); err != nil {
 		return errors.Wrap(err, "failed to mount overlay")
 	}

--- a/vendor/github.com/containers/storage/drivers/overlay/overlay.go
+++ b/vendor/github.com/containers/storage/drivers/overlay/overlay.go
@@ -206,7 +206,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, fmt.Errorf("Storage option overlay.size only supported for backingFS XFS. Found %v", backingFs)
 	}
 
-	logrus.Debugf("backingFs=%s, projectQuotaSupported=%v, useNativeDiff=%v", backingFs, projectQuotaSupported, !useNaiveDiff(home))
+	logrus.Debugf("backingFs=%s, projectQuotaSupported=%v, useNativeDiff=%v", backingFs, projectQuotaSupported, !d.useNaiveDiff())
 
 	return d, nil
 }
@@ -338,9 +338,9 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 	return supportsDType, errors.Wrap(graphdriver.ErrNotSupported, "'overlay' not found as a supported filesystem on this host. Please ensure kernel is new enough and has overlay support loaded.")
 }
 
-func useNaiveDiff(home string) bool {
+func (d *Driver) useNaiveDiff() bool {
 	useNaiveDiffLock.Do(func() {
-		if err := doesSupportNativeDiff(home); err != nil {
+		if err := doesSupportNativeDiff(d.home, d.options.mountOptions); err != nil {
 			logrus.Warnf("Not using native diff for overlay, this may cause degraded performance for building images: %v", err)
 			useNaiveDiffOnly = true
 		}
@@ -358,7 +358,7 @@ func (d *Driver) Status() [][2]string {
 	return [][2]string{
 		{"Backing Filesystem", backingFs},
 		{"Supports d_type", strconv.FormatBool(d.supportsDType)},
-		{"Native Overlay Diff", strconv.FormatBool(!useNaiveDiff(d.home))},
+		{"Native Overlay Diff", strconv.FormatBool(!d.useNaiveDiff())},
 	}
 }
 
@@ -883,7 +883,7 @@ func (d *Driver) getDiffPath(id string) string {
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
 func (d *Driver) DiffSize(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (size int64, err error) {
-	if useNaiveDiff(d.home) || !d.isParent(id, parent) {
+	if d.useNaiveDiff() || !d.isParent(id, parent) {
 		return d.naiveDiff.DiffSize(id, idMappings, parent, parentMappings, mountLabel)
 	}
 	return directory.Size(d.getDiffPath(id))
@@ -892,7 +892,7 @@ func (d *Driver) DiffSize(id string, idMappings *idtools.IDMappings, parent stri
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
 func (d *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (io.ReadCloser, error) {
-	if useNaiveDiff(d.home) || !d.isParent(id, parent) {
+	if d.useNaiveDiff() || !d.isParent(id, parent) {
 		return d.naiveDiff.Diff(id, idMappings, parent, parentMappings, mountLabel)
 	}
 
@@ -919,7 +919,7 @@ func (d *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, 
 // Changes produces a list of changes between the specified layer
 // and its parent layer. If parent is "", then all changes will be ADD changes.
 func (d *Driver) Changes(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) ([]archive.Change, error) {
-	if useNaiveDiff(d.home) || !d.isParent(id, parent) {
+	if d.useNaiveDiff() || !d.isParent(id, parent) {
 		return d.naiveDiff.Changes(id, idMappings, parent, parentMappings, mountLabel)
 	}
 	// Overlay doesn't have snapshots, so we need to get changes from all parent


### PR DESCRIPTION
This version of containers/storage will allow us to use metadata copyup
in overlay file system.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>