### PR TITLE
Pull cleanups

### DIFF
--- a/new.go
+++ b/new.go
@@ -122,16 +122,6 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 			return ref, transport, img, nil
 		}
 
-		if options.PullPolicy == PullAlways {
-			pulledImg, pulledReference, err := pullAndFindImage(ctx, store, transport, image, options, systemContext)
-			if err != nil {
-				logrus.Debugf("unable to pull and read image %q: %v", image, err)
-				failures = append(failures, failure{resolvedImageName: image, err: err})
-				continue
-			}
-			return pulledReference, transport, pulledImg, nil
-		}
-
 		trans := transport
 		if transport != util.DefaultTransport {
 			trans = trans + ":"
@@ -144,6 +134,16 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 				err:               errors.Wrapf(err, "error parsing attempted image name %q", trans+image),
 			})
 			continue
+		}
+
+		if options.PullPolicy == PullAlways {
+			pulledImg, pulledReference, err := pullAndFindImage(ctx, store, transport, image, options, systemContext)
+			if err != nil {
+				logrus.Debugf("unable to pull and read image %q: %v", image, err)
+				failures = append(failures, failure{resolvedImageName: image, err: err})
+				continue
+			}
+			return pulledReference, transport, pulledImg, nil
 		}
 
 		destImage, err := localImageNameForReference(ctx, store, srcRef)

--- a/new.go
+++ b/new.go
@@ -132,24 +132,18 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 			return pulledReference, transport, pulledImg, nil
 		}
 
-		srcRef, err := alltransports.ParseImageName(image)
+		trans := transport
+		if transport != util.DefaultTransport {
+			trans = trans + ":"
+		}
+		srcRef, err := alltransports.ParseImageName(trans + image)
 		if err != nil {
-			logrus.Debugf("error parsing image name %q as given, trying with transport %q: %v", image, transport, err)
-
-			trans := transport
-			if transport != util.DefaultTransport {
-				trans = trans + ":"
-			}
-			srcRef2, err := alltransports.ParseImageName(trans + image)
-			if err != nil {
-				logrus.Debugf("error parsing image name %q: %v", trans+image, err)
-				failures = append(failures, failure{
-					resolvedImageName: image,
-					err:               errors.Wrapf(err, "error parsing attempted image name %q", trans+image),
-				})
-				continue
-			}
-			srcRef = srcRef2
+			logrus.Debugf("error parsing image name %q: %v", trans+image, err)
+			failures = append(failures, failure{
+				resolvedImageName: image,
+				err:               errors.Wrapf(err, "error parsing attempted image name %q", trans+image),
+			})
+			continue
 		}
 
 		destImage, err := localImageNameForReference(ctx, store, srcRef, options.FromImage)

--- a/new.go
+++ b/new.go
@@ -142,10 +142,10 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 			}
 			srcRef2, err := alltransports.ParseImageName(trans + image)
 			if err != nil {
-				logrus.Debugf("error parsing image name %q: %v", transport+image, err)
+				logrus.Debugf("error parsing image name %q: %v", trans+image, err)
 				failures = append(failures, failure{
 					resolvedImageName: image,
-					err:               errors.Wrapf(err, "error parsing attempted image name %q", transport+image),
+					err:               errors.Wrapf(err, "error parsing attempted image name %q", trans+image),
 				})
 				continue
 			}

--- a/new.go
+++ b/new.go
@@ -24,21 +24,21 @@ const (
 	BaseImageFakeName = imagebuilder.NoBaseImageSpecifier
 )
 
