### PR TITLE
Add BUILDAH_ISOLATION rootless back

### DIFF
--- a/pkg/unshare/unshare.go
+++ b/pkg/unshare/unshare.go
@@ -404,6 +404,16 @@ func MaybeReexecUsingUserNamespace(evenForRoot bool) {
 	err = os.Setenv(UsernsEnvName, "1")
 	bailOnError(err, "error setting %s=1 in environment", UsernsEnvName)
 
+	// Set the default isolation type to use the "rootless" method.
+	if _, present := os.LookupEnv("BUILDAH_ISOLATION"); !present {
+		if err = os.Setenv("BUILDAH_ISOLATION", "rootless"); err != nil {
+			if err := os.Setenv("BUILDAH_ISOLATION", "rootless"); err != nil {
+				logrus.Errorf("error setting BUILDAH_ISOLATION=rootless in environment: %v", err)
+				os.Exit(1)
+			}
+		}
+	}
+
 	// Reuse our stdio.
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Adds BUILDAH_ISOLATION env back when in rootless.
Fixes #1498 