### PR TITLE
fix bug to not separate each --label value with comma

### DIFF
--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -82,7 +82,7 @@ func init() {
 	flags.StringVar(&opts.healthcheckTimeout, "healthcheck-timeout", "", "set the maximum amount of `time` to wait for a `healthcheck` command for the target image")
 	flags.StringVar(&opts.historyComment, "history-comment", "", "set a `comment` for the history of the target image")
 	flags.StringVar(&opts.hostname, "hostname", "", "set a host`name` for containers based on image")
-	flags.StringSliceVarP(&opts.label, "label", "l", []string{}, "add image configuration `label` e.g. label=value")
+	flags.StringArrayVarP(&opts.label, "label", "l", []string{}, "add image configuration `label` e.g. label=value")
 	flags.StringSliceVar(&opts.onbuild, "onbuild", []string{}, "add onbuild command to be run on images based on this image. Only supported on 'docker' formatted images")
 	flags.StringVar(&opts.os, "os", "", "set `operating system` of the target image")
 	flags.StringSliceVarP(&opts.ports, "port", "p", []string{}, "add `port` to expose when running containers based on image (default [])")

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -172,6 +172,7 @@ load helpers
    --volume /VOLUME \
    --workingdir /tmp \
    --label LABEL=VALUE \
+   --label exec='podman run -it --mount=type=bind,bind-propagation=Z,source=foo,destination=bar /script buz'\
    --stop-signal SIGINT \
    --annotation ANNOTATION=VALUE \
    --shell /bin/arbitrarysh \
@@ -243,6 +244,11 @@ load helpers
   buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Labels}}' scratch-image-docker | grep LABEL:VALUE
   buildah --debug=false inspect --type=image --format '{{.Docker.Config.Labels}}' scratch-image-oci | grep LABEL:VALUE
   buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Labels}}' scratch-image-oci | grep LABEL:VALUE
+
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Labels}}' scratch-image-docker | grep 'exec:podman run -it --mount=type=bind,bind-propagation=Z,source=foo,destination=bar /script buz'
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Labels}}' scratch-image-docker | grep 'exec:podman run -it --mount=type=bind,bind-propagation=Z,source=foo,destination=bar /script buz'
+  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Labels}}' scratch-image-oci | grep 'exec:podman run -it --mount=type=bind,bind-propagation=Z,source=foo,destination=bar /script buz'
+  buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Labels}}' scratch-image-oci | grep 'exec:podman run -it --mount=type=bind,bind-propagation=Z,source=foo,destination=bar /script buz'
 
   buildah --debug=false inspect --type=image --format '{{.Docker.Config.StopSignal}}' scratch-image-docker | grep SIGINT
   buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.StopSignal}}' scratch-image-docker | grep SIGINT


### PR DESCRIPTION
fix #1414 
Change `StringSliceVarP` to `StringArrayVarP`. Avoid to separate each flag value with comma.
After this patch
```
"Labels": {
                "exec": "podman run -it --mount=type=bind,bind-propagation=Z,source=,destination= /script",
                "maintainer": "Clement Verna <cverna@fedoraproject.org>"
            }
```
Signed-off-by: Qi Wang <qiwan@redhat.com>