### PR TITLE
imagebuildah resolveSymlink: fix handling of relative links

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -293,7 +293,7 @@ func (b *Executor) Preserve(path string) error {
 
 	// Try and resolve the symlink (if one exists)
 	// Set archivedPath and path based on whether a symlink is found or not
-	if symLink, err := ResolveSymLink(b.mountPoint, path); err == nil {
+	if symLink, err := resolveSymlink(b.mountPoint, path); err == nil {
 		archivedPath = filepath.Join(b.mountPoint, symLink)
 		path = symLink
 	} else {

--- a/imagebuildah/chroot_symlink.go
+++ b/imagebuildah/chroot_symlink.go
@@ -24,9 +24,7 @@ func init() {
 	reexec.Register(symlinkModifiedTime, resolveSymlinkTimeModified)
 }
 
-// main() for grandparent subprocess.  Its main job is to shuttle stdio back
-// and forth, managing a pseudo-terminal if we want one, for our child, the
-// parent subprocess.
+// main() for resolveSymlink()'s subprocess.
 func resolveChrootedSymlinks() {
 	status := 0
 	flag.Parse()
@@ -57,9 +55,9 @@ func resolveChrootedSymlinks() {
 	os.Exit(status)
 }
 
-// ResolveSymLink (in the grandparent process) resolves any symlink in filename
+// resolveSymlink uses a child subprocess to resolve any symlinks in filename
 // in the context of rootdir.
-func ResolveSymLink(rootdir, filename string) (string, error) {
+func resolveSymlink(rootdir, filename string) (string, error) {
 	// The child process expects a chroot and one path that
 	// will be consulted relative to the chroot directory and evaluated
 	// for any symbolic links present.
@@ -253,7 +251,7 @@ func hasSymlink(path string) (bool, string, error) {
 	}
 	// if the symlink points to a relative path, prepend the path till now to the resolved path
 	if !filepath.IsAbs(targetDir) {
-		targetDir = filepath.Join(path, targetDir)
+		targetDir = filepath.Join(filepath.Dir(path), targetDir)
 	}
 	// run filepath.Clean to remove the ".." from relative paths
 	return true, filepath.Clean(targetDir), nil

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -660,6 +660,7 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ "test-log -> ../log" ]]
+  test -r $root/var/data/empty
   buildah rm ${cid}
   buildah rmi ${target}
 }

--- a/tests/bud/symlink/Dockerfile.relative-symlink
+++ b/tests/bud/symlink/Dockerfile.relative-symlink
@@ -2,3 +2,7 @@ FROM alpine
 RUN mkdir -p /data
 RUN ln -s ../log /test-log
 VOLUME [ "/test-log/test" ]
+RUN ln -s ../data /var/data
+RUN touch /data/empty
+VOLUME [ "/var/data" ]
+RUN pwd


### PR DESCRIPTION
We don't need to put in as much effort as `getSymbolicLink()` does when we're already in a chroot, so switch back to using `filepath.EvalSymlinks()` to evaluate the path.