### PR TITLE
Remove duplicate entries from images JSON output

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -297,7 +297,8 @@ func outputImages(ctx context.Context, images []storage.Image, store storage.Sto
 						return err2
 					}
 					fmt.Printf("%s\n", data)
-					break
+					// We only want to print each id once
+					break outer
 				}
 				params := imageOutputParams{
 					Tag:       tag,

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -97,6 +97,19 @@ load helpers
   buildah rmi -a -f
 }
 
+@test "images json dup test" {
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
+  buildah tag test new-name
+
+  run buildah --debug=false images --json
+  [ $(grep '"id": "' <<< "$output" | wc -l) -eq 1 ]
+  [ "${status}" -eq 0 ]
+
+  buildah rm -a
+  buildah rmi -a -f
+}
+
 @test "specify an existing image" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)


### PR DESCRIPTION
This change is a follow-up to 7c2467c to use the break outer
construct and only display a single JSON block per image.

Closes: #1259
Signed-off-by: Tristan Cacqueray <tdecacqu@redhat.com>