### PR TITLE
Fix the buildah version command

### DIFF
--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -27,10 +27,14 @@ func versionCmd(c *cli.Context) error {
 		return errors.New("'buildah version' does not accept arguments")
 	}
 
-	//converting unix time from string to int64
-	buildTime, err := strconv.ParseInt(buildInfo, 10, 64)
-	if err != nil {
-		return err
+	var err error
+	buildTime := int64(0)
+	if buildInfo != "" {
+		//converting unix time from string to int64
+		buildTime, err = strconv.ParseInt(buildInfo, 10, 64)
+		if err != nil {
+			return err
+		}
 	}
 
 	fmt.Println("Version:        ", buildah.Version)


### PR DESCRIPTION
Fix the buildah version command output in buildah v1.4

It fails with below error:
~~~
[root@host ~]# buildah version
strconv.ParseInt: parsing "": invalid syntax
[root@host ~]# rpm -q buildah
buildah-1.4-2.git608fa84.el8+2005+c789302b.x86_64
~~~

Signed-off-by: Suresh Gaikwad <sgaikwad@redhat.com>