### PR TITLE
imagebuildah: only initialize imagebuilder configuration once per stage

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -991,6 +991,15 @@ load helpers
   buildah rmi --all
 }
 
+@test "bud-onbuild-layers" {
+  target=onbuild
+  buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile2 ${TESTSDIR}/bud/onbuild
+  run buildah --debug=false inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = '["RUN touch /onbuild1" "RUN touch /onbuild2"]' ]
+}
+
 @test "bud-logfile" {
   rm -f ${TESTDIR}/logfile
   run buildah bud --logfile ${TESTDIR}/logfile --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/preserve-volumes

--- a/tests/bud/onbuild/Dockerfile2
+++ b/tests/bud/onbuild/Dockerfile2
@@ -1,0 +1,6 @@
+FROM alpine
+
+ONBUILD RUN touch /onbuild1
+ONBUILD RUN touch /onbuild2
+RUN touch /firstfile
+RUN touch /secondfile


### PR DESCRIPTION
Only initialize imagebuilder's copy of the image's configuration once per stage, so that `ONBUILD` instructions that we add along with a layer in a multi-layer build won't be prepended to the current stage's list of instructions when we reinitialize our working rootfs using that layer's container, which is not what we want.

Most of the change in `prepare()` should be an indentation change, so if you're reviewing the patch locally, using `git diff`'s `-w` flag will be helpful.