### PR TITLE
unshare: fix unshare parses flags

### DIFF
--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -40,6 +40,8 @@ var (
 
 func init() {
 	unshareCommand.SetUsageTemplate(UsageTemplate())
+	flags := unshareCommand.Flags()
+	flags.SetInterspersed(false)
 	rootCmd.AddCommand(unshareCommand)
 }
 


### PR DESCRIPTION
Fixes: #1374 

Fix buildah unshare parses flags when it shouldn't:

```
➜  cmd git:(unshare-fix) buildah unshare ls -l
unknown shorthand flag: 'l' in -l
```

After change:
```
➜  buildah git:(unshare-fix) ./buildah unshare ls -l
total 43028
-rw-rw-r-- 1 root root     8514 Feb 13 10:22 add.go
...
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>