### PR TITLE
Add a couple of tests

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1019,6 +1019,17 @@ load helpers
   [ "$out" -ne 0 ]
 }
 
+@test "bud with copy-from and cache" {
+  target=busybox-image
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers --iidfile ${TESTDIR}/iid1 -f ${TESTSDIR}/bud/copy-from/Dockerfile2 ${TESTSDIR}/bud/copy-from
+  cat ${TESTDIR}/iid1
+  test -s ${TESTDIR}/iid1
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers --iidfile ${TESTDIR}/iid2 -f ${TESTSDIR}/bud/copy-from/Dockerfile2 ${TESTSDIR}/bud/copy-from
+  cat ${TESTDIR}/iid2
+  test -s ${TESTDIR}/iid2
+  cmp ${TESTDIR}/iid1 ${TESTDIR}/iid2
+}
+
 @test "bud with copy-from in Dockerfile no prior FROM" {
   target=php-image
   run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy-from ${TESTSDIR}/bud/copy-from

--- a/tests/bud/copy-from/Dockerfile2
+++ b/tests/bud/copy-from/Dockerfile2
@@ -1,0 +1,4 @@
+FROM busybox AS basis
+RUN echo hello > /newfile
+FROM basis
+RUN test -s /newfile

--- a/tests/squash.bats
+++ b/tests/squash.bats
@@ -77,4 +77,18 @@ function check_lengths() {
 	for stage in $(seq 10) ; do
 		cmp $mountpoint/layer${stage} ${TESTDIR}/randomfile
 	done
+
+	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --layers -t squashed ${TESTDIR}/squashed
+	run_buildah --debug=false inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	[ "$output" -eq 1 ]
+
+	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
+	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
+	run_buildah --debug=false inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	[ "$output" -eq 1 ]
+
+	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
+	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --layers -t squashed ${TESTDIR}/squashed
+	run_buildah --debug=false inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	[ "$output" -eq 1 ]
 }


### PR DESCRIPTION
Add a test of using `COPY --from` in a Dockerfile while using the cache, checking that we get the same final image, indicating that all cache checks resulted in "hits".

Test squashing (which should probably be called "flattening") of the final image while using the cache for most of the build, in cases where we expect both cache hits and cache misses.