### PR TITLE
add buildah login/logout & fix authfile path

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -29,8 +29,14 @@ func getStore(c *cobra.Command) (storage.Store, error) {
 		options.GraphRoot = globalFlagResults.Root
 		options.RunRoot = globalFlagResults.RunRoot
 	}
-	if err := os.Setenv("XDG_RUNTIME_DIR", options.RunRoot); err != nil {
-		return nil, errors.New("could not set XDG_RUNTIME_DIR")
+	if unshare.IsRootless() && os.Getenv("XDG_RUNTIME_DIR") == "" {
+		runtimeDir, err := storage.GetRootlessRuntimeDir(unshare.GetRootlessUID())
+		if err != nil {
+			return nil, err
+		}
+		if err := os.Setenv("XDG_RUNTIME_DIR", runtimeDir); err != nil {
+			return nil, errors.New("could not set XDG_RUNTIME_DIR")
+		}
 	}
 
 	if c.Flag("storage-driver").Changed {

--- a/cmd/buildah/login.go
+++ b/cmd/buildah/login.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/image/docker"
+	"github.com/containers/image/pkg/docker/config"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+type loginReply struct {
+	authfile      string
+	certDir       string
+	password      string
+	username      string
+	tlsVerify     bool
+	stdinPassword bool
+	getLogin      bool
+}
+
+func init() {
+	var (
+		opts             loginReply
+		loginDescription = "Login to a container registry on a specified server."
+	)
+	loginCommand := &cobra.Command{
+		Use:   "login",
+		Short: "Login to a container registry",
+		Long:  loginDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return loginCmd(cmd, args, &opts)
+		},
+		Example: `buildah login quay.io`,
+	}
+	loginCommand.SetUsageTemplate(UsageTemplate())
+
+	flags := loginCommand.Flags()
+	flags.SetInterspersed(false)
+	flags.StringVar(&opts.authfile, "authfile", "", "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json. Use REGISTRY_AUTH_FILE environment variable to override")
+	flags.StringVar(&opts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
+	flags.StringVarP(&opts.password, "password", "p", "", "Password for registry")
+	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
+	flags.StringVarP(&opts.username, "username", "u", "", "Username for registry")
+	flags.BoolVar(&opts.stdinPassword, "password-stdin", false, "Take the password from stdin")
+	flags.BoolVar(&opts.getLogin, "get-login", true, "Return the current login user for the registry")
+	rootCmd.AddCommand(loginCommand)
+}
+
+func loginCmd(c *cobra.Command, args []string, iopts *loginReply) error {
+	if len(args) > 1 {
+		return errors.Errorf("too many arguments, login takes only 1 argument")
+	}
+	if len(args) == 0 {
+		return errors.Errorf("please specify a registry to login to")
+	}
+	server := parse.RegistryFromFullName(parse.ScrubServer(args[0]))
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return errors.Wrapf(err, "error building system context")
+	}
+	if !iopts.getLogin {
+		user, err := config.GetUserLoggedIn(systemContext, server)
+		if err != nil {
+			return errors.Wrapf(err, "unable to check for login user")
+		}
+
+		if user == "" {
+			return errors.Errorf("not logged into %s", server)
+		}
+		fmt.Printf("%s\n", user)
+		return nil
+	}
+
+	// username of user logged in to server (if one exists)
+	userFromAuthFile, passFromAuthFile, err := config.GetAuthentication(systemContext, server)
+	if err != nil {
+		return errors.Wrapf(err, "error reading auth file")
+	}
+
+	ctx := getContext()
+	password := iopts.password
+
+	if iopts.stdinPassword {
+		var stdinPasswordStrBuilder strings.Builder
+		if iopts.password != "" {
+			return errors.Errorf("Can't specify both --password-stdin and --password")
+		}
+		if iopts.username == "" {
+			return errors.Errorf("Must provide --username with --password-stdin")
+		}
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			fmt.Fprint(&stdinPasswordStrBuilder, scanner.Text())
+		}
+		password = stdinPasswordStrBuilder.String()
+	}
+
+	// If no username and no password is specified, try to use existing ones.
+	if iopts.username == "" && password == "" && userFromAuthFile != "" && passFromAuthFile != "" {
+		fmt.Println("Authenticating with existing credentials...")
+		if err := docker.CheckAuth(ctx, systemContext, userFromAuthFile, passFromAuthFile, server); err == nil {
+			fmt.Println("Existing credentials are valid. Already logged in to", server)
+			return nil
+		}
+		fmt.Println("Existing credentials are invalid, please enter valid username and password")
+	}
+
+	username, password, err := GetUserAndPass(iopts.username, password, userFromAuthFile)
+	if err != nil {
+		return errors.Wrapf(err, "error getting username and password")
+	}
+
+	if err = docker.CheckAuth(ctx, systemContext, username, password, server); err == nil {
+		// Write the new credentials to the authfile
+		if err = config.SetAuthentication(systemContext, server, username, password); err != nil {
+			return err
+		}
+	}
+	switch err {
+	case nil:
+		fmt.Println("Login Succeeded!")
+		return nil
+	case docker.ErrUnauthorizedForCredentials:
+		return errors.Errorf("error logging into %q: invalid username/password", server)
+	default:
+		return errors.Wrapf(err, "error authenticating creds for %q", server)
+	}
+}
+
+// GetUserAndPass gets the username and password from STDIN if not given
+// using the -u and -p flags.  If the username prompt is left empty, the
+// displayed userFromAuthFile will be used instead.
+func GetUserAndPass(username, password, userFromAuthFile string) (string, string, error) {
+	var err error
+	reader := bufio.NewReader(os.Stdin)
+	if username == "" {
+		if userFromAuthFile != "" {
+			fmt.Printf("Username (%s): ", userFromAuthFile)
+		} else {
+			fmt.Print("Username: ")
+		}
+		username, err = reader.ReadString('\n')
+		if err != nil {
+			return "", "", errors.Wrapf(err, "error reading username")
+		}
+		// If the user just hit enter, use the displayed user from the
+		// the authentication file.  This allows to do a lazy
+		// `$ buildah login -p $NEW_PASSWORD` without specifying the
+		// user.
+		if strings.TrimSpace(username) == "" {
+			username = userFromAuthFile
+		}
+	}
+	if password == "" {
+		fmt.Print("Password: ")
+		pass, err := terminal.ReadPassword(0)
+		if err != nil {
+			return "", "", errors.Wrapf(err, "error reading password")
+		}
+		password = string(pass)
+		fmt.Println()
+	}
+	return strings.TrimSpace(username), password, err
+}

