### PR TITLE
pull: add all-tags option

### DIFF
--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -9,13 +8,16 @@ import (
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
 	util "github.com/containers/buildah/util"
-	is "github.com/containers/image/storage"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
 var (
 	pullFlags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "all-tags, a",
+			Usage: "download all tagged images in the repository",
+		},
 		cli.StringFlag{
 			Name:  "authfile",
 			Usage: "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json",
@@ -94,6 +96,9 @@ func pullCmd(c *cli.Context) error {
 	transport := util.DefaultTransport
 	arr := strings.SplitN(args[0], ":", 2)
 	if len(arr) == 2 {
+		if c.Bool("all-tags") {
+			return errors.Errorf("tag can't be used with --all-tags")
+		}
 		if _, ok := util.Transports[arr[0]]; ok {
 			transport = arr[0]
 		}
@@ -105,22 +110,12 @@ func pullCmd(c *cli.Context) error {
 		Store:               store,
 		SystemContext:       systemContext,
 		BlobDirectory:       c.String("blob-cache"),
+		AllTags:             c.Bool("all-tags"),
 	}
 
 	if !c.Bool("quiet") {
 		options.ReportWriter = os.Stderr
 	}
 
-	ref, err := buildah.Pull(getContext(), args[0], options)
-	if err != nil {
-		return err
-	}
-
-	img, err := is.Transport.GetStoreImage(store, ref)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%s\n", img.ID)
-	return nil
+	return buildah.Pull(getContext(), args[0], options)
 }

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -560,6 +560,8 @@ return 1
 
  _buildah_pull() {
      local boolean_options="
+     --all-tags
+     -a
      --help
      -h
      --quiet

--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -42,6 +42,10 @@ The image ID of the image that was pulled.  On error 1 is returned.
 
 ## OPTIONS
 
+**--all-tags, a**
+
+All tagged images in the repository will be pulled.
+
 **--authfile** *path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.

--- a/pull.go
+++ b/pull.go
@@ -2,12 +2,14 @@ package buildah
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 
 	"github.com/containers/buildah/pkg/blobcache"
 	"github.com/containers/buildah/util"
 	cp "github.com/containers/image/copy"
+	"github.com/containers/image/docker"
 	"github.com/containers/image/docker/reference"
 	tarfile "github.com/containers/image/docker/tarfile"
 	ociarchive "github.com/containers/image/oci/archive"
@@ -17,6 +19,7 @@ import (
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -45,6 +48,9 @@ type PullOptions struct {
 	// store copies of layer blobs that we pull down, if any.  It should
 	// already exist.
 	BlobDirectory string
+	// AllTags is a boolean value that determines if all tagged images
+	// will be downloaded from the repository. The default is false.
+	AllTags bool
 }
 
 func localImageNameForReference(ctx context.Context, store storage.Store, srcRef types.ImageReference, spec string) (string, error) {
@@ -141,9 +147,61 @@ func localImageNameForReference(ctx context.Context, store storage.Store, srcRef
 }
 
 // Pull copies the contents of the image from somewhere else to local storage.
-func Pull(ctx context.Context, imageName string, options PullOptions) (types.ImageReference, error) {
+func Pull(ctx context.Context, imageName string, options PullOptions) error {
+	spec := imageName
 	systemContext := getSystemContext(options.SystemContext, options.SignaturePolicyPath)
-	return pullImage(ctx, options.Store, imageName, options, systemContext)
+	srcRef, err := alltransports.ParseImageName(spec)
+	if err != nil {
+		if options.Transport == "" {
+			options.Transport = util.DefaultTransport
+		}
+		logrus.Debugf("error parsing image name %q, trying with transport %q: %v", spec, options.Transport, err)
+		transport := options.Transport
+		if transport != util.DefaultTransport {
+			transport = transport + ":"
+		}
+		spec = transport + spec
+		srcRef2, err2 := alltransports.ParseImageName(spec)
+		if err2 != nil {
+			return errors.Wrapf(err2, "error parsing image name %q", imageName)
+		}
+		srcRef = srcRef2
+	}
+	var names []string
+	if options.AllTags {
+		if srcRef.DockerReference() == nil {
+			return errors.New("Non-docker transport is currently not supported")
+		}
+		tags, err := docker.GetRepositoryTags(ctx, systemContext, srcRef)
+		if err != nil {
+			return errors.Wrapf(err, "error getting repository tags")
+		}
+		for _, tag := range tags {
+			name := spec + ":" + tag
+			names = append(names, name)
+		}
+	} else {
+		names = append(names, spec)
+	}
+	var errs *multierror.Error
+	for _, name := range names {
+		if options.ReportWriter != nil {
+			options.ReportWriter.Write([]byte("Pulling " + name + "\n"))
+		}
+		ref, err := pullImage(ctx, options.Store, name, options, systemContext)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+			continue
+		}
+		img, err := is.Transport.GetStoreImage(options.Store, ref)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+			continue
+		}
+		fmt.Printf("%s\n", img.ID)
+	}
+
+	return errs.ErrorOrNil()
 }
 
 func pullImage(ctx context.Context, store storage.Store, imageName string, options PullOptions, sc *types.SystemContext) (types.ImageReference, error) {


### PR DESCRIPTION
Add all-tags option to download all tagged images in the repository

After change:
```
➜  buildah git:(add-pull-all) ✗ ./buildah pull --all-tags busybox
Pulling docker://busybox:1-glibc
Getting image source signatures
Skipping fetch of repeat blob sha256:68d65759a692b254073928cce9b3da459b59ee063f4aeb217cd6bcdfac5f838b
Copying config sha256:755a2703667876f4259f24a3225ef503483953ef553fba8758406beefc2ce3f9
 1.46 KiB / 1.46 KiB [======================================================] 0s
Writing manifest to image destination
Storing signatures
755a2703667876f4259f24a3225ef503483953ef553fba8758406beefc2ce3f9
Pulling docker://busybox:1-musl                  
Getting image source signatures     
Skipping fetch of repeat blob sha256:d900fc804a8829d0ea4db613927f60a28a1ef933aa1dbafdaab43630579646c2
Copying config sha256:3cc47384c4cb779466fe40182420bd90ba761a5f26f8564580a114bcd0dfa911
 1.46 KiB / 1.46 KiB [======================================================] 0s
Writing manifest to image destination
Storing signatures                     
3cc47384c4cb779466fe40182420bd90ba761a5f26f8564580a114bcd0dfa911
Pulling docker://busybox:1-ubuntu
...
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>