### PR TITLE
Fix buildah commit compress by default

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -214,10 +214,9 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budResults) error {
 		logrus.Debugf("--compress option specified but is ignored")
 	}
 
-	compression := imagebuildah.Uncompressed
-
-	if c.Flag("disable-compression").Changed && !iopts.DisableCompression {
-		compression = imagebuildah.Gzip
+	compression := imagebuildah.Gzip
+	if iopts.DisableCompression {
+		compression = imagebuildah.Uncompressed
 	}
 
 	if c.Flag("disable-content-trust").Changed {

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -93,9 +93,9 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 		return errors.Errorf("too many arguments specified")
 	}
 	image := args[0]
-	compress := imagebuildah.Uncompressed
-	if c.Flag("disable-compression").Changed && !iopts.disableCompression {
-		compress = imagebuildah.Gzip
+	compress := imagebuildah.Gzip
+	if iopts.disableCompression {
+		compress = imagebuildah.Uncompressed
 	}
 	timestamp := time.Now().UTC()
 	if c.Flag("reference-time").Changed {


### PR DESCRIPTION
The change to switch over to cobra had the effect of always setting
compress to imagebuildah.Uncompressed. This is because the conditional
to set it to Gzip always returns false regardless of whether
--disable-compression is set or not.

This change fixes that, and make the logic match the intent of Gzip
being the default option.