### PR TITLE
Fix contrib/rpm/bulidah.spec changelog date

### DIFF
--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -97,7 +97,7 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
-* Wed Nov 21 2018 Tom Sweeney <tsweeney@redhat.com> 1.6-dev-1
+* Tue Jan 15 2019 Tom Sweeney <tsweeney@redhat.com> 1.6-1
 - Vendor in latest containers/storage
 - Revendor everything
 - Revendor in latest code by release


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

I messed up the contrib/rpm/buildah.spec in the original 1.6 PR, I'd the wrong version/date in the changelog portion.  This PR fixes that.
@rhatdan PTAL and let me know if I need to adjust further.