### PR TITLE
Make CLI help descriptions and usage a bit more consistent

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -23,7 +23,7 @@ var (
 		},
 	}
 	addDescription  = "Adds the contents of a file, URL, or directory to a container's working\n   directory.  If a local file appears to be an archive, its contents are\n   extracted and added instead of the archive file itself."
-	copyDescription = "Copies the contents of a file, URL, or directory into a container's working\n   directory"
+	copyDescription = "Copies the contents of a file, URL, or directory into a container's working\n   directory."
 
 	addCommand = cli.Command{
 		Name:                   "add",

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -78,7 +78,7 @@ var (
 			Usage: "Require HTTPS and verify certificates when accessing the registry",
 		},
 	}
-	commitDescription = "Writes a new image using the container's read-write layer and, if it is based\n   on an image, the layers of that image"
+	commitDescription = "Writes a new image using the container's read-write layer and, if it is based\n   on an image, the layers of that image."
 	commitCommand     = cli.Command{
 		Name:                   "commit",
 		Usage:                  "Create an image from a working container",

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -118,7 +118,7 @@ var (
 			Usage: "set working `directory` for containers based on image",
 		},
 	}
-	configDescription = "Modifies the configuration values which will be saved to the image"
+	configDescription = "Modifies the configuration values which will be saved to the image."
 	configCommand     = cli.Command{
 		Name:                   "config",
 		Usage:                  "Update image configuration settings",

--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -77,7 +77,7 @@ var (
 			Usage: "display only container IDs",
 		},
 	}
-	containersDescription = "Lists containers which appear to be " + buildah.Package + " working containers, their\n   names and IDs, and the names and IDs of the images from which they were\n   initialized"
+	containersDescription = "Lists containers which appear to be " + buildah.Package + " working containers, their\n   names and IDs, and the names and IDs of the images from which they were\n   initialized."
 	containersCommand     = cli.Command{
 		Name:                   "containers",
 		Aliases:                []string{"list", "ls", "ps"},

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -66,7 +66,7 @@ var (
 			Usage: "require HTTPS and verify certificates when accessing the registry",
 		},
 	}
-	fromDescription = "Creates a new working container, either from scratch or using a specified\n   image as a starting point"
+	fromDescription = "Creates a new working container, either from scratch or using a specified\n   image as a starting point."
 
 	fromCommand = cli.Command{
 		Name:                   "from",

--- a/cmd/buildah/info.go
+++ b/cmd/buildah/info.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	infoDescription = "The information displayed pertains to the host and current storage statistics which is useful when reporting issues."
+	infoDescription = "Display information about the host and current storage statistics which are useful when reporting issues."
 	infoFlags       = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "debug, D",

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -35,7 +35,7 @@ var (
 	inspectDescription = "Inspects a build container's or built image's configuration."
 	inspectCommand     = cli.Command{
 		Name:                   "inspect",
-		Usage:                  "Inspects the configuration of a container or image",
+		Usage:                  "Inspect the configuration of a container or image",
 		Description:            inspectDescription,
 		Flags:                  sortFlags(inspectFlags),
 		Action:                 inspectCmd,

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	mountDescription = "Mounts a working container's root filesystem for manipulation"
+	mountDescription = "Mounts a working container's root filesystem for manipulation."
 	mountFlags       = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "notruncate",

--- a/cmd/buildah/rename.go
+++ b/cmd/buildah/rename.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	renameDescription = "Rename a local container"
+	renameDescription = "Renames a local container."
 	renameCommand     = cli.Command{
 		Name:                   "rename",
 		Usage:                  "Rename a container",

--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	rmDescription = "Removes one or more working containers, unmounting them if necessary"
+	rmDescription = "Removes one or more working containers, unmounting them if necessary."
 	rmFlags       = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "all, a",

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	rmiDescription = "removes one or more locally stored images."
+	rmiDescription = "Removes one or more locally stored images."
 	rmiFlags       = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "all, a",
@@ -36,7 +36,7 @@ var (
 	}
 	rmiCommand = cli.Command{
 		Name:                   "rmi",
-		Usage:                  "removes one or more images from local storage",
+		Usage:                  "Remove one or more images from local storage",
 		Description:            rmiDescription,
 		Action:                 rmiCmd,
 		ArgsUsage:              "IMAGE-NAME-OR-ID [...]",

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -60,7 +60,7 @@ var (
 			Usage: "bind mount a host location into the container while running the command",
 		},
 	}
-	runDescription = "Runs a specified command using the container's root filesystem as a root\n   filesystem, using configuration settings inherited from the container's\n   image or as specified using previous calls to the config command"
+	runDescription = "Runs a specified command using the container's root filesystem as a root\n   filesystem, using configuration settings inherited from the container's\n   image or as specified using previous calls to the config command."
 	runCommand     = cli.Command{
 		Name:                   "run",
 		Usage:                  "Run a command inside of the container",

--- a/cmd/buildah/tag.go
+++ b/cmd/buildah/tag.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	tagDescription = "Adds one or more additional names to locally-stored image"
+	tagDescription = "Adds one or more additional names to locally-stored image."
 	tagCommand     = cli.Command{
 		Name:                   "tag",
 		Usage:                  "Add an additional name to a local image",

--- a/cmd/buildah/umount.go
+++ b/cmd/buildah/umount.go
@@ -20,8 +20,8 @@ var (
 	umountCommand = cli.Command{
 		Name:                   "umount",
 		Aliases:                []string{"unmount"},
-		Usage:                  "Unmounts the root file system on the specified working containers",
-		Description:            "Unmounts the root file system on the specified working containers",
+		Usage:                  "Unmount the root file system of the specified working containers",
+		Description:            "Unmounts the root file system of the specified working containers.",
 		Action:                 umountCmd,
 		ArgsUsage:              "[CONTAINER-NAME-OR-ID [...]]",
 		Flags:                  sortFlags(umountFlags),

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -27,7 +27,7 @@ const (
 )
 
 var (
-	unshareDescription = "Runs a command in a modified user namespace"
+	unshareDescription = "Runs a command in a modified user namespace."
 	unshareCommand     = cli.Command{
 		Name:                   "unshare",
 		Usage:                  "Run a command in a modified user namespace",

--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -55,7 +55,8 @@ func versionCmd(c *cli.Context) error {
 //cli command to print out the version info of buildah
 var versionCommand = cli.Command{
 	Name:                   "version",
-	Usage:                  "Display the Buildah Version Information",
+	Usage:                  "Display the Buildah version information",
+	Description:            "Displays Buildah version information.",
 	Action:                 versionCmd,
 	SkipArgReorder:         true,
 	UseShortOptionHandling: true,


### PR DESCRIPTION
Start with capital letters; a description ends with a period; usage doesn't.