### PR TITLE
Fix support for multiple Short options

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -26,23 +26,25 @@ var (
 	copyDescription = "Copies the contents of a file, URL, or directory into a container's working\n   directory"
 
 	addCommand = cli.Command{
-		Name:           "add",
-		Usage:          "Add content to the container",
-		Description:    addDescription,
-		Flags:          addAndCopyFlags,
-		Action:         addCmd,
-		ArgsUsage:      "CONTAINER-NAME-OR-ID [FILE | DIRECTORY | URL] [[...] DESTINATION]",
-		SkipArgReorder: true,
+		Name:                   "add",
+		Usage:                  "Add content to the container",
+		Description:            addDescription,
+		Flags:                  addAndCopyFlags,
+		Action:                 addCmd,
+		ArgsUsage:              "CONTAINER-NAME-OR-ID [FILE | DIRECTORY | URL] [[...] DESTINATION]",
+		SkipArgReorder:         true,
+		UseShortOptionHandling: true,
 	}
 
 	copyCommand = cli.Command{
-		Name:           "copy",
-		Usage:          "Copy content into the container",
-		Description:    copyDescription,
-		Flags:          sortFlags(addAndCopyFlags),
-		Action:         copyCmd,
-		ArgsUsage:      "CONTAINER-NAME-OR-ID [FILE | DIRECTORY | URL] [[...] DESTINATION]",
-		SkipArgReorder: true,
+		Name:                   "copy",
+		Usage:                  "Copy content into the container",
+		Description:            copyDescription,
+		Flags:                  sortFlags(addAndCopyFlags),
+		Action:                 copyCmd,
+		ArgsUsage:              "CONTAINER-NAME-OR-ID [FILE | DIRECTORY | URL] [[...] DESTINATION]",
+		SkipArgReorder:         true,
+		UseShortOptionHandling: true,
 	}
 )
 

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -69,13 +69,14 @@ var (
 	fromDescription = "Creates a new working container, either from scratch or using a specified\n   image as a starting point"
 
 	fromCommand = cli.Command{
-		Name:           "from",
-		Usage:          "Create a working container based on an image",
-		Description:    fromDescription,
-		Flags:          sortFlags(append(fromFlags, buildahcli.FromAndBudFlags...)),
-		Action:         fromCmd,
-		ArgsUsage:      "IMAGE",
-		SkipArgReorder: true,
+		Name:                   "from",
+		Usage:                  "Create a working container based on an image",
+		Description:            fromDescription,
+		Flags:                  sortFlags(append(fromFlags, buildahcli.FromAndBudFlags...)),
+		Action:                 fromCmd,
+		ArgsUsage:              "IMAGE",
+		SkipArgReorder:         true,
+		UseShortOptionHandling: true,
 	}
 )
 

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -54,13 +54,14 @@ An image can be pulled using its tag or digest. If a tag is not
 specified, the image with the 'latest' tag (if it exists) is pulled.`
 
 	pullCommand = cli.Command{
-		Name:           "pull",
-		Usage:          "Pull an image from the specified location",
-		Description:    pullDescription,
-		Flags:          sortFlags(append(pullFlags)),
-		Action:         pullCmd,
-		ArgsUsage:      "IMAGE",
-		SkipArgReorder: true,
+		Name:                   "pull",
+		Usage:                  "Pull an image from the specified location",
+		Description:            pullDescription,
+		Flags:                  sortFlags(append(pullFlags)),
+		Action:                 pullCmd,
+		ArgsUsage:              "IMAGE",
+		SkipArgReorder:         true,
+		UseShortOptionHandling: true,
 	}
 )
 

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -29,12 +29,13 @@ const (
 var (
 	unshareDescription = "Runs a command in a modified user namespace"
 	unshareCommand     = cli.Command{
-		Name:           "unshare",
-		Usage:          "Run a command in a modified user namespace",
-		Description:    unshareDescription,
-		Action:         unshareCmd,
-		ArgsUsage:      "[COMMAND [ARGS [...]]]",
-		SkipArgReorder: true,
+		Name:                   "unshare",
+		Usage:                  "Run a command in a modified user namespace",
+		Description:            unshareDescription,
+		Action:                 unshareCmd,
+		ArgsUsage:              "[COMMAND [ARGS [...]]]",
+		SkipArgReorder:         true,
+		UseShortOptionHandling: true,
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>

Adds the UseShortOptionHandling  option to several of the commands.  Allowing for multiple short options to be passed together.  i.e. instead of `buildah pull -c -q alpine` the two options could be combined to `buildah pull -cq alpine`