### PR TITLE
Travis: do not use traviswait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ script:
     - make install.tools install.libseccomp.sudo all runc validate SECURITYTAGS="apparmor seccomp"
     - go test -c -tags "apparmor seccomp `./btrfs_tag.sh` `./libdm_tag.sh` `./ostree_tag.sh` `./selinux_tag.sh`" ./cmd/buildah
     - tmp=`mktemp -d`; mkdir $tmp/root $tmp/runroot; sudo PATH="$PATH" ./buildah.test -test.v --root $tmp/root --runroot $tmp/runroot --storage-driver vfs --signature-policy `pwd`/tests/policy.json --registries-conf `pwd`/tests/registries.conf
-    - cd tests; travis_wait 60 sudo PATH="$PATH" ./test_runner.sh
+    - cd tests; sudo PATH="$PATH" ./test_runner.sh
     - cd ..
 after_script:
     - echo "Run conformance tests in Fedora container..."


### PR DESCRIPTION
The traviswait script has plenty of undesired side-effects, mainly but
not limited to not printing std{err,out} when hitting the time out.
This is especially painful when the tests hit a deadlock, rendering it
useless for debugging the deadlock.  Besides that, it also slows down
the tests causing frequent time outs.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>