### PR TITLE
imagebuildah: reorganize stage and per-stage logic

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -911,6 +911,8 @@ func (s *StageExecutor) Execute(ctx context.Context, stage imagebuilder.Stage) (
 			if err != nil {
 				return "", nil, errors.Wrapf(err, "error building at step %+v", *step)
 			}
+			now := time.Now()
+			s.builder.AddPrependedEmptyLayer(&now, getCreatedBy(node), "", "")
 			continue
 		}
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -45,13 +45,13 @@ load helpers
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTDIR}/use-layers
   run buildah --debug=false images -a
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 8 ]
   [ "${status}" -eq 0 ]
+  [ $(wc -l <<< "$output") -eq 6 ]
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 ${TESTDIR}/use-layers
   run buildah --debug=false images -a
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 10 ]
   [ "${status}" -eq 0 ]
+  [ $(wc -l <<< "$output") -eq 8 ]
   run buildah inspect --format "{{.Docker.ContainerConfig.Env}}" test2
   echo "$output"
   [ "$status" -eq 0 ]
@@ -64,26 +64,33 @@ load helpers
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTDIR}/use-layers
   run buildah --debug=false images -a
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 12 ]
+  [ $(wc -l <<< "$output") -eq 10 ]
   [ "${status}" -eq 0 ]
 
   mkdir -p ${TESTDIR}/use-layers/mount/subdir
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test4 -f Dockerfile.3 ${TESTDIR}/use-layers
   run buildah --debug=false images -a
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 14 ]
+  [ $(wc -l <<< "$output") -eq 12 ]
   [ "${status}" -eq 0 ]
-  touch ${TESTDIR}/use-layers/mount/subdir/file.txt
+
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test5 -f Dockerfile.3 ${TESTDIR}/use-layers
   run buildah --debug=false images -a
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 16 ]
+  [ $(wc -l <<< "$output") -eq 13 ]
   [ "${status}" -eq 0 ]
 
-  buildah bud --signature-policy ${TESTSDIR}/policy.json --no-cache -t test6 -f Dockerfile.2 ${TESTDIR}/use-layers
+  touch ${TESTDIR}/use-layers/mount/subdir/file.txt
+  buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test6 -f Dockerfile.3 ${TESTDIR}/use-layers
   run buildah --debug=false images -a
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 19 ]
+  [ "${status}" -eq 0 ]
+  [ $(wc -l <<< "$output") -eq 15 ]
+
+  buildah bud --signature-policy ${TESTSDIR}/policy.json --no-cache -t test7 -f Dockerfile.2 ${TESTDIR}/use-layers
+  run buildah --debug=false images -a
+  echo "$output"
+  [ $(wc -l <<< "$output") -eq 16 ]
   [ "${status}" -eq 0 ]
 
   buildah rmi -a -f
@@ -118,18 +125,27 @@ load helpers
   echo "$output"
   [ $(wc -l <<< "$output") -eq 6 ]
   [ "${status}" -eq 0 ]
+  # The second time through, the layers should all get reused.
+  buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
+  run buildah --debug=false images -a
+  echo "$output"
+  [ $(wc -l <<< "$output") -eq 6 ]
+  [ "${status}" -eq 0 ]
+  # The third time through, the layers should all get reused, but we'll have a new line of output for the new name.
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
   run buildah --debug=false images -a
   echo "$output"
   [ $(wc -l <<< "$output") -eq 7 ]
   [ "${status}" -eq 0 ]
 
+  # Both interim images will be different, and all of the layers in the final image will be different.
   uuidgen > ${TESTDIR}/use-layers/uuid/data
   date > ${TESTDIR}/use-layers/date/data
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
   run buildah --debug=false images -a
   echo "$output"
   [ $(wc -l <<< "$output") -eq 11 ]
+  # No leftover containers, just the header line.
   [ "${status}" -eq 0 ]
   run buildah --debug=false containers
   echo "$output"
