### PR TITLE
run: check if SELinux is enabled

### DIFF
--- a/chroot/selinux.go
+++ b/chroot/selinux.go
@@ -13,7 +13,7 @@ import (
 // setSelinuxLabel sets the process label for child processes that we'll start.
 func setSelinuxLabel(spec *specs.Spec) error {
 	logrus.Debugf("setting selinux label")
-	if spec.Process.SelinuxLabel != "" && selinux.EnforceMode() != selinux.Disabled {
+	if spec.Process.SelinuxLabel != "" && selinux.GetEnabled() {
 		if err := label.SetProcessLabel(spec.Process.SelinuxLabel); err != nil {
 			return errors.Wrapf(err, "error setting process label to %q", spec.Process.SelinuxLabel)
 		}

--- a/selinux.go
+++ b/selinux.go
@@ -4,9 +4,12 @@ package buildah
 
 import (
 	"github.com/opencontainers/runtime-tools/generate"
+	selinux "github.com/opencontainers/selinux/go-selinux"
 )
 
 func setupSelinux(g *generate.Generator, processLabel, mountLabel string) {
-	g.SetProcessSelinuxLabel(processLabel)
-	g.SetLinuxMountLabel(mountLabel)
+	if processLabel != "" && selinux.GetEnabled() {
+		g.SetProcessSelinuxLabel(processLabel)
+		g.SetLinuxMountLabel(mountLabel)
+	}
 }


### PR DESCRIPTION
When we're built with support for SELinux, refrain from setting process and mount labels if SELinux isn't detected as enabled at runtime.