### PR TITLE
cmd/commit: add flag omit-timestamp to allow for deterministic builds

### DIFF
--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -53,6 +53,10 @@ var (
 			Usage: "Write the image ID to the file",
 		},
 		cli.BoolFlag{
+			Name:  "omit-timestamp",
+			Usage: "set created timestamp to epoch 0 to allow for deterministic builds",
+		},
+		cli.BoolFlag{
 			Name:  "quiet, q",
 			Usage: "don't output progress information when writing images",
 		},
@@ -172,6 +176,7 @@ func commitCmd(c *cli.Context) error {
 		IIDFile:               c.String("iidfile"),
 		Squash:                c.Bool("squash"),
 		BlobDirectory:         c.String("blob-cache"),
+		OmitTimestamp:         c.Bool("omit-timestamp"),
 	}
 	if !c.Bool("quiet") {
 		options.ReportWriter = os.Stderr

--- a/commit.go
+++ b/commit.go
@@ -67,6 +67,10 @@ type CommitOptions struct {
 	OnBuild []string
 	// Parent is the base image that this image was created by.
 	Parent string
+
+	// OmitTimestamp forces epoch 0 as created timestamp to allow for
+	// deterministic, content-addressable builds.
+	OmitTimestamp bool
 }
 
 // PushOptions can be used to alter how an image is copied somewhere.
@@ -140,7 +144,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 			}
 		}
 	}
-	src, err := b.makeImageRef(options.PreferredManifestType, options.Parent, exportBaseLayers, options.Squash, options.BlobDirectory, options.Compression, options.HistoryTimestamp)
+	src, err := b.makeImageRef(options.PreferredManifestType, options.Parent, exportBaseLayers, options.Squash, options.BlobDirectory, options.Compression, options.HistoryTimestamp, options.OmitTimestamp)
 	if err != nil {
 		return imgID, nil, "", errors.Wrapf(err, "error computing layer digests and building metadata for container %q", b.ContainerID)
 	}

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -316,6 +316,7 @@ return 1
           --rm
           --squash
           --tls-verify
+          --omit-timestamp
   "
 
      local options_with_args="

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -76,6 +76,14 @@ Squash all of the new image's layers (including those inherited from a base imag
 
 Require HTTPS and verify certificates when talking to container registries (defaults to true)
 
+**--omit-timestamp** *bool-value*
+
+Set the create timestamp to epoch 0 to allow for deterministic builds (defaults to false).
+By default, the created timestamp is changed and written into the image manifest with every commit,
+causing the image's sha256 hash to be different even if the sources are exactly the same otherwise.
+When --omit-timestamp is set to true, the created timestamp is always set to the epoch and therefore not
+changed, allowing the image's sha256 to remain the same.
+
 ## EXAMPLE
 
 This example saves an image based on the container.

--- a/image.go
+++ b/image.go
@@ -603,7 +603,7 @@ func (i *containerImageSource) GetBlob(ctx context.Context, blob types.BlobInfo,
 	return ioutils.NewReadCloserWrapper(layerFile, closer), size, nil
 }
 
