### PR TITLE
Fix bud-args to allow comma separation

### DIFF
--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -134,7 +134,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs := pflag.FlagSet{}
 	fs.StringArrayVar(&flags.Annotation, "annotation", []string{}, "Set metadata for an image (default [])")
 	fs.StringVar(&flags.Authfile, "authfile", "", "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json")
-	fs.StringSliceVar(&flags.BuildArg, "build-arg", []string{}, "`argument=value` to supply to the builder")
+	fs.StringArrayVar(&flags.BuildArg, "build-arg", []string{}, "`argument=value` to supply to the builder")
 	fs.StringVar(&flags.CacheFrom, "cache-from", "", "Images to utilise as potential cache sources. The build process does not currently support caching so this is a NOOP.")
 	fs.StringVar(&flags.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	fs.BoolVar(&flags.Compress, "compress", false, "This is legacy option, which has no effect on the image")

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -846,6 +846,13 @@ load helpers
   is "$output" ".*one or more build args were not consumed: \[UNUSED_ARG\]" "buildah bud output"
 }
 
+@test "bud with multi-value ARGS" {
+  target=alpine-image
+  run_buildah --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=plugin1,plugin2,plugin3 ${TESTSDIR}/bud/run-scenarios
+  is "$output" ".*plugin1,plugin2,plugin3" "buildah bud output"
+  [[ ! "$output" =~ "one or more build args were not consumed: [UNUSED_ARG]" ]]
+}
+
 @test "bud-from-stdin" {
   target=scratch-image
   cat ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch | buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f - ${TESTSDIR}/bud/from-multiple-files


### PR DESCRIPTION
Allow `--bud-args` to take an argument like: `PLUGINS="plugin1,plugin2,plugin3"`

Fixes #1493

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>