### PR TITLE
buildah: correctly create the userns if euid!=0

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"syscall"
 	"time"
@@ -43,6 +44,14 @@ func getStore(c *cobra.Command) (storage.Store, error) {
 		if len(globalFlagResults.StorageOpts) > 0 {
 			options.GraphDriverOptions = globalFlagResults.StorageOpts
 		}
+	}
+
+	// Do not allow to mount a graphdriver that is not vfs if we are creating the userns as part
+	// of the mount command.
+	// Differently, allow the mount if we are already in a userns, as the mount point will still
+	// be accessible once "buildah mount" exits.
+	if os.Geteuid() != 0 && options.GraphDriverName != "vfs" {
+		return nil, fmt.Errorf("cannot mount using driver %s in rootless mode. You need to run it in a `buildah unshare` session", options.GraphDriverName)
 	}
 
 	// For uid/gid mappings, first we check the global definitions

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	buildahcli "github.com/containers/buildah/pkg/cli"
-	"github.com/containers/buildah/unshare"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -63,7 +62,7 @@ func mountCmd(c *cobra.Command, args []string, noTruncate bool) error {
 		// of the mount command.
 		// Differently, allow the mount if we are already in a userns, as the mount point will still
 		// be accessible once "buildah mount" exits.
-		if unshare.IsRootless() && store.GraphDriverName() != "vfs" {
+		if os.Geteuid() != 0 && store.GraphDriverName() != "vfs" {
 			return fmt.Errorf("cannot mount using driver %s in rootless mode. You need to run it in a `buildah unshare` session", store.GraphDriverName())
 		}
 

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -57,7 +57,7 @@ func bailOnError(err error, format string, a ...interface{}) {
 
 func maybeReexecUsingUserNamespace(cmdName string, evenForRoot bool) {
 	// If we've already been through this once, no need to try again.
-	if unshare.IsRootless() {
+	if os.Geteuid() == 0 && unshare.IsRootless() {
 		return
 	}
 

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -62,7 +62,7 @@ func maybeReexecUsingUserNamespace(cmdName string, evenForRoot bool) {
 	}
 
 	switch cmdName {
-	case "", "help", "version":
+	case "", "help", "version", "mount":
 		return
 	}
 

--- a/unshare/unshare.go
+++ b/unshare/unshare.go
@@ -304,5 +304,5 @@ func GetRootlessUID() int {
 
 // RootlessEnv returns the environment settings for the rootless containers
 func RootlessEnv() []string {
-	return append(os.Environ(), UsernsEnvName+"=")
+	return append(os.Environ(), UsernsEnvName+"=done")
 }


### PR DESCRIPTION
we were skipping the creation of the creation of a namespace if the
euid != 0.

regression introduced by 3d7403130100c3558ea14a1c21482559109de043

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>