### PR TITLE
unshare: reexec using a memfd copy instead of the binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-dist: trusty
+dist: xenial
 sudo: required
 go:
     - 1.10.x
@@ -39,10 +39,11 @@ matrix:
 services:
     - docker
 before_install:
+    - sudo apt-get update
+    - sudo apt-get -qq install software-properties-common
     - sudo add-apt-repository -y ppa:duggan/bats
     - sudo apt-get update
-    - sudo apt-get -qq install bats btrfs-tools git libapparmor-dev libc-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libselinux1-dev realpath
-    - sudo apt-get -qq remove libseccomp2
+    - sudo apt-get -qq install bats btrfs-tools git libapparmor-dev libc-dev libdevmapper-dev libglib2.0-dev libgpgme11-dev libselinux1-dev linux-libc-dev realpath
     - sudo apt-get -qq update
     - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
     - mkdir /home/travis/auth


### PR DESCRIPTION
When we're unshare()ing, copy `/proc/self/exe` into a memory FD before exec()ing it, so that the descriptor which we leak into our child process's namespace through the /proc/$parent/exe link is one that gets discarded after the process exits, and seal it against modifications as soon as we're finished populating it, mimicking patches for other projects that mitigate CVE-2019-5736.

If `github.com/containers/storage/pkg/reexec` already required `cgo`, so that adding this there didn't add a new build requirement, it would have been better to do this there.