### PR TITLE
Fix cache issue with COPY/ADD --from

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -222,7 +222,7 @@ type Executor struct {
 	forceRmIntermediateCtrs        bool
 	containerIDs                   []string          // Stores the IDs of the successful intermediate containers used during layer build
 	imageMap                       map[string]string // Used to map images that we create to handle the AS construct.
-
+	copyFrom                       string            // Used to keep track of the --from flag from COPY and ADD
 }
 
 // withName creates a new child executor that will be used whenever a COPY statement uses --from=NAME.
@@ -826,6 +826,18 @@ func (b *Executor) Execute(ctx context.Context, stage imagebuilder.Stage) error 
 			err     error
 			imgID   string
 		)
+
+		b.copyFrom = ""
+		// Check if --from exists in the step command of COPY or ADD
+		// If it exists, set b.copyfrom to that value
+		for _, n := range step.Flags {
+			if strings.Contains(n, "--from") && (step.Command == "copy" || step.Command == "add") {
+				arr := strings.Split(n, "=")
+				b.copyFrom = b.named[arr[1]].mountPoint
+				break
+			}
+		}
+
 		// checkForLayers will be true if b.layers is true and a cached intermediate image is found.
 		// checkForLayers is set to false when either there is no cached image or a break occurs where
 		// the instructions in the Dockerfile change from a previous build.
@@ -848,6 +860,7 @@ func (b *Executor) Execute(ctx context.Context, stage imagebuilder.Stage) error 
 			if err := b.copyExistingImage(ctx, cacheID); err != nil {
 				return err
 			}
+			b.containerIDs = append(b.containerIDs, b.builder.ContainerID)
 			break
 		}
 
@@ -1009,6 +1022,11 @@ func (b *Executor) getFilesToCopy(node *parser.Node) ([]string, error) {
 			currNode = currNode.Next
 			continue
 		}
+		if b.copyFrom != "" {
+			src = append(src, filepath.Join(b.copyFrom, currNode.Value))
+			currNode = currNode.Next
+			continue
+		}
 		matches, err := filepath.Glob(filepath.Join(b.contextDir, currNode.Value))
 		if err != nil {
 			return nil, errors.Wrapf(err, "error finding match for pattern %q", currNode.Value)
@@ -1049,7 +1067,12 @@ func (b *Executor) copiedFilesMatch(node *parser.Node, historyTime *time.Time) (
 		// Change the time format to ensure we don't run into a parsing error when converting again from string
 		// to time.Time. It is a known Go issue that the conversions cause errors sometimes, so specifying a particular
 		// time format here when converting to a string.
-		timeIsGreater, err := resolveModifiedTime(b.contextDir, item, historyTime.Format(time.RFC3339Nano))
+		// If the COPY has --from in the command, change the rootdir to mountpoint of the container it is copying from
+		rootdir := b.contextDir
+		if b.copyFrom != "" {
+			rootdir = b.copyFrom
+		}
+		timeIsGreater, err := resolveModifiedTime(rootdir, item, historyTime.Format(time.RFC3339Nano))
 		if err != nil {
 			return false, errors.Wrapf(err, "error resolving symlinks and comparing modified times: %q", item)
 		}

--- a/tests/bud/use-layers/Dockerfile.multistage-copy
+++ b/tests/bud/use-layers/Dockerfile.multistage-copy
@@ -1,0 +1,9 @@
+FROM alpine AS uuid
+COPY uuid /src
+
+FROM alpine AS date
+COPY date /src
+
+FROM alpine
+COPY --from=uuid /src/data /uuid
+COPY --from=date /src/data /date


### PR DESCRIPTION
In multi-stage builds, it is possible to copy data from
a previous build. When using cached images, buildah wasn't
able to detect a change in the previous build and would proceed
to use cached images. Fix buildah bud to be keep track of any
files coming from a previous build and checking whether the cached
image is still valid or not.
Also fix removal of intermediate build containers when building
from cache. We were not keeping track of those containers so they
weren't getting deleted at the end of the build process.

Fixes https://github.com/containers/buildah/issues/1179

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>