### PR TITLE
vendor: update selinux

### DIFF
--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
@@ -687,7 +687,11 @@ func Chcon(fpath string, label string, recurse bool) error {
 		return err
 	}
 	callback := func(p string, info os.FileInfo, err error) error {
-		return SetFileLabel(p, label)
+		e := SetFileLabel(p, label)
+		if os.IsNotExist(e) {
+			return nil
+		}
+		return e
 	}
 
 	if recurse {


### PR DESCRIPTION
inherit a change for not failing a recursive relabelling if the file
is removed between the directory is read and the lsetxattr syscall.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>