### PR TITLE
cli.BudFlags: add `--platform` nop

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -404,6 +404,7 @@ return 1
      --network
      --no-pivot
      --pid
+     --platform
      --runtime
      --runtime-flag
      --security-opt

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -298,6 +298,12 @@ that the PID namespace in which `buildah` itself is being run should be reused,
 or it can be the path to a PID namespace which is already in use by another
 process.
 
+**--platform**="Linux"
+
+This option has no effect on the build. Other container engines use this option
+to control the execution platform for the build (e.g., Windows, Linux) which is
+not required for Buildah as it supports only Linux.
+
 **--pull**
 
 Pull the image if it is not present.  If this flag is disabled (with

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -148,6 +148,10 @@ var (
 			Name:  "loglevel",
 			Usage: "adjust logging level (range from -2 to 3)",
 		},
+		cli.StringFlag{
+			Name:  "platform",
+			Usage: "CLI compatibility: no action or effect",
+		},
 		cli.BoolTFlag{
 			Name:  "pull",
 			Usage: "pull the image if not present",

--- a/tests/validate/git-validation.sh
+++ b/tests/validate/git-validation.sh
@@ -8,6 +8,6 @@ if ! which git-validation > /dev/null 2> /dev/null ; then
 fi
 if test "$TRAVIS" != true ; then
 	#GITVALIDATE_EPOCH=":/git-validation epoch"
-	GITVALIDATE_EPOCH="5fa3c0bd3fbceca38b6ad2f8a893bc918a8a514a"
+	GITVALIDATE_EPOCH="87cb532ab33f1f242a56e362e799f95549519d3b"
 fi
 exec git-validation -q -run DCO,short-subject ${GITVALIDATE_EPOCH:+-range "${GITVALIDATE_EPOCH}""..${GITVALIDATE_TIP:-@}"} ${GITVALIDATE_FLAGS}


### PR DESCRIPTION
Add the `--platform` option for Moby/Docker CLI-compat reasons.  This
option allows to control which platform (i.e., Windows or Linux) the
image will be build on and for.  Make this a nop as Buildah supports
only Linux.

Fixes: #629
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>