### PR TITLE
Add --all-tags to push

### DIFF
--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -45,9 +45,9 @@ The image ID of the image that was pulled.  On error 1 is returned.
 
 ## OPTIONS
 
-**--all-tags, a**
+**--all-tags, -a**
 
-All tagged images in the repository will be pulled.
+All tagged images in the repository will be pulled, not just `:latest`.
 
 **--authfile** *path*
 
@@ -100,6 +100,7 @@ buildah pull --creds=myusername:mypassword --cert-dir ~/auth myregistry/myreposi
 
 buildah pull --authfile=/tmp/auths/myauths.json myregistry/myrepository/imagename:imagetag
 
+buildah pull --all-tags alpine
 
 ## Files
 

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -45,6 +45,10 @@ If the transport part of DESTINATION is omitted, "docker://" is assumed.
 
 ## OPTIONS
 
+**--all-tags, -a**
+
+All tagged images in the repository will be pushed, not just `:latest`.  A tag can not be included in the imageID or DESTINATION fields.
+
 **--authfile** *path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
@@ -112,6 +116,9 @@ This example extracts the imageID image and puts it into the registry on the loc
 
 This example extracts the imageID image and puts it into the registry on the localhost using credentials and certificates for authentication.
  `# buildah push --cert-dir ~/auth --tls-verify=true --creds=username:password imageID docker://localhost:5000/my-imageID`
+
+This example pushes all the tagged alpine images to the quay.io registry.
+ `# buildah push --all-tags alpine docker://quay.io/myrepo/alpine`
 
 ## Files
 

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -76,3 +76,16 @@ load helpers
   echo "$output" | grep -q "docker://busybox"
   buildah rmi busybox
 }
+
+@test "push-all-tags" {
+  buildah pull --signature-policy ${TESTSDIR}/policy.json --all-tags alpine
+  run buildah push --signature-policy ${TESTSDIR}/policy.json --all-tags alpine dir:/my-dir
+  echo "$output"
+  [[ "$output" =~ "my-dir:latest" ]]
+  [ "$status" -eq 0 ]
+
+  run ls /my-dir*
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ $(wc -l <<< "$output") -ge 50 ]
+}


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Adds the --all-tags to the push command to emulate the one in
the pull command.   Addresses https://github.com/containers/libpod/issues/2369
on the Buildah side, once approved similar changes will be made to Podman.