### PR TITLE
Allow buildah bud options and arguments to be interspersed.

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -56,7 +56,7 @@ func init() {
 	budCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := budCommand.Flags()
-	flags.SetInterspersed(false)
+	flags.SetInterspersed(true)
 
 	// BUD is a all common flags
 	budFlags := buildahcli.GetBudFlags(&budFlagResults)


### PR DESCRIPTION
No reason to not allow

buildah bud . -f Dockerfile
versus
buidlah bud -f Dockerfile .

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>