### PR TITLE
Do not set OCIInsecureSkipTLSVerify based on registries.conf

### DIFF
--- a/common.go
+++ b/common.go
@@ -6,10 +6,8 @@ import (
 	"path/filepath"
 
 	cp "github.com/containers/image/copy"
-	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/containers/libpod/pkg/rootless"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -34,12 +32,6 @@ func getCopyOptions(reportWriter io.Writer, sourceReference types.ImageReference
 
 		}
 	}
-	sourceInsecure, err := isReferenceInsecure(sourceReference, sourceCtx)
-	if err != nil {
-		logrus.Debugf("error determining if registry for %q is insecure: %v", transports.ImageName(sourceReference), err)
-	} else if sourceInsecure {
-		sourceCtx.OCIInsecureSkipTLSVerify = true
-	}
 
 	destinationCtx := &types.SystemContext{}
 	if destinationSystemContext != nil {
@@ -50,12 +42,6 @@ func getCopyOptions(reportWriter io.Writer, sourceReference types.ImageReference
 				destinationCtx.SystemRegistriesConfPath = userRegistriesFile
 			}
 		}
-	}
-	destinationInsecure, err := isReferenceInsecure(destinationReference, destinationCtx)
-	if err != nil {
-		logrus.Debugf("error determining if registry for %q is insecure: %v", transports.ImageName(destinationReference), err)
-	} else if destinationInsecure {
-		destinationCtx.OCIInsecureSkipTLSVerify = true
 	}
 
 	return &cp.Options{

--- a/util.go
+++ b/util.go
@@ -173,24 +173,6 @@ func (b *Builder) tarPath() func(path string) (io.ReadCloser, error) {
 	}
 }
 
-// isRegistryInsecure checks if the named registry is marked as not secure
-func isRegistryInsecure(registry string, sc *types.SystemContext) (bool, error) {
-	reginfo, err := sysregistriesv2.FindRegistry(sc, registry)
-	if err != nil {
-		return false, errors.Wrapf(err, "unable to parse the registries configuration (%s)", sysregistries.RegistriesConfPath(sc))
-	}
-	if reginfo != nil {
-		if reginfo.Insecure {
-			logrus.Debugf("registry %q is marked insecure in registries configuration %q", registry, sysregistries.RegistriesConfPath(sc))
-		} else {
-			logrus.Debugf("registry %q is not marked insecure in registries configuration %q", registry, sysregistries.RegistriesConfPath(sc))
-		}
-		return reginfo.Insecure, nil
-	}
-	logrus.Debugf("registry %q is not listed in registries configuration %q, assuming it's secure", registry, sysregistries.RegistriesConfPath(sc))
-	return false, nil
-}
-
 // isRegistryBlocked checks if the named registry is marked as blocked
 func isRegistryBlocked(registry string, sc *types.SystemContext) (bool, error) {
 	reginfo, err := sysregistriesv2.FindRegistry(sc, registry)
@@ -219,11 +201,6 @@ func isReferenceSomething(ref types.ImageReference, sc *types.SystemContext, wha
 		}
 	}
 	return false, nil
-}
-
-// isReferenceInsecure checks if the registry part of a reference is insecure
-func isReferenceInsecure(ref types.ImageReference, sc *types.SystemContext) (bool, error) {
-	return isReferenceSomething(ref, sc, isRegistryInsecure)
 }
 
 // isReferenceBlocked checks if the registry part of a reference is blocked


### PR DESCRIPTION
- `OCIInsecureSkipTLSVerify` applies only to `c/image/layout.Transport` and `c/image/archive.Transport`; in both, `ImageTransport.DockerReference` always returns `nil`, which causes `isReferenceSomething`, and therefore `isRegistryInsecure`, to always return `false`; i.e., this code was never executed for those transports for which it could make a difference.
- The `oci:` and `oci-archive:` transports refer to local filesystems, so matching that against `docker/distribution` hostnames does not really make sense.

Then, drop the no longer used `isReferenceInsecure` / `isRegistryInsecure` functions.