### PR TITLE
main: fix rootless mode

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -98,7 +98,7 @@ func before(cmd *cobra.Command, args []string) error {
 	if globalFlagResults.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-	maybeReexecUsingUserNamespace(args, false)
+	maybeReexecUsingUserNamespace(cmd.Use, false)
 	return nil
 }
 

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -57,19 +57,14 @@ func bailOnError(err error, format string, a ...interface{}) {
 	}
 }
 
-func maybeReexecUsingUserNamespace(args []string, evenForRoot bool) {
+func maybeReexecUsingUserNamespace(cmdName string, evenForRoot bool) {
 	// If we've already been through this once, no need to try again.
 	if os.Getenv(startedInUserNS) != "" {
 		return
 	}
 
-	// If this is one of the commands that doesn't need this indirection, skip it.
-	if len(args) == 0 {
-		return
-	}
-
-	switch args[0] {
-	case "help", "version":
+	switch cmdName {
+	case "", "help", "version":
 		return
 	}
 
@@ -199,7 +194,7 @@ func execRunnable(cmd runnable) {
 // unshareCmd execs whatever using the ID mappings that we want to use for ourselves
 func unshareCmd(c *cobra.Command, args []string) error {
 	// force reexec using the configured ID mappings
-	maybeReexecUsingUserNamespace(args, true)
+	maybeReexecUsingUserNamespace(c.Use, true)
 	// exec the specified command, if there is one
 	if len(args) < 1 {
 		// try to exec the shell, if one's set

--- a/cmd/buildah/unshare_unsupported.go
+++ b/cmd/buildah/unshare_unsupported.go
@@ -21,6 +21,6 @@ func init() {
 	rootCmd.AddCommand(&unshareCommand)
 }
 
-func maybeReexecUsingUserNamespace(args []string, evenForRoot bool) {
+func maybeReexecUsingUserNamespace(cmd string, evenForRoot bool) {
 	return
 }


### PR DESCRIPTION
the args argument is always an empty slice, so it breaks the code for
detecting if we need a new user namespace.  Use directly os.Args[1:].

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>