### PR TITLE
healthcheck start-period: update documentation

### DIFF
--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -77,7 +77,7 @@ func init() {
 	flags.StringVar(&opts.healthcheck, "healthcheck", "", "set a `healthcheck` command for the target image")
 	flags.StringVar(&opts.healthcheckInterval, "healthcheck-interval", "", "set the `interval` between runs of the `healthcheck` command for the target image")
 	flags.IntVar(&opts.healthcheckRetries, "healthcheck-retries", 0, "set the `number` of times the `healthcheck` command has to fail")
-	flags.StringVar(&opts.healthcheckStartPeriod, "healthcheck-start-period", "", "set the amount of `time` to wait after starting a container before running a `healthcheck` command")
+	flags.StringVar(&opts.healthcheckStartPeriod, "healthcheck-start-period", "", "set the amount of `time` to wait after starting a container before a failed `healthcheck` command will count as a failure")
 	flags.StringVar(&opts.healthcheckTimeout, "healthcheck-timeout", "", "set the maximum amount of `time` to wait for a `healthcheck` command for the target image")
 	flags.StringVar(&opts.historyComment, "history-comment", "", "set a `comment` for the history of the target image")
 	flags.StringVar(&opts.hostname, "hostname", "", "set a host`name` for containers based on image")

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -106,8 +106,12 @@ Note: this setting is not present in the OCIv1 image format, so it is discarded 
 
 **--healthcheck-start-period** *interval*
 
-Specify how long to wait after starting a container before running the command
-specified using the *--healthcheck* option.
+Specify how much time can elapse after a container has started before a failure
+to run the command specified using the *--healthcheck* option should be treated
+as an indication that the container is failing.  During this time period,
+failures will be attributed to the container not yet having fully started, and
+will not be counted as errors.  After the command succeeds, or the time period
+has elapsed, failures will be counted as errors.
 
 Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
 


### PR DESCRIPTION
A re-reading of the spec doesn't agree with our docs - the healthcheck start period isn't a delay in the first invocation of the healthcheck command, but is instead a grace period where failures aren't counted as indications of problems.  Instead, during that grace period, failures are attributed to the container not yet having finished starting.  Once the healthcheck command succeeds, the engine should start counting
failures.