### PR TITLE
Add --target to bud command

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -271,6 +271,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budResults) error {
 		RemoveIntermediateCtrs:  iopts.Rm,
 		ForceRmIntermediateCtrs: iopts.ForceRm,
 		BlobDirectory:           iopts.BlobCache,
+		Target:                  iopts.Target,
 	}
 
 	if iopts.Quiet {

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -414,6 +414,7 @@ return 1
      --signature-policy
      -t
      --tag
+     --target
      --ulimit
      --userns
      --userns-uid-map

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -385,6 +385,12 @@ Specifies the name which will be assigned to the resulting image if the build
 process completes successfully.
 If _imageName_ does not include a registry name, the registry name *localhost* will be prepended to the image name.
 
+**--target** *stageName*
+
+Set the target build stage to build.  When building a Dockerfile with multiple build stages, --target
+can be used to specify an intermediate build stage by name as the final stage for the resulting image.
+Commands after the target stage will be skipped.
+
 **--tls-verify** *bool-value*
 
 Require HTTPS and verify certificates when talking to container registries (defaults to true).

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -171,6 +171,8 @@ type BuildOptions struct {
 	ForceRmIntermediateCtrs bool
 	// BlobDirectory is a directory which we'll use for caching layer blobs.
 	BlobDirectory string
+	// Target the targeted FROM in the Dockerfile to build
+	Target string
 }
 
 // Executor is a buildah-based implementation of the imagebuilder.Executor
@@ -1440,6 +1442,13 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options BuildOpt
 	stages, err := imagebuilder.NewStages(mainNode, b)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "error reading multiple stages")
+	}
+	if options.Target != "" {
+		stagesTargeted, ok := stages.ThroughTarget(options.Target)
+		if !ok {
+			return "", nil, errors.Errorf("The target %q was not found in the provided Dockerfile", options.Target)
+		}
+		stages = stagesTargeted
 	}
 	return exec.Build(ctx, stages)
 }

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -69,6 +69,7 @@ type BudResults struct {
 	SignaturePolicy     string
 	Squash              bool
 	Tag                 []string
+	Target              string
 	TlsVerify           bool
 }
 
@@ -157,6 +158,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.SignaturePolicy, "signature-policy", "", "`pathname` of signature policy file (not usually used)")
 	fs.BoolVar(&flags.Squash, "squash", false, "Squash newly built layers into a single new layer. The build process does not currently support caching so this is a NOOP.")
 	fs.StringSliceVarP(&flags.Tag, "tag", "t", []string{}, "tagged `name` to apply to the built image")
+	fs.StringVar(&flags.Target, "target", "", "set the target build stage to build")
 	fs.BoolVar(&flags.TlsVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	return fs
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1172,3 +1172,20 @@ load helpers
   run test -e $mnt/usr/local/bin/composer
   [ "$status" -eq 0 ]
 }
+
+@test "bud-target" {
+  target=target
+  run buildah bud --debug=false --signature-policy ${TESTSDIR}/policy.json -t ${target} --target mytarget ${TESTSDIR}/bud/target
+  [[ $output =~ "STEP 1: FROM ubuntu:latest" ]]
+  [[ $output =~ "STEP 3: FROM alpine:latest AS mytarget" ]]
+  [ "$status" -eq 0 ]
+  cid=$(buildah from ${target})
+  root=$(buildah mount ${cid})
+  run ls ${root}/2 
+  echo "$output"
+  [ "$status" -eq 0 ]
+  run ls ${root}/3 
+  [ "$status" -ne 0 ]
+  buildah umount ${cid}
+  buildah rm ${cid}
+}

--- a/tests/bud/target/Dockerfile
+++ b/tests/bud/target/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:latest
+RUN touch /1
+
+FROM alpine:latest AS mytarget 
+RUN touch /2
+
+FROM busybox:latest AS mytarget2 
+RUN touch /3

