### PR TITLE
Exclude --force-rm from common bud cli flags

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -279,7 +279,7 @@ func (b *Executor) Preserve(path string) error {
 
 	// Try and resolve the symlink (if one exists)
 	// Set archivedPath and path based on whether a symlink is found or not
-	if symLink, err := resolveSymLink(b.mountPoint, path); err == nil {
+	if symLink, err := ResolveSymLink(b.mountPoint, path); err == nil {
 		archivedPath = filepath.Join(b.mountPoint, symLink)
 		path = symLink
 	} else {

--- a/imagebuildah/chroot_symlink.go
+++ b/imagebuildah/chroot_symlink.go
@@ -57,9 +57,9 @@ func resolveChrootedSymlinks() {
 	os.Exit(status)
 }
 
-// resolveSymLink (in the grandparent process) resolves any symlink in filename
+// ResolveSymLink (in the grandparent process) resolves any symlink in filename
 // in the context of rootdir.
-func resolveSymLink(rootdir, filename string) (string, error) {
+func ResolveSymLink(rootdir, filename string) (string, error) {
 	// The child process expects a chroot and one path that
 	// will be consulted relative to the chroot directory and evaluated
 	// for any symbolic links present.

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -71,6 +71,10 @@ var (
 
 	LayerFlags = []cli.Flag{
 		cli.BoolFlag{
+			Name:  "force-rm",
+			Usage: "Always remove intermediate containers after a build, even if the build is unsuccessful.",
+		},
+		cli.BoolFlag{
 			Name:  "layers",
 			Usage: fmt.Sprintf("cache intermediate layers during build. Use BUILDAH_LAYERS environment variable to override. (default %t)", UseLayers()),
 		},
@@ -114,10 +118,6 @@ var (
 		cli.StringSliceFlag{
 			Name:  "file, f",
 			Usage: "`pathname or URL` of a Dockerfile",
-		},
-		cli.BoolFlag{
-			Name:  "force-rm",
-			Usage: "Always remove intermediate containers after a build, even if the build is unsuccessful.",
 		},
 		cli.StringFlag{
 			Name:  "format",


### PR DESCRIPTION
Need this so we can override it to true by default in podman.

Used in fixing this https://github.com/containers/libpod/issues/1586

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>