### PR TITLE
inspect: add output option

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -685,6 +685,7 @@ return 1
      local options_with_args="
        --format
        -f
+       --output
        --type
        -t
      "

--- a/docs/buildah-inspect.md
+++ b/docs/buildah-inspect.md
@@ -21,6 +21,9 @@ Users of this option should be familiar with the [*text/template*
 package](https://golang.org/pkg/text/template/) in the Go standard library, and
 of internals of Buildah's implementation.
 
+**--output**=PATH
+Write the contents of the inspect to a file at *PATH* (overwriting the existing content if a file already exists at *PATH*).
+
 **--type** **container** | **image**
 
 Specify whether *object* is a container or an image.


### PR DESCRIPTION
Writes the contents of inspect to the specified file for easy viewing and use.

Example:
```
➜  buildah git:(inspect-output) ✗ ./buildah inspect --output config.json ea4c82dcd15a
➜  buildah git:(inspect-output) ✗ cat config.json
{
    "Type": "buildah 0.0.1",
    "FromImage": "docker.io/library/ubuntu:latest",
    "FromImageID": "ea4c82dcd15a33e3e9c4c37050def20476856a08e59526fbe533cc4e98387e39",
......
```
```
➜  buildah git:(inspect-output) ✗ ./buildah inspect --output config.json --format '{{.OCIv1.Config}}' ea4c82dcd15a
➜  buildah git:(inspect-output) ✗ cat config.json
{ map[] [PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin] [] [/bin/bash] map[]  map[] }%
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>