### PR TITLE
Remove global flags from cli help

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -30,10 +30,11 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addCmd(cmd, args, addOpts)
 		},
-		Example: `  buildah add containerID '/myapp/app.conf'
+		Example: `buildah add containerID '/myapp/app.conf'
   buildah add containerID '/myapp/app.conf' '/myapp/app.conf'`,
 		Args: cobra.MinimumNArgs(1),
 	}
+	addCommand.SetUsageTemplate(UsageTemplate())
 
 	copyCommand := &cobra.Command{
 		Use:   "copy",
@@ -42,10 +43,11 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return copyCmd(cmd, args, copyOpts)
 		},
-		Example: `  buildah copy containerID '/myapp/app.conf'
+		Example: `buildah copy containerID '/myapp/app.conf'
   buildah copy containerID '/myapp/app.conf' '/myapp/app.conf'`,
 		Args: cobra.MinimumNArgs(1),
 	}
+	copyCommand.SetUsageTemplate(UsageTemplate())
 
 	addFlags := addCommand.Flags()
 	addFlags.SetInterspersed(false)

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -49,10 +49,11 @@ func init() {
 			}
 			return budCmd(cmd, args, br)
 		},
-		Example: `  buildah bud -f Dockerfile.simple .
+		Example: `buildah bud -f Dockerfile.simple .
   buildah bud --volume /home/test:/myvol:ro,Z -t imageName .
   buildah bud -f Dockerfile.simple -f Dockerfile.notsosimple .`,
 	}
+	budCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := budCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -46,9 +46,10 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return commitCmd(cmd, args, opts)
 		},
-		Example: `  buildah commit containerID newImageName
+		Example: `buildah commit containerID newImageName
   buildah commit containerID docker://localhost:5000/imageId`,
 	}
+	commitCommand.SetUsageTemplate(UsageTemplate())
 	flags := commitCommand.Flags()
 	flags.SetInterspersed(false)
 

--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -277,3 +277,27 @@ func Tail(a []string) []string {
 	}
 	return []string{}
 }
+
+// UsageTemplate returns the usage template for podman commands
+// This blocks the desplaying of the global options. The main podman
+// command should not use this.
+func UsageTemplate() string {
+	return `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+  {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+{{end}}
+`
+}

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -57,10 +57,11 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return configCmd(cmd, args, opts)
 		},
-		Example: `  buildah config --author='Jane Austen' --workingdir='/etc/mycontainers' containerID
+		Example: `buildah config --author='Jane Austen' --workingdir='/etc/mycontainers' containerID
   buildah config --entrypoint '[ "/entrypoint.sh", "dev" ]' containerID
   buildah config --env foo=bar --env PATH=$PATH containerID`,
 	}
+	configCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := configCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -69,10 +69,11 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return containersCmd(cmd, args, opts)
 		},
-		Example: `  buildah containers
+		Example: `buildah containers
   buildah containers --format "{{.ContainerID}} {{.ContainerName}}"
   buildah containers -q --noheading --notruncate`,
 	}
+	containersCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := containersCommand.Flags()
 	flags.BoolVarP(&opts.all, "all", "a", false, "also list non-buildah containers")

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -51,10 +51,11 @@ func init() {
 			opts.NameSpaceResults = &namespaceResults
 			return fromCmd(cmd, args, opts)
 		},
-		Example: `  buildah from --pull imagename
+		Example: `buildah from --pull imagename
   buildah from docker-daemon:imagename:imagetag
   buildah from --name "myimagename" myregistry/myrepository/imagename:imagetag`,
 	}
+	fromCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := fromCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -71,10 +71,11 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return imagesCmd(cmd, args, &opts)
 		},
-		Example: `  buildah images --all
+		Example: `buildah images --all
   buildah images [imageName]
   buildah images --format '{{.ID}} {{.Name}} {{.Size}} {{.CreatedAtRaw}}'`,
 	}
+	imagesCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := imagesCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/info.go
+++ b/cmd/buildah/info.go
@@ -31,8 +31,10 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return infoCmd(cmd, args, opts)
 		},
-		Args: cobra.NoArgs,
+		Args:    cobra.NoArgs,
+		Example: `buildah info`,
 	}
+	infoCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := infoCommand.Flags()
 	flags.BoolVarP(&opts.debug, "debug", "d", false, "display additional debug information")

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -38,10 +38,11 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return inspectCmd(cmd, args, opts)
 		},
-		Example: `  buildah inspect containerID
+		Example: `buildah inspect containerID
   buildah inspect --type image imageID
   buildah inspect --format '{{.OCIv1.Config.Env}}' alpine`,
 	}
+	inspectCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := inspectCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -27,7 +27,7 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return mountCmd(cmd, args, noTruncate)
 		},
-		Example: `  buildah mount
+		Example: `buildah mount
   buildah mount containerID
   buildah mount containerID1 containerID2
 
@@ -36,6 +36,7 @@ func init() {
   buildah mount containerID
 `,
 	}
+	mountCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := mountCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -39,10 +39,11 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pullCmd(cmd, args, opts)
 		},
