### PR TITLE
Bump baseline test Fedora to 29

### DIFF
--- a/tests/test_buildah_baseline.sh
+++ b/tests/test_buildah_baseline.sh
@@ -30,7 +30,7 @@ buildah run $ctrid ls /
 ########
 ctr=$(buildah from scratch)
 mnt=$(buildah mount $ctr)
-dnf -y install --installroot=$mnt --releasever=28 httpd
+dnf -y install --installroot=$mnt --releasever=29 httpd
 buildah run $ctr touch /test
 
 ########
@@ -90,9 +90,9 @@ scratchmnt=$(buildah mount $newcontainer)
 echo $scratchmnt
 
 ########
-# Install Fedora 28 bash and coreutils
+# Install Fedora 29 bash and coreutils
 ########
-dnf install --installroot $scratchmnt --release 28 bash coreutils --setopt install_weak_deps=false -y
+dnf install --installroot $scratchmnt --release 29 bash coreutils --setopt install_weak_deps=false -y
 
 ########
 # Check /usr/bin on the new container
@@ -123,7 +123,7 @@ buildah run $newcontainer /usr/bin/runecho.sh
 # Add configuration information
 ########
 buildah config --created-by "ipbabble"  $newcontainer
-buildah config --author "wgh at redhat.com @ipbabble" --label name=fedora28-bashecho $newcontainer
+buildah config --author "wgh at redhat.com @ipbabble" --label name=fedora29-bashecho $newcontainer
 
 ########
 # Inspect the container, verifying above was put into it


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Bumps the Buildah Baseline Test up to Fedora 29 from 28.

This test is only used "by hand", nothing related to the CI.