### PR TITLE
Handle one line Dockerfile with layers

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1307,7 +1307,12 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (strin
 
 	var imageRef reference.Canonical
 	imageID := ""
-	if !b.layers && !b.noCache {
+
+	// Check if we have a one line Dockerfile making layers irrelevant
+	// or the user told us to ignore layers.
+	ignoreLayers := (len(stages) < 2 && len(stages[0].Node.Children) < 2) || (!b.layers && !b.noCache)
+
+	if ignoreLayers {
 		imgID, ref, err := stageExecutor.Commit(ctx, stages[len(stages)-1].Builder, "")
 		if err != nil {
 			return "", nil, err


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Addresses https://github.com/containers/libpod/issues/1993 once merged there.

Podman turns layers on by default with every build. The layer logic does not behave if there's only a one line Dockerfile given to the build, a commit is never done as the layer logic doesn't do a commit because it's waiting for the last of two ore more layers before doing so. If we have only one line in one Dockerfile that we're building, the most layers we will have is one, so just ignore layering.