### PR TITLE
vendor containers/image v1.5

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -3,7 +3,7 @@ github.com/blang/semver v3.5.0
 github.com/BurntSushi/toml v0.2.0
 github.com/containerd/continuity 004b46473808b3e7a4a3049c20e4376c91eb966d
 github.com/containernetworking/cni v0.7.0-alpha1
-github.com/containers/image v1.4
+github.com/containers/image v1.5
 github.com/vbauerster/mpb v3.3.4
 github.com/mattn/go-isatty v0.0.4
 github.com/VividCortex/ewma v1.1.1

--- a/vendor/github.com/containers/image/version/version.go
+++ b/vendor/github.com/containers/image/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 5
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Fixes a race condition in the blobinfocache that can lead to a panic
when copying images.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>