### PR TITLE
Use errors.Cause() when checking for IsNotExist errors

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -115,7 +115,7 @@ func getStore(c *cobra.Command) (storage.Store, error) {
 func openBuilder(ctx context.Context, store storage.Store, name string) (builder *buildah.Builder, err error) {
 	if name != "" {
 		builder, err = buildah.OpenBuilder(store, name)
-		if os.IsNotExist(err) {
+		if os.IsNotExist(errors.Cause(err)) {
 			options := buildah.ImportOptions{
 				Container: name,
 			}


### PR DESCRIPTION
Use `errors.Cause()` when asking if `os.IsNotExist()` recognizes an error result from any call that isn't into the standard library or the `golang.org/x/sys` package.