### PR TITLE
imagebuildah.ReposToMap(): move to cmd/buildah, which is its only consumer

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -270,16 +270,8 @@ func outputImages(ctx context.Context, images []storage.Image, store storage.Sto
 			imageID = shortID(image.ID)
 		}
 
-		names := []string{}
-		if len(image.Names) > 0 {
-			names = image.Names
-		} else {
-			// images without names should be printed with "<none>" as the image name
-			names = append(names, "<none>:<none>")
-		}
-
 	outer:
-		for name, tags := range imageReposToMap(names) {
+		for name, tags := range imageReposToMap(image.Names) {
 			for _, tag := range tags {
 				if !matchesReference(name+":"+tag, argName) {
 					continue

--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -111,28 +111,3 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 func InitReexec() bool {
 	return buildah.InitReexec()
 }
-
-// ReposToMap parses the specified repotags and returns a map with repositories
-// as keys and the corresponding arrays of tags as values.
-func ReposToMap(repotags []string) map[string][]string {
-	// map format is repo -> tag
-	repos := make(map[string][]string)
-	for _, repo := range repotags {
-		var repository, tag string
-		if strings.Contains(repo, ":") {
-			li := strings.LastIndex(repo, ":")
-			repository = repo[0:li]
-			tag = repo[li+1:]
-		} else if len(repo) > 0 {
-			repository = repo
-			tag = "<none>"
-		} else {
-			logrus.Warnf("Found image with empty name")
-		}
-		repos[repository] = append(repos[repository], tag)
-	}
-	if len(repos) == 0 {
-		repos["<none>"] = []string{"<none>"}
-	}
-	return repos
-}


### PR DESCRIPTION
The imagebuildah.ReposToMap() function is only called from the CLI, so move it there.  This makes it easier to spot a duplicate `<none>:<none>` being added to the list that `buildah images` outputs, so fix that.