### PR TITLE
docs/buildah.md: add "containers-" prefixes under "SEE ALSO"

### DIFF
--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -147,7 +147,7 @@ Print the version
 Directory which contains configuration snippets which specify registries which should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
-podman(1), mounts.conf(5), newuidmap(1), newgidmap(1), registries.conf(5), storage.conf(5)
+podman(1), containers-mounts.conf(5), newuidmap(1), newgidmap(1), containers-registries.conf(5), containers-storage.conf(5)
 
 ## HISTORY
 December 2017, Originally compiled by Tom Sweeney <tsweeney@redhat.com>


### PR DESCRIPTION
Some entries under "SEE ALSO" now need the "containers-" prefix.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>