### PR TITLE
commit: provide an image ID more often

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1050,3 +1050,22 @@ load helpers
 @test "bud-no-target-name" {
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/maintainer
 }
+
+@test "bud-no-target-name-iid" {
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --iidfile ${TESTDIR}/iid ${TESTSDIR}/bud/maintainer
+  test -s ${TESTDIR}/iid
+  run cat ${TESTDIR}/iid
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  expect_line_count 1
+}
+
+@test "bud-dir-target-iid" {
+  mkdir -p ${TESTDIR}/image
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --iidfile ${TESTDIR}/iid -t dir:${TESTDIR}/image ${TESTSDIR}/bud/maintainer
+  test -s ${TESTDIR}/iid
+  run cat ${TESTDIR}/iid
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  expect_line_count 1
+}

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -96,3 +96,26 @@ load helpers
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid
 }
+
+@test "commit-iid-no-name" {
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --iidfile ${TESTDIR}/iid $cid
+  test -s ${TESTDIR}/iid
+  run cat ${TESTDIR}/iid
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  expect_line_count 1
+  [ $(wc -c <<< "$output") -ge 64 ] && [ $(wc -c <<< "$output") -le 66 ]
+}
+
+@test "commit-iid-dir" {
+  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  mkdir -p ${TESTDIR}/image
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --iidfile ${TESTDIR}/iid $cid dir:${TESTDIR}/image
+  test -s ${TESTDIR}/iid
+  run cat ${TESTDIR}/iid
+  echo "$output"
+  [ "${status}" -eq 0 ]
+  expect_line_count 1
+  [ $(wc -c <<< "$output") -ge 64 ] && [ $(wc -c <<< "$output") -le 66 ]
+}


### PR DESCRIPTION
When we finish committing the image, use the just-written image's manifest and the diffIDs list from its config blob to compute the image's ID, so that it can be known even if it was written to a location other than local storage.