--- a/cmd/buildah/logout.go
+++ b/cmd/buildah/logout.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/image/pkg/docker/config"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+type logoutReply struct {
+	authfile string
+	all      bool
+}
+
+func init() {
+	var (
+		opts              logoutReply
+		logoutDescription = "Remove the cached username and password for the registry."
+	)
+	logoutCommand := &cobra.Command{
+		Use:   "logout",
+		Short: "Logout of a container registry",
+		Long:  logoutDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return logoutCmd(cmd, args, &opts)
+		},
+		Example: `buildah logout quay.io`,
+	}
+	logoutCommand.SetUsageTemplate(UsageTemplate())
+
+	flags := logoutCommand.Flags()
+	flags.SetInterspersed(false)
+	flags.StringVar(&opts.authfile, "authfile", "", "path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json. Use REGISTRY_AUTH_FILE environment variable to override")
+	flags.BoolVarP(&opts.all, "all", "a", false, "Remove the cached credentials for all registries in the auth file")
+	rootCmd.AddCommand(logoutCommand)
+}
+
+func logoutCmd(c *cobra.Command, args []string, iopts *logoutReply) error {
+	if len(args) > 1 {
+		return errors.Errorf("too many arguments, logout takes at most 1 argument")
+	}
+	if len(args) == 0 && !iopts.all {
+		return errors.Errorf("registry must be given")
+	}
+	var server string
+	if len(args) == 1 {
+		server = parse.ScrubServer(args[0])
+	}
+
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return errors.Wrapf(err, "error building system context")
+	}
+
+	if iopts.all {
+		if err := config.RemoveAllAuthentication(systemContext); err != nil {
+			return err
+		}
+		fmt.Println("Removed login credentials for all registries")
+		return nil
+	}
+
+	err = config.RemoveAuthentication(systemContext, server)
+	switch err {
+	case nil:
+		fmt.Printf("Removed login credentials for %s\n", server)
+		return nil
+	case config.ErrNotLoggedIn:
+		return errors.Errorf("Not logged into %s\n", server)
+	default:
+		return errors.Wrapf(err, "error logging out of %q", server)
+	}
+}

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/containers/buildah"
 	"os"
 
