### PR TITLE
Touch up cli help examples and a few nits

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -18,8 +18,8 @@ type addCopyResults struct {
 
 func init() {
 	var (
-		addDescription  = "Adds the contents of a file, URL, or directory to a container's working\n   directory.  If a local file appears to be an archive, its contents are\n   extracted and added instead of the archive file itself."
-		copyDescription = "Copies the contents of a file, URL, or directory into a container's working\n   directory."
+		addDescription  = "\n  Adds the contents of a file, URL, or directory to a container's working\n  directory.  If a local file appears to be an archive, its contents are\n  extracted and added instead of the archive file itself."
+		copyDescription = "\n  Copies the contents of a file, URL, or directory into a container's working\n  directory."
 		addOpts         addCopyResults
 		copyOpts        addCopyResults
 	)
@@ -30,8 +30,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addCmd(cmd, args, addOpts)
 		},
-		Example: "CONTAINER-NAME-OR-ID [FILE | DIRECTORY | URL] [[...] DESTINATION]",
-		Args:    cobra.MinimumNArgs(1),
+		Example: `  buildah add containerID '/myapp/app.conf'
+  buildah add containerID '/myapp/app.conf' '/myapp/app.conf'`,
+		Args: cobra.MinimumNArgs(1),
 	}
 
 	copyCommand := &cobra.Command{
@@ -41,8 +42,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return copyCmd(cmd, args, copyOpts)
 		},
-		Example: "CONTAINER-NAME-OR-ID [FILE | DIRECTORY | URL] [[...] DESTINATION]",
-		Args:    cobra.MinimumNArgs(1),
+		Example: `  buildah copy containerID '/myapp/app.conf'
+  buildah copy containerID '/myapp/app.conf' '/myapp/app.conf'`,
+		Args: cobra.MinimumNArgs(1),
 	}
 
 	addFlags := addCommand.Flags()

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -24,7 +24,7 @@ type budResults struct {
 
 func init() {
 	var (
-		budDescription = "Builds an OCI image using instructions in one or more Dockerfiles."
+		budDescription = "\n  Builds an OCI image using instructions in one or more Dockerfiles."
 	)
 
 	layerFlagsResults := buildahcli.LayerResults{}
@@ -49,7 +49,9 @@ func init() {
 			}
 			return budCmd(cmd, args, br)
 		},
-		Example: "CONTEXT-DIRECTORY | URL",
+		Example: `  buildah bud -f Dockerfile.simple .
+  buildah bud --volume /home/test:/myvol:ro,Z -t imageName .
+  buildah bud -f Dockerfile.simple -f Dockerfile.notsosimple .`,
 	}
 
 	flags := budCommand.Flags()
@@ -187,7 +189,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budResults) error {
 	}
 
 	runtimeFlags := []string{}