--- a/vendor.conf
+++ b/vendor.conf
@@ -36,7 +36,7 @@ github.com/opencontainers/runc v1.0.0-rc6
 github.com/opencontainers/runtime-spec v1.0.0
 github.com/opencontainers/runtime-tools v0.8.0
 github.com/opencontainers/selinux v1.1
-github.com/openshift/imagebuilder a4122153148e3b34161191f868565d8dffe65a69
+github.com/openshift/imagebuilder 36823496a6868f72bc36282cc475eb8a070c0934
 github.com/ostreedev/ostree-go 9ab99253d365aac3a330d1f7281cf29f3d22820b
 github.com/pkg/errors v0.8.1
 github.com/pquerna/ffjson d49c2bc1aa135aad0c6f4fc2056623ec78f5d5ac

--- a/vendor/github.com/openshift/imagebuilder/builder.go
+++ b/vendor/github.com/openshift/imagebuilder/builder.go
@@ -163,6 +163,7 @@ func (stages Stages) ByName(name string) (Stage, bool) {
 	return Stage{}, false
 }
 
+// Get just the target stage.
 func (stages Stages) ByTarget(target string) (Stages, bool) {
 	if len(target) == 0 {
 		return stages, true
@@ -170,6 +171,19 @@ func (stages Stages) ByTarget(target string) (Stages, bool) {
 	for i, stage := range stages {
 		if stage.Name == target {
 			return stages[i : i+1], true
+		}
+	}
+	return nil, false
+}
+
+// Get all the stages up to and including the target.
+func (stages Stages) ThroughTarget(target string) (Stages, bool) {
+	if len(target) == 0 {
+		return stages, true
+	}
+	for i, stage := range stages {
+		if stage.Name == target {
+			return stages[0 : i+1], true
 		}
 	}
 	return nil, false


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add the --target option to the bud command.  This allows the
user to specify the last stage to build in a multi stage
Dockerfile.

Addresses #632

Tests:
```
cat ./bud/target/Dockerfile
FROM ubuntu:latest
RUN touch /1

FROM alpine:latest AS mytarget
RUN touch /2

FROM busybox:latest AS mytarget2
RUN touch /3

buildah bud --debug=false -t tom --target mytarget ./bud/target .
STEP 1: FROM ubuntu:latest
STEP 2: RUN touch /1
STEP 3: FROM alpine:latest AS mytarget
STEP 4: RUN touch /2
STEP 5: COMMIT containers-storage:[overlay@/var/lib/containers/storage+/var/run/containers/storage]localhost/tom:latest
Getting image source signatures
Skipping blob 503e53e365f3 (already present): 5.52 MiB / 5.52 MiB [=========] 0s
Copying blob 66e5f29a7649: 3.50 KiB / 3.50 KiB [============================] 0s
Copying config e72f1fa3d72d: 704 B / 704 B [================================] 0s
Writing manifest to image destination
Storing signatures
--> e72f1fa3d72ddd3f23acb22a059ecce33dad571433223389e3ce92a5fd9ebae5
STEP 6: COMMIT containers-storage:[overlay@/var/lib/containers/storage+/var/run/containers/storage]localhost/tom:latest
Getting image source signatures
Skipping blob 503e53e365f3 (already present): 5.52 MiB / 5.52 MiB [=========] 0s
Skipping blob 66e5f29a7649 (already present): 3.50 KiB / 3.50 KiB [=========] 0s
Copying config e72620d8efe7: 704 B / 704 B [================================] 0s
Writing manifest to image destination
Storing signatures
--> e72620d8efe764178d1352dfb3a9a773794309ee9e879e17d3803b18553f5025

buildah images
IMAGE NAME                                               IMAGE TAG            IMAGE ID             CREATED AT             SIZE
docker.io/library/ubuntu                                 latest               20bb25d32758         Jan 22, 2019 17:41     90 MB
docker.io/library/alpine                                 latest               caf27325b298         Jan 30, 2019 17:19     5.8 MB
localhost/tom                                            latest               993ee7ded616         Feb 5, 2019 13:49      5.8 MB
```

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>