### PR TITLE
fix bug images use the template to print results

### DIFF
--- a/cmd/buildah/rmi_test.go
+++ b/cmd/buildah/rmi_test.go
@@ -86,9 +86,6 @@ func TestStorageImageIDTrue(t *testing.T) {
 	// Make sure the tests are running as root
 	failTestIfNotRoot(t)
 
-	opts := imageOptions{
-		quiet: true,
-	}
 	store, err := storage.GetStore(storeOptions)
 	if store != nil {
 		is.Transport.SetStore(store)
@@ -106,13 +103,13 @@ func TestStorageImageIDTrue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error reading images: %v", err)
 	}
-	id, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images, store, nil, "busybox:latest", opts)
-	})
-	if err != nil {
-		t.Fatalf("Error getting id of image: %v", err)
+	var id string
+	if len(images) > 0 {
+		id = strings.TrimSpace(images[0].ID)
 	}
-	id = strings.TrimSpace(id)
+	if id == "" {
+		t.Fatalf("Error getting image id")
+	}
 
 	imgRef, err := storageImageID(getContext(), store, id)
 	if err != nil {

--- a/pkg/formats/formats.go
+++ b/pkg/formats/formats.go
@@ -1,0 +1,171 @@
+package formats
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+const (
+	// JSONString const to save on duplicate variable names
+	JSONString = "json"
+	// IDString const to save on duplicates for Go templates
+	IDString = "{{.ID}}"
+
+	parsingErrorStr = "Template parsing error"
+)
+
+// Writer interface for outputs
+type Writer interface {
+	Out() error
+}
+
+// JSONStructArray for JSON output
+type JSONStructArray struct {
+	Output []interface{}
+}
+
+// StdoutTemplateArray for Go template output
+type StdoutTemplateArray struct {
+	Output   []interface{}
+	Template string
+	Fields   map[string]string
+}
+
+// JSONStruct for JSON output
+type JSONStruct struct {
+	Output interface{}
+}
+
+// StdoutTemplate for Go template output
+type StdoutTemplate struct {
+	Output   interface{}
+	Template string
+	Fields   map[string]string
+}
+
+// YAMLStruct for YAML output
+type YAMLStruct struct {
+	Output interface{}
+}
+
+func setJSONFormatEncoder(isTerminal bool, w io.Writer) *json.Encoder {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "    ")
+	if isTerminal {
+		enc.SetEscapeHTML(false)
+	}
+	return enc
+}
+
+// Out method for JSON Arrays
+func (j JSONStructArray) Out() error {
+	buf := bytes.NewBuffer(nil)
+	enc := setJSONFormatEncoder(terminal.IsTerminal(int(os.Stdout.Fd())), buf)
+	if err := enc.Encode(j.Output); err != nil {
+		return err
+	}
+	data := buf.Bytes()
+
+	// JSON returns a byte array with a literal null [110 117 108 108] in it
+	// if it is passed empty data.  We used bytes.Compare to see if that is
+	// the case.
+	if diff := bytes.Compare(data, []byte("null")); diff == 0 {
+		data = []byte("[]")
+	}
+
+	// If the we did get NULL back, we should spit out {} which is
+	// at least valid JSON for the consumer.
+	fmt.Printf("%s", data)
+	humanNewLine()
+	return nil
+}
+
+// Out method for Go templates
+func (t StdoutTemplateArray) Out() error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	if strings.HasPrefix(t.Template, "table") {
+		// replace any spaces with tabs in template so that tabwriter can align it
+		t.Template = strings.Replace(strings.TrimSpace(t.Template[5:]), " ", "\t", -1)
+		headerTmpl, err := template.New("header").Funcs(headerFunctions).Parse(t.Template)
+		if err != nil {
+			return errors.Wrapf(err, parsingErrorStr)
+		}
+		err = headerTmpl.Execute(w, t.Fields)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(w, "")
+	}
+	t.Template = strings.Replace(t.Template, " ", "\t", -1)
+	tmpl, err := template.New("image").Funcs(basicFunctions).Parse(t.Template)
+	if err != nil {
+		return errors.Wrapf(err, parsingErrorStr)
+	}
+	for i, raw := range t.Output {
+		basicTmpl := tmpl.Funcs(basicFunctions)
+		if err := basicTmpl.Execute(w, raw); err != nil {
+			return errors.Wrapf(err, parsingErrorStr)
+		}
+		if i != len(t.Output)-1 {
+			fmt.Fprintln(w, "")
+			continue
+		}
+	}
+	fmt.Fprintln(w, "")
+	return w.Flush()
+}
+
+// Out method for JSON struct
+func (j JSONStruct) Out() error {
+	data, err := json.MarshalIndent(j.Output, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s", data)
+	humanNewLine()
+	return nil
+}
+
+//Out method for Go templates
+func (t StdoutTemplate) Out() error {
+	tmpl, err := template.New("image").Parse(t.Template)
+	if err != nil {
+		return errors.Wrapf(err, "template parsing error")
+	}
+	err = tmpl.Execute(os.Stdout, t.Output)
+	if err != nil {
+		return err
+	}
+	humanNewLine()
+	return nil
+}
+
+// Out method for YAML
+func (y YAMLStruct) Out() error {
+	var buf []byte
+	var err error
+	buf, err = yaml.Marshal(y.Output)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s", string(buf))
+	humanNewLine()
+	return nil
+}
+
+// humanNewLine prints a new line at the end of the output only if stdout is the terminal
+func humanNewLine() {
+	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+		fmt.Println()
+	}
+}

