### PR TITLE
commit: always set created-by

### DIFF
--- a/image.go
+++ b/image.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/containers/buildah/docker"
@@ -661,6 +662,13 @@ func (b *Builder) makeImageRef(manifestType, parent string, exporting bool, squa
 	if historyTimestamp != nil {
 		created = historyTimestamp.UTC()
 	}
+	createdBy := b.CreatedBy()
+	if createdBy == "" {
+		createdBy = strings.Join(b.Shell(), " ")
+		if createdBy == "" {
+			createdBy = "/bin/sh"
+		}
+	}
 
 	if omitTimestamp {
 		created = time.Unix(0, 0)
@@ -677,7 +685,7 @@ func (b *Builder) makeImageRef(manifestType, parent string, exporting bool, squa
 		oconfig:               oconfig,
 		dconfig:               dconfig,
 		created:               created,
-		createdBy:             b.CreatedBy(),
+		createdBy:             createdBy,
 		historyComment:        b.HistoryComment(),
 		annotations:           b.Annotations(),
 		preferredManifestType: manifestType,

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -71,3 +71,41 @@ load helpers
   [ "${status}" -ne 0 ]
   [[ "${output}" =~ "must be lower" ]]
 }
+
+@test "commit-no-empty-created-by" {
+  if ! python -c 'import json, sys' 2> /dev/null ; then
+    skip "python interpreter with json module not found"
+  fi
+  target=new-image
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+
+  run buildah --debug=false config --created-by "untracked actions" $cid
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  run buildah --debug=false commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  run buildah --debug=false inspect --format '{{.Config}}' ${target}
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  config="$output"
+  run python -c 'import json, sys; config = json.load(sys.stdin); print config["history"][len(config["history"])-1]["created_by"]' <<< "$config"
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  [ "$output" == "untracked actions" ]
+
+  run buildah --debug=false config --created-by "" $cid
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  run buildah --debug=false commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  run buildah --debug=false inspect --format '{{.Config}}' ${target}
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  config="$output"
+  run python -c 'import json, sys; config = json.load(sys.stdin); print config["history"][len(config["history"])-1]["created_by"]' <<< "$config"
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  [ "$output" == "/bin/sh" ]
+}


### PR DESCRIPTION
Set the `CreatedBy` field of the new image's new history item to the shell if we don't have a different value to set.