+	"github.com/containers/buildah"
 	"github.com/containers/buildah/pkg/unshare"
 	"github.com/containers/storage"
 	ispecs "github.com/opencontainers/image-spec/specs-go"

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -641,6 +641,54 @@ return 1
      esac
  }
 
+ _buildah_logout() {
+     local boolean_options="
+     --help
+     -h
+     --all
+     -a
+  "
+
+     local options_with_args="
+     --authfile
+  "
+
+     local all_options="$options_with_args $boolean_options"
+
+     case "$cur" in
+         -*)
+             COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+             ;;
+     esac
+ }
+
+ _buildah_login() {
+     local boolean_options="
+     --help
+     -h
+     --get-login
+     --tls-verify
+  "
+
+     local options_with_args="
+     --authfile
+     --cert-dir
+     --password string
+     -p
+     --password-stdin
+     --username
+     -u
+  "
+
+     local all_options="$options_with_args $boolean_options"
+
+     case "$cur" in
+         -*)
+             COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+             ;;
+     esac
+ }
+
  _buildah_mount() {
      local boolean_options="
      --help

--- a/demos/README.md
+++ b/demos/README.md
@@ -25,7 +25,7 @@ This demo builds a container image from scratch. The container is going to injec
 
 Please make sure you have installed Buildah and Podman. Also this demo uses Quay.io to push the image to that registry when it is completed. If you are not logged in then it will fail at that step and finish. If you wish to login to Quay.io before running the demo, then it will push to your repository successfully.
 
-    $ sudo podman login quay.io
+    $ sudo buildah login quay.io
 
 There are several variables you will want to set that are listed at the top of the script. The name for the container image, your quay.io username, your name, and the Fedora release number:
 

--- a/demos/buildah-scratch-demo.sh
+++ b/demos/buildah-scratch-demo.sh
@@ -1,17 +1,17 @@
-#!/bin/bash 
+#!/bin/bash
 
 # author : ipbabble
 # Assumptions install buildah and podman
-# login to Quay.io using podman if you want to see the image push
+# login to Quay.io using buildah if you want to see the image push
 #   otherwise it will just fail the last step and no biggy.
-#   podman login quay.io
+#   buildah login quay.io
 # Set some of the variables below
 
 demoimg=myshdemo
 quayuser=ipbabble
 myname=WilliamHenry
 distrorelease=28
-pkgmgr=dnf   # switch to yum if using yum 
+pkgmgr=dnf   # switch to yum if using yum
 
 #Setting up some colors for helping read the demo output
 bold=$(tput bold)

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -40,7 +40,7 @@ Note: this information is not present in Docker image formats, so it is discarde
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--build-arg** *arg=value*
@@ -657,4 +657,4 @@ registries.conf is the configuration file which specifies which container regist
 Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
-buildah(1), CPP(1), podman-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)
+buildah(1), CPP(1), buildah-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -18,7 +18,7 @@ The image ID of the image that was created.  On error, 1 is returned and errno i
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--cert-dir** *path*

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -17,7 +17,7 @@ Multiple transports are supported:
   An existing local directory _path_ containing the manifest, layer tarballs, and signatures in individual files. This is a non-standardized format, primarily useful for debugging or noninvasive image inspection.
 
   **docker://**_docker-reference_ (Default)
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG\_RUNTIME\_DIR/containers/auth.json`, which is set using `(podman login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG\_RUNTIME\_DIR/containers/auth.json`, which is set using `(buildah login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
   If _docker-reference_ does not include a registry name, *localhost* will be consulted first, followed by any registries named in the registries configuration.
 
   **docker-archive:**_path_
@@ -54,7 +54,7 @@ Add a line to /etc/hosts. The format is hostname:ip. The **--add-host** option c
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--cap-add**=*CAP\_xxx*
@@ -513,4 +513,4 @@ registries.conf is the configuration file which specifies which container regist
 Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
-buildah(1), buildah-pull(1), podman-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)
+buildah(1), buildah-pull(1), buildah-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)