--- a/pkg/formats/formats_test.go
+++ b/pkg/formats/formats_test.go
@@ -1,0 +1,44 @@
+package formats
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+type ImageData struct {
+	Author string `json:"Author"`
+}
+
+func TestSetJSONFormatEncoder(t *testing.T) {
+	tt := []struct {
+		name       string
+		imageData  *ImageData
+		expected   string
+		isTerminal bool
+	}{
+		{
+			name:       "HTML tags are not escaped",
+			imageData:  &ImageData{Author: "dave <dave@corp.io>"},
+			expected:   `"Author": "dave <dave@corp.io>"`,
+			isTerminal: true,
+		},
+		{
+			name:       "HTML tags are escaped",
+			imageData:  &ImageData{Author: "dave <dave@corp.io>"},
+			expected:   `"Author": "dave \u003cdave@corp.io\u003e"`,
+			isTerminal: false,
+		},
+	}
+
+	for _, tc := range tt {
+		buf := bytes.NewBuffer(nil)
+		enc := setJSONFormatEncoder(tc.isTerminal, buf)
+		if err := enc.Encode(tc.imageData); err != nil {
+			t.Errorf("test %#v failed encoding: %s", tc.name, err)
+		}
+		if !strings.Contains(buf.String(), tc.expected) {
+			t.Errorf("test %#v expected output to contain %#v. Output:\n%v\n", tc.name, tc.expected, buf.String())
+		}
+	}
+}

