### PR TITLE
rootless: honor --net host

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -228,7 +228,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budResults) error {
 	if err != nil {
 		return errors.Wrapf(err, "error parsing namespace-related options")
 	}
-	usernsOption, idmappingOptions, err := parse.IDMappingOptions(c)
+	usernsOption, idmappingOptions, err := parse.IDMappingOptions(c, isolation)
 	if err != nil {
 		return errors.Wrapf(err, "error parsing ID mapping options")
 	}

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -198,7 +198,7 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 	if err != nil {
 		return errors.Wrapf(err, "error parsing namespace-related options")
 	}
-	usernsOption, idmappingOptions, err := parse.IDMappingOptions(c)
+	usernsOption, idmappingOptions, err := parse.IDMappingOptions(c, isolation)
 	if err != nil {
 		return errors.Wrapf(err, "error parsing ID mapping options")
 	}

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -510,20 +510,21 @@ func (b *Executor) Run(run imagebuilder.Run, config docker.Config) error {
 		stdin = devNull
 	}
 	options := buildah.RunOptions{
-		Hostname:   config.Hostname,
-		Runtime:    b.runtime,
-		Args:       b.runtimeArgs,
-		NoPivot:    os.Getenv("BUILDAH_NOPIVOT") != "",
-		Mounts:     convertMounts(b.transientMounts),
-		Env:        config.Env,
-		User:       config.User,
-		WorkingDir: config.WorkingDir,
-		Entrypoint: config.Entrypoint,
-		Cmd:        config.Cmd,
-		Stdin:      stdin,
-		Stdout:     b.out,
-		Stderr:     b.err,
-		Quiet:      b.quiet,
+		Hostname:         config.Hostname,
+		Runtime:          b.runtime,
+		Args:             b.runtimeArgs,
+		NoPivot:          os.Getenv("BUILDAH_NOPIVOT") != "",
+		Mounts:           convertMounts(b.transientMounts),
+		Env:              config.Env,
+		User:             config.User,
+		WorkingDir:       config.WorkingDir,
+		Entrypoint:       config.Entrypoint,
+		Cmd:              config.Cmd,
+		Stdin:            stdin,
+		Stdout:           b.out,
+		Stderr:           b.err,
+		Quiet:            b.quiet,
+		NamespaceOptions: b.namespaceOptions,
 	}
 	if config.NetworkDisabled {
 		options.ConfigureNetwork = buildah.NetworkDisabled

--- a/run.go
+++ b/run.go
@@ -1765,7 +1765,9 @@ func runConfigureNetwork(isolation Isolation, options RunOptions, configureNetwo
 	var netconf, undo []*libcni.NetworkConfigList
 
 	if isolation == IsolationOCIRootless {
-		return setupRootlessNetwork(pid)
+		if ns := options.NamespaceOptions.Find(string(specs.NetworkNamespace)); ns != nil && !ns.Host {
+			return setupRootlessNetwork(pid)
+		}
 	}
 	// Scan for CNI configuration files.
 	confdir := options.CNIConfigDir


### PR DESCRIPTION
when running in rootless mode, do not use slirp4netns if --net host is
specified.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>