### PR TITLE
Fix dangling filter for images command

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -356,9 +356,9 @@ func matchesFilter(ctx context.Context, image storage.Image, store storage.Store
 }
 
 func matchesDangling(name string, dangling string) bool {
-	if dangling == "false" && name != "<none>" {
+	if dangling == "false" && !strings.Contains(name, "<none>") {
 		return true
-	} else if dangling == "true" && name == "<none>" {
+	} else if dangling == "true" && strings.Contains(name, "<none>") {
 		return true
 	}
 	return false


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

In version 1.4 of Buildah and earlier, the internal name for a dangling image was `<none>`.  With changes that came in after 1.4, the internal name was changed to `<none>:<none>` and this caused the `buildah images --filter dangling=true` command to no longer work.

Rather than comparing strictly to `<none>`, this change does a strings.contains() for that.  I've also added tests so if we fall off the rails again in the future, the test system will catch it.

Addresses: #1199 
Tests:
```
# ctr=$(buildah from scratch)

# buildah commit $ctr test
{output removed for brevity}
Storing signatures
1ace9c1b7814267c30e6377b900dbfaacdba9aee6adb692f3d140e20d0e19d30

# buildah commit $ctr test
{output removed for brevity}
Storing signatures
2d9f02d2fb65ba3a9ca4e70ec158892183427aecfe30b8e9e15d8153d20222ba

# buildah images
IMAGE NAME                                               IMAGE TAG            IMAGE ID             CREATED AT             SIZE
<none>                                                   <none>               1ace9c1b7814         Nov 27, 2018 08:56     1.63 KB
localhost/test                                           latest               2d9f02d2fb65         Nov 27, 2018 08:56     1.63 KB

# buildah images --filter dangling=false
IMAGE NAME                                               IMAGE TAG            IMAGE ID             CREATED AT             SIZE
localhost/test                                           latest               2d9f02d2fb65         Nov 27, 2018 08:56     1.63 KB

# buildah images --filter dangling=true
IMAGE NAME                                               IMAGE TAG            IMAGE ID             CREATED AT             SIZE
<none>                                                   <none>               1ace9c1b7814         Nov 27, 2018 08:56     1.63 KB

```