### PR TITLE
unshare: Fix running errors in non-privileged container

### DIFF
--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -63,8 +63,7 @@ func maybeReexecUsingUserNamespace(c *cli.Context, evenForRoot bool) {
 	if c.NArg() == 0 {
 		return
 	}
-	switch c.Args()[0] {
-	case "help", "version":
+	if c.Args()[0] != "run" {
 		return
 	}
 


### PR DESCRIPTION
Solve the problem that buildah cannot be run in a non-privileged container. Although the non-privileged container cannot run the container, other commands can be executed, so all commands should not be reported and other commands should be executed.

No commands can be executed (except help and version) before modification:
```
root@zz-ubuntu-6fcc5f5d55-4plr7:~# buildah images
Error during unshare(CLONE_NEWUSER): Invalid argument
User namespaces are not enabled in /proc/sys/user/max_user_namespaces.
ERRO[0000] error parsing PID "": strconv.Atoi: parsing "": invalid syntax
ERRO[0000] (unable to determine exit status)
root@zz-ubuntu-6fcc5f5d55-4plr7:~# buildah pull busybox
Error during unshare(CLONE_NEWUSER): Invalid argument
User namespaces are not enabled in /proc/sys/user/max_user_namespaces.
ERRO[0000] error parsing PID "": strconv.Atoi: parsing "": invalid syntax
ERRO[0000] (unable to determine exit status)
```

After the modification, only the run command cannot be executed (because there is no permission to execute):
```
root@zz-ubuntu-6fcc5f5d55-4plr7:~# buildah pull busybox                                                                                                                        [33/1810]
Getting image source signatures
Copying blob sha256:90e01955edcd85dac7985b72a8374545eac617ccdddcc992b732e43cd42534af
 710.92 KiB / 710.92 KiB [==================================================] 1s
Copying config sha256:59788edf1f3e78cd0ebe6ce1446e9d10788225db3dedcfd1a59f764bad2b2690
 1.46 KiB / 1.46 KiB [======================================================] 0s
Writing manifest to image destination
Storing signatures
59788edf1f3e78cd0ebe6ce1446e9d10788225db3dedcfd1a59f764bad2b2690
root@zz-ubuntu-6fcc5f5d55-4plr7:~# buildah images
IMAGE ID             IMAGE NAME                                               CREATED AT             SIZE
59788edf1f3e         docker.io/library/busybox:latest                         Oct 2, 2018 17:19      1.37 MB
root@zz-ubuntu-6fcc5f5d55-4plr7:~# buildah from 597
busybox-working-container
root@zz-ubuntu-6fcc5f5d55-4plr7:~# buildah run busybox-working-container bash
Error during unshare(CLONE_NEWUSER): Invalid argument
User namespaces are not enabled in /proc/sys/user/max_user_namespaces.
ERRO[0000] error parsing PID "": strconv.Atoi: parsing "": invalid syntax
ERRO[0000] (unable to determine exit status)
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>