### PR TITLE
Hide from users command options that we don't want them to use.

### DIFF
--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -71,6 +71,7 @@ func init() {
 
 	flags.BoolVar(&opts.rm, "rm", false, "remove the container and its content after committing it to an image. Default leaves the container and its content in place.")
 	flags.StringVar(&opts.signaturePolicy, "signature-policy", "", "`pathname` of signature policy file (not usually used)")
+	flags.MarkHidden("signature-policy")
 	flags.BoolVar(&opts.squash, "squash", false, "produce an image with only one layer")
 	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when accessing the registry")
 

--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -58,6 +58,7 @@ func TestGetStore(t *testing.T) {
 	flags.String("runroot", storeOptions.RunRoot, "")
 	flags.String("storage-driver", storeOptions.GraphDriverName, "")
 	flags.String("signature-policy", "", "")
+	flags.MarkHidden("signature-policy")
 	// The following flags had to be added or we get panics in common.go when
 	// the lookups occur
 	flags.StringSlice("storage-opt", []string{}, "")

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -68,6 +68,7 @@ func init() {
 	flags.BoolVar(&opts.pullAlways, "pull-always", false, "pull the image even if named image is present in store (supersedes pull option)")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "don't output progress information when pulling images")
 	flags.StringVar(&opts.signaturePolicy, "signature-policy", "", "`pathname` of signature policy file (not usually used)")
+	flags.MarkHidden("signature-policy")
 	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 
 	// Add in the common flags

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -51,6 +51,7 @@ func init() {
 	flags.StringVar(&opts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	flags.StringVar(&opts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	flags.StringVar(&opts.signaturePolicy, "signature-policy", "", "`pathname` of signature policy file (not usually used)")
+	flags.MarkHidden("signature-policy")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "don't output progress information when pulling images")
 	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	flags.MarkHidden("blob-cache")

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -69,6 +69,7 @@ func init() {
 	flags.StringVarP(&opts.format, "format", "f", "", "manifest type (oci, v2s1, or v2s2) to use when saving image using the 'dir:' transport (default is manifest type of source)")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "don't output progress information when pushing images")
 	flags.StringVar(&opts.signaturePolicy, "signature-policy", "", "`pathname` of signature policy file (not usually used)")
+	flags.MarkHidden("signature-policy")
 	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 
 	flags.MarkHidden("blob-cache")

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -327,7 +327,6 @@ return 1
           --format
           -f
           --iidfile
-          --signature-policy
   "
 
      local all_options="$options_with_args $boolean_options"
@@ -411,7 +410,6 @@ return 1
      --runtime-flag
      --security-opt
      --shm-size
-     --signature-policy
      -t
      --tag
      --target
@@ -579,7 +577,6 @@ return 1
      --authfile
      --cert-dir
      --creds
-     --signature-policy
   "
 
      local all_options="$options_with_args $boolean_options"
@@ -608,7 +605,6 @@ return 1
           --creds
           --format
           -f
-          --signature-policy
   "
 
      local all_options="$options_with_args $boolean_options"
@@ -814,7 +810,6 @@ _buildah_containers() {
      --net
      --network
      --pid
-     --signature-policy
      --security-opt
      --shm-size
      --ulimit

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -369,12 +369,6 @@ Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater tha
 Unit is optional and can be `b` (bytes), `k` (kilobytes), `m`(megabytes), or `g` (gigabytes).
 If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
 
-**--signature-policy** *signaturepolicy*
-
-Pathname of a signature policy file to use.  It is not recommended that this
-option be used, as the default behavior of using the system-wide default policy
-(frequently */etc/containers/policy.json*) is most often preferred.
-
 **--squash**
 
 Squash all of the new image's layers (including those inherited from a base image) into a single new layer.
@@ -625,6 +619,10 @@ buildah bud --no-cache --rm=false -t imageName .
 **registries.conf** (`/etc/containers/registries.conf`)
 
 registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
+
+**policy.json** (`/etc/containers/policy.json`)
+
+Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
 buildah(1), CPP(1), podman-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -62,12 +62,6 @@ When writing the output image, suppress progress output.
 Remove the container and its content after committing it to an image.
 Default leaves the container and its content in place.
 
-**--signature-policy**
-
-Pathname of a signature policy file to use.  It is not recommended that this
-option be used, as the default behavior of using the system-wide default policy
-(frequently */etc/containers/policy.json*) is most often preferred.
-
 **--squash**
 
 Squash all of the new image's layers (including those inherited from a base image) into a single new layer.
@@ -112,6 +106,10 @@ This example commits the container to the image on the local registry using cred
 **registries.conf** (`/etc/containers/registries.conf`)
 
 registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
+
+**policy.json** (`/etc/containers/policy.json`)
+
+Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
 buildah(1), policy.json(5), registries.conf(5)

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -278,12 +278,6 @@ Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater tha
 Unit is optional and can be `b` (bytes), `k` (kilobytes), `m`(megabytes), or `g` (gigabytes).
 If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
 
-**--signature-policy** *signaturepolicy*
-
-Pathname of a signature policy file to use.  It is not recommended that this
-option be used, as the default behavior of using the system-wide default policy
-(frequently */etc/containers/policy.json*) is most often preferred.
-
 **--tls-verify** *bool-value*
 
 Require HTTPS and verify certificates when talking to container registries (defaults to true)
@@ -476,8 +470,6 @@ buildah from oci-archive:filename
 
 buildah from --name mycontainer dir:directoryname
 
-buildah from --signature-policy /etc/containers/policy.json imagename
-
 buildah from --pull-always --name "mycontainer" docker://myregistry.example.com/imagename
 
 buildah from --tls-verify=false myregistry/myrepository/imagename:imagetag
@@ -497,6 +489,10 @@ buildah from --volume /home/test:/myvol:ro,Z myregistry/myrepository/imagename:i
 **registries.conf** (`/etc/containers/registries.conf`)
 
 registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
+
+**policy.json** (`/etc/containers/policy.json`)
+
+Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
 buildah(1), buildah-pull(1), podman-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)

--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -75,12 +75,6 @@ Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater tha
 Unit is optional and can be `b` (bytes), `k` (kilobytes), `m`(megabytes), or `g` (gigabytes).
 If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
 
-**--signature-policy** *signaturepolicy*
-
-Pathname of a signature policy file to use.  It is not recommended that this
-option be used, as the default behavior of using the system-wide default policy
-(frequently */etc/containers/policy.json*) is most often preferred.
-
 **--tls-verify** *bool-value*
 
 Require HTTPS and verify certificates when talking to container registries (defaults to true)
@@ -100,8 +94,6 @@ buildah pull oci-archive:filename
 
 buildah pull dir:directoryname
 
-buildah pull --signature-policy /etc/containers/policy.json imagename
-
 buildah pull --tls-verify=false myregistry/myrepository/imagename:imagetag
 
 buildah pull --creds=myusername:mypassword --cert-dir ~/auth myregistry/myrepository/imagename:imagetag
@@ -114,6 +106,10 @@ buildah pull --authfile=/tmp/auths/myauths.json myregistry/myrepository/imagenam
 **registries.conf** (`/etc/containers/registries.conf`)
 
 registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
+
+**policy.json** (`/etc/containers/policy.json`)
+
+Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
 buildah(1), buildah-from(1), podman-login(1), docker-login(1), policy.json(5), registries.conf(5)

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -73,12 +73,6 @@ Manifest Type (oci, v2s1, or v2s2) to use when saving image to directory using t
 
 When writing the output image, suppress progress output.
 
-**--signature-policy**
-
-Pathname of a signature policy file to use.  It is not recommended that this
-option be used, as the default behavior of using the system-wide default policy
-(frequently */etc/containers/policy.json*) is most often preferred.
-
 **--tls-verify** *bool-value*
 
 Require HTTPS and verify certificates when talking to container registries (defaults to true)
@@ -125,5 +119,9 @@ This example extracts the imageID image and puts it into the registry on the loc
 
 registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
+**policy.json** (`/etc/containers/policy.json`)
+
+Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
+
 ## SEE ALSO
-buildah(1), podman-login(1), docker-login(1), policy.json(5), registries.conf(5)
+buildah(1), podman-login(1), policy.json(5), docker-login(1), registries.conf(5)

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -142,6 +142,10 @@ Print the version
 
 	registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
+**registries.d** (`/etc/containers/registries.d`)
+
+Directory which contains configuration snippets which specify registries which should be consulted when completing image names which do not include a registry or domain portion.
+
 ## SEE ALSO
 podman(1), mounts.conf(5), newuidmap(1), newgidmap(1), registries.conf(5), storage.conf(5)
 

--- a/tests/validate/git-validation.sh
+++ b/tests/validate/git-validation.sh
@@ -8,6 +8,6 @@ if ! which git-validation > /dev/null 2> /dev/null ; then
 fi
 if test "$TRAVIS" != true ; then
 	#GITVALIDATE_EPOCH=":/git-validation epoch"
-	GITVALIDATE_EPOCH="93747b1fd5124fdc64344e569b79a8ec49d5f8ae"
+	GITVALIDATE_EPOCH="8b1d11f52721ab062c587abc711b40a6e1a1f7dc"
 fi
 exec git-validation -q -run DCO,short-subject ${GITVALIDATE_EPOCH:+-range "${GITVALIDATE_EPOCH}""..${GITVALIDATE_TIP:-@}"} ${GITVALIDATE_FLAGS}


### PR DESCRIPTION
We really want users to use the registries.conf file specified by
the administrator.  We also don't want them overriding the signature-policy.
Thes options are mainly their for CI/CD Systems, so they should be hidden
from the user.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>