### PR TITLE
Use sprintf to generate port numbers for commit

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1159,7 +1159,7 @@ func (b *Executor) Commit(ctx context.Context, ib *imagebuilder.Builder, created
 	b.builder.SetUser(config.User)
 	b.builder.ClearPorts()
 	for p := range config.ExposedPorts {
-		b.builder.SetPort(string(p))
+		b.builder.SetPort(fmt.Sprintf("%d", p))
 	}
 	for _, envSpec := range config.Env {
 		spec := strings.SplitN(envSpec, "=", 2)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Use sprintf to properly format the ports integer to a string value.  This mimics the work done by @mheon in Podman at https://github.com/containers/libpod/pull/2067