### PR TITLE
run --volume: Created if hostdir does not exist.

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -167,7 +167,12 @@ func validateVolumeHostDir(hostDir string) error {
 		return errors.Errorf("invalid host path, must be an absolute path %q", hostDir)
 	}
 	if _, err := os.Stat(hostDir); err != nil {
-		return errors.Wrapf(err, "error checking path %q", hostDir)
+		if !os.IsNotExist(err) {
+			return errors.Wrapf(err, "fail to stat %q", hostDir)
+		}
+		if err = os.MkdirAll(hostDir, 0755); err != nil {
+			return errors.Wrapf(err, "error creating directory %q", hostDir)
+		}
 	}
 	return nil
 }

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -350,6 +350,10 @@ load helpers
 	run buildah --debug=false run -v ${TESTDIR}/was-empty/testfile:/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
 	echo "$output"
 	[ "$status" -eq 0 ]
+	# If hostdir doesn't exist yet, this should succeed.
+	run buildah --debug=false run -v ${TESTDIR}/testdir/subdirectory:/var/testdir/subdirectory        $cid touch /var/testdir/subdirectory/testfile
+	echo "$output"
+	[ "$status" -eq 0 ]
 }
 
 @test "run symlinks" {


### PR DESCRIPTION
When using the `volume` option in the `run` command again, create if the specified hostdir does not exist.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>