### PR TITLE
Update c/image for sysregistriesv2 changes and automatic docker:// insecure configuration

### DIFF
--- a/common.go
+++ b/common.go
@@ -38,7 +38,6 @@ func getCopyOptions(reportWriter io.Writer, sourceReference types.ImageReference
 	if err != nil {
 		logrus.Debugf("error determining if registry for %q is insecure: %v", transports.ImageName(sourceReference), err)
 	} else if sourceInsecure {
-		sourceCtx.DockerInsecureSkipTLSVerify = true
 		sourceCtx.OCIInsecureSkipTLSVerify = true
 	}
 
@@ -56,7 +55,6 @@ func getCopyOptions(reportWriter io.Writer, sourceReference types.ImageReference
 	if err != nil {
 		logrus.Debugf("error determining if registry for %q is insecure: %v", transports.ImageName(destinationReference), err)
 	} else if destinationInsecure {
-		destinationCtx.DockerInsecureSkipTLSVerify = true
 		destinationCtx.OCIInsecureSkipTLSVerify = true
 	}
 

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -282,7 +282,7 @@ func SystemContextFromOptions(c *cli.Context) (*types.SystemContext, error) {
 		DockerCertPath: c.String("cert-dir"),
 	}
 	if c.IsSet("tls-verify") {
-		ctx.DockerInsecureSkipTLSVerify = !c.BoolT("tls-verify")
+		ctx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!c.BoolT("tls-verify"))
 		ctx.OCIInsecureSkipTLSVerify = !c.BoolT("tls-verify")
 		ctx.DockerDaemonInsecureSkipTLSVerify = !c.BoolT("tls-verify")
 	}

--- a/util.go
+++ b/util.go
@@ -175,11 +175,11 @@ func (b *Builder) tarPath() func(path string) (io.ReadCloser, error) {
 
 // isRegistryInsecure checks if the named registry is marked as not secure
 func isRegistryInsecure(registry string, sc *types.SystemContext) (bool, error) {
-	registries, err := sysregistriesv2.GetRegistries(sc)
+	reginfo, err := sysregistriesv2.FindRegistry(sc, registry)
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to parse the registries configuration (%s)", sysregistries.RegistriesConfPath(sc))
 	}
-	if reginfo := sysregistriesv2.FindRegistry(registry, registries); reginfo != nil {
+	if reginfo != nil {
 		if reginfo.Insecure {
 			logrus.Debugf("registry %q is marked insecure in registries configuration %q", registry, sysregistries.RegistriesConfPath(sc))
 		} else {
@@ -193,11 +193,11 @@ func isRegistryInsecure(registry string, sc *types.SystemContext) (bool, error) 
 
 // isRegistryBlocked checks if the named registry is marked as blocked
 func isRegistryBlocked(registry string, sc *types.SystemContext) (bool, error) {
-	registries, err := sysregistriesv2.GetRegistries(sc)
+	reginfo, err := sysregistriesv2.FindRegistry(sc, registry)
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to parse the registries configuration (%s)", sysregistries.RegistriesConfPath(sc))
 	}
-	if reginfo := sysregistriesv2.FindRegistry(registry, registries); reginfo != nil {
+	if reginfo != nil {
 		if reginfo.Blocked {
 			logrus.Debugf("registry %q is marked as blocked in registries configuration %q", registry, sysregistries.RegistriesConfPath(sc))
 		} else {

--- a/util/util.go
+++ b/util/util.go
@@ -122,12 +122,11 @@ func ResolveName(name string, firstRegistry string, sc *types.SystemContext, sto
 
 	// Figure out the list of registries.
 	var registries []string
-	allRegistries, err := sysregistriesv2.GetRegistries(sc)
+	searchRegistries, err := sysregistriesv2.FindUnqualifiedSearchRegistries(sc)
 	if err != nil {
 		logrus.Debugf("unable to read configured registries to complete %q: %v", name, err)
-		registries = []string{}
 	}
-	for _, registry := range sysregistriesv2.FindUnqualifiedSearchRegistries(allRegistries) {
+	for _, registry := range searchRegistries {
 		if !registry.Blocked {
 			registries = append(registries, registry.URL)
 		}

--- a/vendor.conf
+++ b/vendor.conf
@@ -3,7 +3,7 @@ github.com/blang/semver master
 github.com/BurntSushi/toml master
 github.com/containerd/continuity master
 github.com/containernetworking/cni v0.7.0-alpha1
-github.com/containers/image de7be82ee3c7fb676bf6cfdc9090be7cc28f404c
+github.com/containers/image 63a1cbdc5e6537056695cf0d627c0a33b334df53
 github.com/containers/libpod fe4f09493f41f675d24c969d1b60d1a6a45ddb9e
 github.com/containers/storage 3161726d1db0d0d4e86a9667dd476f09b997f497
 github.com/docker/distribution 5f6282db7d65e6d72ad7c2cc66310724a57be716

--- a/vendor/github.com/containers/image/docker/docker_client.go
+++ b/vendor/github.com/containers/image/docker/docker_client.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/pkg/docker/config"
+	"github.com/containers/image/pkg/sysregistriesv2"
 	"github.com/containers/image/pkg/tlsclientconfig"
 	"github.com/containers/image/types"
 	"github.com/docker/distribution/registry/client"
@@ -78,11 +79,13 @@ type bearerToken struct {
 // dockerClient is configuration for dealing with a single Docker registry.
 type dockerClient struct {
 	// The following members are set by newDockerClient and do not change afterwards.
-	sys           *types.SystemContext
-	registry      string
+	sys                   *types.SystemContext
+	registry              string
+	client                *http.Client
+	insecureSkipTLSVerify bool
+	// The following members are not set by newDockerClient and must be set by callers if needed.
 	username      string
 	password      string
-	client        *http.Client
 	signatureBase signatureStorageBase
 	scope         authScope
 	// The following members are detected registry properties:
@@ -194,13 +197,26 @@ func newDockerClientFromRef(sys *types.SystemContext, ref dockerReference, write
 	if err != nil {
 		return nil, err
 	}
-	remoteName := reference.Path(ref.ref)
 
-	return newDockerClientWithDetails(sys, registry, username, password, actions, sigBase, remoteName)
+	client, err := newDockerClient(sys, registry, ref.ref.Name())
+	if err != nil {
+		return nil, err
+	}
+	client.username = username
+	client.password = password
+	client.signatureBase = sigBase
+	client.scope.actions = actions
+	client.scope.remoteName = reference.Path(ref.ref)
+	return client, nil
 }
 
-// newDockerClientWithDetails returns a new dockerClient instance for the given parameters
-func newDockerClientWithDetails(sys *types.SystemContext, registry, username, password, actions string, sigBase signatureStorageBase, remoteName string) (*dockerClient, error) {
+// newDockerClient returns a new dockerClient instance for the given registry
+// and reference.  The reference is used to query the registry configuration
+// and can either be a registry (e.g, "registry.com[:5000]"), a repository
+// (e.g., "registry.com[:5000][/some/namespace]/repo").
+// Please note that newDockerClient does not set all members of dockerClient
+// (e.g., username and password); those must be set by callers if necessary.
+func newDockerClient(sys *types.SystemContext, registry, reference string) (*dockerClient, error) {
 	hostName := registry
 	if registry == dockerHostname {
 		registry = dockerRegistry
@@ -221,33 +237,43 @@ func newDockerClientWithDetails(sys *types.SystemContext, registry, username, pa
 		return nil, err
 	}
 
-	if sys != nil && sys.DockerInsecureSkipTLSVerify {
-		tr.TLSClientConfig.InsecureSkipVerify = true
+	// Check if TLS verification shall be skipped (default=false) which can
+	// either be specified in the sysregistriesv2 configuration or via the
+	// SystemContext, whereas the SystemContext is prioritized.
+	skipVerify := false
+	if sys != nil && sys.DockerInsecureSkipTLSVerify != types.OptionalBoolUndefined {
+		// Only use the SystemContext if the actual value is defined.
+		skipVerify = sys.DockerInsecureSkipTLSVerify == types.OptionalBoolTrue
+	} else {
+		reg, err := sysregistriesv2.FindRegistry(sys, reference)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error loading registries")
+		}
+		if reg != nil {
+			skipVerify = reg.Insecure
+		}
 	}
+	tr.TLSClientConfig.InsecureSkipVerify = skipVerify
 
 	return &dockerClient{
-		sys:           sys,
-		registry:      registry,
-		username:      username,
-		password:      password,
-		client:        &http.Client{Transport: tr},
-		signatureBase: sigBase,
-		scope: authScope{
-			actions:    actions,
-			remoteName: remoteName,
-		},
+		sys:                   sys,
+		registry:              registry,
+		client:                &http.Client{Transport: tr},
+		insecureSkipTLSVerify: skipVerify,
 	}, nil
 }
 
 // CheckAuth validates the credentials by attempting to log into the registry
 // returns an error if an error occcured while making the http request or the status code received was 401
 func CheckAuth(ctx context.Context, sys *types.SystemContext, username, password, registry string) error {
-	newLoginClient, err := newDockerClientWithDetails(sys, registry, username, password, "", nil, "")
+	client, err := newDockerClient(sys, registry, registry)
 	if err != nil {
 		return errors.Wrapf(err, "error creating new docker client")
 	}
+	client.username = username
+	client.password = password
 
-	resp, err := newLoginClient.makeRequest(ctx, "GET", "/v2/", nil, nil, v2Auth)
+	resp, err := client.makeRequest(ctx, "GET", "/v2/", nil, nil, v2Auth)
 	if err != nil {
 		return err
 	}
@@ -299,16 +325,21 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 		return nil, errors.Wrapf(err, "error getting username and password")
 	}
 
-	// The /v2/_catalog endpoint has been disabled for docker.io therefore the call made to that endpoint will fail
-	// So using the v1 hostname for docker.io for simplicity of implementation and the fact that it returns search results
+	// The /v2/_catalog endpoint has been disabled for docker.io therefore
+	// the call made to that endpoint will fail.  So using the v1 hostname
+	// for docker.io for simplicity of implementation and the fact that it
+	// returns search results.
+	hostname := registry
 	if registry == dockerHostname {
-		registry = dockerV1Hostname
+		hostname = dockerV1Hostname
 	}
 
-	client, err := newDockerClientWithDetails(sys, registry, username, password, "", nil, "")
+	client, err := newDockerClient(sys, hostname, registry)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating new docker client")
 	}
+	client.username = username
+	client.password = password
 
 	// Only try the v1 search endpoint if the search query is not empty. If it is
 	// empty skip to the v2 endpoint.
@@ -530,7 +561,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 		return nil
 	}
 	err := ping("https")
-	if err != nil && c.sys != nil && c.sys.DockerInsecureSkipTLSVerify {
+	if err != nil && c.insecureSkipTLSVerify {
 		err = ping("http")
 	}
 	if err != nil {
@@ -554,7 +585,7 @@ func (c *dockerClient) detectProperties(ctx context.Context) error {
 			return true
 		}
 		isV1 := pingV1("https")
-		if !isV1 && c.sys != nil && c.sys.DockerInsecureSkipTLSVerify {
+		if !isV1 && c.insecureSkipTLSVerify {
 			isV1 = pingV1("http")
 		}
 		if isV1 {

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -324,6 +324,30 @@ type DockerAuthConfig struct {
 	Password string
 }
 
+// OptionalBool is a boolean with an additional undefined value, which is meant
+// to be used in the context of user input to distinguish between a
+// user-specified value and a default value.
+type OptionalBool byte
+
+const (
+	// OptionalBoolUndefined indicates that the OptionalBoolean hasn't been written.
+	OptionalBoolUndefined OptionalBool = iota
+	// OptionalBoolTrue represents the boolean true.
+	OptionalBoolTrue
+	// OptionalBoolFalse represents the boolean false.
+	OptionalBoolFalse
+)
+
+// NewOptionalBool converts the input bool into either OptionalBoolTrue or
+// OptionalBoolFalse.  The function is meant to avoid boilerplate code of users.
+func NewOptionalBool(b bool) OptionalBool {
+	o := OptionalBoolFalse
+	if b == true {
+		o = OptionalBoolTrue
+	}
+	return o
+}
+
 // SystemContext allows parameterizing access to implicitly-accessed resources,
 // like configuration files in /etc and users' login state in their home directory.
 // Various components can share the same field only if their semantics is exactly
@@ -376,7 +400,7 @@ type SystemContext struct {
 	// Ignored if DockerCertPath is non-empty.
 	DockerPerHostCertDirPath string
 	// Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
-	DockerInsecureSkipTLSVerify bool
+	DockerInsecureSkipTLSVerify OptionalBool
 	// if nil, the library tries to parse ~/.docker/config.json to retrieve credentials
 	DockerAuthConfig *DockerAuthConfig
 	// if not "", an User-Agent header is added to each request when contacting a registry.


### PR DESCRIPTION
This updates c/image to include https://github.com/containers/image/pull/468 , and updates the callers.  This is a prerequisite to merging the blob-info-caching branch.