### PR TITLE
Add optional blob caching for very specific use cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LIBSECCOMP_COMMIT := release-2.3
 
 EXTRALDFLAGS :=
 LDFLAGS := -ldflags '-X main.GitCommit=$(GIT_COMMIT) -X main.buildInfo=$(BUILD_INFO) -X main.cniVersion=$(CNI_COMMIT)' $(EXTRALDFLAGS)
-SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go cmd/buildah/*.go docker/*.go pkg/cli/*.go pkg/parse/*.go unshare/*.c unshare/*.go util/*.go
+SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go cmd/buildah/*.go docker/*.go pkg/blobcache/*.go pkg/cli/*.go pkg/parse/*.go unshare/*.c unshare/*.go util/*.go
 
 all: buildah imgtype docs
 

--- a/buildah.go
+++ b/buildah.go
@@ -317,6 +317,10 @@ type BuilderOptions struct {
 	// the registry together, can not be resolved to a reference to a
 	// source image.  No separator is implicitly added.
 	Transport string
+	// PullBlobDirectory is the name of a directory in which we'll attempt
+	// to store copies of layer blobs that we pull down, if any.  It should
+	// already exist.
+	PullBlobDirectory string
 	// Mount signals to NewBuilder() that the container should be mounted
 	// immediately.
 	Mount bool

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -232,6 +232,7 @@ func budCmd(c *cli.Context) error {
 		NoCache:                 c.Bool("no-cache"),
 		RemoveIntermediateCtrs:  c.BoolT("rm"),
 		ForceRmIntermediateCtrs: c.Bool("force-rm"),
+		BlobDirectory:           c.String("blob-cache"),
 	}
 
 	if c.Bool("quiet") {

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -178,6 +178,11 @@ func budCmd(c *cli.Context) error {
 		logrus.Debugf("--compress option specified but is ignored")
 	}
 
+	compression := imagebuildah.Gzip
+	if c.Bool("disable-compression") {
+		compression = imagebuildah.Uncompressed
+	}
+
 	if c.IsSet("disable-content-trust") {
 		logrus.Debugf("--disable-content-trust option specified but is ignored")
 	}
@@ -195,7 +200,7 @@ func budCmd(c *cli.Context) error {
 	options := imagebuildah.BuildOptions{
 		ContextDirectory:        contextDir,
 		PullPolicy:              pullPolicy,
-		Compression:             imagebuildah.Gzip,
+		Compression:             compression,
 		Quiet:                   c.Bool("quiet"),
 		SignaturePolicyPath:     c.String("signature-policy"),
 		Args:                    args,

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -24,6 +24,12 @@ var (
 			Usage: "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
 		},
 		cli.StringFlag{
+			Name:   "blob-cache",
+			Value:  "",
+			Usage:  "assume image blobs in the specified directory will be available for pushing",
+			Hidden: true, // this is here mainly so that we can test the API during integration tests
+		},
+		cli.StringFlag{
 			Name:  "cert-dir",
 			Value: "",
 			Usage: "use certificates at the specified path to access the registry",
@@ -165,6 +171,7 @@ func commitCmd(c *cli.Context) error {
 		SystemContext:         systemContext,
 		IIDFile:               c.String("iidfile"),
 		Squash:                c.Bool("squash"),
+		BlobDirectory:         c.String("blob-cache"),
 	}
 	if !c.Bool("quiet") {
 		options.ReportWriter = os.Stderr
@@ -173,10 +180,14 @@ func commitCmd(c *cli.Context) error {
 	if err != nil {
 		return util.GetFailureCause(err, errors.Wrapf(err, "error committing container %q to %q", builder.Container, image))
 	}
-	if ref != nil {
+	if ref != nil && id != "" {
 		logrus.Debugf("wrote image %s with ID %s", ref, id)
-	} else {
+	} else if ref != nil {
+		logrus.Debugf("wrote image %s", ref)
+	} else if id != "" {
 		logrus.Debugf("wrote image with ID %s", id)
+	} else {
+		logrus.Debugf("wrote image")
 	}
 	if options.IIDFile == "" && id != "" {
 		fmt.Printf("%s\n", id)

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -243,6 +243,7 @@ func fromCmd(c *cli.Context) error {
 		DropCapabilities:      c.StringSlice("cap-drop"),
 		CommonBuildOpts:       commonOpts,
 		Format:                format,
+		PullBlobDirectory:     c.String("blob-cache"),
 	}
 
 	if !c.Bool("quiet") {

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -21,6 +21,12 @@ var (
 			Usage: "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
 		},
 		cli.StringFlag{
+			Name:   "blob-cache",
+			Value:  "",
+			Usage:  "store copies of pulled image blobs in the specified directory",
+			Hidden: true, // this is here mainly so that we can test the API during integration tests
+		},
+		cli.StringFlag{
 			Name:  "cert-dir",
 			Value: "",
 			Usage: "use certificates at the specified path to access the registry",
@@ -98,6 +104,7 @@ func pullCmd(c *cli.Context) error {
 		SignaturePolicyPath: signaturePolicy,
 		Store:               store,
 		SystemContext:       systemContext,
+		BlobDirectory:       c.String("blob-cache"),
 	}
 
 	if !c.Bool("quiet") {

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -26,6 +26,12 @@ var (
 			Usage: "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
 		},
 		cli.StringFlag{
+			Name:   "blob-cache",
+			Value:  "",
+			Usage:  "assume image blobs in the specified directory will be available for pushing",
+			Hidden: true, // this is here mainly so that we can test the API during integration tests
+		},
+		cli.StringFlag{
 			Name:  "cert-dir",
 			Value: "",
 			Usage: "use certificates at the specified path to access the registry",
@@ -160,6 +166,7 @@ func pushCmd(c *cli.Context) error {
 		SignaturePolicyPath: c.String("signature-policy"),
 		Store:               store,
 		SystemContext:       systemContext,
+		BlobDirectory:       c.String("blob-cache"),
 	}
 	if !c.Bool("quiet") {
 		options.ReportWriter = os.Stderr

--- a/commit.go
+++ b/commit.go
@@ -133,6 +133,12 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 		return imgID, nil, "", errors.Wrapf(err, "error computing layer digests and building metadata for container %q", b.ContainerID)
 	}
 	// "Copy" our image to where it needs to be.
+	switch options.Compression {
+	case archive.Uncompressed:
+		systemContext.OCIAcceptUncompressedLayers = true
+	case archive.Gzip:
+		systemContext.DirForceCompress = true
+	}
 	var manifestBytes []byte
 	if manifestBytes, err = cp.Image(ctx, policyContext, dest, src, getCopyOptions(options.ReportWriter, src, nil, dest, systemContext, "")); err != nil {
 		return imgID, nil, "", errors.Wrapf(err, "error copying layers and metadata for container %q", b.ContainerID)
@@ -210,6 +216,12 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 		return nil, "", err
 	}
 	// Copy everything.
+	switch options.Compression {
+	case archive.Uncompressed:
+		systemContext.OCIAcceptUncompressedLayers = true
+	case archive.Gzip:
+		systemContext.DirForceCompress = true
+	}
 	var manifestBytes []byte
 	if manifestBytes, err = cp.Image(ctx, policyContext, dest, src, getCopyOptions(options.ReportWriter, src, nil, dest, systemContext, options.ManifestType)); err != nil {
 		return nil, "", errors.Wrapf(err, "error copying layers and metadata from %q to %q", transports.ImageName(src), transports.ImageName(dest))

--- a/commit.go
+++ b/commit.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/containers/buildah/pkg/blobcache"
 	"github.com/containers/buildah/util"
 	cp "github.com/containers/image/copy"
 	"github.com/containers/image/docker/reference"
@@ -55,6 +56,12 @@ type CommitOptions struct {
 	// Squash tells the builder to produce an image with a single layer
 	// instead of with possibly more than one layer.
 	Squash bool
+	// BlobDirectory is the name of a directory in which we'll look for
+	// prebuilt copies of layer blobs that we might otherwise need to
+	// regenerate from on-disk layers.  If blobs are available, the
+	// manifest of the new image will reference the blobs rather than
+	// on-disk layers.
+	BlobDirectory string
 
 	// OnBuild is a list of commands to be run by images based on this image
 	OnBuild []string
@@ -85,6 +92,11 @@ type PushOptions struct {
 	// ManifestType is the format to use when saving the imge using the 'dir' transport
 	// possible options are oci, v2s1, and v2s2
 	ManifestType string
+	// BlobDirectory is the name of a directory in which we'll look for
+	// prebuilt copies of layer blobs that we might otherwise need to
+	// regenerate from on-disk layers, substituting them in the list of
+	// blobs to copy whenever possible.
+	BlobDirectory string
 }
 
 // Commit writes the contents of the container, along with its updated
@@ -128,9 +140,27 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 			}
 		}
 	}
-	src, err := b.makeImageRef(options.PreferredManifestType, options.Parent, exportBaseLayers, options.Squash, options.Compression, options.HistoryTimestamp)
+	src, err := b.makeImageRef(options.PreferredManifestType, options.Parent, exportBaseLayers, options.Squash, options.BlobDirectory, options.Compression, options.HistoryTimestamp)
 	if err != nil {
 		return imgID, nil, "", errors.Wrapf(err, "error computing layer digests and building metadata for container %q", b.ContainerID)
+	}
+	var maybeCachedSrc types.ImageReference = src
+	var maybeCachedDest types.ImageReference = dest
+	if options.BlobDirectory != "" {
+		compress := types.PreserveOriginal
+		if options.Compression != archive.Uncompressed {
+			compress = types.Compress
+		}
+		cache, err := blobcache.NewBlobCache(src, options.BlobDirectory, compress)
+		if err != nil {
+			return imgID, nil, "", errors.Wrapf(err, "error wrapping image reference %q in blob cache at %q", transports.ImageName(src), options.BlobDirectory)
+		}
+		maybeCachedSrc = cache
+		cache, err = blobcache.NewBlobCache(dest, options.BlobDirectory, compress)
+		if err != nil {
+			return imgID, nil, "", errors.Wrapf(err, "error wrapping image reference %q in blob cache at %q", transports.ImageName(dest), options.BlobDirectory)
+		}
+		maybeCachedDest = cache
 	}
 	// "Copy" our image to where it needs to be.
 	switch options.Compression {
@@ -140,7 +170,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 		systemContext.DirForceCompress = true
 	}
 	var manifestBytes []byte
-	if manifestBytes, err = cp.Image(ctx, policyContext, dest, src, getCopyOptions(options.ReportWriter, src, nil, dest, systemContext, "")); err != nil {
+	if manifestBytes, err = cp.Image(ctx, policyContext, maybeCachedDest, maybeCachedSrc, getCopyOptions(options.ReportWriter, maybeCachedSrc, nil, maybeCachedDest, systemContext, "")); err != nil {
 		return imgID, nil, "", errors.Wrapf(err, "error copying layers and metadata for container %q", b.ContainerID)
 	}
 	if len(options.AdditionalTags) > 0 {
@@ -215,6 +245,18 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 	if err != nil {
 		return nil, "", err
 	}
+	var maybeCachedSrc types.ImageReference = src
+	if options.BlobDirectory != "" {
+		compress := types.PreserveOriginal
+		if options.Compression != archive.Uncompressed {
+			compress = types.Compress
+		}
+		cache, err := blobcache.NewBlobCache(src, options.BlobDirectory, compress)
+		if err != nil {
+			return nil, "", errors.Wrapf(err, "error wrapping image reference %q in blob cache at %q", transports.ImageName(src), options.BlobDirectory)
+		}
+		maybeCachedSrc = cache
+	}
 	// Copy everything.
 	switch options.Compression {
 	case archive.Uncompressed:
@@ -223,8 +265,8 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 		systemContext.DirForceCompress = true
 	}
 	var manifestBytes []byte
-	if manifestBytes, err = cp.Image(ctx, policyContext, dest, src, getCopyOptions(options.ReportWriter, src, nil, dest, systemContext, options.ManifestType)); err != nil {
-		return nil, "", errors.Wrapf(err, "error copying layers and metadata from %q to %q", transports.ImageName(src), transports.ImageName(dest))
+	if manifestBytes, err = cp.Image(ctx, policyContext, dest, maybeCachedSrc, getCopyOptions(options.ReportWriter, maybeCachedSrc, nil, dest, systemContext, options.ManifestType)); err != nil {
+		return nil, "", errors.Wrapf(err, "error copying layers and metadata from %q to %q", transports.ImageName(maybeCachedSrc), transports.ImageName(dest))
 	}
 	if options.ReportWriter != nil {
 		fmt.Fprintf(options.ReportWriter, "")

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -170,6 +170,10 @@ The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
 
+**--disable-compression, -D**
+
+Don't default to compressing filesystem layers when building the image.
+
 **--disable-content-trust**
 
 This is a Docker specific option to disable image verification to a Docker

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -34,7 +34,7 @@ value can be entered.  The password is entered without echo.
 
 **--disable-compression, -D**
 
-Don't compress filesystem layers when building the image.
+Don't default to compressing filesystem layers when building the image.
 
 **--format**
 

--- a/image.go
+++ b/image.go
@@ -57,22 +57,24 @@ type containerImageRef struct {
 	squash                bool
 	tarPath               func(path string) (io.ReadCloser, error)
 	parent                string
+	blobDirectory         string
 }
 
 type containerImageSource struct {
-	path         string
-	ref          *containerImageRef
-	store        storage.Store
-	containerID  string
-	mountLabel   string
-	layerID      string
-	names        []string
-	compression  archive.Compression
-	config       []byte
-	configDigest digest.Digest
-	manifest     []byte
-	manifestType string
-	exporting    bool
+	path          string
+	ref           *containerImageRef
+	store         storage.Store
+	containerID   string
+	mountLabel    string
+	layerID       string
+	names         []string
+	compression   archive.Compression
+	config        []byte
+	configDigest  digest.Digest
+	manifest      []byte
+	manifestType  string
+	exporting     bool
+	blobDirectory string
 }
 
 func (i *containerImageRef) NewImage(ctx context.Context, sc *types.SystemContext) (types.ImageCloser, error) {
@@ -105,11 +107,11 @@ func expectedDockerDiffIDs(image docker.V2Image) int {
 
 // Compute the media types which we need to attach to a layer, given the type of
 // compression that we'll be applying.
-func (i *containerImageRef) computeLayerMIMEType(what string) (omediaType, dmediaType string, err error) {
+func computeLayerMIMEType(what string, layerCompression archive.Compression) (omediaType, dmediaType string, err error) {
 	omediaType = v1.MediaTypeImageLayer
 	dmediaType = docker.V2S2MediaTypeUncompressedLayer
-	if i.compression != archive.Uncompressed {
-		switch i.compression {
+	if layerCompression != archive.Uncompressed {
+		switch layerCompression {
 		case archive.Gzip:
 			omediaType = v1.MediaTypeImageLayerGzip
 			dmediaType = manifest.DockerV2Schema2LayerMediaType
@@ -280,19 +282,21 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, sc *types.System
 		// The default layer media type assumes no compression.
 		omediaType := v1.MediaTypeImageLayer
 		dmediaType := docker.V2S2MediaTypeUncompressedLayer
+		// Look up this layer.
+		layer, err := i.store.Layer(layerID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to locate layer %q", layerID)
+		}
 		// If we're not re-exporting the data, and we're reusing layers individually, reuse
 		// the blobsum and diff IDs.
 		if !i.exporting && !i.squash && layerID != i.layerID {
-			layer, err2 := i.store.Layer(layerID)
-			if err2 != nil {
-				return nil, errors.Wrapf(err, "unable to locate layer %q", layerID)
-			}
 			if layer.UncompressedDigest == "" {
 				return nil, errors.Errorf("unable to look up size of layer %q", layerID)
 			}
 			layerBlobSum := layer.UncompressedDigest
 			layerBlobSize := layer.UncompressedSize
-			// Note this layer in the manifest, using the uncompressed blobsum.
+			diffID := layer.UncompressedDigest
+			// Note this layer in the manifest, using the appropriate blobsum.
 			olayerDescriptor := v1.Descriptor{
 				MediaType: omediaType,
 				Digest:    layerBlobSum,
@@ -305,13 +309,13 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, sc *types.System
 				Size:      layerBlobSize,
 			}
 			dmanifest.Layers = append(dmanifest.Layers, dlayerDescriptor)
-			// Note this layer in the list of diffIDs, again using the uncompressed blobsum.
-			oimage.RootFS.DiffIDs = append(oimage.RootFS.DiffIDs, layerBlobSum)
-			dimage.RootFS.DiffIDs = append(dimage.RootFS.DiffIDs, layerBlobSum)
+			// Note this layer in the list of diffIDs, again using the uncompressed digest.
+			oimage.RootFS.DiffIDs = append(oimage.RootFS.DiffIDs, diffID)
+			dimage.RootFS.DiffIDs = append(dimage.RootFS.DiffIDs, diffID)
 			continue
 		}
-		// Figure out if we need to change the media type, in case we're using compression.
-		omediaType, dmediaType, err = i.computeLayerMIMEType(what)
+		// Figure out if we need to change the media type, in case we've changed the compression.
+		omediaType, dmediaType, err = computeLayerMIMEType(what, i.compression)
 		if err != nil {
 			return nil, err
 		}
@@ -368,8 +372,9 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, sc *types.System
 		}
 		logrus.Debugf("%s size is %d bytes", what, size)
 		// Rename the layer so that we can more easily find it by digest later.
-		if err = os.Rename(filepath.Join(path, "layer"), filepath.Join(path, destHasher.Digest().String())); err != nil {
-			return nil, errors.Wrapf(err, "error storing %s to file while renaming %q to %q", what, filepath.Join(path, "layer"), filepath.Join(path, destHasher.Digest().String()))
+		finalBlobName := filepath.Join(path, destHasher.Digest().String())
+		if err = os.Rename(filepath.Join(path, "layer"), finalBlobName); err != nil {
+			return nil, errors.Wrapf(err, "error storing %s to file while renaming %q to %q", what, filepath.Join(path, "layer"), finalBlobName)
 		}
 		// Add a note in the manifest about the layer.  The blobs are identified by their possibly-
 		// compressed blob digests.
@@ -472,19 +477,20 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, sc *types.System
 		panic("unreachable code: unsupported manifest type")
 	}
 	src = &containerImageSource{
-		path:         path,
-		ref:          i,
-		store:        i.store,
-		containerID:  i.containerID,
-		mountLabel:   i.mountLabel,
-		layerID:      i.layerID,
-		names:        i.names,
-		compression:  i.compression,
-		config:       config,
-		configDigest: digest.Canonical.FromBytes(config),
-		manifest:     imageManifest,
-		manifestType: manifestType,
-		exporting:    i.exporting,
+		path:          path,
+		ref:           i,
+		store:         i.store,
+		containerID:   i.containerID,
+		mountLabel:    i.mountLabel,
+		layerID:       i.layerID,
+		names:         i.names,
+		compression:   i.compression,
+		config:        config,
+		configDigest:  digest.Canonical.FromBytes(config),
+		manifest:      imageManifest,
+		manifestType:  manifestType,
+		exporting:     i.exporting,
+		blobDirectory: i.blobDirectory,
 	}
 	return src, nil
 }
@@ -561,7 +567,16 @@ func (i *containerImageSource) GetBlob(ctx context.Context, blob types.BlobInfo)
 		}
 		return ioutils.NewReadCloserWrapper(reader, closer), reader.Size(), nil
 	}
-	layerFile, err := os.OpenFile(filepath.Join(i.path, blob.Digest.String()), os.O_RDONLY, 0600)
+	var layerFile *os.File
+	for _, path := range []string{i.blobDirectory, i.path} {
+		layerFile, err = os.OpenFile(filepath.Join(path, blob.Digest.String()), os.O_RDONLY, 0600)
+		if err == nil {
+			break
+		}
+		if !os.IsNotExist(err) {
+			logrus.Debugf("error checking for layer %q in %q: %v", blob.Digest.String(), path, err)
+		}
+	}
 	if err != nil {
 		logrus.Debugf("error reading layer %q: %v", blob.Digest.String(), err)
 		return nil, -1, errors.Wrapf(err, "error opening file %q to buffer layer blob", filepath.Join(i.path, blob.Digest.String()))
@@ -584,7 +599,7 @@ func (i *containerImageSource) GetBlob(ctx context.Context, blob types.BlobInfo)
 	return ioutils.NewReadCloserWrapper(layerFile, closer), size, nil
 }
 
-func (b *Builder) makeImageRef(manifestType, parent string, exporting bool, squash bool, compress archive.Compression, historyTimestamp *time.Time) (types.ImageReference, error) {
+func (b *Builder) makeImageRef(manifestType, parent string, exporting bool, squash bool, blobDirectory string, compress archive.Compression, historyTimestamp *time.Time) (types.ImageReference, error) {
 	var name reference.Named
 	container, err := b.store.Container(b.ContainerID)
 	if err != nil {
@@ -630,6 +645,7 @@ func (b *Builder) makeImageRef(manifestType, parent string, exporting bool, squa
 		squash:                squash,
 		tarPath:               b.tarPath(),
 		parent:                parent,
+		blobDirectory:         blobDirectory,
 	}
 	return ref, nil
 }

--- a/new.go
+++ b/new.go
@@ -34,6 +34,7 @@ func pullAndFindImage(ctx context.Context, store storage.Store, imageName string
 		Store:         store,
 		SystemContext: options.SystemContext,
 		Transport:     options.Transport,
+		BlobDirectory: options.PullBlobDirectory,
 	}
 	ref, err := pullImage(ctx, store, imageName, pullOptions, sc)
 	if err != nil {

--- a/pkg/blobcache/blobcache.go
+++ b/pkg/blobcache/blobcache.go
@@ -1,0 +1,548 @@
+package blobcache
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/containers/buildah/docker"
+	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/image"
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/transports"
+	"github.com/containers/image/types"
+	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/ioutils"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	_ types.ImageReference   = &blobCacheReference{}
+	_ types.ImageSource      = &blobCacheSource{}
+	_ types.ImageDestination = &blobCacheDestination{}
+)
+
+const (
+	compressedNote   = ".compressed"
+	decompressedNote = ".decompressed"
+)
+
+// BlobCache is an object which saves copies of blobs that are written to it while passing them
+// through to some real destination, and which can be queried directly in order to read them
+// back.
+type BlobCache interface {
+	types.ImageReference
+	// HasBlob checks if a blob that matches the passed-in digest (and
+	// size, if not -1), is present in the cache.
+	HasBlob(types.BlobInfo) (bool, int64, error)
+	// PutBlob adds a blob to the cache.  The expected digest of the blob
+	// must be provided.
+	PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) error
+	// Directories returns the list of cache directories.
+	Directory() string
+	// ClearCache() clears the contents of the cache directories.  Note
+	// that this also clears content which was not placed there by this
+	// cache implementation.
+	ClearCache() error
+}
+
+type blobCacheReference struct {
+	reference types.ImageReference
+	directory string
+	compress  types.LayerCompression
+}
+
+type blobCacheSource struct {
+	reference   *blobCacheReference
+	source      types.ImageSource
+	sys         types.SystemContext
+	cacheHits   int64
+	cacheMisses int64
+	cacheErrors int64
+}
+
+type blobCacheDestination struct {
+	reference   *blobCacheReference
+	destination types.ImageDestination
+}
+
+func makeFilename(blobSum digest.Digest, isConfig bool) string {
+	if isConfig {
+		return blobSum.String() + ".config"
+	}
+	return blobSum.String()
+}
+
+// NewBlobCache creates a new blob cache that wraps an image reference.  Any blobs which are
+// written to the destination image created from the resulting reference will also be stored
+// as-is to the specifed directory or a temporary directory.  The cache directory's contents
+// can be cleared by calling the returned BlobCache()'s ClearCache() method.
+// The compress argument controls whether or not the cache will try to substitute a compressed
+// or different version of a blob when preparing the list of layers when reading an image.
+func NewBlobCache(ref types.ImageReference, directory string, compress types.LayerCompression) (BlobCache, error) {
+	if directory == "" {
+		return nil, errors.Errorf("error creating cache around reference %q: no directory specified", transports.ImageName(ref))
+	}
+	switch compress {
+	case types.Compress, types.Decompress, types.PreserveOriginal:
+		// valid value, accept it
+	default:
+		return nil, errors.Errorf("unhandled LayerCompression value %v", compress)
+	}
+	return &blobCacheReference{
+		reference: ref,
+		directory: directory,
+		compress:  compress,
+	}, nil
+}
+
+func (r *blobCacheReference) Transport() types.ImageTransport {
+	return r.reference.Transport()
+}
+
+func (r *blobCacheReference) StringWithinTransport() string {
+	return r.reference.StringWithinTransport()
+}
+
+func (r *blobCacheReference) DockerReference() reference.Named {
+	return r.reference.DockerReference()
+}
+
+func (r *blobCacheReference) PolicyConfigurationIdentity() string {
+	return r.reference.PolicyConfigurationIdentity()
+}
+
+func (r *blobCacheReference) PolicyConfigurationNamespaces() []string {
+	return r.reference.PolicyConfigurationNamespaces()
+}
+
+func (r *blobCacheReference) DeleteImage(ctx context.Context, sys *types.SystemContext) error {
+	return r.reference.DeleteImage(ctx, sys)
+}
+
+func (r *blobCacheReference) HasBlob(blobinfo types.BlobInfo) (bool, int64, error) {
+	if blobinfo.Digest == "" {
+		return false, -1, nil
+	}
+
+	for _, isConfig := range []bool{false, true} {
+		filename := filepath.Join(r.directory, makeFilename(blobinfo.Digest, isConfig))
+		fileInfo, err := os.Stat(filename)
+		if err == nil && (blobinfo.Size == -1 || blobinfo.Size == fileInfo.Size()) {
+			return true, fileInfo.Size(), nil
+		}
+		if !os.IsNotExist(err) {
+			return false, -1, errors.Wrapf(err, "error checking size of %q", filename)
+		}
+	}
+
+	return false, -1, nil
+}
+
+// Decompress and save the contents of the decompressReader stream into the passed-in temporary
+// file.  If we successfully save all of the data, rename the file to match the digest of the data,
+// and make notes about the relationship between the file that holds a copy of the compressed data
+// and this new file.
+func saveStream(wg *sync.WaitGroup, decompressReader io.ReadCloser, tempFile *os.File, compressedFilename string, compressedDigest digest.Digest, isConfig bool, alternateDigest *digest.Digest) {
+	defer wg.Done()
+	// Decompress from and digest the reading end of that pipe.
+	decompressed, err3 := archive.DecompressStream(decompressReader)
+	digester := digest.Canonical.Digester()
+	if err3 == nil {
+		// Read the decompressed data through the filter over the pipe, blocking until the
+		// writing end is closed.
+		_, err3 = io.Copy(io.MultiWriter(tempFile, digester.Hash()), decompressed)
+	} else {
+		// Drain the pipe to keep from stalling the PutBlob() thread.
+		io.Copy(ioutil.Discard, decompressReader)
+	}
+	decompressReader.Close()
+	decompressed.Close()
+	tempFile.Close()
+	// Determine the name that we should give to the uncompressed copy of the blob.
+	decompressedFilename := filepath.Join(filepath.Dir(tempFile.Name()), makeFilename(digester.Digest(), isConfig))
+	if err3 == nil {
+		// Rename the temporary file.
+		if err3 = os.Rename(tempFile.Name(), decompressedFilename); err3 != nil {
+			logrus.Debugf("error renaming new decompressed copy of blob %q into place at %q: %v", digester.Digest().String(), decompressedFilename, err3)
+			// Remove the temporary file.
+			if err3 = os.Remove(tempFile.Name()); err3 != nil {
+				logrus.Debugf("error cleaning up temporary file %q for decompressed copy of blob %q: %v", tempFile.Name(), compressedDigest.String(), err3)
+			}
+		} else {
+			*alternateDigest = digester.Digest()
+			// Note the relationship between the two files.
+			if err3 = ioutils.AtomicWriteFile(decompressedFilename+compressedNote, []byte(compressedDigest.String()), 0600); err3 != nil {
+				logrus.Debugf("error noting that the compressed version of %q is %q: %v", digester.Digest().String(), compressedDigest.String(), err3)
+			}
+			if err3 = ioutils.AtomicWriteFile(compressedFilename+decompressedNote, []byte(digester.Digest().String()), 0600); err3 != nil {
+				logrus.Debugf("error noting that the decompressed version of %q is %q: %v", compressedDigest.String(), digester.Digest().String(), err3)
+			}
+		}
+	} else {
+		// Remove the temporary file.
+		if err3 = os.Remove(tempFile.Name()); err3 != nil {
+			logrus.Debugf("error cleaning up temporary file %q for decompressed copy of blob %q: %v", tempFile.Name(), compressedDigest.String(), err3)
+		}
+	}
+}
+
+func (r *blobCacheReference) putBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool, destination types.ImageDestination) (types.BlobInfo, error) {
+	newBlobInfo := inputInfo
+	var tempfile *os.File
+	var err error
+	var n int
+	var alternateDigest digest.Digest
+	wg := new(sync.WaitGroup)
+	defer wg.Wait()
+	compression := archive.Uncompressed
+	if inputInfo.Digest != "" {
+		filename := filepath.Join(r.directory, makeFilename(inputInfo.Digest, isConfig))
+		tempfile, err = ioutil.TempFile(r.directory, makeFilename(inputInfo.Digest, isConfig))
+		if err == nil {
+			stream = io.TeeReader(stream, tempfile)
+			defer func() {
+				if err == nil {
+					if err = os.Rename(tempfile.Name(), filename); err != nil {
+						if err2 := os.Remove(tempfile.Name()); err2 != nil {
+							logrus.Debugf("error cleaning up temporary file %q for blob %q: %v", tempfile.Name(), inputInfo.Digest.String(), err2)
+						}
+						err = errors.Wrapf(err, "error renaming new layer for blob %q into place at %q", inputInfo.Digest.String(), filename)
+					}
+				} else {
+					if err2 := os.Remove(tempfile.Name()); err2 != nil {
+						logrus.Debugf("error cleaning up temporary file %q for blob %q: %v", tempfile.Name(), inputInfo.Digest.String(), err2)
+					}
+				}
+				tempfile.Close()
+			}()
+		} else {
+			logrus.Debugf("error while creating a temporary file under %q to hold blob %q: %v", r.directory, inputInfo.Digest.String(), err)
+		}
+		if !isConfig {
+			initial := make([]byte, 8)
+			n, err = stream.Read(initial)
+			if n > 0 {
+				// Build a Reader that will still return the bytes that we just
+				// read, for PutBlob()'s sake.
+				stream = io.MultiReader(bytes.NewReader(initial[:n]), stream)
+				if n >= len(initial) {
+					compression = archive.DetectCompression(initial[:n])
+				}
+				if compression != archive.Uncompressed {
+					// The stream is compressed, so create a file which we'll
+					// use to store a decompressed copy.
+					decompressedTemp, err2 := ioutil.TempFile(r.directory, makeFilename(inputInfo.Digest, isConfig))
+					if err2 != nil {
+						logrus.Debugf("error while creating a temporary file under %q to hold decompressed blob %q: %v", r.directory, inputInfo.Digest.String(), err2)
+						decompressedTemp.Close()
+					} else {
+						// Write a copy of the compressed data to a pipe,
+						// closing the writing end of the pipe after
+						// PutBlob() returns.
+						decompressReader, decompressWriter := io.Pipe()
+						defer decompressWriter.Close()
+						stream = io.TeeReader(stream, decompressWriter)
+						// Let saveStream() close the reading end and handle the temporary file.
+						wg.Add(1)
+						go saveStream(wg, decompressReader, decompressedTemp, filename, inputInfo.Digest, isConfig, &alternateDigest)
+					}
+				}
+			}
+		}
+	}
+	if destination != nil {
+		newBlobInfo, err = destination.PutBlob(ctx, stream, inputInfo, isConfig)
+		if err != nil {
+			return newBlobInfo, errors.Wrapf(err, "error storing blob to image destination for cache %q", transports.ImageName(r))
+		}
+	} else {
+		digester := digest.Canonical.Digester()
+		counter := ioutils.NewWriteCounter(digester.Hash())
+		_, err = io.Copy(counter, stream)
+		if err != nil {
+			return newBlobInfo, errors.Wrapf(err, "error storing blob to cache %q", transports.ImageName(r))
+		}
+		newBlobInfo.Size = counter.Count
+		newBlobInfo.Digest = digester.Digest()
+	}
+	if alternateDigest.Validate() == nil {
+		logrus.Debugf("added blob %q (also %q) to the cache at %q", inputInfo.Digest.String(), alternateDigest.String(), r.directory)
+	} else {
+		logrus.Debugf("added blob %q to the cache at %q", inputInfo.Digest.String(), r.directory)
+	}
+	return newBlobInfo, nil
+}
+
+func (r *blobCacheReference) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) error {
+	_, err := r.putBlob(ctx, stream, inputInfo, isConfig, nil)
+	return err
+}
+
+func (r *blobCacheReference) Directory() string {
+	return r.directory
+}
+
+func (r *blobCacheReference) ClearCache() error {
+	f, err := os.Open(r.directory)
+	if err != nil {
+		return errors.Wrapf(err, "error opening directory %q", r.directory)
+	}
+	defer f.Close()
+	names, err := f.Readdirnames(-1)
+	if err != nil {
+		return errors.Wrapf(err, "error reading directory %q", r.directory)
+	}
+	for _, name := range names {
+		pathname := filepath.Join(r.directory, name)
+		if err = os.RemoveAll(pathname); err != nil {
+			return errors.Wrapf(err, "error removing %q while clearing cache for %q", pathname, transports.ImageName(r))
+		}
+	}
+	return nil
+}
+
+func (r *blobCacheReference) NewImage(ctx context.Context, sys *types.SystemContext) (types.ImageCloser, error) {
+	src, err := r.NewImageSource(ctx, sys)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating new image %q", transports.ImageName(r.reference))
+	}
+	return image.FromSource(ctx, sys, src)
+}
+
+func (r *blobCacheReference) NewImageSource(ctx context.Context, sys *types.SystemContext) (types.ImageSource, error) {
+	src, err := r.reference.NewImageSource(ctx, sys)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating new image source %q", transports.ImageName(r.reference))
+	}
+	logrus.Debugf("starting to read from image %q using blob cache in %q (compression=%v)", transports.ImageName(r.reference), r.directory, r.compress)
+	return &blobCacheSource{reference: r, source: src, sys: *sys}, nil
+}
+
+func (r *blobCacheReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
+	dest, err := r.reference.NewImageDestination(ctx, sys)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating new image destination %q", transports.ImageName(r.reference))
+	}
+	logrus.Debugf("starting to write to image %q using blob cache in %q", transports.ImageName(r.reference), r.directory)
+	return &blobCacheDestination{reference: r, destination: dest}, nil
+}
+
+func (s *blobCacheSource) Reference() types.ImageReference {
+	return s.reference
+}
+
+func (s *blobCacheSource) Close() error {
+	logrus.Debugf("finished reading from image %q using blob cache: cache had %d hits, %d misses, %d errors", transports.ImageName(s.reference), s.cacheHits, s.cacheMisses, s.cacheErrors)
+	return s.source.Close()
+}
+
+func (s *blobCacheSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
+	if instanceDigest != nil {
+		filename := filepath.Join(s.reference.directory, makeFilename(*instanceDigest, false))
+		manifestBytes, err := ioutil.ReadFile(filename)
+		if err == nil {
+			s.cacheHits++
+			return manifestBytes, manifest.GuessMIMEType(manifestBytes), nil
+		}
+		if !os.IsNotExist(err) {
+			s.cacheErrors++
+			return nil, "", errors.Wrapf(err, "error checking for manifest file %q", filename)
+		}
+	}
+	s.cacheMisses++
+	return s.source.GetManifest(ctx, instanceDigest)
+}
+
+func (s *blobCacheSource) GetBlob(ctx context.Context, blobinfo types.BlobInfo) (io.ReadCloser, int64, error) {
+	present, size, err := s.reference.HasBlob(blobinfo)
+	if err != nil {
+		return nil, -1, err
+	}
+	if present {
+		for _, isConfig := range []bool{false, true} {
+			filename := filepath.Join(s.reference.directory, makeFilename(blobinfo.Digest, isConfig))
+			f, err := os.Open(filename)
+			if err == nil {
+				s.cacheHits++
+				return f, size, nil
+			}
+			if !os.IsNotExist(err) {
+				s.cacheErrors++
+				return nil, -1, errors.Wrapf(err, "error checking for cache file %q", filepath.Join(s.reference.directory, filename))
+			}
+		}
+	}
+	s.cacheMisses++
+	rc, size, err := s.source.GetBlob(ctx, blobinfo)
+	if err != nil {
+		return rc, size, errors.Wrapf(err, "error reading blob from source image %q", transports.ImageName(s.reference))
+	}
+	return rc, size, nil
+}
+
+func (s *blobCacheSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
+	return s.source.GetSignatures(ctx, instanceDigest)
+}
+
+func (s *blobCacheSource) LayerInfosForCopy(ctx context.Context) ([]types.BlobInfo, error) {
+	signatures, err := s.source.GetSignatures(ctx, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error checking if image %q has signatures", transports.ImageName(s.reference))
+	}
+	canReplaceBlobs := !(len(signatures) > 0 && len(signatures[0]) > 0)
+
+	infos, err := s.source.LayerInfosForCopy(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting layer infos for copying image %q through cache", transports.ImageName(s.reference))
+	}
+	if infos == nil {
+		image, err := s.reference.NewImage(ctx, &s.sys)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error opening image to get layer infos for copying image %q through cache", transports.ImageName(s.reference))
+		}
+		defer image.Close()
+		infos = image.LayerInfos()
+	}
+
+	if canReplaceBlobs && s.reference.compress != types.PreserveOriginal {
+		replacedInfos := make([]types.BlobInfo, 0, len(infos))
+		for _, info := range infos {
+			var replaceDigest []byte
+			var err error
+			blobFile := filepath.Join(s.reference.directory, makeFilename(info.Digest, false))
+			alternate := ""
+			switch s.reference.compress {
+			case types.Compress:
+				alternate = blobFile + compressedNote
+				replaceDigest, err = ioutil.ReadFile(alternate)
+			case types.Decompress:
+				alternate = blobFile + decompressedNote
+				replaceDigest, err = ioutil.ReadFile(alternate)
+			}
+			if err == nil && digest.Digest(replaceDigest).Validate() == nil {
+				alternate = filepath.Join(filepath.Dir(alternate), makeFilename(digest.Digest(replaceDigest), false))
+				fileInfo, err := os.Stat(alternate)
+				if err == nil {
+					logrus.Debugf("suggesting cached blob with digest %q and compression %v in place of blob with digest %q", string(replaceDigest), s.reference.compress, info.Digest.String())
+					info.Digest = digest.Digest(replaceDigest)
+					info.Size = fileInfo.Size()
+					switch info.MediaType {
+					case v1.MediaTypeImageLayer, v1.MediaTypeImageLayerGzip:
+						switch s.reference.compress {
+						case types.Compress:
+							info.MediaType = v1.MediaTypeImageLayerGzip
+						case types.Decompress:
+							info.MediaType = v1.MediaTypeImageLayer
+						}
+					case docker.V2S2MediaTypeUncompressedLayer, manifest.DockerV2Schema2LayerMediaType:
+						switch s.reference.compress {
+						case types.Compress:
+							info.MediaType = manifest.DockerV2Schema2LayerMediaType
+						case types.Decompress:
+							info.MediaType = docker.V2S2MediaTypeUncompressedLayer
+						}
+					}
+				}
+			}
+			replacedInfos = append(replacedInfos, info)
+		}
+		infos = replacedInfos
+	}
+
+	return infos, nil
+}
+
+func (d *blobCacheDestination) Reference() types.ImageReference {
+	return d.reference
+}
+
+func (d *blobCacheDestination) Close() error {
+	logrus.Debugf("finished writing to image %q using blob cache", transports.ImageName(d.reference))
+	return d.destination.Close()
+}
+
+func (d *blobCacheDestination) SupportedManifestMIMETypes() []string {
+	return d.destination.SupportedManifestMIMETypes()
+}
+
+func (d *blobCacheDestination) SupportsSignatures(ctx context.Context) error {
+	return d.destination.SupportsSignatures(ctx)
+}
+
+func (d *blobCacheDestination) DesiredLayerCompression() types.LayerCompression {
+	return d.destination.DesiredLayerCompression()
+}
+
+func (d *blobCacheDestination) AcceptsForeignLayerURLs() bool {
+	return d.destination.AcceptsForeignLayerURLs()
+}
+
+func (d *blobCacheDestination) MustMatchRuntimeOS() bool {
+	return d.destination.MustMatchRuntimeOS()
+}
+
+func (d *blobCacheDestination) IgnoresEmbeddedDockerReference() bool {
+	return d.destination.IgnoresEmbeddedDockerReference()
+}
+
+func (d *blobCacheDestination) PutBlob(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, isConfig bool) (types.BlobInfo, error) {
+	return d.reference.putBlob(ctx, stream, inputInfo, isConfig, d.destination)
+}
+
+func (d *blobCacheDestination) HasBlob(ctx context.Context, info types.BlobInfo) (bool, int64, error) {
+	present, size, err := d.reference.HasBlob(info)
+	if err != nil {
+		return false, -1, errors.Wrapf(err, "error checking for blob %q in cache %q", info.Digest.String(), d.reference.directory)
+	}
+	if present {
+		return present, size, nil
+	}
+	return d.destination.HasBlob(ctx, info)
+}
+
+func (d *blobCacheDestination) ReapplyBlob(ctx context.Context, info types.BlobInfo) (types.BlobInfo, error) {
+	present, _, err := d.destination.HasBlob(ctx, info)
+	if err != nil {
+		return types.BlobInfo{}, errors.Wrapf(err, "error checking for blob %q in cache %q", info.Digest.String(), d.reference.directory)
+	}
+	if !present {
+		for _, isConfig := range []bool{false, true} {
+			filename := filepath.Join(d.reference.directory, makeFilename(info.Digest, isConfig))
+			f, err := os.Open(filename)
+			if err == nil {
+				defer f.Close()
+				return d.destination.PutBlob(ctx, f, info, isConfig)
+			}
+		}
+	}
+	return d.destination.ReapplyBlob(ctx, info)
+}
+
+func (d *blobCacheDestination) PutManifest(ctx context.Context, manifestBytes []byte) error {
+	manifestDigest, err := manifest.Digest(manifestBytes)
+	if err != nil {
+		logrus.Warnf("error digesting manifest %q: %v", string(manifestBytes), err)
+	} else {
+		filename := filepath.Join(d.reference.directory, makeFilename(manifestDigest, false))
+		if err = ioutils.AtomicWriteFile(filename, manifestBytes, 0600); err != nil {
+			logrus.Warnf("error saving manifest as %q: %v", filename, err)
+		}
+	}
+	return d.destination.PutManifest(ctx, manifestBytes)
+}
+
+func (d *blobCacheDestination) PutSignatures(ctx context.Context, signatures [][]byte) error {
+	return d.destination.PutSignatures(ctx, signatures)
+}
+
+func (d *blobCacheDestination) Commit(ctx context.Context) error {
+	return d.destination.Commit(ctx)
+}

--- a/pkg/blobcache/blobcache_test.go
+++ b/pkg/blobcache/blobcache_test.go
@@ -1,0 +1,256 @@
+package blobcache
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cp "github.com/containers/image/copy"
+	"github.com/containers/image/signature"
+	"github.com/containers/image/transports/alltransports"
+	"github.com/containers/image/types"
+	"github.com/containers/storage/pkg/archive"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	"github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Verbose() {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	os.Exit(m.Run())
+}
+
+// Create a layer containing a single file with the specified name (and its
+// name as its contents), compressed using the specified compression type, and
+// return the .
+func makeLayer(filename string, repeat int, compression archive.Compression) ([]byte, digest.Digest, error) {
+	var compressed, uncompressed bytes.Buffer
+	layer, err := archive.Generate(filename, strings.Repeat(filename, repeat))
+	if err != nil {
+		return nil, "", err
+	}
+	writer, err := archive.CompressStream(&compressed, compression)
+	if err != nil {
+		return nil, "", err
+	}
+	reader := io.TeeReader(layer, &uncompressed)
+	_, err = io.Copy(writer, reader)
+	writer.Close()
+	if err != nil {
+		return nil, "", err
+	}
+	return compressed.Bytes(), digest.FromBytes(uncompressed.Bytes()), nil
+}
+
+func TestBlobCache(t *testing.T) {
+	cacheDir, err := ioutil.TempDir("", "blobcache")
+	if err != nil {
+		t.Fatalf("error creating persistent cache directory: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(cacheDir); err != nil {
+			t.Fatalf("error removing persistent cache directory %q: %v", cacheDir, err)
+		}
+	}()
+
+	for _, repeat := range []int{1, 10, 100, 1000, 10000} {
+		for _, desiredCompression := range []types.LayerCompression{types.PreserveOriginal, types.Compress, types.Decompress} {
+			for _, layerCompression := range []archive.Compression{archive.Uncompressed, archive.Gzip} {
+				// Create a layer with the specified layerCompression.
+				blobBytes, diffID, err := makeLayer(fmt.Sprintf("layer-content-%d", int(layerCompression)), repeat, layerCompression)
+				blobInfo := types.BlobInfo{
+					Digest: digest.FromBytes(blobBytes),
+					Size:   int64(len(blobBytes)),
+				}
+				// Create a configuration that includes the diffID for the layer and not much else.
+				config := v1.Image{
+					RootFS: v1.RootFS{
+						Type:    "layers",
+						DiffIDs: []digest.Digest{diffID},
+					},
+				}
+				configBytes, err := json.Marshal(&config)
+				if err != nil {
+					t.Fatalf("error encoding image configuration: %v", err)
+				}
+				configInfo := types.BlobInfo{
+					Digest: digest.FromBytes(configBytes),
+					Size:   int64(len(configBytes)),
+				}
+				// Create a manifest that uses this configuration and layer.
+				manifest := v1.Manifest{
+					Versioned: specs.Versioned{
+						SchemaVersion: 2,
+					},
+					Config: v1.Descriptor{
+						Digest: configInfo.Digest,
+						Size:   configInfo.Size,
+					},
+					Layers: []v1.Descriptor{{
+						Digest: blobInfo.Digest,
+						Size:   blobInfo.Size,
+					}},
+				}
+				manifestBytes, err := json.Marshal(&manifest)
+				if err != nil {
+					t.Fatalf("error encoding image manifest: %v", err)
+				}
+				// Write this image to a "dir" destination with blob caching using this directory.
+				srcdir, err := ioutil.TempDir("", "blobcache-source")
+				if err != nil {
+					t.Fatalf("error creating temporary source directory: %v", err)
+				}
+				defer os.RemoveAll(srcdir)
+				srcName := "dir:" + srcdir
+				srcRef, err := alltransports.ParseImageName(srcName)
+				if err != nil {
+					t.Fatalf("error parsing source image name %q: %v", srcName, err)
+				}
+				cachedSrcRef, err := NewBlobCache(srcRef, cacheDir, desiredCompression)
+				if err != nil {
+					t.Fatalf("failed to wrap reference in cache: %v", err)
+				}
+				destImage, err := cachedSrcRef.NewImageDestination(context.TODO(), nil)
+				if err != nil {
+					t.Fatalf("error opening source image for writing: %v", err)
+				}
+				has, _, err := destImage.HasBlob(context.TODO(), blobInfo)
+				if err != nil {
+					t.Fatalf("error checking if source image has layer blob: %v", err)
+				}
+				if has {
+					t.Fatalf("new directory surprisingly already has the layer blob we never wrote to it: %v", err)
+				}
+				_, err = destImage.PutBlob(context.TODO(), bytes.NewReader(blobBytes), blobInfo, false)
+				if err != nil {
+					t.Fatalf("error writing layer blob to source image: %v", err)
+				}
+				has, _, err = destImage.HasBlob(context.TODO(), configInfo)
+				if err != nil {
+					t.Fatalf("error checking if source image has config blob: %v", err)
+				}
+				if has {
+					t.Fatalf("new directory surprisingly already has a config blob we never wrote to it: %v", err)
+				}
+				_, err = destImage.PutBlob(context.TODO(), bytes.NewReader(configBytes), configInfo, true)
+				if err != nil {
+					t.Fatalf("error writing config blob to source image: %v", err)
+				}
+				err = destImage.PutManifest(context.TODO(), manifestBytes)
+				if err != nil {
+					t.Fatalf("error writing manifest to source image: %v", err)
+				}
+				err = destImage.Commit(context.TODO())
+				if err != nil {
+					t.Fatalf("error committing source image: %v", err)
+				}
+				if err = destImage.Close(); err != nil {
+					t.Fatalf("error closing source image: %v", err)
+				}
+				// Check that the cache was populated.
+				cache, err := os.Open(cacheDir)
+				if err != nil {
+					t.Fatalf("error opening cache directory %q: %v", cacheDir, err)
+				}
+				defer cache.Close()
+				cachedNames, err := cache.Readdirnames(-1)
+				if err != nil {
+					t.Fatalf("error reading contents of cache directory %q: %v", cacheDir, err)
+				}
+				// Expect a layer blob, a config blob, and the manifest.
+				expected := 3
+				if layerCompression != archive.Uncompressed {
+					// Expect a compressed blob, an uncompressed blob, notes for each about the other, a config blob, and the manifest.
+					expected = 6
+				}
+				if len(cachedNames) != expected {
+					t.Fatalf("expected %d items in cache directory %q, got %d: %v", expected, cacheDir, len(cachedNames), cachedNames)
+				}
+				// Check that the blobs were all correctly stored.
+				for _, cachedName := range cachedNames {
+					if digest.Digest(cachedName).Validate() == nil {
+						cacheMember := filepath.Join(cacheDir, cachedName)
+						cacheMemberBytes, err := ioutil.ReadFile(cacheMember)
+						if err != nil {
+							t.Fatalf("error reading cache member %q: %v", cacheMember, err)
+						}
+						if digest.FromBytes(cacheMemberBytes).String() != cachedName {
+							t.Fatalf("cache member %q was stored incorrectly!", cacheMember)
+						}
+					}
+				}
+				// Clear out anything in the source directory that probably isn't a manifest, so that we'll
+				// have to depend on the cached copies of some of the blobs.
+				srcNameDir, err := os.Open(srcdir)
+				if err != nil {
+					t.Fatalf("error opening source directory %q: %v", srcdir, err)
+				}
+				defer srcNameDir.Close()
+				srcNames, err := srcNameDir.Readdirnames(-1)
+				if err != nil {
+					t.Fatalf("error reading contents of source directory %q: %v", srcdir, err)
+				}
+				for _, name := range srcNames {
+					if !strings.HasPrefix(name, "manifest") {
+						os.Remove(filepath.Join(srcdir, name))
+					}
+				}
+				// Now that we've deleted some of the contents, try to copy from the source image
+				// to a second image.  It should fail because the source is missing some blobs.
+				destdir, err := ioutil.TempDir("", "blobcache-destination")
+				if err != nil {
+					t.Fatalf("error creating temporary destination directory: %v", err)
+				}
+				defer os.RemoveAll(destdir)
+				destName := "dir:" + destdir
+				destRef, err := alltransports.ParseImageName(destName)
+				if err != nil {
+					t.Fatalf("error parsing destination image name %q: %v", destName, err)
+				}
+				systemContext := types.SystemContext{}
+				options := cp.Options{
+					SourceCtx:      &systemContext,
+					DestinationCtx: &systemContext,
+				}
+				policy, err := signature.DefaultPolicy(&systemContext)
+				if err != nil {
+					t.Fatalf("error loading default signature policy: %v", err)
+				}
+				policyContext, err := signature.NewPolicyContext(policy)
+				if err != nil {
+					t.Fatalf("error loading default signature policy context: %v", err)
+				}
+				_, err = cp.Image(context.TODO(), policyContext, destRef, srcRef, &options)
+				if err == nil {
+					t.Fatalf("expected an error copying the image, but got success")
+				} else {
+					if os.IsNotExist(errors.Cause(err)) {
+						t.Logf("ok: got expected does-not-exist error copying the image with blobs missing: %v", err)
+					} else {
+						t.Logf("got an error copying the image with missing blobs, but not sure which error: %v", err)
+					}
+				}
+				_, err = cp.Image(context.TODO(), policyContext, destRef, cachedSrcRef, &options)
+				if err != nil {
+					t.Fatalf("unexpected error copying the image using the cache: %v", err)
+				}
+				if err = cachedSrcRef.ClearCache(); err != nil {
+					t.Fatalf("error clearing cache: %v", err)
+				}
+			}
+		}
+	}
+}

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -112,6 +112,10 @@ var (
 			Usage: "use `[username[:password]]` for accessing the registry",
 		},
 		cli.BoolFlag{
+			Name:  "disable-compression, D",
+			Usage: "don't compress layers by default",
+		},
+		cli.BoolFlag{
 			Name:  "disable-content-trust",
 			Usage: "This is a Docker specific option and is a NOOP",
 		},

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -196,6 +196,12 @@ var (
 			Name:  "add-host",
 			Usage: "add a custom host-to-IP mapping (`host:ip`) (default [])",
 		},
+		cli.StringFlag{
+			Name:   "blob-cache",
+			Value:  "",
+			Usage:  "assume image blobs in the specified directory will be available for pushing",
+			Hidden: true, // this is here mainly so that we can test the API during integration tests
+		},
 		cli.StringSliceFlag{
 			Name:  "cap-add",
 			Usage: "add the specified capability when running (default [])",

--- a/tests/blobcache.bats
+++ b/tests/blobcache.bats
@@ -1,0 +1,374 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "blobcache-pull" {
+	blobcachedir=${TESTDIR}/cache
+	mkdir -p ${blobcachedir}
+	# Pull an image using a fresh directory for the blob cache.
+	run buildah pull --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json docker.io/kubernetes/pause
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Check that we dropped some files in there.
+	run find ${blobcachedir} -type f
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "${#lines[@]}" -gt 0 ]
+}
+
+@test "blobcache-from" {
+	blobcachedir=${TESTDIR}/cache
+	mkdir -p ${blobcachedir}
+	# Pull an image using a fresh directory for the blob cache.
+	run buildah from --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json docker.io/kubernetes/pause
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Check that we dropped some files in there.
+	run find ${blobcachedir} -type f
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "${#lines[*]}" -gt 0 ]
+}
+
+@test "blobcache-commit" {
+	blobcachedir=${TESTDIR}/cache
+	mkdir -p ${blobcachedir}
+	# Pull an image using a fresh directory for the blob cache.
+	run buildah --debug=false from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json docker.io/kubernetes/pause
+	echo "$output"
+	ctr="$output"
+	[ "$status" -eq 0 ]
+	run buildah add ${ctr} ${TESTSDIR}/bud/add-file/file /
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Commit the image without using the blob cache.
+	doomeddir=${TESTDIR}/doomed
+	mkdir -p ${doomeddir}
+	ls -l ${blobcachedir}
+	echo buildah commit --signature-policy ${TESTSDIR}/policy.json ${ctr} dir:${doomeddir}
+	run buildah commit --signature-policy ${TESTSDIR}/policy.json ${ctr} dir:${doomeddir}
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Look for layer blobs in the destination that match the ones in the cache.
+	matched=0
+	unmatched=0
+	for content in ${doomeddir}/* ; do
+		match=false
+		for blob in ${blobcachedir}/* ; do
+			if cmp -s ${content} ${blob} ; then
+				echo $(file ${blob}) and ${content} have the same contents, was cached
+				match=true
+				break
+			fi
+		done
+		if ${match} ; then
+			matched=$(( ${matched} + 1 ))
+		else
+			unmatched=$(( ${unmatched} + 1 ))
+			echo ${content} was not cached
+		fi
+	done
+	[ ${matched} -eq 0 ] # nothing should match items in the cache
+	[ ${unmatched} -eq 6 ] # nothing should match items in the cache
+	# Commit the image using the blob cache.
+	destdir=${TESTDIR}/dest
+	mkdir -p ${destdir}
+	ls -l ${blobcachedir}
+	echo buildah commit --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} ${ctr} dir:${destdir}
+	run buildah commit --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} ${ctr} dir:${destdir}
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Look for layer blobs in the destination that match the ones in the cache.
+	matched=0
+	unmatched=0
+	for content in ${destdir}/* ; do
+		match=false
+		for blob in ${blobcachedir}/* ; do
+			if cmp -s ${content} ${blob} ; then
+				echo $(file ${blob}) and ${content} have the same contents, was cached
+				match=true
+				break
+			fi
+		done
+		if ${match} ; then
+			matched=$(( ${matched} + 1 ))
+		else
+			unmatched=$(( ${unmatched} + 1 ))
+			echo ${content} was not cached
+		fi
+	done
+	[ ${matched} -eq 5 ] # the base layers, our new layer, our config, and manifest should match items in the cache
+	[ ${unmatched} -eq 1 ] # the version shouldn't match an item in the cache
+}
+
+@test "blobcache-push" {
+	target=targetimage
+	blobcachedir=${TESTDIR}/cache
+	mkdir -p ${blobcachedir}
+	# Pull an image using a fresh directory for the blob cache.
+	run buildah --debug=false from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json docker.io/kubernetes/pause
+	echo "$output"
+	ctr="$output"
+	[ "$status" -eq 0 ]
+	run buildah add ${ctr} ${TESTSDIR}/bud/add-file/file /
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Commit the image using the blob cache.
+	ls -l ${blobcachedir}
+	echo buildah commit --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} ${ctr} ${target}
+	run buildah commit --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} ${ctr} ${target}
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Try to push the image without the blob cache.
+	doomeddir=${TESTDIR}/doomed
+	mkdir -p ${doomeddir}
+	ls -l ${blobcachedir}
+	echo buildah push --signature-policy ${TESTSDIR}/policy.json ${target} dir:${doomeddir}
+	run buildah push --signature-policy ${TESTSDIR}/policy.json ${target} dir:${doomeddir}
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Look for layer blobs in the doomed copy that match the ones in the cache.
+	matched=0
+	unmatched=0
+	for content in ${doomeddir}/* ; do
+		match=false
+		for blob in ${blobcachedir}/* ; do
+			if cmp -s ${content} ${blob} ; then
+				echo $(file ${blob}) and ${content} have the same contents, was cached
+				match=true
+				break
+			fi
+		done
+		if ${match} ; then
+			matched=$(( ${matched} + 1 ))
+		else
+			unmatched=$(( ${unmatched} + 1 ))
+			echo ${content} was not cached
+		fi
+	done
+	[ ${matched} -eq 2 ] # basically, only the config and our new layer should be the same as anything in the cache
+	[ ${unmatched} -eq 4 ] # none of the version, manifest, and base layers should match items in the cache, since the base layers were recompressed
+	# Now try to push the image using the blob cache.
+	destdir=${TESTDIR}/dest
+	mkdir -p ${destdir}
+	ls -l ${blobcachedir}
+	echo buildah push --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} ${target} dir:${destdir}
+	run buildah push --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} ${target} dir:${destdir}
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Look for layer blobs in the destination that match the ones in the cache.
+	matched=0
+	unmatched=0
+	for content in ${destdir}/* ; do
+		match=false
+		for blob in ${blobcachedir}/* ; do
+			if cmp -s ${content} ${blob} ; then
+				echo $(file ${blob}) and ${content} have the same contents, was cached
+				match=true
+				break
+			fi
+		done
+		if ${match} ; then
+			matched=$(( ${matched} + 1 ))
+		else
+			unmatched=$(( ${unmatched} + 1 ))
+			echo ${content} was not cached
+		fi
+	done
+	[ ${matched} -eq 5 ] # the base image's layers, our new layer, the config, and the manifest should already have been cached
+	[ ${unmatched} -eq 1 ] # expected mismatch is only the "version"
+}
+
+@test "blobcache-build-compressed-using-dockerfile-explicit-push" {
+	blobcachedir=${TESTDIR}/cache
+	mkdir -p ${blobcachedir}
+	target=new-image
+	# Build an image while pulling the base image.
+	run buildah build-using-dockerfile -t ${target} --pull-always --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/add-file
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Try to push the image without the blob cache.
+	doomeddir=${TESTDIR}/doomed
+	mkdir -p ${doomeddir}
+	run buildah push --signature-policy ${TESTSDIR}/policy.json ${target} dir:${doomeddir}
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Look for layer blobs in the destination that match the ones in the cache.
+	matched=0
+	unmatched=0
+	for content in ${doomeddir}/* ; do
+		match=false
+		for blob in ${blobcachedir}/* ; do
+			if cmp -s ${content} ${blob} ; then
+				echo $(file ${blob}) and ${content} have the same contents, was cached
+				match=true
+				break
+			fi
+		done
+		if ${match} ; then
+			matched=$(( ${matched} + 1 ))
+		else
+			unmatched=$(( ${unmatched} + 1 ))
+			echo ${content} was not cached
+		fi
+	done
+	[ ${matched} -eq 4 ] # the base layer, our new layer, config, and manifest should all match the cache
+	[ ${unmatched} -eq 1 ] # the only mismatch should be "version"
+	# Now try to push the image using the blob cache.
+	destdir=${TESTDIR}/dest
+	mkdir -p ${destdir}
+	run buildah push --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} ${target} dir:${destdir}
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Look for layer blobs in the destination that match the ones in the cache.
+	matched=0
+	unmatched=0
+	for content in ${destdir}/* ; do
+		match=false
+		for blob in ${blobcachedir}/* ; do
+			if cmp -s ${content} ${blob} ; then
+				echo $(file ${blob}) and ${content} have the same contents, was cached
+				match=true
+				break
+			fi
+		done
+		if ${match} ; then
+			matched=$(( ${matched} + 1 ))
+		else
+			unmatched=$(( ${unmatched} + 1 ))
+			echo ${content} was not cached
+		fi
+	done
+	[ ${matched} -eq 4 ] # the config, the base layer, our new layer, and the manifest should match the cache
+	[ ${unmatched} -eq 1 ] # the only expected mismatch should be "version"
+}
+
+@test "blobcache-build-uncompressed-using-dockerfile-explicit-push" {
+	blobcachedir=${TESTDIR}/cache
+	mkdir -p ${blobcachedir}
+	target=new-image
+	# Build an image while pulling the base image.
+	run buildah build-using-dockerfile -t ${target} -D --pull-always --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/add-file
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Try to push the image without the blob cache.
+	doomeddir=${TESTDIR}/doomed
+	mkdir -p ${doomeddir}
+	run buildah push --signature-policy ${TESTSDIR}/policy.json ${target} dir:${doomeddir}
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Look for layer blobs in the destination that match the ones in the cache.
+	matched=0
+	unmatched=0
+	for content in ${doomeddir}/* ; do
+		match=false
+		for blob in ${blobcachedir}/* ; do
+			if cmp -s ${content} ${blob} ; then
+				echo $(file ${blob}) and ${content} have the same contents, was cached
+				match=true
+				break
+			fi
+		done
+		if ${match} ; then
+			matched=$(( ${matched} + 1 ))
+		else
+			unmatched=$(( ${unmatched} + 1 ))
+			echo ${content} was not cached
+		fi
+	done
+	[ ${matched} -eq 2 ] # our new layer (written at build-time) and config should match the cache
+	[ ${unmatched} -eq 3 ] # expected mismatches should be "version", and the base layers, which had to be recompressed
+	# Now try to push the image using the blob cache.
+	destdir=${TESTDIR}/dest
+	mkdir -p ${destdir}
+	run buildah push --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} ${target} dir:${destdir}
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Look for layer blobs in the destination that match the ones in the cache.
+	matched=0
+	unmatched=0
+	for content in ${destdir}/* ; do
+		match=false
+		for blob in ${blobcachedir}/* ; do
+			if cmp -s ${content} ${blob} ; then
+				echo $(file ${blob}) and ${content} have the same contents, was cached
+				match=true
+				break
+			fi
+		done
+		if ${match} ; then
+			matched=$(( ${matched} + 1 ))
+		else
+			unmatched=$(( ${unmatched} + 1 ))
+			echo ${content} was not cached
+		fi
+	done
+	[ ${matched} -eq 2 ] # the config and previously-compressed base layer should match the cache
+	[ ${unmatched} -eq 3 ] # expected "version", our new layer, and the manifest to mismatch
+}
+
+@test "blobcache-build-compressed-using-dockerfile-implicit-push" {
+	blobcachedir=${TESTDIR}/cache
+	mkdir -p ${blobcachedir}
+	target=new-image
+	destdir=${TESTDIR}/dest
+	mkdir -p ${destdir}
+	# Build an image while pulling the base image, implicitly pushing while writing.
+	run buildah build-using-dockerfile -t dir:${destdir} --pull-always --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/add-file
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Look for layer blobs in the destination that match the ones in the cache.
+	matched=0
+	unmatched=0
+	for content in ${destdir}/* ; do
+		match=false
+		for blob in ${blobcachedir}/* ; do
+			if cmp -s ${content} ${blob} ; then
+				echo $(file ${blob}) and ${content} have the same contents, was cached
+				match=true
+				break
+			fi
+		done
+		if ${match} ; then
+			matched=$(( ${matched} + 1 ))
+		else
+			unmatched=$(( ${unmatched} + 1 ))
+			echo ${content} was not cached
+		fi
+	done
+	[ ${matched} -eq 4 ] # the layers from the base image, our layer, our config, and our manifest should match items in the cache
+	[ ${unmatched} -eq 1 ] # expect only the "version" to not match the cache
+}
+
+@test "blobcache-build-uncompressed-using-dockerfile-implicit-push" {
+	blobcachedir=${TESTDIR}/cache
+	mkdir -p ${blobcachedir}
+	target=new-image
+	destdir=${TESTDIR}/dest
+	mkdir -p ${destdir}
+	# Build an image while pulling the base image, implicitly pushing while writing.
+	run buildah build-using-dockerfile -t dir:${destdir} -D --pull-always --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/add-file
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# Look for layer blobs in the destination that match the ones in the cache.
+	matched=0
+	unmatched=0
+	for content in ${destdir}/* ; do
+		match=false
+		for blob in ${blobcachedir}/* ; do
+			if cmp -s ${content} ${blob} ; then
+				echo $(file ${blob}) and ${content} have the same contents, was cached
+				match=true
+				break
+			fi
+		done
+		if ${match} ; then
+			matched=$(( ${matched} + 1 ))
+		else
+			unmatched=$(( ${unmatched} + 1 ))
+			echo ${content} was not cached
+		fi
+	done
+	[ ${matched} -eq 4 ] # the layers from the base image, our layer, our config, and our manifest should match items in the cache
+	[ ${unmatched} -eq 1 ] # expect only the "version" to not match the cache
+}

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -26,7 +26,7 @@ load helpers
       buildah commit -D ${format:+--format ${format}} --reference-time ${TESTDIR}/reference-time-file --signature-policy ${TESTSDIR}/policy.json "$cid" scratch-image${format:+-${format}}
       buildah commit -D ${format:+--format ${format}} --reference-time ${TESTDIR}/reference-time-file --signature-policy ${TESTSDIR}/policy.json "$cid" dir:${TESTDIR}/committed${format:+.${format}}
       mkdir -p ${TESTDIR}/pushed${format:+.${format}}
-      buildah push --signature-policy ${TESTSDIR}/policy.json scratch-image${format:+-${format}} dir:${TESTDIR}/pushed${format:+.${format}}
+      buildah push -D --signature-policy ${TESTSDIR}/policy.json scratch-image${format:+-${format}} dir:${TESTDIR}/pushed${format:+.${format}}
       # Reencode the manifest to lose variations due to different encoders or definitions of structures.
       imgtype -expected-manifest-type "*" -rebuild-manifest -show-manifest dir:${TESTDIR}/committed${format:+.${format}} > ${TESTDIR}/manifest.committed${format:+.${format}}
       imgtype -expected-manifest-type "*" -rebuild-manifest -show-manifest dir:${TESTDIR}/pushed${format:+.${format}} > ${TESTDIR}/manifest.pushed${format:+.${format}}


### PR DESCRIPTION
Add a blob cache reference type which wraps other reference types.  When used to create source and destination images for copying, it returns wrappers for source and destination images created by the wrapped references.

The cache reference can be created with a specified directory, or it will create a temporary directory of its own.  When told to clear its cache, if a temporary directory is being used, the reference will also remove the temporary directory.

Blobs that are written to a cache image destination are stored as-is on disk.  When reading a blob from a cache image source, if a blob with the matching digest (and if specified, a matching size) can be found on disk, read it directly instead of reading it from the real image source.

Add API hooks for designating locations to be used as blob caches when pulling and pushing images.  When we commit read-only copies of container layers for use in images, if we're using blob caching, store a copy of the layer in the blob cache directory so that it can be found.