-	for _, arg := range iopts.RuntimeOpts {
+	for _, arg := range iopts.RuntimeFlags {
 		runtimeFlags = append(runtimeFlags, "--"+arg)
 	}
 

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -37,7 +37,7 @@ type commitInputOptions struct {
 func init() {
 	var (
 		opts              commitInputOptions
-		commitDescription = "Writes a new image using the container's read-write layer and, if it is based\n   on an image, the layers of that image."
+		commitDescription = "\n  Writes a new image using the container's read-write layer and, if it is based\n  on an image, the layers of that image."
 	)
 	commitCommand := &cobra.Command{
 		Use:   "commit",
@@ -46,7 +46,8 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return commitCmd(cmd, args, opts)
 		},
-		Example: "CONTAINER-NAME-OR-ID IMAGE",
+		Example: `  buildah commit containerID newImageName
+  buildah commit containerID docker://localhost:5000/imageId`,
 	}
 	flags := commitCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -34,7 +34,7 @@ type configResults struct {
 	healthcheckTimeout     string
 	historyComment         string
 	hostname               string
-	labels                 []string
+	label                  []string
 	onbuild                []string
 	os                     string
 	ports                  []string
@@ -47,7 +47,7 @@ type configResults struct {
 
 func init() {
 	var (
-		configDescription = "Modifies the configuration values which will be saved to the image."
+		configDescription = "\n  Modifies the configuration values which will be saved to the image."
 		opts              configResults
 	)
 	configCommand := &cobra.Command{
@@ -57,7 +57,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return configCmd(cmd, args, opts)
 		},
-		Example: "CONTAINER-NAME-OR-ID",
+		Example: `  buildah config --author='Jane Austen' --workingdir='/etc/mycontainers' containerID
+  buildah config --entrypoint '[ "/entrypoint.sh", "dev" ]' containerID
+  buildah config --env foo=bar PATH=$PATH containerID`,
 	}
 
 	flags := configCommand.Flags()
@@ -79,7 +81,7 @@ func init() {
 	flags.StringVar(&opts.healthcheckTimeout, "healthcheck-timeout", "", "set the maximum amount of `time` to wait for a `healthcheck` command for the target image")
 	flags.StringVar(&opts.historyComment, "history-comment", "", "set a `comment` for the history of the target image")
 	flags.StringVar(&opts.hostname, "hostname", "", "set a host`name` for containers based on image")
-	flags.StringSliceVarP(&opts.labels, "label", "l", []string{}, "add image configuration `label` e.g. label=value")
+	flags.StringSliceVarP(&opts.label, "label", "l", []string{}, "add image configuration `label` e.g. label=value")
 	flags.StringSliceVar(&opts.onbuild, "onbuild", []string{}, "add onbuild command to be run on images based on this image. Only supported on 'docker' formatted images")
 	flags.StringVar(&opts.os, "os", "", "set `operating system` of the target image")
 	flags.StringSliceVarP(&opts.ports, "port", "p", []string{}, "add `port` to expose when running containers based on image (default [])")
@@ -208,7 +210,7 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 	}
 	updateHealthcheck(builder, c, iopts)
 	if c.Flag("label").Changed {
-		for _, labelSpec := range iopts.labels {
+		for _, labelSpec := range iopts.label {
 			label := strings.SplitN(labelSpec, "=", 2)
 			if len(label) > 1 {
 				builder.SetLabel(label[0], label[1])
@@ -216,7 +218,7 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 				builder.UnsetLabel(label[0])
 			}
 		}
-		conditionallyAddHistory(builder, c, "/bin/sh -c #(nop) LABEL %s", strings.Join(iopts.labels, " "))
+		conditionallyAddHistory(builder, c, "/bin/sh -c #(nop) LABEL %s", strings.Join(iopts.label, " "))
 	}
 	if c.Flag("workingdir").Changed {
 		builder.SetWorkDir(iopts.workingDir)

--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -57,7 +57,7 @@ type containersResults struct {
 
 func init() {
 	var (
-		containersDescription = "Lists containers which appear to be " + buildah.Package + " working containers, their\n   names and IDs, and the names and IDs of the images from which they were\n   initialized."
+		containersDescription = "\n  Lists containers which appear to be " + buildah.Package + " working containers, their\n  names and IDs, and the names and IDs of the images from which they were\n  initialized."
 		opts                  containersResults
 	)
 	containersCommand := &cobra.Command{
@@ -69,7 +69,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return containersCmd(cmd, args, opts)
 		},
-		Example: " ",
+		Example: `  buildah containers
+  buildah containers --format "{{.ContainerID}} {{.ContainerName}}"
+  buildah containers -q --noheading --notruncate`,
 	}
 
 	flags := containersCommand.Flags()

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -34,7 +34,7 @@ type fromReply struct {
 
 func init() {
 	var (
-		fromDescription = "Creates a new working container, either from scratch or using a specified\n   image as a starting point."
+		fromDescription = "\n  Creates a new working container, either from scratch or using a specified\n  image as a starting point."
 		opts            fromReply
 	)
 	fromAndBudResults := buildahcli.FromAndBudResults{}
@@ -51,7 +51,9 @@ func init() {
 			opts.NameSpaceResults = &namespaceResults
 			return fromCmd(cmd, args, opts)
 		},
-		Example: "IMAGE",
+		Example: `  buildah from --pull imagename
+  buildah from docker-daemon:imagename:imagetag
+  buildah from --name "myimagename" myregistry/myrepository/imagename:imagetag`,
 	}
 
 	flags := fromCommand.Flags()

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -62,7 +62,7 @@ type imageResults struct {
 func init() {
 	var (
 		opts              imageResults
-		imagesDescription = "Lists locally stored images."
+		imagesDescription = "\n  Lists locally stored images."
 	)
 	imagesCommand := &cobra.Command{
 		Use:   "images",
@@ -71,7 +71,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return imagesCmd(cmd, args, &opts)
 		},
-		Example: "[imageName]",
+		Example: `  buildah images --all
+  buildah images [imageName]
+  buildah images --format '{{.ID}} {{.Name}} {{.Size}} {{.CreatedAtRaw}}'`,
 	}
 
 	flags := imagesCommand.Flags()

--- a/cmd/buildah/info.go
+++ b/cmd/buildah/info.go
@@ -21,7 +21,7 @@ type infoResults struct {
 
 func init() {
 	var (
-		infoDescription = "Display information about the host and current storage statistics which are useful when reporting issues."
+		infoDescription = "\n  Display information about the host and current storage statistics which are useful when reporting issues."
 		opts            infoResults
 	)
 	infoCommand := &cobra.Command{

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -28,7 +28,7 @@ type inspectResults struct {
 func init() {
 	var (
 		opts               inspectResults
-		inspectDescription = "Inspects a build container's or built image's configuration."
+		inspectDescription = "\n  Inspects a build container's or built image's configuration."
 	)
 
 	inspectCommand := &cobra.Command{
@@ -38,7 +38,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return inspectCmd(cmd, args, opts)
 		},
-		Example: "CONTAINER-OR-IMAGE",
+		Example: `  buildah inspect containerID
+  buildah inspect --type image imageID
+  buildah inspect --format '{{.OCIv1.Config.Env}}' alpine`,
 	}
 
 	flags := inspectCommand.Flags()

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -84,7 +84,8 @@ func init() {
 }
 
 func initConfig() {
-	// TODO We can do extra stuff here
+	// TODO Cobra allows us to do extra stuff here at init
+	// time if we ever want to take advantage.
 }
 
 func before(cmd *cobra.Command, args []string) error {

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -11,7 +11,7 @@ import (
 
 func init() {
 	var (
-		mountDescription = "Mounts a working container's root filesystem for manipulation."
+		mountDescription = "\n  Mounts a working container's root filesystem for manipulation."
 		noTruncate       bool
 	)
 	mountCommand := &cobra.Command{
@@ -21,7 +21,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return mountCmd(cmd, args, noTruncate)
 		},
-		Example: "[CONTAINER-NAME-OR-ID [...]]",
+		Example: `buildah mount
+  buildah mount containerID
+  buildah mount containerID1 containerID2`,
 	}
 
 	flags := mountCommand.Flags()

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -27,9 +27,9 @@ func init() {
 	var (
 		opts pullResults
 
-		pullDescription = `Pulls an image from a registry and stores it locally.
-An image can be pulled using its tag or digest. If a tag is not
-specified, the image with the 'latest' tag (if it exists) is pulled.`
+		pullDescription = `  Pulls an image from a registry and stores it locally.
+  An image can be pulled using its tag or digest. If a tag is not
+  specified, the image with the 'latest' tag (if it exists) is pulled.`
 	)
 
 	pullCommand := &cobra.Command{
@@ -39,7 +39,9 @@ specified, the image with the 'latest' tag (if it exists) is pulled.`
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pullCmd(cmd, args, opts)
 		},
-		Example: "IMAGE",
+		Example: `  buildah pull imagename
+  buildah pull docker-daemon:imagename:imagetag
+  buildah pull myregistry/myrepository/imagename:imagetag`,
 	}
 
 	flags := pullCommand.Flags()

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -35,14 +35,14 @@ func init() {
 	var (
 		opts            pushResults
 		pushDescription = fmt.Sprintf(`
-   Pushes an image to a specified location.
+  Pushes an image to a specified location.
 
-   The Image "DESTINATION" uses a "transport":"details" format. If not specified, will reuse source IMAGE as DESTINATION.
+  The Image "DESTINATION" uses a "transport":"details" format. If not specified, will reuse source IMAGE as DESTINATION.
 
-   Supported transports:
-   %s
+  Supported transports:
+  %s
 
-   See buildah-push(1) section "DESTINATION" for the expected format
+  See buildah-push(1) section "DESTINATION" for the expected format
 `, getListOfTransports())
 	)
 
@@ -53,7 +53,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pushCmd(cmd, args, opts)
 		},
-		Example: "IMAGE [DESTINATION]",
+		Example: `  buildah push imageID docker://registry.example.com/repository:tag
+  buildah push imageID docker-daemon:image:tagi
+  buildah push imageID oci:/path/to/layout:image:tag`,
 	}
 	flags := pushCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/rename.go
+++ b/cmd/buildah/rename.go
@@ -7,14 +7,15 @@ import (
 )
 
 var (
-	renameDescription = "Renames a local container."
+	renameDescription = "\n  Renames a local container."
 	renameCommand     = &cobra.Command{
-		Use:     "rename",
-		Short:   "Rename a container",
-		Long:    renameDescription,
-		RunE:    renameCmd,
-		Example: "CONTAINER-NAME-OR-ID CONTAINER-NAME",
-		Args:    cobra.ExactArgs(2),
+		Use:   "rename",
+		Short: "Rename a container",
+		Long:  renameDescription,
+		RunE:  renameCmd,
+		Example: `  buildah rename containerName NewName
+  buildah rename containerID NewName`,
+		Args: cobra.ExactArgs(2),
 	}
 )
 

--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -16,7 +16,7 @@ type rmResults struct {
 
 func init() {
 	var (
-		rmDescription = "Removes one or more working containers, unmounting them if necessary."
+		rmDescription = "\n  Removes one or more working containers, unmounting them if necessary."
 		opts          rmResults
 	)
 	rmCommand := &cobra.Command{
@@ -27,7 +27,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return rmCmd(cmd, args, opts)
 		},
-		Example: "CONTAINER-NAME-OR-ID [...]",
+		Example: `  buildah rm containerID
+  buildah rm containerID1 containerID2 containerID3
+  buildah rm --all`,
 	}
 
 	flags := rmCommand.Flags()

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -26,7 +26,7 @@ type rmiResults struct {
 
 func init() {
 	var (
-		rmiDescription = "Removes one or more locally stored images."
+		rmiDescription = "\n  Removes one or more locally stored images."
 		opts           rmiResults
 	)
 	rmiCommand := &cobra.Command{
@@ -36,7 +36,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return rmiCmd(cmd, args, opts)
 		},
-		Example: "IMAGE-NAME-OR-ID [...]",
+		Example: `  buildah rmi imageID
+  buildah rmi --all --force
+  buildah rmi imageID1 imageID2 imageID3`,
 	}
 	flags := rmiCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -33,7 +33,7 @@ type runInputOptions struct {
 
 func init() {
 	var (
-		runDescription = "Runs a specified command using the container's root filesystem as a root\n   filesystem, using configuration settings inherited from the container's\n   image or as specified using previous calls to the config command."
+		runDescription = "\n  Runs a specified command using the container's root filesystem as a root\n  filesystem, using configuration settings inherited from the container's\n  image or as specified using previous calls to the config command."
 		opts           runInputOptions
 	)
 
@@ -48,7 +48,9 @@ func init() {
 			return runCmd(cmd, args, opts)
 
 		},
-		Example: "CONTAINER-NAME-OR-ID COMMAND [ARGS [...]]",
+		Example: `  buildah run containerID -- ps -auxw
+  buildah run --tty containerID /bin/bash
+  buildah run --volume /path/on/host:/path/in/container:ro,z containerID /bin/sh`,
 	}
 
 	flags := runCommand.Flags()

--- a/cmd/buildah/tag.go
+++ b/cmd/buildah/tag.go
@@ -8,15 +8,16 @@ import (
 )
 
 var (
-	tagDescription = "Adds one or more additional names to locally-stored image."
+	tagDescription = "\n  Adds one or more additional names to locally-stored image."
 	tagCommand     = &cobra.Command{
 		Use:   "tag",
 		Short: "Add an additional name to a local image",
 		Long:  tagDescription,
 		RunE:  tagCmd,
 
-		Example: "IMAGE-NAME NEW-IMAGE-NAME",
-		Args:    cobra.MinimumNArgs(2),
+		Example: `  buildah tag imageName firstNewName
+  buildah tag imageName firstNewName SecondNewName`,
+		Args: cobra.MinimumNArgs(2),
 	}
 )
 

--- a/cmd/buildah/umount.go
+++ b/cmd/buildah/umount.go
@@ -17,7 +17,9 @@ func init() {
 		Short:   "Unmount the root file system of the specified working containers",
 		Long:    "Unmounts the root file system of the specified working containers.",
 		RunE:    umountCmd,
-		Example: "[CONTAINER-NAME-OR-ID [...]]",
+		Example: `  buildah umount containerID
+  buildah umount containerID1 containerID2 containerID3
+  buildah umount --all`,
 	}
 
 	flags := umountCommand.Flags()

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -27,13 +27,14 @@ const (
 )
 
 var (
-	unshareDescription = "Runs a command in a modified user namespace."
+	unshareDescription = "\n  Runs a command in a modified user namespace."
 	unshareCommand     = &cobra.Command{
-		Use:     "unshare",
-		Short:   "Run a command in a modified user namespace",
-		Long:    unshareDescription,
-		RunE:    unshareCmd,
-		Example: "[COMMAND [ARGS [...]]]",
+		Use:   "unshare",
+		Short: "Run a command in a modified user namespace",
+		Long:  unshareDescription,
+		RunE:  unshareCmd,
+		Example: `  buildah unshare id
+  buildah unshare cat /proc/self/uid_map`,
 	}
 )
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -55,17 +55,17 @@ type BudResults struct {
 	File                []string
 	Format              string
 	Iidfile             string
-	NoCache             bool
 	Label               []string
 	Logfile             string
 	Loglevel            int
+	NoCache             bool
 	Platform            string
 	Pull                bool
 	PullAlways          bool
 	Quiet               bool
 	Rm                  bool
 	Runtime             string
-	RuntimeOpts         []string
+	RuntimeFlags        []string
 	SignaturePolicy     string
 	Squash              bool
 	Tag                 []string
@@ -153,7 +153,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.BoolVarP(&flags.Quiet, "quiet", "q", false, "refrain from announcing build instructions and image read/write progress")
 	fs.BoolVar(&flags.Rm, "rm", true, "Remove intermediate containers after a successful build (default true)")
 	fs.StringVar(&flags.Runtime, "runtime", util.Runtime(), "`path` to an alternate runtime. Use BUILDAH_RUNTIME environment variable to override.")
-	fs.StringSliceVar(&flags.RuntimeOpts, "runtime-flag", []string{}, "add global flags for the container runtime")
+	fs.StringSliceVar(&flags.RuntimeFlags, "runtime-flag", []string{}, "add global flags for the container runtime")
 	fs.StringVar(&flags.SignaturePolicy, "signature-policy", "", "`pathname` of signature policy file (not usually used)")
 	fs.BoolVar(&flags.Squash, "squash", false, "Squash newly built layers into a single new layer. The build process does not currently support caching so this is a NOOP.")
 	fs.StringSliceVarP(&flags.Tag, "tag", "t", []string{}, "tagged `name` to apply to the built image")


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Picks off a few left over nits from #1303.  Also formats the
description of each help to have a blank line then everything spaced
over by two.  Examples have been added for each too.

For example, here's the top part of help for containers:

```
# buildah containers -h

  Lists containers which appear to be buildah working containers, their
  names and IDs, and the names and IDs of the images from which they were
  initialized.

Usage:
  buildah containers [flags]

Aliases:
  containers, list, ls, ps

Examples:
  buildah containers
  buildah containers --format "{{.ContainerID}} {{.ContainerName}}"
  buildah containers -q --noheading --notruncate
```