### PR TITLE
Resolve symlink when checking container path

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1140,3 +1140,19 @@ load helpers
   echo "$output"
   test "${#lines[@]}" -eq 0
 }
+
+@test "bud copy to symlink" {
+  target=alpine-image
+  ctr=alpine-ctr
+  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-symlink
+  expect_output --substring "STEP 5: RUN ln -s "
+
+  run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
+  expect_output --substring ${ctr}
+
+  run_buildah --debug=false run ${ctr} ls -alF /etc/hbase
+  expect_output --substring "/etc/hbase -> /usr/local/hbase/"
+
+  run_buildah --debug=false run ${ctr} ls -alF /usr/local/hbase 
+  expect_output --substring "Dockerfile"
+}

--- a/tests/bud/dest-symlink/Dockerfile
+++ b/tests/bud/dest-symlink/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine
+
+ENV HBASE_HOME="/usr/local/hbase"
+ENV HBASE_CONF_DIR="/etc/hbase"
+
+RUN mkdir $HBASE_HOME
+RUN ln -s $HBASE_HOME $HBASE_CONF_DIR
+
+COPY Dockerfile $HBASE_CONF_DIR


### PR DESCRIPTION
When checking the container path, check to see if the path is a symlink and convert it if necessary
before writing the file.

Fixes: #1439

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>