### PR TITLE
WIP - Update rpm spec file in contrib to pass rpmlint

### DIFF
--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in buildah.go too
-Version:        1.8-dev
+Version:        1.8dev
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,9 +100,9 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
-* Tue Mar 28, 2019 Tom Sweeney <tsweeney@redhat.com> 1.8-dev-1
+* Thu Mar 28 2019 Tom Sweeney <tsweeney@redhat.com> 1.8dev-1
 
-* Tue Mar 28, 2019 Tom Sweeney <tsweeney@redhat.com> 1.7.2-1
+* Thu Mar 28 2019 Tom Sweeney <tsweeney@redhat.com> 1.7.2-1
 - mount: do not create automatically a namespace
 - buildah: correctly create the userns if euid!=0
 - imagebuildah.Build: consolidate cleanup logic

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -12,7 +12,7 @@ load helpers
 	fi
 	bversion=$(buildah version | awk '/^Version:/ { print $NF }')
 	rversion=$(cat ${TESTSDIR}/../contrib/rpm/buildah.spec | awk '/^Version:/ { print $NF }')
-	run test "${bversion}" = "${rversion}" -o "${bversion}" = "${rversion}-dev"
+	run test "${bversion}" = "${rversion}" -o "${bversion}" = "${rversion}dev"
 	[ "$status" -eq 0 ]
 }
 
@@ -21,6 +21,6 @@ load helpers
 		skip "No source dir available"
 	fi
 	bversion=$(buildah version | awk '/^Version:/ { print $NF }')
-	run bash -c "grep -A1 ^%changelog ${TESTSDIR}/../contrib/rpm/buildah.spec | grep -q \" ${bversion}-.*$\""
+	run bash -c "grep -A1 ^%changelog ${TESTSDIR}/../contrib/rpm/buildah.spec | grep -q \" ${bversion}\(dev\)\?-.*$\""
 	[ "$status" -eq 0 ]
 }

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -10,9 +10,9 @@ load helpers
 	if [ ! -d "${TESTSDIR}/../contrib/rpm" ]; then
 		skip "No source dir available"
 	fi
-	bversion=$(buildah version | awk '/^Version:/ { print $NF }')
+	bversion=$(buildah version | awk '/^Version:/ { print $NF }' | sed 's/-dev/dev/')
 	rversion=$(cat ${TESTSDIR}/../contrib/rpm/buildah.spec | awk '/^Version:/ { print $NF }')
-	run test "${bversion}" = "${rversion}" -o "${bversion}" = "${rversion}dev"
+	run test "${bversion}" = "${rversion}"
 	[ "$status" -eq 0 ]
 }
 
@@ -20,7 +20,7 @@ load helpers
 	if [ ! -d "${TESTSDIR}/../contrib/rpm" ]; then
 		skip "No source dir available"
 	fi
-	bversion=$(buildah version | awk '/^Version:/ { print $NF }')
-	run bash -c "grep -A1 ^%changelog ${TESTSDIR}/../contrib/rpm/buildah.spec | grep -q \" ${bversion}\(dev\)\?-.*$\""
+	bversion=$(buildah version | awk '/^Version:/ { print $NF }' | sed 's/-dev/dev/')
+	run bash -c "grep -A1 ^%changelog ${TESTSDIR}/../contrib/rpm/buildah.spec | grep -q \" ${bversion}-[0-9]\+$\""
 	[ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Recent changes to the RPM spec file resulted in failure to pass rpmlint validation which was breaking `rpmbuild`. This update fixes minor issues so the spec file once again passes `rpmlint`.

Signed-off-by: pixdrift <support@pixeldrift.net>