### PR TITLE
buildah-bud.md: correct a typo, note a default

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -199,7 +199,7 @@ If you specify `-f -`, the Dockerfile contents will be read from stdin.
 
 **--force-rm** *bool-value*
 
-Always remove intermediate containers after a build, even if the build is unsuccessful..
+Always remove intermediate containers after a build, even if the build fails (default false).
 
 **--format**
 


### PR DESCRIPTION
Note the default for the `--force-rm` flag in the man page.