### PR TITLE
imagebuildah: check for unused args across stages

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -987,6 +987,20 @@ load helpers
   [ "$status" -eq 0 ]
 }
 
+@test "bud with unused ARGS" {
+  target=alpine-image
+  run buildah --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE ${TESTSDIR}/bud/run-scenarios
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "USED_VALUE" ]]
+  [[ ! "$output" =~ "one or more build args were not consumed: [UNUSED_ARG]" ]]
+  run buildah --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE --build-arg UNUSED_ARG=whaaaat ${TESTSDIR}/bud/run-scenarios
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "USED_VALUE" ]]
+  [[ "$output" =~ "one or more build args were not consumed: [UNUSED_ARG]" ]]
+}
+
 @test "bud-from-stdin" {
   target=scratch-image
   cat ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch | buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f - ${TESTSDIR}/bud/from-multiple-files

--- a/tests/bud/run-scenarios/Dockerfile.multi-args
+++ b/tests/bud/run-scenarios/Dockerfile.multi-args
@@ -1,0 +1,5 @@
+FROM alpine
+ARG USED_ARG="used_value"
+RUN echo ${USED_ARG}
+FROM scratch
+COPY --from=0 /etc/passwd /root/passwd-file


### PR DESCRIPTION
Check for unused arguments across all of the stages of a multi-stage build.  They can only be passed to us once for the whole build, so we shouldn't treat it as an error if a given stage doesn't reference all of
them.