### PR TITLE
Add buildah info command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ RUNC_COMMIT := 2c632d1a2de0192c3f18a2542ccb6f30a8719b1f
 LIBSECCOMP_COMMIT := release-2.3
 
 EXTRALDFLAGS :=
-LDFLAGS := -ldflags '-X main.gitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO} -X main.cniVersion=${CNI_COMMIT}' ${EXTRALDFLAGS}
+LDFLAGS := -ldflags '-X main.GitCommit=${GIT_COMMIT} -X main.buildInfo=${BUILD_INFO} -X main.cniVersion=${CNI_COMMIT}' ${EXTRALDFLAGS}
 SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go cmd/buildah/*.go docker/*.go pkg/cli/*.go pkg/parse/*.go unshare/*.c unshare/*.go util/*.go
 
 all: buildah imgtype docs

--- a/cmd/buildah/info.go
+++ b/cmd/buildah/info.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"runtime"
+	"text/template"
+
+	"github.com/containers/buildah"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var (
+	infoDescription = "The information displayed pertains to the host and current storage statistics which is useful when reporting issues."
+	infoFlags       = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "debug, D",
+			Usage: "display additional debug information",
+		},
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "use `format` as a Go template to format the output",
+		},
+	}
+	infoCommand = cli.Command{
+		Name:                   "info",
+		Usage:                  "Display Buildah system information",
+		Description:            infoDescription,
+		Action:                 infoCmd,
+		Flags:                  sortFlags(infoFlags),
+		SkipArgReorder:         true,
+		UseShortOptionHandling: true,
+	}
+)
+
+func infoCmd(c *cli.Context) error {
+	if len(c.Args()) > 0 {
+		return errors.New("'buildah info' does not accept arguments")
+	}
+
+	if err := parse.ValidateFlags(c, infoFlags); err != nil {
+		return err
+	}
+	info := map[string]interface{}{}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	infoArr, err := buildah.Info(store)
+	if err != nil {
+		return errors.Wrapf(err, "error getting info")
+	}
+
+	if c.Bool("debug") {
+		debugInfo := debugInfo(c)
+		infoArr = append(infoArr, buildah.InfoData{Type: "debug", Data: debugInfo})
+	}
+
+	for _, currInfo := range infoArr {
+		info[currInfo.Type] = currInfo.Data
+	}
+
+	if c.IsSet("format") {
+		format := c.String("format")
+		if matched, err := regexp.MatchString("{{.*}}", format); err != nil {
+			return errors.Wrapf(err, "error validating format provided: %s", format)
+		} else if !matched {
+			return errors.Errorf("error invalid format provided: %s", format)
+		}
+		t, err := template.New("format").Parse(format)
+		if err != nil {
+			return errors.Wrapf(err, "Template parsing error")
+		}
+		if err = t.Execute(os.Stdout, info); err != nil {
+			return err
+		}
+		if terminal.IsTerminal(int(os.Stdout.Fd())) {
+			fmt.Println()
+		}
+		return nil
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "    ")
+	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+		enc.SetEscapeHTML(false)
+	}
+	return enc.Encode(info)
+}
+
+// top-level "debug" info
+func debugInfo(c *cli.Context) map[string]interface{} {
+	info := map[string]interface{}{}
+	info["compiler"] = runtime.Compiler
+	info["go version"] = runtime.Version()
+	info["buildah version"] = buildah.Version
+	info["git commit"] = GitCommit
+	return info
+}

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -110,6 +110,7 @@ func main() {
 		copyCommand,
 		fromCommand,
 		imagesCommand,
+		infoCommand,
 		inspectCommand,
 		mountCommand,
 		pullCommand,

--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -16,7 +16,7 @@ import (
 
 //Overwritten at build time
 var (
-	gitCommit  string
+	GitCommit  string
 	buildInfo  string
 	cniVersion string
 )
@@ -43,7 +43,7 @@ func versionCmd(c *cli.Context) error {
 	fmt.Println("Runtime Spec:   ", rspecs.Version)
 	fmt.Println("CNI Spec:       ", cniversion.Current())
 	fmt.Println("libcni Version: ", cniVersion)
-	fmt.Println("Git Commit:     ", gitCommit)
+	fmt.Println("Git Commit:     ", GitCommit)
 
 	//Prints out the build time in readable format
 	fmt.Println("Built:          ", time.Unix(buildTime, 0).Format(time.ANSIC))

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -711,6 +711,22 @@ return 1
      esac
  }
 
+ _buildah_info() {
+     local options_with_args="
+       --debug
+       --D
+       --format
+     "
+
+     local all_options="$options_with_args"
+
+     case "$cur" in
+         -*)
+             COMPREPLY=($(compgen -W "$options_with_args" -- "$cur"))
+             ;;
+     esac
+}
+
  _buildah_inspect() {
      local options_with_args="
        --format
@@ -846,6 +862,7 @@ return 1
        delete
        from
        images
+       info
        inspect
        mount
        pull

--- a/docs/buildah-info.md
+++ b/docs/buildah-info.md
@@ -1,0 +1,71 @@
+# buildah-info "1" "November 2018" "Buildah"
+
+## NAME
+buildah\-info - Display Buildah system information.
+
+## SYNOPSIS
+**buildah info** [*options*]
+
+## DESCRIPTION
+The information displayed pertains to the host and current storage statistics which is useful when reporting issues.
+
+## OPTIONS
+**--debug, -D**
+Show additional information.
+
+**--format** *template*
+
+Use *template* as a Go template when formatting the output.
+
+## EXAMPLE
+Run buildah info response:
+```
+$ buildah info
+{
+    "host": {
+        "Distribution": {
+            "distribution": "ubuntu",
+            "version": "18.04"
+        },
+        "MemTotal": 16702980096,
+        "MenFree": 309428224,
+        "SwapFree": 2146693120,
+        "SwapTotal": 2147479552,
+        "arch": "amd64",
+        "cpus": 4,
+        "hostname": "localhost.localdomain",
+        "kernel": "4.15.0-36-generic",
+        "os": "linux",
+        "rootless": false,
+        "uptime": "91h 30m 59.9s (Approximately 3.79 days)"
+    },
+    "store": {
+        "ContainerStore": {
+            "number": 2
+        },
+        "GraphDriverName": "overlay",
+        "GraphOptions": [
+            "overlay.override_kernel_check=true"
+        ],
+        "GraphRoot": "/var/lib/containers/storage",
+        "GraphStatus": {
+            "Backing Filesystem": "extfs",
+            "Native Overlay Diff": "true",
+            "Supports d_type": "true"
+        },
+        "ImageStore": {
+            "number": 1
+        },
+        "RunRoot": "/var/run/containers/storage"
+    }
+}
+```
+
+Run buildah info and retrieve only the store information:
+```
+$ buildah info --format={{".store"}}
+map[GraphOptions:[overlay.override_kernel_check=true] GraphStatus:map[Backing Filesystem:extfs Supports d_type:true Native Overlay Diff:true] ImageStore:map[number:1] ContainerStore:map[number:2] GraphRoot:/var/lib/containers/storage RunRoot:/var/run/containers/storage GraphDriverName:overlay]
+```
+
+## SEE ALSO
+buildah(1)

--- a/info.go
+++ b/info.go
@@ -1,0 +1,207 @@
+package buildah
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/containers/libpod/pkg/rootless"
+	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/system"
+	"github.com/sirupsen/logrus"
+)
+
+// InfoData holds the info type, i.e store, host etc and the data for each type
+type InfoData struct {
+	Type string
+	Data map[string]interface{}
+}
+
+// Info returns the store and host information
+func Info(store storage.Store) ([]InfoData, error) {
+	info := []InfoData{}
+	// get host information
+	hostInfo, err := hostInfo()
+	if err != nil {
+		logrus.Error(err, "error getting host info")
+	}
+	info = append(info, InfoData{Type: "host", Data: hostInfo})
+
+	// get store information
+	storeInfo, err := storeInfo(store)
+	if err != nil {
+		logrus.Error(err, "error getting store info")
+	}
+	info = append(info, InfoData{Type: "store", Data: storeInfo})
+	return info, nil
+}
+
+func hostInfo() (map[string]interface{}, error) {
+	info := map[string]interface{}{}
+	info["os"] = runtime.GOOS
+	info["arch"] = runtime.GOARCH
+	info["cpus"] = runtime.NumCPU()
+	info["rootless"] = rootless.IsRootless()
+	mi, err := system.ReadMemInfo()
+	if err != nil {
+		logrus.Error(err, "err reading memory info")
+		info["MemTotal"] = ""
+		info["MenFree"] = ""
+		info["SwapTotal"] = ""
+		info["SwapFree"] = ""
+	} else {
+		info["MemTotal"] = mi.MemTotal
+		info["MenFree"] = mi.MemFree
+		info["SwapTotal"] = mi.SwapTotal
+		info["SwapFree"] = mi.SwapFree
+	}
+	hostDistributionInfo := getHostDistributionInfo()
+	info["Distribution"] = map[string]interface{}{
+		"distribution": hostDistributionInfo["Distribution"],
+		"version":      hostDistributionInfo["Version"],
+	}
+
+	kv, err := readKernelVersion()
+	if err != nil {
+		logrus.Error(err, "error reading kernel version")
+	}
+	info["kernel"] = kv
+
+	up, err := readUptime()
+	if err != nil {
+		logrus.Error(err, "error reading up time")
+	}
+	// Convert uptime in seconds to a human-readable format
+	upSeconds := up + "s"
+	upDuration, err := time.ParseDuration(upSeconds)
+	if err != nil {
+		logrus.Error(err, "error parsing system uptime")
+	}
+
+	hoursFound := false
+	var timeBuffer bytes.Buffer
+	var hoursBuffer bytes.Buffer
+	for _, elem := range upDuration.String() {
+		timeBuffer.WriteRune(elem)
+		if elem == 'h' || elem == 'm' {
+			timeBuffer.WriteRune(' ')
+			if elem == 'h' {
+				hoursFound = true
+			}
+		}
+		if !hoursFound {
+			hoursBuffer.WriteRune(elem)
+		}
+	}
+
+	info["uptime"] = timeBuffer.String()
+	if hoursFound {
+		hours, err := strconv.ParseFloat(hoursBuffer.String(), 64)
+		if err == nil {
+			days := hours / 24
+			info["uptime"] = fmt.Sprintf("%s (Approximately %.2f days)", info["uptime"], days)
+		}
+	}
+
+	host, err := os.Hostname()
+	if err != nil {
+		logrus.Error(err, "error getting hostname")
+	}
+	info["hostname"] = host
+
+	return info, nil
+
+}
+
+// top-level "store" info
+func storeInfo(store storage.Store) (map[string]interface{}, error) {
+	// lets say storage driver in use, number of images, number of containers
+	info := map[string]interface{}{}
+	info["GraphRoot"] = store.GraphRoot()
+	info["RunRoot"] = store.RunRoot()
+	info["GraphDriverName"] = store.GraphDriverName()
+	info["GraphOptions"] = store.GraphOptions()
+	statusPairs, err := store.Status()
+	if err != nil {
+		return nil, err
+	}
+	status := map[string]string{}
+	for _, pair := range statusPairs {
+		status[pair[0]] = pair[1]
+	}
+	info["GraphStatus"] = status
+	images, err := store.Images()
+	if err != nil {
+		logrus.Error(err, "error getting number of images")
+	}
+	info["ImageStore"] = map[string]interface{}{
+		"number": len(images),
+	}
+
+	containers, err := store.Containers()
+	if err != nil {
+		logrus.Error(err, "error getting number of containers")
+	}
+	info["ContainerStore"] = map[string]interface{}{
+		"number": len(containers),
+	}
+
+	return info, nil
+}
+
+func readKernelVersion() (string, error) {
+	buf, err := ioutil.ReadFile("/proc/version")
+	if err != nil {
+		return "", err
+	}
+	f := bytes.Fields(buf)
+	if len(f) < 2 {
+		return string(bytes.TrimSpace(buf)), nil
+	}
+	return string(f[2]), nil
+}
+
+func readUptime() (string, error) {
+	buf, err := ioutil.ReadFile("/proc/uptime")
+	if err != nil {
+		return "", err
+	}
+	f := bytes.Fields(buf)
+	if len(f) < 1 {
+		return "", fmt.Errorf("invalid uptime")
+	}
+	return string(f[0]), nil
+}
+
+// getHostDistributionInfo returns a map containing the host's distribution and version
+func getHostDistributionInfo() map[string]string {
+	dist := make(map[string]string)
+
+	// Populate values in case we cannot find the values
+	// or the file
+	dist["Distribution"] = "unknown"
+	dist["Version"] = "unknown"
+
+	f, err := os.Open("/etc/os-release")
+	if err != nil {
+		return dist
+	}
+	defer f.Close()
+
+	l := bufio.NewScanner(f)
+	for l.Scan() {
+		if strings.HasPrefix(l.Text(), "ID=") {
+			dist["Distribution"] = strings.TrimPrefix(l.Text(), "ID=")
+		}
+		if strings.HasPrefix(l.Text(), "VERSION_ID=") {
+			dist["Version"] = strings.Trim(strings.TrimPrefix(l.Text(), "VERSION_ID="), "\"")
+		}
+	}
+	return dist
+}

--- a/tests/info.bats
+++ b/tests/info.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "info" {
+  out1=$(buildah info | grep "host" | wc -l)
+  [ "$out1" -ne "0" ]
+
+  out2=$(buildah info --format='{{.store}}')
+  [ "$out2" != "" ]
+}


### PR DESCRIPTION
Add info command to display buildah system information.

```
$ buildah info
{
    "host": {
        "Distribution": {
            "distribution": "ubuntu",
            "version": "18.04"
        },
        "MemTotal": 16702980096,
        "MenFree": 309428224,
        "SwapFree": 2146693120,
        "SwapTotal": 2147479552,
        "arch": "amd64",
        "cpus": 4,
        "hostname": "localhost.localdomain",
        "kernel": "4.15.0-36-generic",
        "os": "linux",
        "rootless": false,
        "uptime": "91h 30m 59.9s (Approximately 3.79 days)"
    },
    "store": {
        "ContainerStore": {
            "number": 2
        },
        "GraphDriverName": "overlay",
        "GraphOptions": [
            "overlay.override_kernel_check=true"
        ],
        "GraphRoot": "/var/lib/containers/storage",
        "GraphStatus": {
            "Backing Filesystem": "extfs",
            "Native Overlay Diff": "true",
            "Supports d_type": "true"
        },
        "ImageStore": {
            "number": 1
        },
        "RunRoot": "/var/run/containers/storage"
    }
}

```
Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>