### PR TITLE
Enable -q when --filter is used for images command

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -273,20 +273,7 @@ func outputImages(ctx context.Context, images []storage.Image, store storage.Sto
 			// images without names should be printed with "<none>" as the image name
 			names = append(names, "<none>:<none>")
 		}
-		if opts.quiet && argName == "" {
-			fmt.Printf("%-64s\n", image.ID)
-			// We only want to print each id once
-			continue
-		}
-		if opts.json && argName == "" {
-			JSONImage := jsonImage{ID: image.ID, Names: image.Names}
-			data, err2 := json.MarshalIndent(JSONImage, "", "    ")
-			if err2 != nil {
-				return err2
-			}
-			fmt.Printf("%s\n", data)
-			continue
-		}
+		breakOuter := false
 		for name, tags := range imagebuildah.ReposToMap(names) {
 			for _, tag := range tags {
 				if !matchesReference(name+":"+tag, argName) {
@@ -300,6 +287,7 @@ func outputImages(ctx context.Context, images []storage.Image, store storage.Sto
 				if opts.quiet {
 					fmt.Printf("%-64s\n", image.ID)
 					// We only want to print each id once
+					breakOuter = true
 					break
 				}
 				if opts.json {
@@ -326,6 +314,9 @@ func outputImages(ctx context.Context, images []storage.Image, store storage.Sto
 					continue
 				}
 				outputUsingFormatString(opts.truncate, opts.digests, params)
+			}
+			if breakOuter { // Show only one imageID when quiet
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

When the images command was reworked recently to handle multiple names for an image, the logic for quiet and json checking was moved up out of a loop that went through all of the multiple names of an image to make things a bit more expedient.  However the filtering logic did not move too so when we now do a `buildah images -q --filter dangling=true` command, the filter is never considered.  Ditto `--json` and `-q` combined.

The code to do the json and quiet checks is still within the loop for multiple names along with the filter checks.  Although less expedient to use there, it is almost immeasurably slower.  The logic for the filtering has some dependencies within the loop and can't be easily moved outside of it.

@QiWang19 PTAL and verify my thinking here.

Finishes addressing #1199 (he hopes!)