### PR TITLE
Add support for ADD --chown

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -990,6 +990,29 @@ load helpers
   [ "$status" -eq 0 ]
 }
 
+@test "bud with chown add" {
+  imgName=alpine-image
+  ctrName=alpine-chown
+  run buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-chown
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ user:2367[[:space:]]group:3267 ]]
+  run buildah --debug=false from --name ${ctrName} ${imgName}
+  echo "$output"
+  [ "$status" -eq 0 ]
+  run buildah --debug=false run alpine-chown -- stat -c '%u' /tmp/addchown.txt
+  echo "$output"
+  # Validate that output starts with "2367"
+  [ $(expr "$output" : "2367") -ne 0 ]
+  [ "$status" -eq 0 ]
+
+  run buildah --debug=false run alpine-chown -- stat -c '%g' /tmp/addchown.txt
+  echo "$output"
+  # Validate that output starts with "3267"
+  [ $(expr "$output" : "3267") -ne 0 ]
+  [ "$status" -eq 0 ]
+}
+
 @test "bud with ADD file construct" {
   buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/add-file
   run buildah --debug=false images -a

--- a/tests/bud/add-chown/Dockerfile
+++ b/tests/bud/add-chown/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine
+
+ADD --chown=2367:3267 addchown.txt /tmp 
+RUN stat -c "user:%u group:%g" /tmp/addchown.txt 
+CMD /bin/sh
+

--- a/tests/bud/add-chown/addchown.txt
+++ b/tests/bud/add-chown/addchown.txt
@@ -1,0 +1,1 @@
+File for testing COPY with chown in a Dockerfile.

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/opencontainers/runc master
 github.com/opencontainers/runtime-spec v1.0.0
 github.com/opencontainers/runtime-tools v0.8.0
 github.com/opencontainers/selinux v1.0.0
-github.com/openshift/imagebuilder master
+github.com/openshift/imagebuilder a4122153148e3b34161191f868565d8dffe65a69
 github.com/ostreedev/ostree-go 9ab99253d365aac3a330d1f7281cf29f3d22820b
 github.com/pborman/uuid master
 github.com/pkg/errors master

--- a/vendor/github.com/openshift/imagebuilder/dispatchers.go
+++ b/vendor/github.com/openshift/imagebuilder/dispatchers.go
@@ -128,9 +128,20 @@ func add(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	if len(args) < 2 {
 		return errAtLeastOneArgument("ADD")
 	}
+	var chown string
 	last := len(args) - 1
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
-	b.PendingCopies = append(b.PendingCopies, Copy{Src: args[0:last], Dest: dest, Download: true})
+	if len(flagArgs) > 0 {
+		for _, arg := range flagArgs {
+			switch {
+			case strings.HasPrefix(arg, "--chown="):
+				chown = strings.TrimPrefix(arg, "--chown=")
+			default:
+				return fmt.Errorf("ADD only supports the --chown=<uid:gid> flag")
+			}
+		}
+	}
+	b.PendingCopies = append(b.PendingCopies, Copy{Src: args[0:last], Dest: dest, Download: true, Chown: chown})
 	return nil
 }
 


### PR DESCRIPTION
Currently buildah support COPY --chown in a Dockerfile build,
but it ignores this flag if it is passed into an ADD.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>