-		Example: `  buildah pull imagename
+		Example: `buildah pull imagename
   buildah pull docker-daemon:imagename:imagetag
   buildah pull myregistry/myrepository/imagename:imagetag`,
 	}
+	pullCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := pullCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -53,10 +53,12 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pushCmd(cmd, args, opts)
 		},
-		Example: `  buildah push imageID docker://registry.example.com/repository:tag
+		Example: `buildah push imageID docker://registry.example.com/repository:tag
   buildah push imageID docker-daemon:image:tagi
   buildah push imageID oci:/path/to/layout:image:tag`,
 	}
+	pushCommand.SetUsageTemplate(UsageTemplate())
+
 	flags := pushCommand.Flags()
 	flags.SetInterspersed(false)
 	flags.StringVar(&opts.authfile, "authfile", "", "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json")

--- a/cmd/buildah/rename.go
+++ b/cmd/buildah/rename.go
@@ -13,13 +13,14 @@ var (
 		Short: "Rename a container",
 		Long:  renameDescription,
 		RunE:  renameCmd,
-		Example: `  buildah rename containerName NewName
+		Example: `buildah rename containerName NewName
   buildah rename containerID NewName`,
 		Args: cobra.ExactArgs(2),
 	}
 )
 
 func init() {
+	renameCommand.SetUsageTemplate(UsageTemplate())
 	rootCmd.AddCommand(renameCommand)
 }
 

--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -27,10 +27,11 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return rmCmd(cmd, args, opts)
 		},
-		Example: `  buildah rm containerID
+		Example: `buildah rm containerID
   buildah rm containerID1 containerID2 containerID3
   buildah rm --all`,
 	}
+	rmCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := rmCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -36,10 +36,12 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return rmiCmd(cmd, args, opts)
 		},
-		Example: `  buildah rmi imageID
+		Example: `buildah rmi imageID
   buildah rmi --all --force
   buildah rmi imageID1 imageID2 imageID3`,
 	}
+	rmiCommand.SetUsageTemplate(UsageTemplate())
+
 	flags := rmiCommand.Flags()
 	flags.SetInterspersed(false)
 

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -48,10 +48,11 @@ func init() {
 			return runCmd(cmd, args, opts)
 
 		},
-		Example: `  buildah run containerID -- ps -auxw
+		Example: `buildah run containerID -- ps -auxw
   buildah run --tty containerID /bin/bash
   buildah run --volume /path/on/host:/path/in/container:ro,z containerID /bin/sh`,
 	}
+	runCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := runCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/tag.go
+++ b/cmd/buildah/tag.go
@@ -15,7 +15,7 @@ var (
 		Long:  tagDescription,
 		RunE:  tagCmd,
 
-		Example: `  buildah tag imageName firstNewName
+		Example: `buildah tag imageName firstNewName
   buildah tag imageName firstNewName SecondNewName`,
 		Args: cobra.MinimumNArgs(2),
 	}
@@ -41,5 +41,6 @@ func tagCmd(c *cobra.Command, args []string) error {
 }
 
 func init() {
+	tagCommand.SetUsageTemplate(UsageTemplate())
 	rootCmd.AddCommand(tagCommand)
 }

--- a/cmd/buildah/umount.go
+++ b/cmd/buildah/umount.go
@@ -17,10 +17,11 @@ func init() {
 		Short:   "Unmount the root file system of the specified working containers",
 		Long:    "Unmounts the root file system of the specified working containers.",
 		RunE:    umountCmd,
-		Example: `  buildah umount containerID
+		Example: `buildah umount containerID
   buildah umount containerID1 containerID2 containerID3
   buildah umount --all`,
 	}
+	umountCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := umountCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -33,12 +33,13 @@ var (
 		Short: "Run a command in a modified user namespace",
 		Long:  unshareDescription,
 		RunE:  unshareCmd,
-		Example: `  buildah unshare id
+		Example: `buildah unshare id
   buildah unshare cat /proc/self/uid_map`,
 	}
 )
 
 func init() {
+	unshareCommand.SetUsageTemplate(UsageTemplate())
 	rootCmd.AddCommand(unshareCommand)
 }
 

--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -49,13 +49,15 @@ func versionCmd(c *cobra.Command, args []string) error {
 
 //cli command to print out the version info of buildah
 var versionCommand = &cobra.Command{
-	Use:   "version",
-	Short: "Display the Buildah version information",
-	Long:  "Displays Buildah version information.",
-	RunE:  versionCmd,
-	Args:  cobra.NoArgs,
+	Use:     "version",
+	Short:   "Display the Buildah version information",
+	Long:    "Displays Buildah version information.",
+	RunE:    versionCmd,
+	Args:    cobra.NoArgs,
+	Example: `buildah version`,
 }
 
 func init() {
+	versionCommand.SetUsageTemplate(UsageTemplate())
 	rootCmd.AddCommand(versionCommand)
 }


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Emulate the Podman cli help style and don't show the
global flags when you do something like `buildah rmi --help`.
Show them only with `buildah --help`.

Also adjust the Examples slightly to make them work with the
new template that was also lifted from Podman.

Sample:
```
# buildah rmi --help

  Removes one or more locally stored images.

Usage:
  buildah rmi [flags]

Examples:
  buildah rmi imageID
  buildah rmi --all --force
  buildah rmi imageID1 imageID2 imageID3

Flags:
  -a, --all     remove all images
  -f, --force   force removal of the image and any containers using the image
  -h, --help    help for rmi
  -p, --prune   prune dangling images

```