### PR TITLE
imagebuildah: only commit images for intermediate stages if we have to

### DIFF
--- a/tests/bud/multi-stage-builds/Dockerfile.rebase
+++ b/tests/bud/multi-stage-builds/Dockerfile.rebase
@@ -1,0 +1,8 @@
+FROM alpine AS myname
+COPY Dockerfile.name /
+
+FROM myname
+RUN pwd
+
+FROM myname
+RUN id


### PR DESCRIPTION
In single-layer mode, if the stage's image isn't going to be used as the basis for a later stage, and it isn't the final stage, don't bother committing it.

In multiple-layer mode, if we're handling the final instruction for a stage, and we've found a suitable image for the stage in the cache, if the container's root filesystem isn't going to be used as the source for a COPY --from instruction in a later stage, don't bother rebasing the working container to match the image.

It turns out that the cache expectation is that we always produce an image at the end of a stage, so remove the TODO comment that suggested that we'd be able to skip it in some cases.