### PR TITLE
Move Host IDMAppings code from util to unshare

### DIFF
--- a/chroot/run.go
+++ b/chroot/run.go
@@ -512,7 +512,7 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 	logNamespaceDiagnostics(spec)
 
 	// If we have configured ID mappings, set them here so that they can apply to the child.
-	hostUidmap, hostGidmap, err := util.GetHostIDMappings("")
+	hostUidmap, hostGidmap, err := unshare.GetHostIDMappings("")
 	if err != nil {
 		return 1, err
 	}

--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/pkg/unshare"
-	"github.com/containers/buildah/util"
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
@@ -67,7 +66,7 @@ func getStore(c *cobra.Command) (storage.Store, error) {
 		if len(gopts) == 0 {
 			return nil, errors.New("--userns-gid-map used with no mappings?")
 		}
-		uidmap, gidmap, err := util.ParseIDMappings(uopts, gopts)
+		uidmap, gidmap, err := unshare.ParseIDMappings(uopts, gopts)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +90,7 @@ func getStore(c *cobra.Command) (storage.Store, error) {
 		if len(gopts) == 0 {
 			return nil, errors.New("--userns-gid-map used with no mappings?")
 		}
-		uidmap, gidmap, err := util.ParseIDMappings(uopts, gopts)
+		uidmap, gidmap, err := unshare.ParseIDMappings(uopts, gopts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/unshare/unshare.go
+++ b/pkg/unshare/unshare.go
@@ -3,6 +3,7 @@
 package unshare
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -15,7 +16,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/containers/buildah/util"
+	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -157,7 +158,7 @@ func (c *Cmd) Start() error {
 		}
 
 		if len(c.UidMappings) == 0 || len(c.GidMappings) == 0 {
-			uidmap, gidmap, err := util.GetHostIDMappings("")
+			uidmap, gidmap, err := GetHostIDMappings("")
 			if err != nil {
 				fmt.Fprintf(continueWrite, "error reading ID mappings in parent: %v", err)
 				return errors.Wrapf(err, "error reading ID mappings in parent")
@@ -352,7 +353,7 @@ func MaybeReexecUsingUserNamespace(evenForRoot bool) {
 		// Read the set of ID mappings that we're allowed to use.  Each
 		// range in /etc/subuid and /etc/subgid file is a starting host
 		// ID and a range size.
-		uidmap, gidmap, err = util.GetSubIDMappings(me.Username, me.Username)
+		uidmap, gidmap, err = GetSubIDMappings(me.Username, me.Username)
 		bailOnError(err, "error reading allowed ID mappings")
 		if len(uidmap) == 0 {
 			logrus.Warnf("Found no UID ranges set aside for user %q in /etc/subuid.", me.Username)
@@ -384,7 +385,7 @@ func MaybeReexecUsingUserNamespace(evenForRoot bool) {
 			return
 		}
 		// Read the set of ID mappings that we're currently using.
-		uidmap, gidmap, err = util.GetHostIDMappings("")
+		uidmap, gidmap, err = GetHostIDMappings("")
 		bailOnError(err, "error reading current ID mappings")
 		// Just reuse them.
 		for i := range uidmap {
@@ -445,4 +446,90 @@ func ExecRunnable(cmd Runnable) {
 		os.Exit(1)
 	}
 	os.Exit(0)
+}
+
+// getHostIDMappings reads mappings from the named node under /proc.
+func getHostIDMappings(path string) ([]specs.LinuxIDMapping, error) {
+	var mappings []specs.LinuxIDMapping
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading ID mappings from %q", path)
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			return nil, errors.Errorf("line %q from %q has %d fields, not 3", line, path, len(fields))
+		}
+		cid, err := strconv.ParseUint(fields[0], 10, 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error parsing container ID value %q from line %q in %q", fields[0], line, path)
+		}
+		hid, err := strconv.ParseUint(fields[1], 10, 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error parsing host ID value %q from line %q in %q", fields[1], line, path)
+		}
+		size, err := strconv.ParseUint(fields[2], 10, 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error parsing size value %q from line %q in %q", fields[2], line, path)
+		}
+		mappings = append(mappings, specs.LinuxIDMapping{ContainerID: uint32(cid), HostID: uint32(hid), Size: uint32(size)})
+	}
+	return mappings, nil
+}
+
+// GetHostIDMappings reads mappings for the specified process (or the current
+// process if pid is "self" or an empty string) from the kernel.
+func GetHostIDMappings(pid string) ([]specs.LinuxIDMapping, []specs.LinuxIDMapping, error) {
+	if pid == "" {
+		pid = "self"
+	}
+	uidmap, err := getHostIDMappings(fmt.Sprintf("/proc/%s/uid_map", pid))
+	if err != nil {
+		return nil, nil, err
+	}
+	gidmap, err := getHostIDMappings(fmt.Sprintf("/proc/%s/gid_map", pid))
+	if err != nil {
+		return nil, nil, err
+	}
+	return uidmap, gidmap, nil
+}
+
+// GetSubIDMappings reads mappings from /etc/subuid and /etc/subgid.
+func GetSubIDMappings(user, group string) ([]specs.LinuxIDMapping, []specs.LinuxIDMapping, error) {
+	mappings, err := idtools.NewIDMappings(user, group)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "error reading subuid mappings for user %q and subgid mappings for group %q", user, group)
+	}
+	var uidmap, gidmap []specs.LinuxIDMapping
+	for _, m := range mappings.UIDs() {
+		uidmap = append(uidmap, specs.LinuxIDMapping{
+			ContainerID: uint32(m.ContainerID),
+			HostID:      uint32(m.HostID),
+			Size:        uint32(m.Size),
+		})
+	}
+	for _, m := range mappings.GIDs() {
+		gidmap = append(gidmap, specs.LinuxIDMapping{
+			ContainerID: uint32(m.ContainerID),
+			HostID:      uint32(m.HostID),
+			Size:        uint32(m.Size),
+		})
+	}
+	return uidmap, gidmap, nil
+}
+
+// ParseIDMappings parses mapping triples.
+func ParseIDMappings(uidmap, gidmap []string) ([]idtools.IDMap, []idtools.IDMap, error) {
+	uid, err := idtools.ParseIDMap(uidmap, "userns-uid-map")
+	if err != nil {
+		return nil, nil, err
+	}
+	gid, err := idtools.ParseIDMap(gidmap, "userns-gid-map")
+	if err != nil {
+		return nil, nil, err
+	}
+	return uid, gid, nil
 }

--- a/pkg/unshare/unshare_test.go
+++ b/pkg/unshare/unshare_test.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/containers/buildah/util"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -88,7 +87,7 @@ func report() {
 	}
 	report.OOMScoreAdj = oom
 
-	uidmap, gidmap, err := util.GetHostIDMappings("")
+	uidmap, gidmap, err := GetHostIDMappings("")
 	if err != nil {
 		logrus.Errorf("error reading current ID mappings: %v", err)
 		os.Exit(1)

--- a/pkg/unshare/unshare_unsupported.go
+++ b/pkg/unshare/unshare_unsupported.go
@@ -4,6 +4,9 @@ package unshare
 
 import (
 	"os"
+
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 const (
@@ -28,4 +31,15 @@ func RootlessEnv() []string {
 
 // MaybeReexecUsingUserNamespace re-exec the process in a new namespace
 func MaybeReexecUsingUserNamespace(evenForRoot bool) {
+}
+
+// GetHostIDMappings reads mappings for the specified process (or the current
+// process if pid is "self" or an empty string) from the kernel.
+func GetHostIDMappings(pid string) ([]specs.LinuxIDMapping, []specs.LinuxIDMapping, error) {
+	return nil, nil, nil
+}
+
+// ParseIDMappings parses mapping triples.
+func ParseIDMappings(uidmap, gidmap []string) ([]idtools.IDMap, []idtools.IDMap, error) {
+	return nil, nil, nil
 }

--- a/run.go
+++ b/run.go
@@ -865,7 +865,7 @@ func setupNamespaces(g *generate.Generator, namespaceOptions NamespaceOptions, i
 		if err := g.AddOrReplaceLinuxNamespace(specs.UserNamespace, ""); err != nil {
 			return false, nil, false, errors.Wrapf(err, "error adding new %q namespace for run", string(specs.UserNamespace))
 		}
-		hostUidmap, hostGidmap, err := util.GetHostIDMappings("")
+		hostUidmap, hostGidmap, err := unshare.GetHostIDMappings("")
 		if err != nil {
 			return false, nil, false, err
 		}


### PR DESCRIPTION
This will make vendoring in pkg/unshare easier into other
packages like skopeo.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>