### PR TITLE
Add aliases for buildah containers, so buildah list, ls and ps work

### DIFF
--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -80,6 +80,7 @@ var (
 	containersDescription = "Lists containers which appear to be " + buildah.Package + " working containers, their\n   names and IDs, and the names and IDs of the images from which they were\n   initialized"
 	containersCommand     = cli.Command{
 		Name:                   "containers",
+		Aliases:                []string{"list", "ls", "ps"},
 		Usage:                  "List working containers and their base images",
 		Description:            containersDescription,
 		Flags:                  sortFlags(containersFlags),

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -652,7 +652,19 @@ return 1
      esac
  }
 
- _buildah_containers() {
+ _buildah_ps() {
+   _buildah_containers
+ }
+
+_buildah_list() {
+   _buildah_containers
+ }
+
+_buildah_ls() {
+   _buildah_containers
+ }
+
+_buildah_containers() {
      local boolean_options="
      --help
      -h
@@ -865,9 +877,12 @@ return 1
        images
        info
        inspect
+       list
+       ls
        mount
        pull
        push
+       ps
        rename
        rm
        rmi


### PR DESCRIPTION
This adds a little more consistency with the podman and docker commands
for listing containers.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>