### PR TITLE
Don't fail bud --layers on dangling symlink

### DIFF
--- a/imagebuildah/errors.go
+++ b/imagebuildah/errors.go
@@ -1,0 +1,7 @@
+package imagebuildah
+
+import "errors"
+
+var (
+	errDanglingSymlink = errors.New("error evaluating dangling symlink")
+)

--- a/tests/bud/use-layers/Dockerfile.dangling-symlink
+++ b/tests/bud/use-layers/Dockerfile.dangling-symlink
@@ -1,0 +1,2 @@
+FROM alpine
+COPY blah /tmp/


### PR DESCRIPTION
If there is a dangling symlink when building with --layers,
don't fail and continue the build process.
It would fail because it would try to stat the file to check
whether it has been modified since the previous build. And since
it would be a dangling symlink, the stat would fail hence causing
the build to fail.

Fixes https://github.com/containers/buildah/issues/1219

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>