### PR TITLE
WIP - Remove images/containers created in bud failure case

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -208,7 +208,7 @@ load helpers
   [ "$status" -ne 0 ]
   run buildah --debug=false containers
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 2 ]
+  [ $(wc -l <<< "$output") -eq 1 ]
   [ "${status}" -eq 0 ]
 
   buildah rm -a
@@ -1247,4 +1247,37 @@ load helpers
   [ "$status" -ne 0 ]
   buildah umount ${cid}
   buildah rm ${cid}
+}
+
+@test "bud-bad-dockerfile-one-stage" {
+  target=target
+  run buildah bud --debug=false --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/bad-dockerfile/Dockerfile.false.onestage  ${TESTSDIR}/bud/bad-dockerfile
+  [[ $output =~ "STEP 1: FROM alpine" ]]
+  [[ $output =~ "STEP 4: RUN /bin/false" ]]
+  [ "$status" -ne 0 ]
+
+  run buildah --debug=false containers
+  [ "$status" -eq 0 ]
+  [ $(wc -l <<< "$output") -eq 1 ]
+  run buildah --debug=false images
+  [ "$status" -eq 0 ]
+  [ $(wc -l <<< "$output") -eq 2 ]
+  [[ $output =~ "alpine" ]]
+}
+
+@test "bud-bad-dockerfile-stages" {
+  target=target
+  run buildah bud --debug=false --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/bad-dockerfile/Dockerfile.false.stages  ${TESTSDIR}/bud/bad-dockerfile
+  [[ $output =~ "STEP 1: FROM busybox" ]]
+  [[ $output =~ "STEP 6: RUN /bin/false" ]]
+  [ "$status" -ne 0 ]
+
+  run buildah --debug=false containers
+  [ "$status" -eq 0 ]
+  [ $(wc -l <<< "$output") -eq 1 ]
+  run buildah --debug=false images
+  [ "$status" -eq 0 ]
+  [ $(wc -l <<< "$output") -eq 3 ]
+  [[ $output =~ "alpine" ]]
+  [[ $output =~ "busybox" ]]
 }

--- a/tests/bud/bad-dockerfile/Dockerfile.false.onestage
+++ b/tests/bud/bad-dockerfile/Dockerfile.false.onestage
@@ -1,0 +1,4 @@
+FROM alpine
+ENV FOO=bar
+ENV BAR=foo
+RUN /bin/false

--- a/tests/bud/bad-dockerfile/Dockerfile.false.stages
+++ b/tests/bud/bad-dockerfile/Dockerfile.false.stages
@@ -1,0 +1,7 @@
+FROM busybox
+ENV RED=sox
+
+FROM alpine
+ENV FOO=bar
+ENV BAR=foo
+RUN /bin/false


### PR DESCRIPTION
When a Dockerfile had clauses that caused a commit to occur,
creating an image, and then had an error in other clauses before
the final commit, the image and containers created were left
behind and should not have been.

Fixes: https://github.com/containers/libpod/issues/2823

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>