-func (b *Builder) makeImageRef(manifestType, parent string, exporting bool, squash bool, blobDirectory string, compress archive.Compression, historyTimestamp *time.Time) (types.ImageReference, error) {
+func (b *Builder) makeImageRef(manifestType, parent string, exporting bool, squash bool, blobDirectory string, compress archive.Compression, historyTimestamp *time.Time, omitTimestamp bool) (types.ImageReference, error) {
 	var name reference.Named
 	container, err := b.store.Container(b.ContainerID)
 	if err != nil {
@@ -628,6 +628,10 @@ func (b *Builder) makeImageRef(manifestType, parent string, exporting bool, squa
 	created := time.Now().UTC()
 	if historyTimestamp != nil {
 		created = historyTimestamp.UTC()
+	}
+
+	if omitTimestamp {
+		created = time.Unix(0, 0)
 	}
 
 	ref := &containerImageRef{


### PR DESCRIPTION
By default, a field called "created" is written into the image manifest.
However, even if my image build process is perfectly deterministic, the image
sha256 hash will be different every time, even if my sources are exactly the
same. In many cases it is desirable that the same input results in the exactly
same output.
This commit introduces the flag --omit-timestamp to the commit command. If set to
true, the timestamp is set to epoch 0, instead of the current timestamp (which
causes different results every time commit is invoked).

Example:
Set up sample content:
`echo x > testfile`

Perform build with buildah:
```
IMG=$(buildah from scratch)
buildah add $IMG testfile
buildah commit $IMG sample-image:sample-tag
```

Old behavior:
```
[root@thinkpad test-build]# buildah commit $IMG sample-image:sample-tag
Getting image source signatures
Skipping blob d01a9af531ac (already present): 2.00 KiB / 2.00 KiB [=========] 0s
Copying config da849ca955ae: 263 B / 263 B [================================] 0s
Writing manifest to image destination
Storing signatures
da849ca955ae7180f896b0e068839dd88aa1c0480d6b70fc84603368c20c5b67
[root@thinkpad test-build]# buildah commit $IMG sample-image:sample-tag
Getting image source signatures
Skipping blob d01a9af531ac (already present): 2.00 KiB / 2.00 KiB [=========] 0s
Copying config 28e7e2761805: 263 B / 263 B [================================] 0s
Writing manifest to image destination
Storing signatures
28e7e2761805826eea37445716b6e185fc3d784a1c7bfeeb69dbee8ac79858db
```
Image is different for each commit, because the timestamp changed.

With this change:

```
[root@thinkpad test-build]# buildah commit --omit-timestamp $IMG sample-image:sample-tag
Getting image source signatures
Skipping blob d01a9af531ac (already present): 2.00 KiB / 2.00 KiB [=========] 0s
Copying config a13f491de92a: 253 B / 253 B [================================] 0s
Writing manifest to image destination
Storing signatures
a13f491de92a8bb478c16e589082a9da093c04d7889d577ab19aa7fb33e902bf
[root@thinkpad test-build]# buildah commit --omit-timestamp $IMG sample-image:sample-tag
Getting image source signatures
Skipping blob d01a9af531ac (already present): 2.00 KiB / 2.00 KiB [=========] 0s
Copying config a13f491de92a: 253 B / 253 B [================================] 0s
Writing manifest to image destination
Storing signatures
a13f491de92a8bb478c16e589082a9da093c04d7889d577ab19aa7fb33e902bf
```

So with this change, it's deterministic. Of course, if your build process itself, or the stuff you do with buildah, e.g. non-deterministic `buildah run`, this change can't help you :)

The background for this:
- For one, it's desirable in general to have fully deterministic builds, down to the image itself. 
- As a more concrete situtation: we have a build process that builds multiple applications at once, and deploys them afterwards through HELM. We tag each image with the Git sha commit hash during the build. Then, we pass the image&tag into HELM and install. 
What happens: even if the image source, e.g. a static go binary, did not change in this run of our CD Pipeline, it will get re-deployed, because the image name & tag is different (different tag, which is the git commit).

It's possible to add a suffix with the concrete SHA hash of the complete image. It looks like this:
`my-image-name:a30e2b0a2cfde329cc5b646c19a94b9e30b617d3@sha256:xxxxxxxxxxxxxxxx` where xxx is the sha256 hash of the image. Then, IIRC, k8s (or better, the deployment controller i guess) will not perform a (rolling) update, because the tag changed, but since the SHA hash is the same, nothing REALLY changed. **For this, i need subsequent builds with no actual change to produce the same docker image SHA.**

With almost all docker image build tools it's NOT possible to fully have deterministic builds due to the timestamp being written into the image manifest. This PR sets it always to 0 if --omit-timestamp is set, so it's an opt-in if this is required. If it's not needed, the "old" behavior is maintained. The drawback is, that tools will show - of course - an old timestamp for the image ;)

I found two tools that also offer deterministic builds for docker images:
- GCP's JIB https://github.com/GoogleContainerTools/jib
- Bazel https://blog.bazel.build/2015/07/28/docker_build.html

I'm happy to discuss other options to achieve this deterministic bevhavior. As far as i can see, docker struggles with this issue for a long time. Since JIB is java specific and Bazel is IMHO a rather heavy weight (this is not meant to be offensive against bazel, i just don't use it, yet), having buildah for deterministic builds would be really great in my opinion.

If this PR is acceptable, i'm happy to write tests for the changes as well. 