### PR TITLE
Add Quiet to PullOptions and PushOptions

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -101,6 +101,10 @@ type PushOptions struct {
 	// regenerate from on-disk layers, substituting them in the list of
 	// blobs to copy whenever possible.
 	BlobDirectory string
+	// Quiet is a boolean value that determines if minimal output to
+	// the user will be displayed, this is best used for logging.
+	// The default is false.
+	Quiet bool
 }
 
 // Commit writes the contents of the container, along with its updated
@@ -228,6 +232,9 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 func Push(ctx context.Context, image string, dest types.ImageReference, options PushOptions) (reference.Canonical, digest.Digest, error) {
 	systemContext := getSystemContext(options.SystemContext, options.SignaturePolicyPath)
 
+	if options.Quiet {
+		options.ReportWriter = nil // Turns off logging output
+	}
 	blocked, err := isReferenceBlocked(dest, systemContext)
 	if err != nil {
 		return nil, "", errors.Wrapf(err, "error checking if pushing to registry for %q is blocked", transports.ImageName(dest))

--- a/pull.go
+++ b/pull.go
@@ -51,6 +51,10 @@ type PullOptions struct {
 	// AllTags is a boolean value that determines if all tagged images
 	// will be downloaded from the repository. The default is false.
 	AllTags bool
+	// Quiet is a boolean value that determines if minimal output to
+	// the user will be displayed, this is best used for logging.
+	// The default is false.
+	Quiet bool
 }
 
 func localImageNameForReference(ctx context.Context, store storage.Store, srcRef types.ImageReference, spec string) (string, error) {
@@ -166,6 +170,9 @@ func Pull(ctx context.Context, imageName string, options PullOptions) error {
 			return errors.Wrapf(err2, "error parsing image name %q", imageName)
 		}
 		srcRef = srcRef2
+	}
+	if options.Quiet {
+		options.ReportWriter = nil // Turns off logging output
 	}
 	var names []string
 	if options.AllTags {


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add Quiet to the PullOptions and PushOptions structures.
If set to true output will be in 'quiet' mode.  This
will primarily be used by callers such as OpenShift.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>