### PR TITLE
mount: Avoid repeating mount

### DIFF
--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -65,6 +65,10 @@ func mountCmd(c *cli.Context) error {
 				lastError = errors.Wrapf(err, "error reading build container %q", name)
 				continue
 			}
+			if builder.MountPoint != "" {
+				fmt.Printf("[Warning] %s has been mounted to %s\n", name, builder.MountPoint)
+				continue
+			}
 			mountPoint, err := builder.Mount(builder.MountLabel)
 			if err != nil {
 				if lastError != nil {

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -62,3 +62,11 @@ load helpers
   buildah rm -all
   buildah rmi -f alpine
 }
+
+@test "mount the container that has been mounted" {
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  out=$(buildah --debug=false mount "$cid" "$cid" | grep "Warning" | wc -l)
+  [ "$out" -ne 0 ]
+  buildah rm -all
+  buildah rmi -f alpine
+}


### PR DESCRIPTION
Avoid repeating the mount of the already mounted container.

After change:
```
➜  buildah git:(mount-fix) ./buildah mount 4229ccab3610 0574587bdb40 4229ccab3610
4229ccab3610 /home/zhouhao/.local/share/containers/storage/vfs/dir/378735eef76991465572ba63bf8be38afa1a76eb32c4743d379a277a231a42f3
0574587bdb40 /home/zhouhao/.local/share/containers/storage/vfs/dir/2ca11592e10a0234c9c3194cd500b1ffdf0e2ed89bf9023224460283617e6a2e
[Warning] 4229ccab3610 has been mounted to /home/zhouhao/.local/share/containers/storage/vfs/dir/378735eef76991465572ba63bf8be38afa1a76eb32c4743d379a277a231a42f3
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>