--- a/docs/buildah-login.md
+++ b/docs/buildah-login.md
@@ -1,0 +1,104 @@
+# buildah-login "1" "Apr 2019" "buildah"
+
+## NAME
+buildah\-login - Login to a container registry
+
+## SYNOPSIS
+**buildah login** [*options*] *registry*
+
+## DESCRIPTION
+**buildah login** logs into a specified registry server with the correct username
+and password. **buildah login** reads in the username and password from STDIN.
+The username and password can also be set using the **username** and **password** flags.
+The path of the authentication file can be specified by the user by setting the **authfile**
+flag. The default path used is **${XDG\_RUNTIME_DIR}/containers/auth.json**.
+
+**buildah [GLOBAL OPTIONS]**
+
+**buildah login [GLOBAL OPTIONS]**
+
+**buildah login [OPTIONS] REGISTRY [GLOBAL OPTIONS]**
+
+## OPTIONS
+
+**--password, -p**
+
+Password for registry
+
+**--password-stdin**
+
+Take the password from stdin
+
+**--username, -u**
+
+Username for registry
+
+**--authfile**
+
+Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
+
+Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
+environment variable. `export REGISTRY_AUTH_FILE=path`
+
+**--get-login**
+
+Return the logged-in user for the registry.  Return error if no login is found.
+
+**--cert-dir** *path*
+
+Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
+Default certificates directory is _/etc/containers/certs.d_.
+
+**--tls-verify**
+
+Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
+then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
+TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
+
+**--help**, **-h**
+
+Print usage statement
+
+## EXAMPLES
+
+```
+$ buildah login docker.io
+Username: qiwanredhat
+Password:
+Login Succeeded!
+```
+
+```
+$ buildah login -u testuser -p testpassword localhost:5000
+Login Succeeded!
+```
+
+```
+$ $ buildah login --authfile ./auth.json docker.io
+Username: qiwanredhat
+Password:
+Login Succeeded!
+```
+
+```
+$ buildah login --tls-verify=false -u test -p test localhost:5000
+Login Succeeded!
+```
+
+```
+$ buildah login --cert-dir /etc/containers/certs.d/ -u foo -p bar localhost:5000
+Login Succeeded!
+```
+
+```
+$ buildah login -u testuser  --password-stdin < pw.txt docker.io
+Login Succeeded!
+```
+
+```
+$ echo $testpassword | buildah login -u testuser --password-stdin docker.io
+Login Succeeded!
+```
+
+## SEE ALSO
+buildah(1), buildah-logout(1)

--- a/docs/buildah-logout.md
+++ b/docs/buildah-logout.md
@@ -1,0 +1,56 @@
+# buildah-logout "1" "Apr 2019" "buildah"
+
+## NAME
+buildah\-logout - Logout of a container registry
+
+## SYNOPSIS
+**buildah logout** [*options*] *registry*
+
+## DESCRIPTION
+**buildah logout** logs out of a specified registry server by deleting the cached credentials
+stored in the **auth.json** file. The path of the authentication file can be overridden by the user by setting the **authfile** flag.
+The default path used is **${XDG\_RUNTIME_DIR}/containers/auth.json**.
+All the cached credentials can be removed by setting the **all** flag.
+
+**buildah [GLOBAL OPTIONS]**
+
+**bildah logout [GLOBAL OPTIONS]**
+
+**buildah logout [OPTIONS] REGISTRY [GLOBAL OPTIONS]**
+
+## OPTIONS
+
+**--authfile**
+
+Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
+
+Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
+environment variable. `export REGISTRY_AUTH_FILE=path`
+
+**--all, -a**
+
+Remove the cached credentials for all registries in the auth file
+
+**--help**, **-h**
+
+Print usage statement
+
+## EXAMPLES
+
+```
+$ buildah logout docker.io
+Removed login credentials for docker.io
+```
+
+```
+$ bildah logout --authfile authdir/myauths.json docker.io
+Removed login credentials for docker.io
+```
+
+```
+$ buildah logout --all
+Remove login credentials for all registries
+```
+
+## SEE ALSO
+buildah(1), buildah-login(1)

