### PR TITLE
Fix example for setting multiple environment variables

### DIFF
--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -59,7 +59,7 @@ func init() {
 		},
 		Example: `  buildah config --author='Jane Austen' --workingdir='/etc/mycontainers' containerID
   buildah config --entrypoint '[ "/entrypoint.sh", "dev" ]' containerID
-  buildah config --env foo=bar PATH=$PATH containerID`,
+  buildah config --env foo=bar --env PATH=$PATH containerID`,
 	}
 
 	flags := configCommand.Flags()

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -191,7 +191,7 @@ buildah config --entrypoint /entrypoint.sh containerID
 
 buildah config --entrypoint '[ "/entrypoint.sh", "dev" ]' containerID
 
-buildah config --env foo=bar PATH=$PATH containerID
+buildah config --env foo=bar --env PATH=$PATH containerID
 
 buildah config --label Name=Mycontainer --label  Version=1.0 containerID
 


### PR DESCRIPTION
On version `1.6-dev` the current example yields:
```
too many arguments specified
```