### PR TITLE
unshare: do not set USER=root

### DIFF
--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -208,7 +208,7 @@ func unshareCmd(c *cli.Context) error {
 		args = []string{shell}
 	}
 	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Env = append(os.Environ(), "USER=root", "USERNAME=root", "GROUP=root", "LOGNAME=root", "UID=0", "GID=0", "_BUILDAH_STARTED_IN_USERNS=")
+	cmd.Env = append(os.Environ(), "_BUILDAH_STARTED_IN_USERNS=")
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
do not override the USER environment variable to "root" as it confuses
the runc rootless mode.  runc is using the USER variable to determine
whether XDG_RUNTIME_DIR must be honored or not.

Closes: https://github.com/containers/buildah/issues/1271

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>