### PR TITLE
Fixing broken link for container-registries.conf

### DIFF
--- a/install.md
+++ b/install.md
@@ -203,7 +203,7 @@ The build steps on Debian are otherwise the same as Ubuntu, above.
 
 ### [registries.conf](https://src.fedoraproject.org/rpms/skopeo/blob/master/f/registries.conf)
 
-#### Man Page: [registries.conf.5](https://github.com/containers/image/blob/master/docs/registries.conf.5.md)
+#### Man Page: [registries.conf.5](https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md)
 
 `/etc/containers/registries.conf`
 


### PR DESCRIPTION
The link to the container-registries.conf man page was a little off - this fixes it.

This patch was originaly submitted by Kris Nova <kris@nivenly.com>
I am signing it to get it merged.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>