### PR TITLE
rootless: do not specify --rootless to the OCI runtime

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -219,11 +219,11 @@ another process.
 Controls what type of isolation is used for running processes as part of `RUN`
 instructions.  Recognized types include *oci* (OCI-compatible runtime, the
 default), *rootless* (OCI-compatible runtime invoked using a modified
-configuration and its --rootless flag enabled, with *--no-new-keyring* added to
-its *create* invocation, with network and UTS namespaces disabled, and IPC,
-PID, and user namespaces enabled; the default for unprivileged users), and
-*chroot* (an internal wrapper that leans more toward chroot(1) than container
-technology).
+configuration, with *--no-new-keyring* added to its *create*
+invocation, with network and UTS namespaces disabled, and IPC, PID,
+and user namespaces enabled; the default for unprivileged users), and
+*chroot* (an internal wrapper that leans more toward chroot(1) than
+container technology).
 
 Note: You can also override the default isolation type by setting the
 BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -182,12 +182,12 @@ another process.
 
 Controls what type of isolation is used for running processes under `buildah
 run`.  Recognized types include *oci* (OCI-compatible runtime, the default),
-*rootless* (OCI-compatible runtime invoked using a modified configuration and
-its --rootless flag enabled, with *--no-new-keyring* added to its
-*create* invocation, with network and UTS namespaces disabled, and IPC, PID,
-and user namespaces enabled; the default for unprivileged users), and *chroot*
-(an internal wrapper that leans more toward chroot(1) than container
-technology).
+*rootless* (OCI-compatible runtime invoked using a modified
+configuration, with *--no-new-keyring* added to its *create*
+invocation, with network and UTS namespaces disabled, and IPC, PID,
+and user namespaces enabled; the default for unprivileged users), and
+*chroot* (an internal wrapper that leans more toward chroot(1) than
+container technology).
 
 Note: You can also override the default isolation type by setting the
 BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -67,12 +67,11 @@ process.
 
 Controls what type of isolation is used for running the process.  Recognized
 types include *oci* (OCI-compatible runtime, the default), *rootless*
-(OCI-compatible runtime invoked using a modified configuration and its
---rootless flag enabled, with *--no-new-keyring* added to its
-*create* invocation, with network and UTS namespaces disabled, and IPC, PID,
-and user namespaces enabled; the default for unprivileged users), and *chroot*
-(an internal wrapper that leans more toward chroot(1) than container
-technology).
+(OCI-compatible runtime invoked using a modified configuration, with
+*--no-new-keyring* added to its *create* invocation, with network and
+UTS namespaces disabled, and IPC, PID, and user namespaces enabled;
+the default for unprivileged users), and *chroot* (an internal wrapper
+that leans more toward chroot(1) than container technology).
 
 Note: You can also override the default isolation type by setting the
 BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`

--- a/run.go
+++ b/run.go
@@ -1104,14 +1104,6 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 
 	switch isolation {
 	case IsolationOCI:
-		// The default is --rootless=auto, which makes troubleshooting a bit harder.
-		// rootlessFlag := []string{"--rootless=false"}
-		// for _, arg := range options.Args {
-		// 	if strings.HasPrefix(arg, "--rootless") {
-		// 		rootlessFlag = nil
-		// 	}
-		// }
-		// options.Args = append(options.Args, rootlessFlag...)
 		var moreCreateArgs []string
 		if options.NoPivot {
 			moreCreateArgs = []string{"--no-pivot"}
@@ -1125,13 +1117,6 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		if err := setupRootlessSpecChanges(spec, path, rootUID, rootGID); err != nil {
 			return err
 		}
-		rootlessFlag := []string{"--rootless=true"}
-		for _, arg := range options.Args {
-			if strings.HasPrefix(arg, "--rootless") {
-				rootlessFlag = nil
-			}
-		}
-		options.Args = append(options.Args, rootlessFlag...)
 		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, configureNetworks, []string{"--no-new-keyring"}, spec, mountPoint, path, Package+"-"+filepath.Base(path))
 	default:
 		err = errors.Errorf("don't know how to run this command")


### PR DESCRIPTION
runc has a good "auto detect" mode to find out when running in
rootless mode.  It also makes easier to plug another OCI runtime,
since --rootless is not part of the OCI specs.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>