### PR TITLE
vendor imagebuilder v1.1.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -39,7 +39,7 @@ github.com/opencontainers/runc v1.0.0-rc6
 github.com/opencontainers/runtime-spec v1.0.0
 github.com/opencontainers/runtime-tools v0.8.0
 github.com/opencontainers/selinux v1.1
-github.com/openshift/imagebuilder 705fe9255c57f8505efb9723a9ac4082b67973bc
+github.com/openshift/imagebuilder v1.1.0
 github.com/ostreedev/ostree-go 9ab99253d365aac3a330d1f7281cf29f3d22820b
 github.com/pkg/errors v0.8.1
 github.com/pquerna/ffjson d49c2bc1aa135aad0c6f4fc2056623ec78f5d5ac

--- a/vendor/github.com/openshift/imagebuilder/vendor.conf
+++ b/vendor/github.com/openshift/imagebuilder/vendor.conf
@@ -1,12 +1,11 @@
 github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/containerd/continuity 004b46473808b3e7a4a3049c20e4376c91eb966d
+github.com/containers/storage v1.2
 github.com/docker/docker b68221c37ee597950364788204546f9c9d0e46a1
 github.com/docker/go-connections 97c2040d34dfae1d1b1275fa3a78dbdd2f41cf7e
 github.com/docker/go-units 2fb04c6466a548a03cb009c5569ee1ab1e35398e
 github.com/fsouza/go-dockerclient openshift-4.0 https://github.com/openshift/go-dockerclient.git
 github.com/gogo/protobuf c5a62797aee0054613cc578653a16c6237fef080
 github.com/golang/glog 23def4e6c14b4da8ac2ed8007337bc5eb5007998
-github.com/golang/protobuf v1.3.0
 github.com/konsorten/go-windows-terminal-sequences f55edac94c9bbba5d6182a4be46d86a2c9b5b50e
 github.com/Microsoft/go-winio 1a8911d1ed007260465c3bfbbc785ac6915a0bb8
 github.com/Nvveen/Gotty cd527374f1e5bff4938207604a14f2e38a9cf512
@@ -14,8 +13,8 @@ github.com/opencontainers/go-digest ac19fd6e7483ff933754af248d80be865e543d22
 github.com/opencontainers/image-spec 243ea084a44451d27322fed02b682d99e2af3ba9
 github.com/opencontainers/runc 923a8f8a9a07aceada5fc48c4d37e905d9b019b5
 github.com/pkg/errors 27936f6d90f9c8e1145f11ed52ffffbfdb9e0af7
+github.com/pquerna/ffjson d49c2bc1aa135aad0c6f4fc2056623ec78f5d5ac
 github.com/sirupsen/logrus d7b6bf5e4d26448fd977d07d745a2a66097ddecb
 golang.org/x/crypto ff983b9c42bc9fbf91556e191cc8efb585c16908
 golang.org/x/net 45ffb0cd1ba084b73e26dee67e667e1be5acce83
-golang.org/x/sync 37e7f081c4d4c64e13b10787722085407fe5d15f
 golang.org/x/sys 7fbe1cd0fcc20051e1fcb87fbabec4a1bacaaeba


### PR DESCRIPTION
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

Note that this is a non-functional change. We cut a new release for imagebuilder to move it to semver to be `go mod`-compatible.

@rhatdan @TomSweeneyRedHat @nalind PTAL