### PR TITLE
Assume user 0 group 0, if /etc/passwd file in container.

### DIFF
--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -68,13 +68,16 @@ func maybeReexecUsingUserNamespace(c *cli.Context, evenForRoot bool) {
 		return
 	}
 
+	var uidNum, gidNum uint64
 	// Figure out who we are.
 	me, err := user.Current()
-	bailOnError(err, "error determining current user")
-	uidNum, err := strconv.ParseUint(me.Uid, 10, 32)
-	bailOnError(err, "error parsing current UID %s", me.Uid)
-	gidNum, err := strconv.ParseUint(me.Gid, 10, 32)
-	bailOnError(err, "error parsing current GID %s", me.Gid)
+	if !os.IsNotExist(err) {
+		bailOnError(err, "error determining current user")
+		uidNum, err = strconv.ParseUint(me.Uid, 10, 32)
+		bailOnError(err, "error parsing current UID %s", me.Uid)
+		gidNum, err = strconv.ParseUint(me.Gid, 10, 32)
+		bailOnError(err, "error parsing current GID %s", me.Gid)
+	}
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()


### PR DESCRIPTION
While attempting to run buildah in a container without an /etc/passwd, it is
blowing up.  This change will cause buildah to assume that it is running as
root.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>