### PR TITLE
Make "images --all" faster

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -47,8 +47,8 @@ type imageOptions struct {
 type filterParams struct {
 	dangling         string
 	label            string
-	beforeImage      string // Images are sorted by date, so we can just output until we see the image
-	sinceImage       string // Images are sorted by date, so we can just output until we don't see the image
+	beforeImage      string
+	sinceImage       string
 	beforeDate       time.Time
 	sinceDate        time.Time
 	referencePattern string

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -245,12 +245,14 @@ func outputImages(ctx context.Context, images []storage.Image, store storage.Sto
 		// If all is false and the image doesn't have a name, check to see if the top layer of the image is a parent
 		// to another image's top layer. If it is, then it is an intermediate image so don't print out if the --all flag
 		// is not set.
-		isParent, err := imageIsParent(store, image.TopLayer)
-		if err != nil {
-			logrus.Errorf("error checking if image is a parent %q: %v", image.ID, err)
-		}
-		if !opts.all && len(image.Names) == 0 && isParent {
-			continue
+		if !opts.all && len(image.Names) == 0 {
+			isParent, err := imageIsParent(store, image.TopLayer)
+			if err != nil {
+				logrus.Errorf("error checking if image is a parent %q: %v", image.ID, err)
+			}
+			if isParent {
+				continue
+			}
 		}
 
 		names := []string{}


### PR DESCRIPTION
Computing `imageIsParent()` for every image can get expensive, and if `--all` was specified, it's entirely unnecessary.