### PR TITLE
commit: commit on every instruction, but not always with layers

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -149,7 +149,7 @@ func openImage(ctx context.Context, sc *types.SystemContext, store storage.Store
 	return builder, nil
 }
 
-func getDateAndDigestAndSize(ctx context.Context, image storage.Image, store storage.Store) (time.Time, string, int64, error) {
+func getDateAndDigestAndSize(ctx context.Context, store storage.Store, image storage.Image) (time.Time, string, int64, error) {
 	created := time.Time{}
 	is.Transport.SetStore(store)
 	storeRef, err := is.Transport.ParseStoreReference(store, image.ID)

--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -93,7 +93,7 @@ func TestGetSize(t *testing.T) {
 		t.Fatalf("Error reading images: %v", err)
 	}
 
-	_, _, _, err = getDateAndDigestAndSize(getContext(), images[0], store)
+	_, _, _, err = getDateAndDigestAndSize(getContext(), store, images[0])
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -106,7 +106,7 @@ func TestOutputImagesQuietNotTruncated(t *testing.T) {
 
 	// Tests quiet and non-truncated output
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], store, nil, "", opts)
+		return outputImages(getContext(), store, images[:1], nil, "", opts)
 	})
 	expectedOutput := fmt.Sprintf("sha256:%s\n", images[0].ID)
 	if err != nil {
@@ -144,7 +144,7 @@ func TestOutputImagesFormatString(t *testing.T) {
 
 	// Tests output with format template
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], store, nil, "", opts)
+		return outputImages(getContext(), store, images[:1], nil, "", opts)
 	})
 	expectedOutput := images[0].ID
 	if err != nil {
@@ -183,7 +183,7 @@ func TestOutputImagesArgNoMatch(t *testing.T) {
 	// because all images in the repository must have a tag, and here the tag is an
 	// empty string
 	_, err = captureOutputWithError(func() error {
-		return outputImages(getContext(), images[:1], store, nil, "foo:", opts)
+		return outputImages(getContext(), store, images[:1], nil, "foo:", opts)
 	})
 	if err == nil || err.Error() != "No such image foo:" {
 		t.Fatalf("expected error arg no match")

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -106,7 +106,7 @@ func TestOutputImagesQuietNotTruncated(t *testing.T) {
 
 	// Tests quiet and non-truncated output
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), store, images[:1], nil, "", opts)
+		return outputImages(getContext(), &testSystemContext, store, images[:1], nil, "", opts)
 	})
 	expectedOutput := fmt.Sprintf("sha256:%s\n", images[0].ID)
 	if err != nil {
@@ -144,7 +144,7 @@ func TestOutputImagesFormatString(t *testing.T) {
 
 	// Tests output with format template
 	output, err := captureOutputWithError(func() error {
-		return outputImages(getContext(), store, images[:1], nil, "", opts)
+		return outputImages(getContext(), &testSystemContext, store, images[:1], nil, "", opts)
 	})
 	expectedOutput := images[0].ID
 	if err != nil {
@@ -183,7 +183,7 @@ func TestOutputImagesArgNoMatch(t *testing.T) {
 	// because all images in the repository must have a tag, and here the tag is an
 	// empty string
 	_, err = captureOutputWithError(func() error {
-		return outputImages(getContext(), store, images[:1], nil, "foo:", opts)
+		return outputImages(getContext(), &testSystemContext, store, images[:1], nil, "foo:", opts)
 	})
 	if err == nil || err.Error() != "No such image foo:" {
 		t.Fatalf("expected error arg no match")

--- a/commit.go
+++ b/commit.go
@@ -167,7 +167,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 		}
 	}
 	// Build an image reference from which we can copy the finished image.
-	src, err := b.makeImageRef(options.PreferredManifestType, exportBaseLayers, options.Squash, options.BlobDirectory, options.Compression, options.HistoryTimestamp, options.OmitTimestamp)
+	src, err := b.makeImageRef(options, exportBaseLayers)
 	if err != nil {
 		return imgID, nil, "", errors.Wrapf(err, "error computing layer digests and building metadata for container %q", b.ContainerID)
 	}

--- a/commit.go
+++ b/commit.go
@@ -64,6 +64,9 @@ type CommitOptions struct {
 	// manifest of the new image will reference the blobs rather than
 	// on-disk layers.
 	BlobDirectory string
+	// EmptyLayer tells the builder to omit the diff for the working
+	// container.
+	EmptyLayer bool
 	// OmitTimestamp forces epoch 0 as created timestamp to allow for
 	// deterministic, content-addressable builds.
 	OmitTimestamp bool

--- a/commit.go
+++ b/commit.go
@@ -64,10 +64,6 @@ type CommitOptions struct {
 	// manifest of the new image will reference the blobs rather than
 	// on-disk layers.
 	BlobDirectory string
-
-	// OnBuild is a list of commands to be run by images based on this image
-	OnBuild []string
-
 	// OmitTimestamp forces epoch 0 as created timestamp to allow for
 	// deterministic, content-addressable builds.
 	OmitTimestamp bool

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -30,7 +30,7 @@ load helpers
   expect_line_count 3
 
   run_buildah --debug=false images -a
-  expect_line_count 6
+  expect_line_count 8
 
   # create a no name image which should show up when doing buildah images without the --all flag
   buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/use-layers

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -135,13 +135,13 @@ load helpers
   buildah rmi -a -f
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
   run_buildah --debug=false images -a -q
-  expect_line_count 5
+  expect_line_count 7
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
   run_buildah --debug=false images -a -q
-  expect_line_count 7
+  expect_line_count 9
   run_buildah --debug=false rmi test2
   run_buildah --debug=false images -a -q
-  expect_line_count 5
+  expect_line_count 7
   run_buildah --debug=false rmi test1
   run_buildah --debug=false images -a -q
   expect_line_count 1


### PR DESCRIPTION
When building an image with multiple layers, go back to committing images for instructions for which we previously wouldn't bother committing an image, but create them without adding a new layer.

This violates some assumptions that we currently make elsewhere, as it's possible for an image that's derived from a base image to add no layers relative to the base image, when previously it was always the case that we'd add at least one whenever we committed it.  This would already have been the case with images built with `docker build`, so we have to make some adjustments to our CLI logic to not be confused by it.