### PR TITLE
Do not state that buildah always requires root

### DIFF
--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -17,7 +17,7 @@ The Buildah package provides a command line tool which can be used to:
     * Delete a working container or an image.
     * Rename a local container.
 
-This tool needs to be run as the root user.
+This tool may need to be run as the root user on older versions of Linux.
 
 ## OPTIONS
 


### PR DESCRIPTION
It is very possible today to use buildah as a non-root user (at least on Fedora 29 and probably CentOS 7.6, etc.).  This changes the wording to allow for that nuance.

