### PR TITLE
Errors should be printed to stderr

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -118,7 +118,7 @@ func main() {
 		return
 	}
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This seems like another bug in the conversion to cobra.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>