### PR TITLE
Create buildahimage Dockerfile for Quay

### DIFF
--- a/buildahimage/Dockerfile
+++ b/buildahimage/Dockerfile
@@ -1,0 +1,6 @@
+FROM fedora
+RUN yum -y install buildah --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+RUN sed 's|^#mount_program|mount_program|g' -i /etc/containers/storage.conf
+ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
+COPY Dockerfile /root
+


### PR DESCRIPTION
The Dockerfile in the buildahimage directory will be
used by quay.io/buildah when ever a new tag is created
here in this GitHub repo.  It will build a new buildahimage
image automatically.

At least that's the theory.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>