--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -16,7 +16,7 @@ Multiple transports are supported:
   An existing local directory _path_ containing the manifest, layer tarballs, and signatures in individual files. This is a non-standardized format, primarily useful for debugging or noninvasive image inspection.
 
   **docker://**_docker-reference_ (Default)
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG\_RUNTIME\_DIR/containers/auth.json`, which is set using `(podman login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG\_RUNTIME\_DIR/containers/auth.json`, which is set using `(buildah login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
   If _docker-reference_ does not include a registry name, *localhost* will be consulted first, followed by any registries named in the registries configuration.
 
   **docker-archive:**_path_
@@ -51,7 +51,7 @@ All tagged images in the repository will be pulled.
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--cert-dir** *path*
@@ -112,4 +112,4 @@ registries.conf is the configuration file which specifies which container regist
 Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
-buildah(1), buildah-from(1), podman-login(1), docker-login(1), policy.json(5), registries.conf(5)
+buildah(1), buildah-from(1), buildah-login(1), docker-login(1), policy.json(5), registries.conf(5)

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -23,7 +23,7 @@ Image stored in local container/storage
   An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
 
   **docker://**_docker-reference_
-  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG\_RUNTIME\_DIR/containers/auth.json`, which is set using `(podman login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG\_RUNTIME\_DIR/containers/auth.json`, which is set using `(buildah login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
   If _docker-reference_ does not include a registry name, the image will be pushed to a registry running on *localhost*.
 
   **docker-archive:**_path_[**:**_docker-reference_]
@@ -47,7 +47,7 @@ If the transport part of DESTINATION is omitted, "docker://" is assumed.
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 **--cert-dir** *path*
@@ -124,4 +124,4 @@ registries.conf is the configuration file which specifies which container regist
 Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
-buildah(1), podman-login(1), policy.json(5), docker-login(1), registries.conf(5)
+buildah(1), buildah-login(1), policy.json(5), docker-login(1), registries.conf(5)

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -107,6 +107,8 @@ Print the version
 | buildah-info(1)       | Display Buildah system information.                                                                  |
 | buildah-inspect(1)    | Inspects the configuration of a container or image                                                   |
 | buildah-mount(1)      | Mount the working container's root filesystem.                                                       |
+| buildah-login(1)      | Login to a container registry.                                                                       |
+| buildah-logout(1)     | Logout of a container registry                                                                       |
 | buildah-pull(1)       | Pull an image from the specified location.                                                           |
 | buildah-push(1)       | Push an image from local storage to elsewhere.                                                       |
 | buildah-rename(1)     | Rename a local container.                                                                            |

--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -2,6 +2,12 @@
 
 load helpers
 
+@test "login/logout" {
+  run_buildah 0 login --username testuserfoo --password testpassword docker.io
+
+  run_buildah 0 logout docker.io
+}
+
 @test "from-authenticate-cert-and-creds" {
 
   run_buildah from --pull --name "alpine" --signature-policy ${TESTSDIR}/policy.json alpine


### PR DESCRIPTION
Fix the bug that buildah reads /var/run/containers.. as authentication file.(in readme files it should be /run/containers/uid).

Add ` [buildah login`](https://github.com/containers/buildah/issues/1329#issuecomment-470949534) , `biuldah logout` to close #1329, enable to use buildah login before running buildah bud for multi-stage bud and avoid using --creds flag.

Signed-off-by: Qi Wang <qiwan@redhat.com>