### PR TITLE
Add options for empty-layer history entries

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/containers/buildah/docker"
 	"github.com/containers/buildah/util"
@@ -175,6 +176,15 @@ type Builder struct {
 	// after processing the AddCapabilities set, when running commands in the container.
 	// If a capability appears in both lists, it will be dropped.
 	DropCapabilities []string
+	// PrependedEmptyLayers are history entries that we'll add to a
+	// committed image, after any history items that we inherit from a base
+	// image, but before the history item for the layer that we're
+	// committing.
+	PrependedEmptyLayers []v1.History
+	// AppendedEmptyLayers are history entries that we'll add to a
+	// committed image after the history item for the layer that we're
+	// committing.
+	AppendedEmptyLayers []v1.History
 
 	CommonBuildOpts *CommonBuildOptions
 	// TopLayer is the top layer of the image
@@ -209,11 +219,24 @@ type BuilderInfo struct {
 	DefaultCapabilities   []string
 	AddCapabilities       []string
 	DropCapabilities      []string
+	History               []v1.History
 }
 
 // GetBuildInfo gets a pointer to a Builder object and returns a BuilderInfo object from it.
 // This is used in the inspect command to display Manifest and Config as string and not []byte.
 func GetBuildInfo(b *Builder) BuilderInfo {
+	history := copyHistory(b.OCIv1.History)
+	history = append(history, copyHistory(b.PrependedEmptyLayers)...)
+	now := time.Now().UTC()
+	created := &now
+	history = append(history, v1.History{
+		Created:    created,
+		CreatedBy:  b.ImageCreatedBy,
+		Author:     b.Maintainer(),
+		Comment:    b.ImageHistoryComment,
+		EmptyLayer: false,
+	})
+	history = append(history, copyHistory(b.AppendedEmptyLayers)...)
 	return BuilderInfo{
 		Type:                  b.Type,
 		FromImage:             b.FromImage,
@@ -239,6 +262,7 @@ func GetBuildInfo(b *Builder) BuilderInfo {
 		DefaultCapabilities:   append([]string{}, util.DefaultCapabilities...),
 		AddCapabilities:       append([]string{}, b.AddCapabilities...),
 		DropCapabilities:      append([]string{}, b.DropCapabilities...),
+		History:               history,
 	}
 }
 

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -18,6 +18,10 @@ import (
 
 var (
 	runFlags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "add-history",
+			Usage: "add an entry for this operation to the image's history.  Use BUILDAH_HISTORY environment variable to override. (default false)",
+		},
 		cli.StringSliceFlag{
 			Name:  "cap-add",
 			Usage: "add the specified capability (default [])",
@@ -175,6 +179,14 @@ func runCmd(c *cli.Context) error {
 		if w, ok := ee.Sys().(syscall.WaitStatus); ok {
 			os.Exit(w.ExitStatus())
 		}
+	}
+	if runerr == nil {
+		shell := "/bin/sh -c"
+		if len(builder.Shell()) > 0 {
+			shell = strings.Join(builder.Shell(), " ")
+		}
+		conditionallyAddHistory(builder, c, "%s %s", shell, strings.Join(args, " "))
+		return builder.Save()
 	}
 	return runerr
 }

--- a/config.go
+++ b/config.go
@@ -574,3 +574,50 @@ func (b *Builder) SetHealthcheck(config *docker.HealthConfig) {
 		}
 	}
 }
+
+// AddPrependedEmptyLayer adds an item to the history that we'll create when
+// commiting the image, after any history we inherit from the base image, but
+// before the history item that we'll use to describe the new layer that we're
+// adding.
+func (b *Builder) AddPrependedEmptyLayer(created *time.Time, createdBy, author, comment string) {
+	if created != nil {
+		copiedTimestamp := *created
+		created = &copiedTimestamp
+	}
+	b.PrependedEmptyLayers = append(b.PrependedEmptyLayers, ociv1.History{
+		Created:    created,
+		CreatedBy:  createdBy,
+		Author:     author,
+		Comment:    comment,
+		EmptyLayer: true,
+	})
+}
+
+// ClearPrependedEmptyLayers clears the list of history entries that we'll add
+// to the committed image before the entry for the layer that we're adding.
+func (b *Builder) ClearPrependedEmptyLayers() {
+	b.PrependedEmptyLayers = nil
+}
+
+// AddAppendedEmptyLayer adds an item to the history that we'll create when
+// commiting the image, after the history item that we'll use to describe the
+// new layer that we're adding.
+func (b *Builder) AddAppendedEmptyLayer(created *time.Time, createdBy, author, comment string) {
+	if created != nil {
+		copiedTimestamp := *created
+		created = &copiedTimestamp
+	}
+	b.AppendedEmptyLayers = append(b.AppendedEmptyLayers, ociv1.History{
+		Created:    created,
+		CreatedBy:  createdBy,
+		Author:     author,
+		Comment:    comment,
+		EmptyLayer: true,
+	})
+}
+
+// ClearAppendedEmptyLayers clears the list of history entries that we'll add
+// to the committed image after the entry for the layer that we're adding.
+func (b *Builder) ClearAppendedEmptyLayers() {
+	b.AppendedEmptyLayers = nil
+}

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -258,6 +258,7 @@ return 1
 
  _buildah_config() {
      local boolean_options="
+     --add-history
      --help
      -h
   "
@@ -447,6 +448,7 @@ return 1
 
  _buildah_run() {
      local boolean_options="
+     --add-history
      --help
      -t
      --tty
@@ -494,6 +496,7 @@ return 1
 
  _buildah_copy() {
      local boolean_options="
+     --add-history
      --help
      -h
      --quiet
@@ -515,6 +518,7 @@ return 1
 
  _buildah_add() {
      local boolean_options="
+     --add-history
      --help
      -h
      --quiet

--- a/docs/buildah-add.md
+++ b/docs/buildah-add.md
@@ -15,6 +15,14 @@ archive file itself.  If a local directory is specified as a source, its
 
 ## OPTIONS
 
+**--add-history**
+
+Add an entry to the history which will note the digest of the added content.
+Defaults to false.
+
+Note: You can also override the default value of --add-history by setting the
+BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
+
 **--chown** *owner*:*group*
 
 Sets the user and group ownership of the destination content.

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -11,6 +11,17 @@ Updates one or more of the settings kept for a container.
 
 ## OPTIONS
 
+**--add-history**
+
+Add an entry to the image's history which will note changes to the settings for
+**--cmd**, **--entrypoint**, **--env**, **--healthcheck**, **--label**,
+**--onbuild**, **--port**, **--shell**, **--stop-signal**, **--user**,
+**--volume**, and **--workingdir**.
+Defaults to false.
+
+Note: You can also override the default value of --add-history by setting the
+BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
+
 **--annotation** *annotation*
 
 Add an image *annotation* (e.g. annotation=*annotation*) to the image manifest

--- a/docs/buildah-copy.md
+++ b/docs/buildah-copy.md
@@ -13,6 +13,14 @@ specified as a source, its *contents* are copied to the destination.
 
 ## OPTIONS
 
+**--add-history**
+
+Add an entry to the history which will note the digest of the added content.
+Defaults to false.
+
+Note: You can also override the default value of --add-history by setting the
+BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
+
 **--chown** *owner*:*group*
 
 Sets the user and group ownership of the destination content.

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -14,6 +14,14 @@ the *buildah config* command.  To execute *buildah run* within an
 interactive shell, specify the --tty option.
 
 ## OPTIONS
+**--add-history**
+
+Add an entry to the history which will note what command is being invoked.
+Defaults to false.
+
+Note: You can also override the default value of --add-history by setting the
+BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
+
 **--cap-add**=*CAP\_xxx*
 
 Add the specified capability to the set of capabilities which will be granted

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -299,6 +299,15 @@ func DefaultIsolation() string {
 	return buildah.OCI
 }
 
+// DefaultHistory returns the default add-history setting
+func DefaultHistory() bool {
+	history := os.Getenv("BUILDAH_HISTORY")
+	if strings.ToLower(history) == "true" || history == "1" {
+		return true
+	}
+	return false
+}
+
 func VerifyFlagsArgsOrder(args []string) error {
 	for _, arg := range args {
 		if strings.HasPrefix(arg, "-") {

--- a/tests/history.bats
+++ b/tests/history.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function testconfighistory() {
+  config="$1"
+  expected="$2"
+  container=$(echo "c$config" | sed -E -e 's|[[:blank:]]|_|g' -e "s,[-=/:'],_,g" | tr '[A-Z]' '[a-z]')
+  image=$(echo "i$config" | sed -E -e 's|[[:blank:]]|_|g' -e "s,[-=/:'],_,g" | tr '[A-Z]' '[a-z]')
+  buildah from --name "$container" --format docker scratch
+  buildah config $config --add-history "$container"
+  buildah commit --signature-policy ${TESTSDIR}/policy.json "$container" "$image"
+  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image"
+  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image" | grep "$expected"
+  if test "$3" != "not-oci" ; then
+    buildah inspect --format '{{range .OCIv1.History}}{{println .CreatedBy}}{{end}}' "$image" | grep "$expected"
+  fi
+}
+
+@test "history-cmd" {
+  testconfighistory "--cmd /foo" "CMD /foo"
+}
+
+@test "history-entrypoint" {
+  testconfighistory "--entrypoint /foo" "ENTRYPOINT /foo"
+}
+
+@test "history-env" {
+  testconfighistory "--env FOO=BAR" "ENV FOO=BAR"
+}
+
+@test "history-healthcheck" {
+  buildah from --name healthcheckctr --format docker scratch
+  buildah config --healthcheck "CMD /foo" --healthcheck-timeout=10s --healthcheck-interval=20s --healthcheck-retries=7 --healthcheck-start-period=30s --add-history healthcheckctr
+  buildah commit --signature-policy ${TESTSDIR}/policy.json healthcheckctr healthcheckimg
+  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg
+  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg | grep "HEALTHCHECK --interval=20s --retries=7 --start-period=30s --timeout=10s CMD /foo"
+}
+
+@test "history-label" {
+  testconfighistory "--label FOO=BAR" "LABEL FOO=BAR"
+}
+
+@test "history-onbuild" {
+  buildah from --name onbuildctr --format docker scratch
+  buildah config --onbuild "CMD /foo" --add-history onbuildctr
+  buildah commit --signature-policy ${TESTSDIR}/policy.json onbuildctr onbuildimg
+  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg
+  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg | grep "ONBUILD CMD /foo"
+}
+
+@test "history-port" {
+  testconfighistory "--port 80/tcp" "EXPOSE 80/tcp"
+}
+
+@test "history-shell" {
+  testconfighistory "--shell /bin/wish" "SHELL /bin/wish"
+}
+
+@test "history-stop-signal" {
+  testconfighistory "--stop-signal SIGHUP" "STOPSIGNAL SIGHUP" not-oci
+}
+
+@test "history-user" {
+  testconfighistory "--user 10:10" "USER 10:10"
+}
+
+@test "history-volume" {
+  testconfighistory "--volume /foo" "VOLUME /foo"
+}
+
+@test "history-workingdir" {
+  testconfighistory "--workingdir /foo" "WORKDIR /foo"
+}
+
+@test "history-add" {
+  createrandom ${TESTDIR}/randomfile
+  buildah from --name addctr --format docker scratch
+  run buildah add --add-history addctr ${TESTDIR}/randomfile
+  echo "$output"
+  [ "$status" -eq 0 ]
+  digest="$output"
+  buildah commit --signature-policy ${TESTSDIR}/policy.json addctr addimg
+  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg
+  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg | grep "ADD file:$digest"
+}
+
+@test "history-copy" {
+  createrandom ${TESTDIR}/randomfile
+  buildah from --name copyctr --format docker scratch
+  run buildah --debug=false copy --add-history copyctr ${TESTDIR}/randomfile
+  echo "$output"
+  [ "$status" -eq 0 ]
+  digest="$output"
+  buildah commit --signature-policy ${TESTSDIR}/policy.json copyctr copyimg
+  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg
+  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg | grep "COPY file:$digest"
+}
+
+@test "history-run" {
+  buildah from --name runctr --format docker --signature-policy ${TESTSDIR}/policy.json busybox
+  buildah run --add-history runctr -- uname -a
+  buildah commit --signature-policy ${TESTSDIR}/policy.json runctr runimg
+  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg
+  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg | grep "/bin/sh -c uname -a"
+}

--- a/util.go
+++ b/util.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/storage/pkg/chrootarchive"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/reexec"
+	"github.com/opencontainers/image-spec/specs-go/v1"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -41,6 +42,28 @@ func copyStringSlice(s []string) []string {
 	t := make([]string, len(s))
 	copy(t, s)
 	return t
+}
+
+func copyHistory(history []v1.History) []v1.History {
+	if len(history) == 0 {
+		return nil
+	}
+	h := make([]v1.History, 0, len(history))
+	for _, entry := range history {
+		created := entry.Created
+		if created != nil {
+			timestamp := *created
+			created = &timestamp
+		}
+		h = append(h, v1.History{
+			Created:    created,
+			CreatedBy:  entry.CreatedBy,
+			Author:     entry.Author,
+			Comment:    entry.Comment,
+			EmptyLayer: entry.EmptyLayer,
+		})
+	}
+	return h
 }
 
 func convertStorageIDMaps(UIDMap, GIDMap []idtools.IDMap) ([]rspec.LinuxIDMapping, []rspec.LinuxIDMapping) {


### PR DESCRIPTION
Add configuration methods for adding entries which will show up in a committed image's history, both before and after the new layer that we add while committing the image.  Expose them from the CLI in the form of a new --add-history option for the "add", "config", "copy", and "run" commands.