@@ -143,6 +159,7 @@ load helpers
   run test -e $mnt/date
   [ "${status}" -eq 0 ]
 
+  # Layers won't get reused because this build won't use caching.
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t test4 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
   run buildah --debug=false images -a
   echo "$output"
@@ -187,7 +204,7 @@ load helpers
   buildah bud --signature-policy ${TESTSDIR}/policy.json --rm=false --layers -t test2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false containers
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 7 ]
+  [ $(wc -l <<< "$output") -eq 5 ]
   [ "${status}" -eq 0 ]
 
   buildah rm -a
@@ -1229,14 +1246,16 @@ load helpers
   mnt=$(buildah --debug=false mount ${ctr})
 
   run test -e $mnt/usr/local/bin/composer
+  echo "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "bud-target" {
   target=target
   run buildah bud --debug=false --signature-policy ${TESTSDIR}/policy.json -t ${target} --target mytarget ${TESTSDIR}/bud/target
+  echo "$output"
   [[ $output =~ "STEP 1: FROM ubuntu:latest" ]]
-  [[ $output =~ "STEP 3: FROM alpine:latest AS mytarget" ]]
+  [[ $output =~ "STEP 4: FROM alpine:latest AS mytarget" ]]
   [ "$status" -eq 0 ]
   cid=$(buildah from ${target})
   root=$(buildah mount ${cid})

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -20,8 +20,9 @@ load helpers
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
   run buildah --debug=false images
-  [ $(wc -l <<< "$output") -eq 3 ]
+  echo "$output"
   [ "${status}" -eq 0 ]
+  [ $(wc -l <<< "$output") -eq 3 ]
   buildah rm -a
   buildah rmi -a -f
 }
@@ -29,14 +30,20 @@ load helpers
 @test "images all test" {
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images
-  [ $(wc -l <<< "$output") -eq 3 ]
+  echo "$output"
   [ "${status}" -eq 0 ]
+  [ $(wc -l <<< "$output") -eq 3 ]
+
   run buildah --debug=false images -a
-  [ $(wc -l <<< "$output") -eq 8 ]
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  [ $(wc -l <<< "$output") -eq 6 ]
 
   # create a no name image which should show up when doing buildah images without the --all flag
   buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images
+  echo "$output"
+  [ "${status}" -eq 0 ]
   [ $(wc -l <<< "$output") -eq 4 ]
 
   buildah rmi -a -f

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -154,19 +154,19 @@ load helpers
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a -q
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 7 ]
+  [ $(wc -l <<< "$output") -eq 5 ]
   [ "${status}" -eq 0 ]
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
   run buildah --debug=false images -a -q
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 9 ]
+  [ $(wc -l <<< "$output") -eq 7 ]
   [ "${status}" -eq 0 ]
   run buildah --debug=false rmi test2
   echo "$output"
   [ "${status}" -eq 0 ]
   run buildah --debug=false images -a -q
   echo "$output"
-  [ $(wc -l <<< "$output") -eq 7 ]
+  [ $(wc -l <<< "$output") -eq 5 ]
   [ "${status}" -eq 0 ]
   run buildah --debug=false rmi test1
   echo "$output"


### PR DESCRIPTION
When we're not building with multiple layers, add empty layer items in the image's history so that the instructions from the Dockerfile don't get lost.

Move the preparation for the first container and the commit of the final image in a single-stage build into the per-stage `Execute()` function.

For multi-stage builds, only create a layer for `ADD`, `COPY`, `RUN`, and the final instruction in a stage, which changes the number of cache images that we create, so a number of tests needed to have their expectations updated.

It also affects the step counts that we output, so a test in the last hunk we change in `bud.bats` needed to be updated to expect the changed value.  In the interests of not making this patch bigger, I expect to include the fix and change that back in a later PR.
    
Stop removing the final image for intermediate stages, since they're expected to be present as cached images, even if they don't end up as ancestors of the final image, except for single-stage builds, which we document as not populating the cache.