### PR TITLE
Handle directories better in bud -f

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1286,15 +1286,24 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options BuildOpt
 		} else {
 			// If the Dockerfile isn't found try prepending the
 			// context directory to it.
-			if _, err := os.Stat(dfile); os.IsNotExist(err) {
+			dinfo, err := os.Stat(dfile)
+			if os.IsNotExist(err) {
 				dfile = filepath.Join(options.ContextDirectory, dfile)
+			}
+			dinfo, err = os.Stat(dfile)
+			if err != nil {
+				return "", nil, errors.Wrapf(err, "error reading info about %q", dfile)
+			}
+			// If given a directory, add '/Dockerfile' to it.
+			if dinfo.Mode().IsDir() {
+				dfile = filepath.Join(dfile, "Dockerfile")
 			}
 			logrus.Debugf("reading local Dockerfile %q", dfile)
 			contents, err := os.Open(dfile)
 			if err != nil {
 				return "", nil, errors.Wrapf(err, "error reading %q", dfile)
 			}
-			dinfo, err := contents.Stat()
+			dinfo, err = contents.Stat()
 			if err != nil {
 				contents.Close()
 				return "", nil, errors.Wrapf(err, "error reading info about %q", dfile)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -981,3 +981,28 @@ load helpers
   [ "$status" -eq 0 ]
   [[ $output =~ "[PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin LOCAL=/1]" ]]
 }
+
+@test "bud with symlink Dockerfile not specified in file" {
+  target=alpine-image
+  run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/symlink ${TESTSDIR}/bud/symlink
+  echo "$output"
+  [[ $output =~ "FROM alpine" ]]
+  [ "$status" -eq 0 ]
+}
+
+@test "bud with dir for file but no Dockerfile in dir" {
+  target=alpine-image
+  run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/empty-dir ${TESTSDIR}/bud/empty-dir
+  echo "$output"
+  [[ $output =~ "no such file or directory" ]]
+  [ "$status" -ne 0 ]
+}
+
+@test "bud with bad dir Dockerfile" {
+  target=alpine-image
+  run buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/baddirname ${TESTSDIR}/baddirname
+  echo "$output"
+  [[ $output =~ "no such file or directory" ]]
+  [ "$status" -ne 0 ]
+}
+


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

A number of other commits addressed #1104, this finishes that up.  If a directory was given in the --file parameter for `buildah bud` a panic would occur.  With this change if a directory only is given as the argument, the code will append '/Dockerfile' to it and attempt to read the file.  If it can't read the file, it fails with an appropriate error.  If it finds the file, it processes it as appropriate.

Testing:

```
# ls tools/Dockerfiles
Dockerfile.hold

#  buildah bud -t tom -f 'tools/Dockerfiles' .
error reading "tools/Dockerfiles/Dockerfile": open tools/Dockerfiles/Dockerfile: no such file or directory

# cp tools/Dockerfiles/Dockerfile.hold tools/Dockerfiles/Dockerfile
#  buildah bud -t tom -f 'tools/Dockerfiles' .
STEP 1: FROM alpine
STEP 2: COMMIT containers-storage:[overlay@/var/lib/containers/storage+/var/run/containers/storage:overlay.override_kernel_check=true]localhost/tom:latest
Getting image source signatures
Skipping fetch of repeat blob sha256:df64d3292fd6194b7865d7326af5255db6d81e9df29f48adde61a918fbd8c332
Skipping fetch of repeat blob sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
Copying config sha256:bb64f9b02d069cc1fa5534d3ca9703c5bbe99467165ac75ca24a8809435a8bd6
 702 B / 702 B [============================================================] 0s
Writing manifest to image destination
Storing signatures
--> bb64f9b02d069cc1fa5534d3ca9703c5bbe99467165ac75ca24a8809435a8bd6

# buildah bud -t tom -f "reallybaddir" .
error reading info about "/root/tsweeney/workspaces/buildah/src/github.com/containers/buildah/reallybaddir": stat /root/tsweeney/workspaces/buildah/src/github.com/containers/buildah/reallybaddir: no such file or directory
```