### PR TITLE
slirp4netns: set mtu to 65520

### DIFF
--- a/run.go
+++ b/run.go
@@ -1720,7 +1720,7 @@ func setupRootlessNetwork(pid int) (teardown func(), err error) {
 		unix.CloseOnExec(fd)
 	}
 
-	cmd := exec.Command(slirp4netns, "-r", "3", "-c", fmt.Sprintf("%d", pid), "tap0")
+	cmd := exec.Command(slirp4netns, "--mtu", "65520", "-r", "3", "-c", fmt.Sprintf("%d", pid), "tap0")
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil
 	cmd.ExtraFiles = []*os.File{rootlessSlirpSyncW}
 


### PR DESCRIPTION
it improves significantly the performance of the slirp4netns network:

https://github.com/rootless-containers/slirp4netns/tree/777bdccceffa5bee38dbfd9eefc06628cc160ff6#iperf3-netns---host

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>