### PR TITLE
 Fix pulling of images within buildah 

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -336,11 +336,6 @@ type BuilderOptions struct {
 	// needs to be pulled and the image name alone can not be resolved to a
 	// reference to a source image.  No separator is implicitly added.
 	Registry string
-	// Transport is a value which is prepended to the image's name, if it
-	// needs to be pulled and the image name alone, or the image name and
-	// the registry together, can not be resolved to a reference to a
-	// source image.  No separator is implicitly added.
-	Transport string
 	// PullBlobDirectory is the name of a directory in which we'll attempt
 	// to store copies of layer blobs that we pull down, if any.  It should
 	// already exist.

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -131,7 +131,7 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 
 	dest, err := alltransports.ParseImageName(image)
 	if err != nil {
-		candidates, _, err := util.ResolveName(image, "", systemContext, store)
+		candidates, _, _, err := util.ResolveName(image, "", systemContext, store)
 		if err != nil {
 			return errors.Wrapf(err, "error parsing target image name %q", image)
 		}

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/buildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
-	"github.com/containers/buildah/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -189,14 +188,6 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 		return err
 	}
 
-	transport := util.DefaultTransport
-	arr := strings.SplitN(args[0], ":", 2)
-	if len(arr) == 2 {
-		if _, ok := util.Transports[arr[0]]; ok {
-			transport = arr[0]
-		}
-	}
-
 	isolation, err := parse.IsolationOption(c)
 	if err != nil {
 		return err
@@ -219,7 +210,6 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 
 	options := buildah.BuilderOptions{
 		FromImage:             args[0],
-		Transport:             transport,
 		Container:             iopts.name,
 		PullPolicy:            pullPolicy,
 		SignaturePolicyPath:   signaturePolicy,

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -86,7 +86,10 @@ func pullCmd(c *cobra.Command, args []string, iopts pullResults) error {
 		BlobDirectory:       iopts.blobCache,
 		AllTags:             iopts.allTags,
 		ReportWriter:        os.Stderr,
-		Quiet:               iopts.quiet,
+	}
+
+	if iopts.quiet {
+		options.ReportWriter = nil // Turns off logging output
 	}
 
 	return buildah.Pull(getContext(), args[0], options)

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"os"
-	"strings"
 
 	"github.com/containers/buildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
-	"github.com/containers/buildah/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -81,27 +79,14 @@ func pullCmd(c *cobra.Command, args []string, iopts pullResults) error {
 		return err
 	}
 
-	transport := util.DefaultTransport
-	arr := strings.SplitN(args[0], ":", 2)
-	if len(arr) == 2 {
-		if iopts.allTags {
-			return errors.Errorf("tag can't be used with --all-tags")
-		}
-		if _, ok := util.Transports[arr[0]]; ok {
-			transport = arr[0]
-		}
-	}
-
 	options := buildah.PullOptions{
-		Transport:           transport,
 		SignaturePolicyPath: iopts.signaturePolicy,
 		Store:               store,
 		SystemContext:       systemContext,
 		BlobDirectory:       iopts.blobCache,
 		AllTags:             iopts.allTags,
-	}
-	if !iopts.quiet {
-		options.ReportWriter = os.Stderr
+		ReportWriter:        os.Stderr,
+		Quiet:               iopts.quiet,
 	}
 
 	return buildah.Pull(getContext(), args[0], options)

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -26,6 +26,9 @@ Multiple transports are supported:
   **docker-daemon:**_docker-reference_
   An image _docker-reference_ stored in the docker daemon's internal storage.  _docker-reference_ must include either a tag or a digest.  Alternatively, when reading images, the format can also be docker-daemon:algo:digest (an image ID).
 
+  **oci:**_path_**:**_tag_**
+  An image tag in a directory compliant with "Open Container Image Layout Specification" at _path_.
+
   **oci-archive:**_path_**:**_tag_
   An image _tag_ in a directory compliant with "Open Container Image Layout Specification" at _path_.
 

--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -25,6 +25,9 @@ Multiple transports are supported:
   **docker-daemon:**_docker-reference_
   An image _docker-reference_ stored in the docker daemon's internal storage.  _docker-reference_ must include either a tag or a digest.  Alternatively, when reading images, the format can also be docker-daemon:algo:digest (an image ID).
 
+  **oci:**_path_**:**_tag_**
+  An image tag in a directory compliant with "Open Container Image Layout Specification" at _path_.
+
   **oci-archive:**_path_**:**_tag_
   An image _tag_ in a directory compliant with "Open Container Image Layout Specification" at _path_.
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -62,11 +62,6 @@ type BuildOptions struct {
 	// needs to be pulled and the image name alone can not be resolved to a
 	// reference to a source image.  No separator is implicitly added.
 	Registry string
-	// Transport is a value which is prepended to the image's name, if it
-	// needs to be pulled and the image name alone, or the image name and
-	// the registry together, can not be resolved to a reference to a
-	// source image.  No separator is implicitly added.
-	Transport string
 	// IgnoreUnrecognizedInstructions tells us to just log instructions we
 	// don't recognize, and try to keep going.
 	IgnoreUnrecognizedInstructions bool
@@ -186,7 +181,6 @@ type Executor struct {
 	builder                        *buildah.Builder
 	pullPolicy                     buildah.PullPolicy
 	registry                       string
-	transport                      string
 	ignoreUnrecognizedInstructions bool
 	quiet                          bool
 	runtime                        string
@@ -582,7 +576,6 @@ func NewExecutor(store storage.Store, options BuildOptions) (*Executor, error) {
 		contextDir:                     options.ContextDirectory,
 		pullPolicy:                     options.PullPolicy,
 		registry:                       options.Registry,
-		transport:                      options.Transport,
 		ignoreUnrecognizedInstructions: options.IgnoreUnrecognizedInstructions,
 		quiet:                          options.Quiet,
 		runtime:                        options.Runtime,
@@ -672,7 +665,6 @@ func (b *Executor) Prepare(ctx context.Context, stage imagebuilder.Stage, from s
 		FromImage:             from,
 		PullPolicy:            b.pullPolicy,
 		Registry:              b.registry,
-		Transport:             b.transport,
 		PullBlobDirectory:     b.blobDirectory,
 		SignaturePolicyPath:   b.signaturePolicyPath,
 		ReportWriter:          b.reportWriter,
@@ -785,7 +777,7 @@ func (b *Executor) resolveNameToImageRef() (types.ImageReference, error) {
 	if b.output != "" {
 		imageRef, err = alltransports.ParseImageName(b.output)
 		if err != nil {
-			candidates, _, err := util.ResolveName(b.output, "", b.systemContext, b.store)
+			candidates, _, _, err := util.ResolveName(b.output, "", b.systemContext, b.store)
 			if err != nil {
 				return nil, errors.Wrapf(err, "error parsing target image name %q", b.output)
 			}

--- a/new.go
+++ b/new.go
@@ -28,15 +28,14 @@ const (
 	minimumTruncatedIDLength = 3
 )
 
-func pullAndFindImage(ctx context.Context, store storage.Store, imageName string, options BuilderOptions, sc *types.SystemContext) (*storage.Image, types.ImageReference, error) {
+func pullAndFindImage(ctx context.Context, store storage.Store, transport string, imageName string, options BuilderOptions, sc *types.SystemContext) (*storage.Image, types.ImageReference, error) {
 	pullOptions := PullOptions{
 		ReportWriter:  options.ReportWriter,
 		Store:         store,
 		SystemContext: options.SystemContext,
-		Transport:     options.Transport,
 		BlobDirectory: options.PullBlobDirectory,
 	}
-	ref, err := pullImage(ctx, store, imageName, pullOptions, sc)
+	ref, err := pullImage(ctx, store, transport, imageName, pullOptions, sc)
 	if err != nil {
 		logrus.Debugf("error pulling image %q: %v", imageName, err)
 		return nil, nil, err
@@ -101,16 +100,16 @@ func newContainerIDMappingOptions(idmapOptions *IDMappingOptions) storage.IDMapp
 	return options
 }
 
-func resolveImage(ctx context.Context, systemContext *types.SystemContext, store storage.Store, options BuilderOptions) (types.ImageReference, *storage.Image, error) {
+func resolveImage(ctx context.Context, systemContext *types.SystemContext, store storage.Store, options BuilderOptions) (types.ImageReference, string, *storage.Image, error) {
 	type failure struct {
 		resolvedImageName string
 		err               error
 	}
-
-	candidates, searchRegistriesWereUsedButEmpty, err := util.ResolveName(options.FromImage, options.Registry, systemContext, store)
+	candidates, transport, searchRegistriesWereUsedButEmpty, err := util.ResolveName(options.FromImage, options.Registry, systemContext, store)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error parsing reference to image %q", options.FromImage)
+		return nil, "", nil, errors.Wrapf(err, "error parsing reference to image %q", options.FromImage)
 	}
+
 	failures := []failure{}
 	for _, image := range candidates {
 		var err error
@@ -118,25 +117,25 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 			if img, err := store.Image(image); err == nil && img != nil && strings.HasPrefix(img.ID, image) {
 				ref, err := is.Transport.ParseStoreReference(store, img.ID)
 				if err != nil {
-					return nil, nil, errors.Wrapf(err, "error parsing reference to image %q", img.ID)
+					return nil, "", nil, errors.Wrapf(err, "error parsing reference to image %q", img.ID)
 				}
-				return ref, img, nil
+				return ref, transport, img, nil
 			}
 		}
 
 		if options.PullPolicy == PullAlways {
-			pulledImg, pulledReference, err := pullAndFindImage(ctx, store, image, options, systemContext)
+			pulledImg, pulledReference, err := pullAndFindImage(ctx, store, transport, image, options, systemContext)
 			if err != nil {
 				logrus.Debugf("unable to pull and read image %q: %v", image, err)
 				failures = append(failures, failure{resolvedImageName: image, err: err})
 				continue
 			}
-			return pulledReference, pulledImg, nil
+			return pulledReference, transport, pulledImg, nil
 		}
 
 		srcRef, err := alltransports.ParseImageName(image)
 		if err != nil {
-			if options.Transport == "" {
+			if transport == "" {
 				logrus.Debugf("error parsing image name %q: %v", image, err)
 				failures = append(failures, failure{
 					resolvedImageName: image,
@@ -144,12 +143,13 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 				})
 				continue
 			}
-			logrus.Debugf("error parsing image name %q as given, trying with transport %q: %v", image, options.Transport, err)
-			transport := options.Transport
+			logrus.Debugf("error parsing image name %q as given, trying with transport %q: %v", image, transport, err)
+
+			trans := transport
 			if transport != util.DefaultTransport {
-				transport = transport + ":"
+				trans = trans + ":"
 			}
-			srcRef2, err := alltransports.ParseImageName(transport + image)
+			srcRef2, err := alltransports.ParseImageName(trans + image)
 			if err != nil {
 				logrus.Debugf("error parsing image name %q: %v", transport+image, err)
 				failures = append(failures, failure{
@@ -163,19 +163,19 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 
 		destImage, err := localImageNameForReference(ctx, store, srcRef, options.FromImage)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "error computing local image name for %q", transports.ImageName(srcRef))
+			return nil, "", nil, errors.Wrapf(err, "error computing local image name for %q", transports.ImageName(srcRef))
 		}
 		if destImage == "" {
-			return nil, nil, errors.Errorf("error computing local image name for %q", transports.ImageName(srcRef))
+			return nil, "", nil, errors.Errorf("error computing local image name for %q", transports.ImageName(srcRef))
 		}
 
 		ref, err := is.Transport.ParseStoreReference(store, destImage)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "error parsing reference to image %q", destImage)
+			return nil, "", nil, errors.Wrapf(err, "error parsing reference to image %q", destImage)
 		}
 		img, err := is.Transport.GetStoreImage(store, ref)
 		if err == nil {
-			return ref, img, nil
+			return ref, transport, img, nil
 		}
 
 		if errors.Cause(err) == storage.ErrImageUnknown && options.PullPolicy != PullIfMissing {
@@ -187,26 +187,26 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 			continue
 		}
 
-		pulledImg, pulledReference, err := pullAndFindImage(ctx, store, image, options, systemContext)
+		pulledImg, pulledReference, err := pullAndFindImage(ctx, store, transport, image, options, systemContext)
 		if err != nil {
 			logrus.Debugf("unable to pull and read image %q: %v", image, err)
 			failures = append(failures, failure{resolvedImageName: image, err: err})
 			continue
 		}
-		return pulledReference, pulledImg, nil
+		return pulledReference, transport, pulledImg, nil
 	}
 
 	if len(failures) != len(candidates) {
-		return nil, nil, fmt.Errorf("internal error: %d candidates (%#v) vs. %d failures (%#v)", len(candidates), candidates, len(failures), failures)
+		return nil, "", nil, fmt.Errorf("internal error: %d candidates (%#v) vs. %d failures (%#v)", len(candidates), candidates, len(failures), failures)
 	}
 
 	registriesConfPath := sysregistries.RegistriesConfPath(systemContext)
 	switch len(failures) {
 	case 0:
 		if searchRegistriesWereUsedButEmpty {
-			return nil, nil, errors.Errorf("image name %q is a short name and no search registries are defined in %s.", options.FromImage, registriesConfPath)
+			return nil, "", nil, errors.Errorf("image name %q is a short name and no search registries are defined in %s.", options.FromImage, registriesConfPath)
 		}
-		return nil, nil, fmt.Errorf("internal error: no pull candidates were available for %q for an unknown reason", options.FromImage)
+		return nil, "", nil, fmt.Errorf("internal error: no pull candidates were available for %q for an unknown reason", options.FromImage)
 
 	case 1:
 		err := failures[0].err
@@ -216,7 +216,7 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 		if searchRegistriesWereUsedButEmpty {
 			err = errors.Wrapf(err, "(image name %q is a short name and no search registries are defined in %s)", options.FromImage, registriesConfPath)
 		}
-		return nil, nil, err
+		return nil, "", nil, err
 
 	default:
 		// NOTE: a multi-line error string:
@@ -224,7 +224,7 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 		for _, f := range failures {
 			e = e + fmt.Sprintf("\n* %q: %s", f.resolvedImageName, f.err.Error())
 		}
-		return nil, nil, errors.New(e)
+		return nil, "", nil, errors.New(e)
 	}
 }
 
@@ -250,21 +250,19 @@ func findUnusedContainer(name string, containers []storage.Container) string {
 }
 
 func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions) (*Builder, error) {
-	var ref types.ImageReference
-	var img *storage.Image
-	var err error
-
+	var (
+		ref types.ImageReference
+		img *storage.Image
+		err error
+	)
 	if options.FromImage == BaseImageFakeName {
 		options.FromImage = ""
-	}
-	if options.Transport == "" {
-		options.Transport = util.DefaultTransport
 	}
 
 	systemContext := getSystemContext(options.SystemContext, options.SignaturePolicyPath)
 
 	if options.FromImage != "" && options.FromImage != "scratch" {
-		ref, img, err = resolveImage(ctx, systemContext, store, options)
+		ref, _, img, err = resolveImage(ctx, systemContext, store, options)
 		if err != nil {
 			return nil, err
 		}

--- a/pull.go
+++ b/pull.go
@@ -50,10 +50,6 @@ type PullOptions struct {
 	// AllTags is a boolean value that determines if all tagged images
 	// will be downloaded from the repository. The default is false.
 	AllTags bool
-	// Quiet is a boolean value that determines if minimal output to
-	// the user will be displayed, this is best used for logging.
-	// The default is false.
-	Quiet bool
 }
 
 func localImageNameForReference(ctx context.Context, store storage.Store, srcRef types.ImageReference, spec string) (string, error) {
@@ -168,9 +164,6 @@ func Pull(ctx context.Context, imageName string, options PullOptions) error {
 		ReportWriter:        options.ReportWriter,
 	}
 
-	if options.Quiet {
-		boptions.ReportWriter = nil // Turns off logging output
-	}
 	storageRef, transport, img, err := resolveImage(ctx, systemContext, options.Store, boptions)
 	if err != nil {
 		return err

--- a/pull.go
+++ b/pull.go
@@ -9,7 +9,9 @@ import (
 	"github.com/containers/buildah/pkg/blobcache"
 	"github.com/containers/buildah/util"
 	cp "github.com/containers/image/copy"
+	"github.com/containers/image/directory"
 	"github.com/containers/image/docker"
+	dockerarchive "github.com/containers/image/docker/archive"
 	"github.com/containers/image/docker/reference"
 	tarfile "github.com/containers/image/docker/tarfile"
 	ociarchive "github.com/containers/image/oci/archive"
@@ -40,10 +42,6 @@ type PullOptions struct {
 	// github.com/containers/image/types SystemContext to hold credentials
 	// and other authentication/authorization information.
 	SystemContext *types.SystemContext
-	// Transport is a value which is prepended to the image's name, if the
-	// image name alone can not be resolved to a reference to a source
-	// image.  No separator is implicitly added.
-	Transport string
 	// BlobDirectory is the name of a directory in which we'll attempt to
 	// store copies of layer blobs that we pull down, if any.  It should
 	// already exist.
@@ -65,7 +63,7 @@ func localImageNameForReference(ctx context.Context, store storage.Store, srcRef
 	file := split[len(split)-1]
 	var name string
 	switch srcRef.Transport().Name() {
-	case util.DockerArchive:
+	case dockerarchive.Transport.Name():
 		tarSource, err := tarfile.NewSourceFromFile(file)
 		if err != nil {
 			return "", errors.Wrapf(err, "error opening tarfile %q as a source image", file)
@@ -92,7 +90,7 @@ func localImageNameForReference(ctx context.Context, store storage.Store, srcRef
 				}
 			}
 		}
-	case util.OCIArchive:
+	case ociarchive.Transport.Name():
 		// retrieve the manifest from index.json to access the image name
 		manifest, err := ociarchive.LoadManifestDescriptor(srcRef)
 		if err != nil {
@@ -107,7 +105,7 @@ func localImageNameForReference(ctx context.Context, store storage.Store, srcRef
 		} else {
 			name = manifest.Annotations["org.opencontainers.image.ref.name"]
 		}
-	case util.DirTransport:
+	case directory.Transport.Name():
 		// supports pull from a directory
 		name = split[1]
 		// remove leading "/"
@@ -152,76 +150,74 @@ func localImageNameForReference(ctx context.Context, store storage.Store, srcRef
 
 // Pull copies the contents of the image from somewhere else to local storage.
 func Pull(ctx context.Context, imageName string, options PullOptions) error {
-	spec := imageName
 	systemContext := getSystemContext(options.SystemContext, options.SignaturePolicyPath)
-	srcRef, err := alltransports.ParseImageName(spec)
-	if err != nil {
-		if options.Transport == "" {
-			options.Transport = util.DefaultTransport
-		}
-		logrus.Debugf("error parsing image name %q, trying with transport %q: %v", spec, options.Transport, err)
-		transport := options.Transport
-		if transport != util.DefaultTransport {
-			transport = transport + ":"
-		}
-		spec = transport + spec
-		srcRef2, err2 := alltransports.ParseImageName(spec)
-		if err2 != nil {
-			return errors.Wrapf(err2, "error parsing image name %q", imageName)
-		}
-		srcRef = srcRef2
+
+	boptions := BuilderOptions{
+		FromImage:           imageName,
+		SignaturePolicyPath: options.SignaturePolicyPath,
+		SystemContext:       systemContext,
+		PullBlobDirectory:   options.BlobDirectory,
+		ReportWriter:        options.ReportWriter,
 	}
+
 	if options.Quiet {
-		options.ReportWriter = nil // Turns off logging output
+		boptions.ReportWriter = nil // Turns off logging output
 	}
-	var names []string
+	storageRef, transport, img, err := resolveImage(ctx, systemContext, options.Store, boptions)
+	if err != nil {
+		return err
+	}
+
+	var errs *multierror.Error
 	if options.AllTags {
-		if srcRef.DockerReference() == nil {
-			return errors.New("Non-docker transport is currently not supported")
+		if transport != util.DefaultTransport {
+			return errors.New("Non-docker transport is not supported, for --all-tags pulling")
 		}
-		tags, err := docker.GetRepositoryTags(ctx, systemContext, srcRef)
+
+		spec := transport + storageRef.DockerReference().Name()
+		storageRef, err = alltransports.ParseImageName(spec)
+		if err != nil {
+			return errors.Wrapf(err, "error getting repository tags")
+		}
+		tags, err := docker.GetRepositoryTags(ctx, systemContext, storageRef)
 		if err != nil {
 			return errors.Wrapf(err, "error getting repository tags")
 		}
 		for _, tag := range tags {
 			name := spec + ":" + tag
-			names = append(names, name)
+			if options.ReportWriter != nil {
+				options.ReportWriter.Write([]byte("Pulling " + name + "\n"))
+			}
+			ref, err := pullImage(ctx, options.Store, transport, name, options, systemContext)
+			if err != nil {
+				errs = multierror.Append(errs, err)
+				continue
+			}
+			img, err := is.Transport.GetStoreImage(options.Store, ref)
+			if err != nil {
+				errs = multierror.Append(errs, err)
+				continue
+			}
+			fmt.Printf("%s\n", img.ID)
 		}
 	} else {
-		names = append(names, spec)
-	}
-	var errs *multierror.Error
-	for _, name := range names {
-		if options.ReportWriter != nil {
-			options.ReportWriter.Write([]byte("Pulling " + name + "\n"))
-		}
-		ref, err := pullImage(ctx, options.Store, name, options, systemContext)
-		if err != nil {
-			errs = multierror.Append(errs, err)
-			continue
-		}
-		img, err := is.Transport.GetStoreImage(options.Store, ref)
-		if err != nil {
-			errs = multierror.Append(errs, err)
-			continue
-		}
 		fmt.Printf("%s\n", img.ID)
 	}
 
 	return errs.ErrorOrNil()
 }
 
-func pullImage(ctx context.Context, store storage.Store, imageName string, options PullOptions, sc *types.SystemContext) (types.ImageReference, error) {
+func pullImage(ctx context.Context, store storage.Store, transport string, imageName string, options PullOptions, sc *types.SystemContext) (types.ImageReference, error) {
 	spec := imageName
 	srcRef, err := alltransports.ParseImageName(spec)
 	if err != nil {
-		if options.Transport == "" {
-			options.Transport = util.DefaultTransport
-		}
-		logrus.Debugf("error parsing image name %q, trying with transport %q: %v", spec, options.Transport, err)
-		transport := options.Transport
-		if transport != util.DefaultTransport {
-			transport = transport + ":"
+		logrus.Debugf("error parsing image name %q, trying with transport %q: %v", spec, transport, err)
+		if transport == "" {
+			transport = util.DefaultTransport
+		} else {
+			if transport != util.DefaultTransport {
+				transport = transport + ":"
+			}
 		}
 		spec = transport + spec
 		srcRef2, err2 := alltransports.ParseImageName(spec)

--- a/pull.go
+++ b/pull.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/image/docker/reference"
 	tarfile "github.com/containers/image/docker/tarfile"
 	ociarchive "github.com/containers/image/oci/archive"
+	oci "github.com/containers/image/oci/layout"
 	"github.com/containers/image/signature"
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/transports"
@@ -106,6 +107,13 @@ func localImageNameForReference(ctx context.Context, store storage.Store, srcRef
 			name = manifest.Annotations["org.opencontainers.image.ref.name"]
 		}
 	case directory.Transport.Name():
+		// supports pull from a directory
+		name = split[1]
+		// remove leading "/"
+		if name[:1] == "/" {
+			name = name[1:]
+		}
+	case oci.Transport.Name():
 		// supports pull from a directory
 		name = split[1]
 		// remove leading "/"

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -84,6 +84,12 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ "alpine" ]]
+  run buildah pull --all-tags --signature-policy ${TESTSDIR}/policy.json docker-archive:${TESTDIR}/alp.tar
+  echo "$output"
+  [ "$status" -ne 0 ]
+  run rm -rf ${TESTDIR}/alp.tar
+  echo "$output"
+  [ "$status" -eq 0 ]
 }
 
 @test "pull-from-oci-archive" {
@@ -103,6 +109,12 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ "alpine" ]]
+  run buildah pull --all-tags --signature-policy ${TESTSDIR}/policy.json oci-archive:${TESTDIR}/alp.tar
+  echo "$output"
+  [ "$status" -ne 0 ]
+  run rm -rf ${TESTDIR}/alp.tar
+  echo "$output"
+  [ "$status" -eq 0 ]
 }
 
 @test "pull-from-local-directory" {
@@ -123,6 +135,9 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ "buildahtest" ]]
+  run buildah pull --all-tags --signature-policy ${TESTSDIR}/policy.json dir:${TESTDIR}/buildahtest
+  echo "$output"
+  [ "$status" -ne 0 ]
   run rm -rf ${TESTDIR}/buildahtest
   echo "$output"
   [ "$status" -eq 0 ]
@@ -151,6 +166,9 @@ load helpers
   run buildah rmi alpine
   echo "$output"
   [ "$status" -eq 0 ]
+  run buildah pull --all-tags --signature-policy ${TESTSDIR}/policy.json docker-daemon:docker.io/library/alpine:latest
+  echo "$output"
+  [ "$status" -ne 0 ]
   run docker rmi -f alpine:latest
   echo "$output"
   [ "$status" -eq 0 ]
@@ -215,4 +233,16 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ "alpine" ]]
+  run buildah pull --all-tags --signature-policy ${TESTSDIR}/policy.json oci:${TESTDIR}/alpine
+  echo "$output"
+  [ "$status" -ne 0 ]
+  run rm -rf ${TESTDIR}/alpine
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "pull-with-alltags-from-registry" {
+  run buildah pull --all-tags --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/alpine_nginx
+  echo "$output"
+  [ "$status" -eq 0 ]
 }

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -197,3 +197,22 @@ load helpers
   [ "$status" -eq 0 ]
   [ $(wc -l <<< "$output") -ge 3 ]
 }
+
+@test "pull-from-oci-directory" {
+  run buildah pull --signature-policy ${TESTSDIR}/policy.json alpine
+  echo "$output"
+  [ "$status" -eq 0 ]
+  run buildah push --signature-policy ${TESTSDIR}/policy.json docker.io/library/alpine:latest oci:${TESTDIR}/alpine
+  echo "$output"
+  [ "$status" -eq 0 ]
+  run buildah rmi alpine
+  echo "$output"
+  [ "$status" -eq 0 ]
+  run buildah pull --signature-policy ${TESTSDIR}/policy.json oci:${TESTDIR}/alpine
+  echo "$output"
+  [ "$status" -eq 0 ]
+  run buildah images --format "{{.Name}}:{{.Tag}}"
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "alpine" ]]
+}


### PR DESCRIPTION
Change references to Transfer to transfer to make it internal only.
It should be determined from the image specification and only determined
in one place.

Make buildah.Pull use registries.conf

Currently buildah pull does not resolve images based on registries.conf
This does not match the behaviour of buildah from or buildah bud

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>