### PR TITLE
Fix bud issue with 2 line Dockerfile

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1311,12 +1311,16 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (strin
 
 	// Check if we have a one line Dockerfile making layers irrelevant
 	// or the user told us to ignore layers.
-	ignoreLayers := (len(stages) < 2 && len(stages[0].Node.Children) < 2) || (!b.layers && !b.noCache)
+	singleLineDockerfile := (len(stages) < 2 && len(stages[0].Node.Children) < 1)
+	ignoreLayers := singleLineDockerfile || !b.layers && !b.noCache
 
 	if ignoreLayers {
 		imgID, ref, err := stageExecutor.Commit(ctx, stages[len(stages)-1].Builder, "")
 		if err != nil {
 			return "", nil, err
+		}
+		if singleLineDockerfile {
+			b.log("COMMIT %s", ref)
 		}
 		imageID = imgID
 		imageRef = ref

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -59,6 +59,20 @@ load helpers
   rm -rf ${TESTSDIR}/bud/use-layers/mount
 }
 
+@test "bud with --layers and single and two line Dockerfiles" {
+  buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test -f Dockerfile.5 ${TESTSDIR}/bud/use-layers
+  run buildah --debug=false images -a
+  [ $(wc -l <<< "$output") -eq 3 ]
+  [ "${status}" -eq 0 ]
+
+  buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 -f Dockerfile.6 ${TESTSDIR}/bud/use-layers
+  run buildah --debug=false images -a
+  [ $(wc -l <<< "$output") -eq 4 ]
+  [ "${status}" -eq 0 ]
+
+  buildah rmi -a -f
+}
+
 @test "bud with --layers, multistage, and COPY with --from" {
   mkdir -p ${TESTSDIR}/bud/use-layers/uuid
   uuidgen > ${TESTSDIR}/bud/use-layers/uuid/data

--- a/tests/bud/use-layers/Dockerfile.5
+++ b/tests/bud/use-layers/Dockerfile.5
@@ -1,0 +1,2 @@
+FROM alpine
+RUN touch /home/blah

--- a/tests/bud/use-layers/Dockerfile.6
+++ b/tests/bud/use-layers/Dockerfile.6
@@ -1,0 +1,1 @@
+FROM alpine


### PR DESCRIPTION
We were checking for single line Dockerfile to ensure
that they are actually built, but the condition was
also applying to two line Dockerfiles causing those
ones to not build properly. Fixed the condition and
now single line as well as 2 or more line dockerfile
build as expected.

Fixes https://github.com/containers/libpod/issues/2248

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>