### PR TITLE
Stop printing default twice in cli --help

### DIFF
--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -125,7 +125,7 @@ func GetNameSpaceFlags(flags *NameSpaceResults) pflag.FlagSet {
 func GetLayerFlags(flags *LayerResults) pflag.FlagSet {
 	fs := pflag.FlagSet{}
 	fs.BoolVar(&flags.ForceRm, "force-rm", false, "Always remove intermediate containers after a build, even if the build is unsuccessful.")
-	fs.BoolVar(&flags.Layers, "layers", false, fmt.Sprintf("cache intermediate layers during build. Use BUILDAH_LAYERS environment variable to override. (default %t)", UseLayers()))
+	fs.BoolVar(&flags.Layers, "layers", UseLayers(), fmt.Sprintf("cache intermediate layers during build. Use BUILDAH_LAYERS environment variable to override."))
 	return fs
 }
 
@@ -152,7 +152,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.BoolVar(&flags.Pull, "pull", true, "pull the image if not present")
 	fs.BoolVar(&flags.PullAlways, "pull-always", false, "pull the image, even if a version is present")
 	fs.BoolVarP(&flags.Quiet, "quiet", "q", false, "refrain from announcing build instructions and image read/write progress")
-	fs.BoolVar(&flags.Rm, "rm", true, "Remove intermediate containers after a successful build (default true)")
+	fs.BoolVar(&flags.Rm, "rm", true, "Remove intermediate containers after a successful build")
 	fs.StringVar(&flags.Runtime, "runtime", util.Runtime(), "`path` to an alternate runtime. Use BUILDAH_RUNTIME environment variable to override.")
 	fs.StringSliceVar(&flags.RuntimeFlags, "runtime-flag", []string{}, "add global flags for the container runtime")
 	fs.StringVar(&flags.SignaturePolicy, "signature-policy", "", "`pathname` of signature policy file (not usually used)")


### PR DESCRIPTION
Currently we are printing two defaults.  This change will
let the flags package print out the defaults.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>