### PR TITLE
mount: allow mount only when using vfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
     - docker ps --all
     - docker images
     - ls -alF /home/travis/auth
-    - docker pull alpine
+    - docker pull docker.io/alpine
     - echo testpassword | docker login localhost:5000 --username testuser --password-stdin
     - docker tag alpine localhost:5000/my-alpine
     - docker push localhost:5000/my-alpine

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -48,6 +48,14 @@ func mountCmd(c *cli.Context) error {
 
 	var lastError error
 	if len(args) > 0 {
+		// Do not allow to mount a graphdriver that is not vfs if we are creating the userns as part
+		// of the mount command.
+		// Differently, allow the mount if we are already in a userns, as the mount point will still
+		// be accessible once "buildah mount" exits.
+		if os.Getenv(startedInUserNS) != "" && store.GraphDriverName() != "vfs" {
+			return fmt.Errorf("cannot mount using driver %s in rootless mode", store.GraphDriverName())
+		}
+
 		for _, name := range args {
 			builder, err := openBuilder(getContext(), store, name)
 			if err != nil {

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -207,7 +207,7 @@ func unshareCmd(c *cli.Context) error {
 		args = []string{shell}
 	}
 	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Env = append(os.Environ(), "USER=root", "USERNAME=root", "GROUP=root", "LOGNAME=root", "UID=0", "GID=0")
+	cmd.Env = append(os.Environ(), "USER=root", "USERNAME=root", "GROUP=root", "LOGNAME=root", "UID=0", "GID=0", "_BUILDAH_STARTED_IN_USERNS=")
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/buildah/unshare_unsupported.go
+++ b/cmd/buildah/unshare_unsupported.go
@@ -6,6 +6,10 @@ import (
 	"github.com/urfave/cli"
 )
 
+const (
+	startedInUserNS = "_BUILDAH_STARTED_IN_USERNS"
+)
+
 var (
 	unshareCommand = cli.Command{
 		Name:           "unshare",

--- a/docs/buildah-mount.md
+++ b/docs/buildah-mount.md
@@ -13,6 +13,14 @@ accessed from the host, and returns its location.
 If the mount command is invoked without any arguments, the tool will list all of the
 currently mounted containers.
 
+When running in rootless mode, mount runs in a different namespace so
+that the mounted volume might not be accessible from the host when
+using a driver different than `vfs`.  To be able to access the file
+system mounted, you might need to create the mount namespace
+separately as part of `buildah unshare`.  In the environment created
+with `buildah unshare` you can then use `buildah mount` and have
+access to the mounted file system.
+
 ## RETURN VALUE
 The location of the mounted file system.  On error an empty string and errno is
 returned.

--- a/tests/bud/from-as/Dockerfile.skip
+++ b/tests/bud/from-as/Dockerfile.skip
@@ -1,4 +1,4 @@
-FROM centos:7 AS base
+FROM registry.centos.org/centos/centos:centos7 AS base
 RUN touch /1
 ENV LOCAL=/1
 RUN find $LOCAL

--- a/tests/conformance/testdata/Dockerfile.reusebase
+++ b/tests/conformance/testdata/Dockerfile.reusebase
@@ -1,4 +1,4 @@
-FROM centos:7 AS base
+FROM registry.centos.org/centos/centos:centos7 AS base
 RUN touch /1
 ENV LOCAL=/1
 

--- a/tests/conformance/testdata/Dockerfile.shell
+++ b/tests/conformance/testdata/Dockerfile.shell
@@ -1,3 +1,3 @@
-FROM centos:7
+FROM registry.centos.org/centos/centos:centos7
 SHELL ["/bin/bash", "-xc"]
 RUN env

--- a/tests/conformance/testdata/copy/Dockerfile
+++ b/tests/conformance/testdata/copy/Dockerfile
@@ -1,3 +1,3 @@
-FROM centos:7
+FROM registry.centos.org/centos/centos:centos7
 COPY script /usr/bin
 RUN ls -al /usr/bin/script

--- a/tests/conformance/testdata/copydir/Dockerfile
+++ b/tests/conformance/testdata/copydir/Dockerfile
@@ -1,3 +1,3 @@
-FROM centos:7
+FROM registry.centos.org/centos/centos:centos7
 COPY dir /dir
 RUN ls -al /dir/file

--- a/tests/conformance/testdata/copyrename/Dockerfile
+++ b/tests/conformance/testdata/copyrename/Dockerfile
@@ -1,3 +1,3 @@
-FROM centos:7
+FROM registry.centos.org/centos/centos:centos7
 COPY file1 /usr/bin/file2
 RUN ls -al /usr/bin/file2 && ! ls -al /usr/bin/file1


### PR DESCRIPTION
when using a driver different than vfs, the mount is probably in a
different mount namespace thus not accessible from the host.  Avoid
the confusion by not allowing mount when a different driver is used.

Closes: https://github.com/containers/buildah/issues/1225

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>