### PR TITLE
unshare: do not set rootless mode if euid=0

### DIFF
--- a/unshare/unshare.go
+++ b/unshare/unshare.go
@@ -56,8 +56,10 @@ func (c *Cmd) Start() error {
 	c.Env = append(c.Env, fmt.Sprintf("_Buildah-unshare=%d", c.UnshareFlags))
 
 	// Please the libpod "rootless" package to find the expected env variables.
-	c.Env = append(c.Env, "_LIBPOD_USERNS_CONFIGURED=done")
-	c.Env = append(c.Env, fmt.Sprintf("_LIBPOD_ROOTLESS_UID=%d", os.Geteuid()))
+	if os.Geteuid() != 0 {
+		c.Env = append(c.Env, "_LIBPOD_USERNS_CONFIGURED=done")
+		c.Env = append(c.Env, fmt.Sprintf("_LIBPOD_ROOTLESS_UID=%d", os.Geteuid()))
+	}
 
 	// Create the pipe for reading the child's PID.
 	pidRead, pidWrite, err := os.Pipe()


### PR DESCRIPTION
when doing an unshare, do not set rootless mode unless the euid != 0.

Closes: https://github.com/containers/buildah/issues/1296

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>