### PR TITLE
ostree: fix tag for build constraint

### DIFF
--- a/ostree_tag.sh
+++ b/ostree_tag.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-if ! pkg-config ostree-1 2> /dev/null ; then
+if pkg-config ostree-1 2> /dev/null ; then
+	echo ostree
+else
 	echo containers_image_ostree_stub
 fi


### PR DESCRIPTION
Build tag 'ostree' is needed to match the constraint of
vendor/github.com/containers/storage/pkg/ostree/ostree.go
instead of that of
vendor/github.com/containers/storage/pkg/ostree/no_ostree.go

Signed-off-by: Silvano Cirujano Cuesta <silvano.cirujano-cuesta@siemens.com>
Closes: #1136