### PR TITLE
We should only warn if user actually requests Hostname be set in image

### DIFF
--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -244,7 +244,11 @@ func updateConfig(builder *buildah.Builder, c *cli.Context) {
 		builder.SetDomainname(c.String("domainname"))
 	}
 	if c.IsSet("hostname") {
-		builder.SetHostname(c.String("hostname"))
+		name := c.String("hostname")
+		if name != "" && builder.Format == buildah.OCIv1ImageManifest {
+			logrus.Errorf("HOSTNAME is not supported for OCI V1 image format, hostname %s will be ignored. Must use `docker` format", name)
+		}
+		builder.SetHostname(name)
 	}
 	if c.IsSet("onbuild") {
 		for _, onbuild := range c.StringSlice("onbuild") {

--- a/config.go
+++ b/config.go
@@ -474,9 +474,6 @@ func (b *Builder) Hostname() string {
 // Note: this setting is not present in the OCIv1 image format, so it is
 // discarded when writing images using OCIv1 formats.
 func (b *Builder) SetHostname(name string) {
-	if name != "" && b.Format != Dockerv2ImageManifest {
-		logrus.Errorf("HOSTNAME is not supported for OCI image format, hostname %s will be ignored. Must use `docker` format", name)
-	}
 	b.Docker.Config.Hostname = name
 }
 

--- a/unshare/unshare.c
+++ b/unshare/unshare.c
@@ -79,7 +79,8 @@ void _buildah_unshare(void)
 	pidfd = _buildah_unshare_parse_envint("_Buildah-pid-pipe");
 	if (pidfd != -1) {
 		snprintf(buf, sizeof(buf), "%llu", (unsigned long long) getpid());
-		if (write(pidfd, buf, strlen(buf)) != strlen(buf)) {
+		size_t size = write(pidfd, buf, strlen(buf));
+		if (size != strlen(buf)) {
 			fprintf(stderr, "Error writing PID to pipe on fd %d: %m\n", pidfd);
 			_exit(1);
 		}


### PR DESCRIPTION
When we set the Hostname to match the container id, we don't want to print
the warning, since the user did not request the hostname being set.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
