### PR TITLE
imagebuildah: deduplicate prepended "FROM" instructions

### DIFF
--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -105,6 +105,18 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 	return "", "", errors.Errorf("unreachable code reached")
 }
 
+func dedupeStringSlice(slice []string) []string {
+	done := make([]string, 0, len(slice))
+	m := make(map[string]struct{})
+	for _, s := range slice {
+		if _, present := m[s]; !present {
+			m[s] = struct{}{}
+			done = append(done, s)
+		}
+	}
+	return done
+}
+
 // InitReexec is a wrapper for buildah.InitReexec().  It should be called at
 // the start of main(), and if it returns true, main() should return
 // immediately.


### PR DESCRIPTION
We currently prepend a `FROM` instruction to the full set of instructions for any images which are referenced in `COPY --from` instructions that we don't create during the build.  Make sure that the
list doesn't include any duplicates.