### PR TITLE
fix bug dest path when COPY .dockerignore

### DIFF
--- a/add.go
+++ b/add.go
@@ -292,7 +292,7 @@ func addHelper(excludes []DockerIgnore, extract bool, dest string, destfi os.Fil
 						break
 					}
 					// combine the filename with the dest directory
-					fpath := strings.TrimPrefix(path, options.ContextDir)
+					fpath := strings.TrimPrefix(path, esrc)
 					if err = copyFileWithTar(path, filepath.Join(dest, fpath)); err != nil {
 						return errors.Wrapf(err, "error copying %q to %q", path, dest)
 					}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -24,7 +24,7 @@ load helpers
 
   run_buildah run myctr ls -l test2.txt
 
-  run_buildah 1 run myctr ls -l test1.txt
+  run_buildah run myctr ls -l sub1.txt
 
   run_buildah run myctr ls -l subdir/sub1.txt
 

--- a/tests/bud/dockerignore/Dockerfile
+++ b/tests/bud/dockerignore/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine
 
 COPY ./ ./
+COPY subdir ./


### PR DESCRIPTION
Fix the destination file path if .dockerignore is not empty. Avoid copying the source directory level into the container.
close #1530 
Signed-off-by: Qi Wang <qiwan@redhat.com>