### PR TITLE
Allow rootless users to use the cache directory in homedir

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -336,10 +336,10 @@ type BuilderOptions struct {
 	// needs to be pulled and the image name alone can not be resolved to a
 	// reference to a source image.  No separator is implicitly added.
 	Registry string
-	// PullBlobDirectory is the name of a directory in which we'll attempt
+	// BlobDirectory is the name of a directory in which we'll attempt
 	// to store copies of layer blobs that we pull down, if any.  It should
 	// already exist.
-	PullBlobDirectory string
+	BlobDirectory string
 	// Mount signals to NewBuilder() that the container should be mounted
 	// immediately.
 	Mount bool

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -183,6 +183,11 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budResults) error {
 	if err != nil {
 		return errors.Wrapf(err, "error building system context")
 	}
+	if iopts.BlobCache != "" {
+		systemContext.BlobInfoCacheDir = iopts.BlobCache
+	} else {
+		systemContext.BlobInfoCacheDir = filepath.Join(store.GraphRoot(), "cache")
+	}
 
 	isolation, err := parse.IsolationOption(c)
 	if err != nil {

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -156,6 +156,7 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 		Squash:                iopts.squash,
 		BlobDirectory:         iopts.blobCache,
 		OmitTimestamp:         iopts.omitTimestamp,
+		Store:                 store,
 	}
 	if !iopts.quiet {
 		options.ReportWriter = os.Stderr

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -226,7 +226,7 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 		DropCapabilities:      iopts.CapDrop,
 		CommonBuildOpts:       commonOpts,
 		Format:                format,
-		PullBlobDirectory:     iopts.BlobCache,
+		BlobDirectory:         iopts.BlobCache,
 	}
 
 	if !iopts.quiet {

--- a/common.go
+++ b/common.go
@@ -8,6 +8,7 @@ import (
 	cp "github.com/containers/image/copy"
 	"github.com/containers/image/types"
 	"github.com/containers/libpod/pkg/rootless"
+	"github.com/containers/storage"
 )
 
 const (
@@ -17,31 +18,15 @@ const (
 	DOCKER = "docker"
 )
 
-// userRegistriesFile is the path to the per user registry configuration file.
-var userRegistriesFile = filepath.Join(os.Getenv("HOME"), ".config/containers/registries.conf")
-
-func getCopyOptions(reportWriter io.Writer, sourceReference types.ImageReference, sourceSystemContext *types.SystemContext, destinationReference types.ImageReference, destinationSystemContext *types.SystemContext, manifestType string) *cp.Options {
-	sourceCtx := &types.SystemContext{}
+func getCopyOptions(store storage.Store, reportWriter io.Writer, sourceReference types.ImageReference, sourceSystemContext *types.SystemContext, destinationReference types.ImageReference, destinationSystemContext *types.SystemContext, manifestType string) *cp.Options {
+	sourceCtx := getSystemContext(store, nil, "")
 	if sourceSystemContext != nil {
 		*sourceCtx = *sourceSystemContext
-	} else {
-		if rootless.IsRootless() {
-			if _, err := os.Stat(userRegistriesFile); err == nil {
-				sourceCtx.SystemRegistriesConfPath = userRegistriesFile
-			}
-
-		}
 	}
 
-	destinationCtx := &types.SystemContext{}
+	destinationCtx := getSystemContext(store, nil, "")
 	if destinationSystemContext != nil {
 		*destinationCtx = *destinationSystemContext
-	} else {
-		if rootless.IsRootless() {
-			if _, err := os.Stat(userRegistriesFile); err == nil {
-				destinationCtx.SystemRegistriesConfPath = userRegistriesFile
-			}
-		}
 	}
 
 	return &cp.Options{
@@ -52,7 +37,7 @@ func getCopyOptions(reportWriter io.Writer, sourceReference types.ImageReference
 	}
 }
 
-func getSystemContext(defaults *types.SystemContext, signaturePolicyPath string) *types.SystemContext {
+func getSystemContext(store storage.Store, defaults *types.SystemContext, signaturePolicyPath string) *types.SystemContext {
 	sc := &types.SystemContext{}
 	if defaults != nil {
 		*sc = *defaults
@@ -60,11 +45,16 @@ func getSystemContext(defaults *types.SystemContext, signaturePolicyPath string)
 	if signaturePolicyPath != "" {
 		sc.SignaturePolicyPath = signaturePolicyPath
 	}
-	if sc.SystemRegistriesConfPath == "" && rootless.IsRootless() {
-		if _, err := os.Stat(userRegistriesFile); err == nil {
-			sc.SystemRegistriesConfPath = userRegistriesFile
+	if store != nil {
+		if sc.BlobInfoCacheDir == "" {
+			sc.BlobInfoCacheDir = filepath.Join(store.GraphRoot(), "cache")
 		}
-
+		if sc.SystemRegistriesConfPath == "" && rootless.IsRootless() {
+			userRegistriesFile := filepath.Join(store.GraphRoot(), "registries.conf")
+			if _, err := os.Stat(userRegistriesFile); err == nil {
+				sc.SystemRegistriesConfPath = userRegistriesFile
+			}
+		}
 	}
 	return sc
 }

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -666,7 +666,7 @@ func (b *Executor) Prepare(ctx context.Context, stage imagebuilder.Stage, from s
 		FromImage:             from,
 		PullPolicy:            b.pullPolicy,
 		Registry:              b.registry,
-		PullBlobDirectory:     b.blobDirectory,
+		BlobDirectory:         b.blobDirectory,
 		SignaturePolicyPath:   b.signaturePolicyPath,
 		ReportWriter:          b.reportWriter,
 		SystemContext:         b.systemContext,

--- a/import.go
+++ b/import.go
@@ -83,7 +83,7 @@ func importBuilder(ctx context.Context, store storage.Store, options ImportOptio
 		return nil, err
 	}
 
-	systemContext := getSystemContext(&types.SystemContext{}, options.SignaturePolicyPath)
+	systemContext := getSystemContext(store, &types.SystemContext{}, options.SignaturePolicyPath)
 
 	builder, err := importBuilderDataFromImage(ctx, store, systemContext, c.ImageID, options.Container, c.ID)
 	if err != nil {
@@ -115,7 +115,7 @@ func importBuilderFromImage(ctx context.Context, store storage.Store, options Im
 		return nil, errors.Errorf("image name must be specified")
 	}
 
-	systemContext := getSystemContext(options.SystemContext, options.SignaturePolicyPath)
+	systemContext := getSystemContext(store, options.SystemContext, options.SignaturePolicyPath)
 
 	_, img, err := util.FindImage(store, "", systemContext, options.Image)
 	if err != nil {

--- a/new.go
+++ b/new.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"path/filepath"
 	"strings"
 
 	"github.com/containers/buildah/util"
@@ -29,7 +30,7 @@ func pullAndFindImage(ctx context.Context, store storage.Store, srcRef types.Ima
 		ReportWriter:  options.ReportWriter,
 		Store:         store,
 		SystemContext: options.SystemContext,
-		BlobDirectory: options.PullBlobDirectory,
+		BlobDirectory: options.BlobDirectory,
 	}
 	ref, err := pullImage(ctx, store, srcRef, pullOptions, sc)
 	if err != nil {
@@ -244,7 +245,12 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		options.FromImage = ""
 	}
 
-	systemContext := getSystemContext(options.SystemContext, options.SignaturePolicyPath)
+	systemContext := getSystemContext(store, options.SystemContext, options.SignaturePolicyPath)
+	if options.BlobDirectory != "" {
+		systemContext.BlobInfoCacheDir = options.BlobDirectory
+	} else {
+		systemContext.BlobInfoCacheDir = filepath.Join(store.GraphRoot(), "cache")
+	}
 
 	if options.FromImage != "" && options.FromImage != "scratch" {
 		ref, _, img, err = resolveImage(ctx, systemContext, store, options)


### PR DESCRIPTION
Currently rootless podman attempts to write to /var/lib/containers/cache
and fails. This causes us to repeatedly push images that have already been
pushed.  This cache directory should be relative to the location of containers/storage
and not always stored in the same directory.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>