### PR TITLE
Fix completions to print Names as well as IDs

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -74,11 +74,11 @@ __buildah_previous_extglob_setting=$(shopt -p extglob)
 shopt -s extglob
 
 __buildah_list_containers() {
-    COMPREPLY=($(compgen -W "$(buildah containers -q)" -- $cur))
+   COMPREPLY=($(compgen -W "$(buildah containers --format '{{.ContainerName}} {{.ContainerID}}' )" -- $cur))
 }
 
 __buildah_list_images() {
-    COMPREPLY=($(compgen -W "$(buildah images -q)" -- $cur))
+   COMPREPLY=($(compgen -W "$(buildah images --format '{{.ID}} {{.Name}}' )" -- $cur))
 }
 
 __buildah_pos_first_nonflag() {


### PR DESCRIPTION
We want to complete based on container and image names as well
as IDs.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>