### PR TITLE
Properly format images JSON output

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -243,6 +243,7 @@ func outputHeader(truncate, digests bool) {
 
 func outputImages(ctx context.Context, images []storage.Image, store storage.Store, filters *filterParams, argName string, opts imageOptions) error {
 	found := false
+	jsonImages := []jsonImage{}
 	for _, image := range images {
 		createdTime := image.Created
 
@@ -291,12 +292,7 @@ func outputImages(ctx context.Context, images []storage.Image, store storage.Sto
 					break outer
 				}
 				if opts.json {
-					JSONImage := jsonImage{ID: image.ID, Names: image.Names}
-					data, err2 := json.MarshalIndent(JSONImage, "", "    ")
-					if err2 != nil {
-						return err2
-					}
-					fmt.Printf("%s\n", data)
+					jsonImages = append(jsonImages, jsonImage{ID: image.ID, Names: image.Names})
 					// We only want to print each id once
 					break outer
 				}
@@ -321,6 +317,13 @@ func outputImages(ctx context.Context, images []storage.Image, store storage.Sto
 
 	if !found && argName != "" {
 		return errors.Errorf("No such image %s", argName)
+	}
+	if opts.json {
+		data, err := json.MarshalIndent(jsonImages, "", "    ")
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s\n", data)
 	}
 
 	return nil

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -87,11 +87,11 @@ load helpers
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
   run buildah --debug=false images --json
-  [ $(wc -l <<< "$output") -eq 12 ]
+  [ $(wc -l <<< "$output") -eq 14 ]
   [ "${status}" -eq 0 ]
  
   run buildah --debug=false images --json alpine
-  [ $(wc -l <<< "$output") -eq 6 ]
+  [ $(wc -l <<< "$output") -eq 8 ]
   [ "${status}" -eq 0 ]
   buildah rm -a
   buildah rmi -a -f
@@ -104,6 +104,20 @@ load helpers
 
   run buildah --debug=false images --json
   [ $(grep '"id": "' <<< "$output" | wc -l) -eq 1 ]
+  [ "${status}" -eq 0 ]
+
+  buildah rm -a
+  buildah rmi -a -f
+}
+
+@test "images json valid" {
+  cid1=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid1 test
+  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid2 test2
+
+  run buildah --debug=false images --json
+  run python -m json.tool <<< "$output"
   [ "${status}" -eq 0 ]
 
   buildah rm -a


### PR DESCRIPTION
This change makes the images --json output a valid JSON list.

Closes: #1257
Signed-off-by: Tristan Cacqueray <tdecacqu@redhat.com>