### PR TITLE
Do not create empty mounts.conf file

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -150,15 +150,6 @@ func SecretMountsWithUIDGID(mountLabel, containerWorkingDir, mountFile, mountPre
 		mountFiles = append(mountFiles, []string{OverrideMountsFile, DefaultMountsFile}...)
 		if rootless.IsRootless() {
 			mountFiles = append([]string{UserOverrideMountsFile}, mountFiles...)
-			_, err := os.Stat(UserOverrideMountsFile)
-			if err != nil && os.IsNotExist(err) {
-				os.MkdirAll(filepath.Dir(UserOverrideMountsFile), 0755)
-				if f, err := os.Create(UserOverrideMountsFile); err != nil {
-					logrus.Warnf("could not create file %s: %v", UserOverrideMountsFile, err)
-				} else {
-					f.Close()
-				}
-			}
 		}
 	} else {
 		mountFiles = append(mountFiles, mountFile)


### PR DESCRIPTION
We want to use the shared /usr/share/containers/mounts.conf by default.

Currently the tools create an empty mounts.conf file which causes RHEL
subscriptions to not work.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>