### PR TITLE
images: suppress a spurious blank line with no images

### DIFF
--- a/pkg/formats/formats.go
+++ b/pkg/formats/formats.go
@@ -111,17 +111,13 @@ func (t StdoutTemplateArray) Out() error {
 	if err != nil {
 		return errors.Wrapf(err, parsingErrorStr)
 	}
-	for i, raw := range t.Output {
+	for _, raw := range t.Output {
 		basicTmpl := tmpl.Funcs(basicFunctions)
 		if err := basicTmpl.Execute(w, raw); err != nil {
 			return errors.Wrapf(err, parsingErrorStr)
 		}
-		if i != len(t.Output)-1 {
-			fmt.Fprintln(w, "")
-			continue
-		}
+		fmt.Fprintln(w, "")
 	}
-	fmt.Fprintln(w, "")
 	return w.Flush()
 }
 


### PR DESCRIPTION
When listing images when there are no images, avoid outputting an unnecessary newline.