### PR TITLE
Add Dockerfiles for buildahimages

### DIFF
--- a/buildahimage/Dockerfile
+++ b/buildahimage/Dockerfile
@@ -1,6 +1,0 @@
-FROM fedora
-RUN yum -y install buildah --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
-RUN sed 's|^#mount_program|mount_program|g' -i /etc/containers/storage.conf
-ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
-COPY Dockerfile /root
-

--- a/buildahimage/README.md
+++ b/buildahimage/README.md
@@ -1,0 +1,47 @@
+![buildah logo](https://cdn.rawgit.com/containers/buildah/master/logos/buildah-logo_large.png)
+
+# buildahimage
+
+## Overview
+
+This directory contains the Dockerfiles necessary to create the three buildahimage container
+images that are housed on quay.io under the buildah account.  All three repositories where
+the images live are public and can be pulled without credentials.  These container images are secured and the
+resulting containers can run safely with privileges within the container.  The container images are built
+using the latest Fedora and then Buildah is installed into them:
+
+  * quay.io/buildah/buildahimage - This image is built using the latest stable version of Buildah in a Fedora based container.  Built with buildahimage/stable/Dockerfile.
+  * quay.io/buildah/buildahimagegit - This image is built using the latest code found in this GitHub repository.  When someone creates a commit and pushes it, the image is created.  Due to that the image changes frequently and is not guaranteed to be stable.  Containers built with this imsage have a Buildah development environment set up in the directory /root/buildah.  Built with buildahimage/git/Dockerfile.
+  * quay.io/buildah/buildahimagetesting - This image is built using the latest version of Buildah that is or was in updates testing for Fedora.  At times this may be the same as the stable image.  This container image will primarily be used by the development teams for verification testing when a new package is created.  Built with buildahimage/testing/Dockerfile.
+
+## Sample Usage
+
+Although not required, it is suggested that [Podman](https://github.com/containers/libpod) be used with these container images.
+
+```
+podman pull docker://quay.io/buildah/buildahimage:latest
+
+podman run buildahimage buildah version
+
+# Create a directory on the host to mount the container's
+# /var/lib/container directory to so containers can be
+# run within the container.
+mkdir /var/lib/mycontainer
+
+# Run the image detached using the host's network in a container name
+# buildahctr, turn off label and seccomp confinement in the container
+# and then do a little shell hackery to keep the container up and running.
+podman run --detach --name=buildahctr --net=host --security-opt label=disable --security-opt seccomp=unconfined --device /dev/fuse:rw -v /var/lib/mycontainer:/var/lib/containers:Z  buildahimage sh -c 'while true ;do wait; done'
+
+podman exec -it  buildahctr /bin/sh
+
+# Now inside of the container
+
+buildah from alpine
+
+buildah images
+
+cd /root/buildah
+
+exit
+```

--- a/buildahimage/git/Dockerfile
+++ b/buildahimage/git/Dockerfile
@@ -1,0 +1,55 @@
+# git/Dockerfile
+#
+# Build a Buildah container image from the latest
+# upstream version of Buildah on GitHub.
+# https://github.com/containers/buildah
+# This image can be used to create a secured container
+# that runs safely with privileges within the container.
+# The containers created by this image also come with a
+# Buildah development environment in /root/buildah.
+#
+FROM fedora
+ENV GOPATH=/root/buildah
+
+# Install the software required to build Buildah.
+RUN dnf -y install --enablerepo=updates-testing \
+     make \
+     golang \
+     bats \
+     btrfs-progs-devel \
+     device-mapper-devel \
+     glib2-devel \
+     gpgme-devel \
+     libassuan-devel \
+     libseccomp-devel \
+     ostree-devel \
+     git \
+     bzip2 \
+     go-md2man \
+     runc \
+     fuse-overlayfs \
+     fuse3 \
+     containers-common;
+
+# Create a directory and clone from the Buildah
+# GitHub repository, then make and install Buildah
+# to the container.
+RUN mkdir /root/buildah; \
+     git clone https://github.com/containers/buildah /root/buildah/src/github.com/containers/buildah; \
+     cd /root/buildah/src/github.com/containers/buildah; \
+     make;\
+     make install
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed 's|^#mount_program|mount_program|g' -i /etc/containers/storage.conf
+
+# Set up environment variables to note that this is
+# not starting with usernamespace and default to 
+# isolate the filesystem with chroot.
+ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
+
+
+
+
+
+

--- a/buildahimage/stable/Dockerfile
+++ b/buildahimage/stable/Dockerfile
@@ -1,0 +1,22 @@
+# stable/Dockerfile
+#
+# Build a Buildah container image from the latest
+# stable version of Buildah on the Fedoras Updates System.
+# https://bodhi.fedoraproject.org/updates/?search=buildah
+# This image can be used to create a secured container
+# that runs safely with privileges within the container.
+#
+FROM fedora
+
+# Don't include container-selinux and remove 
+# directories used by dnf that are just taking
+# up space.
+RUN yum -y install buildah --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed 's|^#mount_program|mount_program|g' -i /etc/containers/storage.conf
+
+# Set up environment variables to note that this is
+# not starting with usernamespace and default to 
+# isolate the filesystem with chroot.
+ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot

--- a/buildahimage/testing/Dockerfile
+++ b/buildahimage/testing/Dockerfile
@@ -1,0 +1,24 @@
+# testing/Dockerfile
+#
+# Build a Buildah image using the latest
+# version of Buildah that is in updates-testing
+# on the Fedoras Updates System.  At times this
+# may be the same the latest stable version.
+# https://bodhi.fedoraproject.org/updates/?search=buildah
+# This image can be used to create a secured container
+# that runs safely with privileges within the container.
+#
+FROM fedora
+
+# Don't include container-selinux and remove 
+# directories used by dnf that are just taking
+# up space.
+RUN yum -y install buildah --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed 's|^#mount_program|mount_program|g' -i /etc/containers/storage.conf
+
+# Set up environment variables to note that this is
+# not starting with usernamespace and default to 
+# isolate the filesystem with chroot.
+ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot


### PR DESCRIPTION
Add a Dockerfile for each buildah image that we will
be maintaining in quay.io/buildah.  They are stable,
git and testing.  The resulting image names will be
buldaimage, buildahimagegit, buildahimagetesting in
order.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>