-func pullAndFindImage(ctx context.Context, store storage.Store, transport string, imageName string, options BuilderOptions, sc *types.SystemContext) (*storage.Image, types.ImageReference, error) {
+func pullAndFindImage(ctx context.Context, store storage.Store, srcRef types.ImageReference, options BuilderOptions, sc *types.SystemContext) (*storage.Image, types.ImageReference, error) {
 	pullOptions := PullOptions{
 		ReportWriter:  options.ReportWriter,
 		Store:         store,
 		SystemContext: options.SystemContext,
 		BlobDirectory: options.PullBlobDirectory,
 	}
-	ref, err := pullImage(ctx, store, transport, imageName, pullOptions, sc)
+	ref, err := pullImage(ctx, store, srcRef, pullOptions, sc)
 	if err != nil {
-		logrus.Debugf("error pulling image %q: %v", imageName, err)
+		logrus.Debugf("error pulling image %q: %v", transports.ImageName(srcRef), err)
 		return nil, nil, err
 	}
 	img, err := is.Transport.GetStoreImage(store, ref)
 	if err != nil {
-		logrus.Debugf("error reading pulled image %q: %v", imageName, err)
+		logrus.Debugf("error reading pulled image %q: %v", transports.ImageName(srcRef), err)
 		return nil, nil, errors.Wrapf(err, "error locating image %q in local storage", transports.ImageName(ref))
 	}
 	return img, ref, nil
@@ -137,7 +137,7 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 		}
 
 		if options.PullPolicy == PullAlways {
-			pulledImg, pulledReference, err := pullAndFindImage(ctx, store, transport, image, options, systemContext)
+			pulledImg, pulledReference, err := pullAndFindImage(ctx, store, srcRef, options, systemContext)
 			if err != nil {
 				logrus.Debugf("unable to pull and read image %q: %v", image, err)
 				failures = append(failures, failure{resolvedImageName: image, err: err})
@@ -172,7 +172,7 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 			continue
 		}
 
-		pulledImg, pulledReference, err := pullAndFindImage(ctx, store, transport, image, options, systemContext)
+		pulledImg, pulledReference, err := pullAndFindImage(ctx, store, srcRef, options, systemContext)
 		if err != nil {
 			logrus.Debugf("unable to pull and read image %q: %v", image, err)
 			failures = append(failures, failure{resolvedImageName: image, err: err})

--- a/new.go
+++ b/new.go
@@ -134,14 +134,6 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 
 		srcRef, err := alltransports.ParseImageName(image)
 		if err != nil {
-			if transport == "" {
-				logrus.Debugf("error parsing image name %q: %v", image, err)
-				failures = append(failures, failure{
-					resolvedImageName: image,
-					err:               errors.Wrapf(err, "error parsing image name"),
-				})
-				continue
-			}
 			logrus.Debugf("error parsing image name %q as given, trying with transport %q: %v", image, transport, err)
 
 			trans := transport

--- a/new.go
+++ b/new.go
@@ -146,7 +146,7 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 			continue
 		}
 
-		destImage, err := localImageNameForReference(ctx, store, srcRef, options.FromImage)
+		destImage, err := localImageNameForReference(ctx, store, srcRef)
 		if err != nil {
 			return nil, "", nil, errors.Wrapf(err, "error computing local image name for %q", transports.ImageName(srcRef))
 		}

--- a/pull.go
+++ b/pull.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -176,11 +176,11 @@ func Pull(ctx context.Context, imageName string, options PullOptions) error {
 		}
 
 		spec := transport + storageRef.DockerReference().Name()
-		storageRef, err = alltransports.ParseImageName(spec)
+		dockerRef, err := alltransports.ParseImageName(spec)
 		if err != nil {
 			return errors.Wrapf(err, "error getting repository tags")
 		}
-		tags, err := docker.GetRepositoryTags(ctx, systemContext, storageRef)
+		tags, err := docker.GetRepositoryTags(ctx, systemContext, dockerRef)
 		if err != nil {
 			return errors.Wrapf(err, "error getting repository tags")
 		}

--- a/pull.go
+++ b/pull.go
@@ -176,7 +176,7 @@ func Pull(ctx context.Context, imageName string, options PullOptions) error {
 		}
 
 		repo := reference.TrimNamed(storageRef.DockerReference())
-		dockerRef, err := alltransports.ParseImageName(transport + repo.Name())
+		dockerRef, err := alltransports.ParseImageName(transport + storageRef.DockerReference().String())
 		if err != nil {
 			return errors.Wrapf(err, "error getting repository tags")
 		}

--- a/pull.go
+++ b/pull.go
@@ -175,8 +175,8 @@ func Pull(ctx context.Context, imageName string, options PullOptions) error {
 			return errors.New("Non-docker transport is not supported, for --all-tags pulling")
 		}
 
-		spec := transport + storageRef.DockerReference().Name()
-		dockerRef, err := alltransports.ParseImageName(spec)
+		repo := storageRef.DockerReference().Name()
+		dockerRef, err := alltransports.ParseImageName(transport + repo)
 		if err != nil {
 			return errors.Wrapf(err, "error getting repository tags")
 		}
@@ -185,7 +185,7 @@ func Pull(ctx context.Context, imageName string, options PullOptions) error {
 			return errors.Wrapf(err, "error getting repository tags")
 		}
 		for _, tag := range tags {
-			name := spec + ":" + tag
+			name := repo + ":" + tag
 			if options.ReportWriter != nil {
 				options.ReportWriter.Write([]byte("Pulling " + name + "\n"))
 			}

--- a/pull.go
+++ b/pull.go
@@ -19,7 +19,6 @@ import (
 	"github.com/containers/image/signature"
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/transports"
-	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	multierror "github.com/hashicorp/go-multierror"
@@ -176,9 +175,9 @@ func Pull(ctx context.Context, imageName string, options PullOptions) error {
 		}
 
 		repo := reference.TrimNamed(storageRef.DockerReference())
-		dockerRef, err := alltransports.ParseImageName(transport + storageRef.DockerReference().String())
+		dockerRef, err := docker.NewReference(reference.TagNameOnly(storageRef.DockerReference()))
 		if err != nil {
-			return errors.Wrapf(err, "error getting repository tags")
+			return errors.Wrapf(err, "internal error creating docker.Transport reference for %s", storageRef.DockerReference().String())
 		}
 		tags, err := docker.GetRepositoryTags(ctx, systemContext, dockerRef)
 		if err != nil {

--- a/pull.go
+++ b/pull.go
@@ -213,23 +213,17 @@ func Pull(ctx context.Context, imageName string, options PullOptions) error {
 }
 
 func pullImage(ctx context.Context, store storage.Store, transport string, imageName string, options PullOptions, sc *types.SystemContext) (types.ImageReference, error) {
-	spec := imageName
+	if transport == "" {
+		transport = util.DefaultTransport
+	} else {
+		if transport != util.DefaultTransport {
+			transport = transport + ":"
+		}
+	}
+	spec := transport + imageName
 	srcRef, err := alltransports.ParseImageName(spec)
 	if err != nil {
-		logrus.Debugf("error parsing image name %q, trying with transport %q: %v", spec, transport, err)
-		if transport == "" {
-			transport = util.DefaultTransport
-		} else {
-			if transport != util.DefaultTransport {
-				transport = transport + ":"
-			}
-		}
-		spec = transport + spec
-		srcRef2, err2 := alltransports.ParseImageName(spec)
-		if err2 != nil {
-			return nil, errors.Wrapf(err2, "error parsing image name %q", spec)
-		}
-		srcRef = srcRef2
+		return nil, errors.Wrapf(err, "error parsing image name %q", spec)
 	}
 	logrus.Debugf("parsed image name %q", spec)
 

--- a/util/util.go
+++ b/util/util.go
@@ -166,15 +166,7 @@ func ExpandNames(names []string, firstRegistry string, systemContext *types.Syst
 			name = named
 		}
 		name = reference.TagNameOnly(name)
-		tag := ""
-		digest := ""
-		if tagged, ok := name.(reference.NamedTagged); ok {
-			tag = ":" + tagged.Tag()
-		}
-		if digested, ok := name.(reference.Digested); ok {
-			digest = "@" + digested.Digest().String()
-		}
-		expanded = append(expanded, name.Name()+tag+digest)
+		expanded = append(expanded, name.String())
 	}
 	return expanded, nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -20,7 +20,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/opencontainers/runtime-spec/specs-go"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -47,6 +47,10 @@ var (
 // correspond to in the set of configured registries, the transport used to
 // pull the image, and a boolean which is true iff
 // 1) the list of search registries was used, and 2) it was empty.
+//
+// The returned image names never include a transport: prefix, and if transport != "",
+// (transport, image) should be a valid input to alltransports.ParseImageName.
+//
 // NOTE: The "list of search registries is empty" check does not count blocked registries,
 // and neither the implied "localhost" nor a possible firstRegistry are counted
 func ResolveName(name string, firstRegistry string, sc *types.SystemContext, store storage.Store) ([]string, string, bool, error) {

--- a/util/util.go
+++ b/util/util.go
@@ -50,6 +50,8 @@ var (
 //
 // The returned image names never include a transport: prefix, and if transport != "",
 // (transport, image) should be a valid input to alltransports.ParseImageName.
+// transport == "" indicates that image that already exists in a local storage,
+// and the name is valid for store.Image() / storage.Transport.ParseStoreReference().
 //
 // NOTE: The "list of search registries is empty" check does not count blocked registries,
 // and neither the implied "localhost" nor a possible firstRegistry are counted


### PR DESCRIPTION
As a follow-up to #1319 , this cleans up some of the name handling to remove ambiguities and redundancies when parsing image names, e.g. correcting handling of `docker://dir:localpath`.

Most users should notice only that the debug log no longer contains various variants of
```
error parsing image name "localhost/fedora" as given, trying with transport "docker://": Invalid image name "localhost/fedora", expected colon-separated transport:reference
```

It would be possible to go even further with this, making `ResolveName` return complete `ImageReference` values for the source and destination (and perhaps fixing the differences in how various code paths do / don’t use `localImageNameForReference`), but this seemed like a reasonably compact unit of changes and a good place to stop.

See the individual commit messages for more details.

WARNING: To be honest, I did only a single smoke-test that all of this works at all; I’m mostly relying on existing tests to detect bugs.