### PR TITLE
Show warning when a build arg not used

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -226,6 +226,18 @@ type Executor struct {
 	copyFrom                       string            // Used to keep track of the --from flag from COPY and ADD
 }
 
+// builtinAllowedBuildArgs is list of built-in allowed build args
+var builtinAllowedBuildArgs = map[string]bool{
+	"HTTP_PROXY":  true,
+	"http_proxy":  true,
+	"HTTPS_PROXY": true,
+	"https_proxy": true,
+	"FTP_PROXY":   true,
+	"ftp_proxy":   true,
+	"NO_PROXY":    true,
+	"no_proxy":    true,
+}
+
 // withName creates a new child executor that will be used whenever a COPY statement uses --from=NAME.
 func (b *Executor) withName(name string, index int) *Executor {
 	if b.named == nil {
@@ -794,12 +806,28 @@ func (b *Executor) Execute(ctx context.Context, stage imagebuilder.Stage) error 
 	commitName := b.output
 	b.containerIDs = nil
 
+	var leftoverArgs []string
+	for arg := range b.builder.Args {
+		if !builtinAllowedBuildArgs[arg] {
+			leftoverArgs = append(leftoverArgs, arg)
+		}
+	}
 	for i, node := range node.Children {
 		step := ib.Step()
 		if err := step.Resolve(node); err != nil {
 			return errors.Wrapf(err, "error resolving step %+v", *node)
 		}
 		logrus.Debugf("Parsed Step: %+v", *step)
+		if step.Command == "arg" {
+			for index, arg := range leftoverArgs {
+				for _, Arg := range step.Args {
+					list := strings.SplitN(Arg, "=", 2)
+					if arg == list[0] {
+						leftoverArgs = append(leftoverArgs[:index], leftoverArgs[index+1:]...)
+					}
+				}
+			}
+		}
 		if !b.quiet {
 			b.log("%s", step.Original)
 		}
@@ -895,6 +923,9 @@ func (b *Executor) Execute(ctx context.Context, stage imagebuilder.Stage) error 
 				return errors.Wrap(err, "error preparing container for next step")
 			}
 		}
+	}
+	if len(leftoverArgs) > 0 {
+		fmt.Fprintf(b.out, "[Warning] One or more build-args %v were not consumed\n", leftoverArgs)
 	}
 	return nil
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1072,3 +1072,9 @@ load helpers
   tenminutes=$(( 10 * 60 * $second ))
   [ "$output" = '["CMD-SHELL" "curl -f http://localhost/ || exit 1"]'" $tenminutes $fiveminutes $threeseconds 4" ]
 }
+
+@test "bud with unused build arg" {
+  target=busybox-image
+  out=$(buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg foo=bar --build-arg foo2=bar2 -f ${TESTSDIR}/bud/build-arg ${TESTSDIR}/bud/build-arg | grep "Warning" | wc -l)
+  [ "$out" -ne 0 ]
+}

--- a/tests/bud/build-arg/Dockerfile
+++ b/tests/bud/build-arg/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+
+ARG foo


### PR DESCRIPTION
When build-args is not used in the bud command, a warning will be output.
Fixes: #1080 

After change:
```
➜  buildah bud --build-arg HTTPS_PROXY=10.1.1.1 --build-arg foo=test --build-arg foo1=test1 .
STEP 1: FROM busybox
STEP 2: ARG foo
STEP 3: RUN echo $foo
test
STEP 4: RUN echo $HTTPS_PROXY
10.1.1.1
[Warning] One or more build-args [foo1] were not consumed
STEP 5: COMMIT containers-storage:[vfs@/home/zhouhao/.local/share/containers/storage+/run/user/1000]@ff6640fd9625347a3553d1350fb633462e65a81a2b174c1291dae64dda101b78
Getting image source signatures
Skipping fetch of repeat blob sha256:8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b
Copying blob sha256:dbf83ee7bc88a4bac97c9be4cb3d5c5e47710db2c3c6a6f308d591c0e19d1185
 173 B / 173 B [============================================================] 0s
Copying config sha256:b0a5c32f61ed4c2c1fe30d5c6d5567a07eec49fa1dc509b7ed10662a2450f6e6
 693 B / 693 B [============================================================] 0s
Writing manifest to image destination
Storing signatures
--> ff6640fd9625347a3553d1350fb633462e65a81a2b174c1291dae64dda101b78
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>