--- a/pkg/formats/templates.go
+++ b/pkg/formats/templates.go
@@ -1,0 +1,78 @@
+package formats
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"text/template"
+)
+
+// basicFunctions are the set of initial
+// functions provided to every template.
+var basicFunctions = template.FuncMap{
+	"json": func(v interface{}) string {
+		buf := &bytes.Buffer{}
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		_ = enc.Encode(v)
+		// Remove the trailing new line added by the encoder
+		return strings.TrimSpace(buf.String())
+	},
+	"split":    strings.Split,
+	"join":     strings.Join,
+	"title":    strings.Title,
+	"lower":    strings.ToLower,
+	"upper":    strings.ToUpper,
+	"pad":      padWithSpace,
+	"truncate": truncateWithLength,
+}
+
+// HeaderFunctions are used to created headers of a table.
+// This is a replacement of basicFunctions for header generation
+// because we want the header to remain intact.
+// Some functions like `split` are irrelevant so not added.
+var headerFunctions = template.FuncMap{
+	"json": func(v string) string {
+		return v
+	},
+	"title": func(v string) string {
+		return v
+	},
+	"lower": func(v string) string {
+		return v
+	},
+	"upper": func(v string) string {
+		return v
+	},
+	"truncate": func(v string, l int) string {
+		return v
+	},
+}
+
+// Parse creates a new anonymous template with the basic functions
+// and parses the given format.
+func Parse(format string) (*template.Template, error) {
+	return NewParse("", format)
+}
+
+// NewParse creates a new tagged template with the basic functions
+// and parses the given format.
+func NewParse(tag, format string) (*template.Template, error) {
+	return template.New(tag).Funcs(basicFunctions).Parse(format)
+}
+
+// padWithSpace adds whitespace to the input if the input is non-empty
+func padWithSpace(source string, prefix, suffix int) string {
+	if source == "" {
+		return source
+	}
+	return strings.Repeat(" ", prefix) + source + strings.Repeat(" ", suffix)
+}
+
+// truncateWithLength truncates the source string up to the length provided by the input
+func truncateWithLength(source string, length int) string {
+	if len(source) < length {
+		return source
+	}
+	return source[:length]
+}

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -12,7 +12,7 @@ load helpers
   run buildah images img1 --filter="service=redis" img2
   check_options_flag_err "--filter=service=redis"
 
-  run buildah images img1 img2 img3 -q 
+  run buildah images img1 img2 img3 -q
   check_options_flag_err "-q"
 }
 
@@ -83,13 +83,25 @@ load helpers
   buildah rmi -a -f
 }
 
+@test "images no-trunc test" {
+  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  run buildah --debug=false images -q --no-trunc
+  [ $(wc -l <<< "$output") -eq 2 ]
+  echo $output
+  [[ ${lines[0]} =~ "sha256" ]]
+  [ "${status}" -eq 0 ]
+  buildah rm -a
+  buildah rmi -a -f
+}
+
 @test "images json test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
   run buildah --debug=false images --json
   [ $(wc -l <<< "$output") -eq 14 ]
   [ "${status}" -eq 0 ]
- 
+
   run buildah --debug=false images --json alpine
   [ $(wc -l <<< "$output") -eq 8 ]
   [ "${status}" -eq 0 ]
@@ -145,7 +157,7 @@ load helpers
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
-  run buildah --debug=false images 
+  run buildah --debug=false images
   [ $(wc -l <<< "$output") -eq 3 ]
   [ "${status}" -eq 0 ]
   run buildah --debug=false images --filter dangling=true


### PR DESCRIPTION
Replace the hard code format with the template from podman. The format is ok with long imag tag or name.

fix #1239 

```
$ sudo buildah images
REPOSITORY                    TAG                                                                IMAGE ID       CREATED        SIZE
<none>                        <none>                                                             bd2e2e2344cc   4 hours ago    83.3 MB
docker.io/library/node        alpine                                                             a13f3a3ed57f   46 hours ago   79.5 MB
localhost/app                 latest                                                             a13f3a3ed57f   46 hours ago   79.5 MB
localhost/hitheretherethere   1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe   a13f3a3ed57f   46 hours ago   79.5 MB
```
```
$ sudo podman images
REPOSITORY                    TAG                                                                IMAGE ID       CREATED        SIZE
<none>                        <none>                                                             bd2e2e2344cc   5 hours ago    83.3 MB
docker.io/library/node        alpine                                                             a13f3a3ed57f   46 hours ago   79.5 MB
localhost/app                 latest                                                             a13f3a3ed57f   46 hours ago   79.5 MB
localhost/hitheretherethere   1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe   a13f3a3ed57f   46 hours ago   79.5 MB

```
Signed-off-by: Qi Wang <qiwan@redhat.com>