### PR TITLE
rootless: by default use the host network namespace

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -393,25 +392,11 @@ func IDMappingOptions(c *cobra.Command, isolation buildah.Isolation) (usernsOpti
 		gidmap = uidmap
 	}
 
-	useSlirp4netns := false
-
-	if isolation == buildah.IsolationOCIRootless {
-		_, err := exec.LookPath("slirp4netns")
-		if execerr, ok := err.(*exec.Error); ok && !strings.Contains(execerr.Error(), "not found") {
-			return nil, nil, errors.Wrapf(err, "cannot lookup slirp4netns %v", execerr)
-		}
-		if err == nil {
-			useSlirp4netns = true
-		} else {
-			logrus.Warningf("could not find slirp4netns. Using host network namespace")
-		}
-	}
-
 	// By default, having mappings configured means we use a user
 	// namespace.  Otherwise, we don't.
 	usernsOption := buildah.NamespaceOption{
 		Name: string(specs.UserNamespace),
-		Host: len(uidmap) == 0 && len(gidmap) == 0 && !useSlirp4netns,
+		Host: len(uidmap) == 0 && len(gidmap) == 0,
 	}
 	// If the user specifically requested that we either use or don't use
 	// user namespaces, override that default.

--- a/run.go
+++ b/run.go
@@ -1765,7 +1765,7 @@ func runConfigureNetwork(isolation Isolation, options RunOptions, configureNetwo
 	var netconf, undo []*libcni.NetworkConfigList
 
 	if isolation == IsolationOCIRootless {
-		if ns := options.NamespaceOptions.Find(string(specs.NetworkNamespace)); ns != nil && !ns.Host {
+		if ns := options.NamespaceOptions.Find(string(specs.NetworkNamespace)); ns != nil && !ns.Host && ns.Path == "" {
 			return setupRootlessNetwork(pid)
 		}
 	}


### PR DESCRIPTION
if --net is not specified, default to use the host network namespace.

It is still possible to use slirp4netns with --network container.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1690209

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>