### PR TITLE
imagebuildah: centralize COMMIT and image ID output

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1268,7 +1268,7 @@ load helpers
   run buildah bud --debug=false --signature-policy ${TESTSDIR}/policy.json -t ${target} --target mytarget ${TESTSDIR}/bud/target
   echo "$output"
   [[ $output =~ "STEP 1: FROM ubuntu:latest" ]]
-  [[ $output =~ "STEP 4: FROM alpine:latest AS mytarget" ]]
+  [[ $output =~ "STEP 3: FROM alpine:latest AS mytarget" ]]
   [ "$status" -eq 0 ]
   cid=$(buildah from ${target})
   root=$(buildah mount ${cid})


### PR DESCRIPTION
Only write the image ID file after we commit the final image, not at every commit.

Log all COMMIT steps and image IDs from inside of Execute().  This undoes a change to step counts that previously required us to adjust the bud-target test in #1473 .