### PR TITLE
commit: always set a parent ID

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -67,8 +67,6 @@ type CommitOptions struct {
 
 	// OnBuild is a list of commands to be run by images based on this image
 	OnBuild []string
-	// Parent is the base image that this image was created by.
-	Parent string
 
 	// OmitTimestamp forces epoch 0 as created timestamp to allow for
 	// deterministic, content-addressable builds.
@@ -169,7 +167,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 		}
 	}
 	// Build an image reference from which we can copy the finished image.
-	src, err := b.makeImageRef(options.PreferredManifestType, options.Parent, exportBaseLayers, options.Squash, options.BlobDirectory, options.Compression, options.HistoryTimestamp, options.OmitTimestamp)
+	src, err := b.makeImageRef(options.PreferredManifestType, exportBaseLayers, options.Squash, options.BlobDirectory, options.Compression, options.HistoryTimestamp, options.OmitTimestamp)
 	if err != nil {
 		return imgID, nil, "", errors.Wrapf(err, "error computing layer digests and building metadata for container %q", b.ContainerID)
 	}

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1452,7 +1452,6 @@ func (s *StageExecutor) commit(ctx context.Context, ib *imagebuilder.Builder, cr
 		SystemContext:         s.executor.systemContext,
 		Squash:                s.executor.squash,
 		BlobDirectory:         s.executor.blobDirectory,
-		Parent:                s.builder.FromImageID,
 	}
 	imgID, _, manifestDigest, err := s.builder.Commit(ctx, imageRef, options)
 	if err != nil {


### PR DESCRIPTION
Always set a parent ID when we go to commit an image, whether it's as part of build-using-dockerfile or our "commit" CLI.  Coerce the parent image's ID directly into the value that we use instead of digesting it
again.