### PR TITLE
[WIP] Move buildah options into buildah/pkg/options for easier podman windows compile

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/containers/buildah/docker"
+	bopts "github.com/containers/buildah/pkg/options"
 	"github.com/containers/buildah/util"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
@@ -154,7 +155,7 @@ type Builder struct {
 	// Isolation controls how we handle "RUN" statements and the Run() method.
 	Isolation Isolation
 	// NamespaceOptions controls how we set up the namespaces for processes that we run in the container.
-	NamespaceOptions NamespaceOptions
+	NamespaceOptions bopts.NamespaceOptions
 	// ConfigureNetwork controls whether or not network interfaces and
 	// routing are configured for a new network namespace (i.e., when not
 	// joining another's namespace and not just using the host's
@@ -186,7 +187,7 @@ type Builder struct {
 	// committing.
 	AppendedEmptyLayers []v1.History
 
-	CommonBuildOpts *CommonBuildOptions
+	CommonBuildOpts *bopts.CommonBuildOptions
 	// TopLayer is the top layer of the image
 	TopLayer string
 	// Format for the build Image
@@ -211,7 +212,7 @@ type BuilderInfo struct {
 	Docker                docker.V2Image
 	DefaultMountsFilePath string
 	Isolation             string
-	NamespaceOptions      NamespaceOptions
+	NamespaceOptions      bopts.NamespaceOptions
 	ConfigureNetwork      string
 	CNIPluginPath         string
 	CNIConfigDir          string
@@ -266,65 +267,6 @@ func GetBuildInfo(b *Builder) BuilderInfo {
 	}
 }
 
-// CommonBuildOptions are resources that can be defined by flags for both buildah from and build-using-dockerfile
-type CommonBuildOptions struct {
-	// AddHost is the list of hostnames to add to the build container's /etc/hosts.
-	AddHost []string
-	// CgroupParent is the path to cgroups under which the cgroup for the container will be created.
-	CgroupParent string
-	// CPUPeriod limits the CPU CFS (Completely Fair Scheduler) period
-	CPUPeriod uint64
-	// CPUQuota limits the CPU CFS (Completely Fair Scheduler) quota
-	CPUQuota int64
-	// CPUShares (relative weight
-	CPUShares uint64
-	// CPUSetCPUs in which to allow execution (0-3, 0,1)
-	CPUSetCPUs string
-	// CPUSetMems memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
-	CPUSetMems string
-	// HTTPProxy determines whether *_proxy env vars from the build host are passed into the container.
-	HTTPProxy bool
-	// Memory is the upper limit (in bytes) on how much memory running containers can use.
-	Memory int64
-	// DNSSearch is the list of DNS search domains to add to the build container's /etc/resolv.conf
-	DNSSearch []string
-	// DNSServers is the list of DNS servers to add to the build container's /etc/resolv.conf
-	DNSServers []string
-	// DNSOptions is the list of DNS
-	DNSOptions []string
-	// MemorySwap limits the amount of memory and swap together.
-	MemorySwap int64
-	// LabelOpts is the a slice of fields of an SELinux context, given in "field:pair" format, or "disable".
-	// Recognized field names are "role", "type", and "level".
-	LabelOpts []string
-	// SeccompProfilePath is the pathname of a seccomp profile.
-	SeccompProfilePath string
-	// ApparmorProfile is the name of an apparmor profile.
-	ApparmorProfile string
-	// ShmSize is the "size" value to use when mounting an shmfs on the container's /dev/shm directory.
-	ShmSize string
-	// Ulimit specifies resource limit options, in the form type:softlimit[:hardlimit].
-	// These types are recognized:
-	// "core": maximimum core dump size (ulimit -c)
-	// "cpu": maximum CPU time (ulimit -t)
-	// "data": maximum size of a process's data segment (ulimit -d)
-	// "fsize": maximum size of new files (ulimit -f)
-	// "locks": maximum number of file locks (ulimit -x)
-	// "memlock": maximum amount of locked memory (ulimit -l)
-	// "msgqueue": maximum amount of data in message queues (ulimit -q)
-	// "nice": niceness adjustment (nice -n, ulimit -e)
-	// "nofile": maximum number of open files (ulimit -n)
-	// "nproc": maximum number of processes (ulimit -u)
-	// "rss": maximum size of a process's (ulimit -m)
-	// "rtprio": maximum real-time scheduling priority (ulimit -r)
-	// "rttime": maximum amount of real-time execution between blocking syscalls
-	// "sigpending": maximum number of pending signals (ulimit -i)
-	// "stack": maximum stack size (ulimit -s)
-	Ulimit []string
-	// Volumes to bind mount into the container
-	Volumes []string
-}
-
 // BuilderOptions are used to initialize a new Builder.
 type BuilderOptions struct {
 	// Args define variables that users can pass at build-time to the builder
@@ -371,7 +313,7 @@ type BuilderOptions struct {
 	Isolation Isolation
 	// NamespaceOptions controls how we set up namespaces for processes that
 	// we might need to run using the container's root filesystem.
-	NamespaceOptions NamespaceOptions
+	NamespaceOptions bopts.NamespaceOptions
 	// ConfigureNetwork controls whether or not network interfaces and
 	// routing are configured for a new network namespace (i.e., when not
 	// joining another's namespace and not just using the host's
@@ -394,7 +336,7 @@ type BuilderOptions struct {
 	// container.  If a capability appears in both lists, it will be dropped.
 	DropCapabilities []string
 
-	CommonBuildOpts *CommonBuildOptions
+	CommonBuildOpts *bopts.CommonBuildOptions
 	// Format for the container image
 	Format string
 }

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/containers/buildah"
 	"github.com/containers/buildah/imagebuildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
+	bopts "github.com/containers/buildah/pkg/options"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
 	"github.com/containers/image/storage"
@@ -150,7 +150,7 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 		}
 	}
 
-	options := buildah.CommitOptions{
+	options := bopts.CommitOptions{
 		PreferredManifestType: format,
 		Compression:           compress,
 		SignaturePolicyPath:   iopts.signaturePolicy,

--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/containers/buildah"
+	bopts "github.com/containers/buildah/pkg/options"
 	"github.com/containers/buildah/pkg/unshare"
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/types"
@@ -200,7 +201,7 @@ func defaultFormat() string {
 	if format != "" {
 		return format
 	}
-	return buildah.OCI
+	return bopts.OCI
 }
 
 // imageIsParent goes through the layers in the store and checks if i.TopLayer is
@@ -267,10 +268,10 @@ func getImageOfTopLayer(images []storage.Image, layer string) []string {
 
 func getFormat(format string) (string, error) {
 	switch format {
-	case buildah.OCI:
-		return buildah.OCIv1ImageManifest, nil
-	case buildah.DOCKER:
-		return buildah.Dockerv2ImageManifest, nil
+	case bopts.OCI:
+		return bopts.OCIv1ImageManifest, nil
+	case bopts.DOCKER:
+		return bopts.Dockerv2ImageManifest, nil
 	default:
 		return "", errors.Errorf("unrecognized image type %q", format)
 	}

--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/containers/buildah"
+	bopts "github.com/containers/buildah/pkg/options"
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
@@ -113,7 +114,7 @@ func pullTestImage(t *testing.T, imageName string) (string, error) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	commonOpts := &buildah.CommonBuildOptions{
+	commonOpts := &bopts.CommonBuildOptions{
 		LabelOpts: nil,
 	}
 	options := buildah.BuilderOptions{

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/docker"
 	buildahcli "github.com/containers/buildah/pkg/cli"
+	bopts "github.com/containers/buildah/pkg/options"
 	"github.com/mattn/go-shellwords"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -236,7 +237,7 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 	}
 	if c.Flag("hostname").Changed {
 		name := iopts.hostname
-		if name != "" && builder.Format == buildah.OCIv1ImageManifest {
+		if name != "" && builder.Format == bopts.OCIv1ImageManifest {
 			logrus.Errorf("HOSTNAME is not supported for OCI V1 image format, hostname %s will be ignored. Must use `docker` format", name)
 		}
 		builder.SetHostname(name)

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/imagebuildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
+	bopts "github.com/containers/buildah/pkg/options"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
 	"github.com/containers/image/manifest"
@@ -148,7 +149,7 @@ func pushCmd(c *cobra.Command, args []string, iopts pushResults) error {
 		}
 	}
 
-	options := buildah.PushOptions{
+	options := bopts.PushOptions{
 		Compression:         compress,
 		ManifestType:        manifestType,
 		SignaturePolicyPath: iopts.signaturePolicy,

--- a/common.go
+++ b/common.go
@@ -11,13 +11,6 @@ import (
 	"github.com/containers/storage"
 )
 
-const (
-	// OCI used to define the "oci" image format
-	OCI = "oci"
-	// DOCKER used to define the "docker" image format
-	DOCKER = "docker"
-)
-
 func getCopyOptions(store storage.Store, reportWriter io.Writer, sourceReference types.ImageReference, sourceSystemContext *types.SystemContext, destinationReference types.ImageReference, destinationSystemContext *types.SystemContext, manifestType string) *cp.Options {
 	sourceCtx := getSystemContext(store, nil, "")
 	if sourceSystemContext != nil {

--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/containers/buildah/docker"
+	bopts "github.com/containers/buildah/pkg/options"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
@@ -108,7 +109,7 @@ func (b *Builder) fixupConfig() {
 	if b.Architecture() == "" {
 		b.SetArchitecture(runtime.GOARCH)
 	}
-	if b.Format == Dockerv2ImageManifest && b.Hostname() == "" {
+	if b.Format == bopts.Dockerv2ImageManifest && b.Hostname() == "" {
 		b.SetHostname(stringid.TruncateID(stringid.GenerateRandomID()))
 	}
 }
@@ -219,7 +220,7 @@ func (b *Builder) ClearOnBuild() {
 // Note: this setting is not present in the OCIv1 image format, so it is
 // discarded when writing images using OCIv1 formats.
 func (b *Builder) SetOnBuild(onBuild string) {
-	if onBuild != "" && b.Format != Dockerv2ImageManifest {
+	if onBuild != "" && b.Format != bopts.Dockerv2ImageManifest {
 		logrus.Errorf("ONBUILD is not supported for OCI image format, %s will be ignored. Must use `docker` format", onBuild)
 	}
 	b.Docker.Config.OnBuild = append(b.Docker.Config.OnBuild, onBuild)
@@ -251,7 +252,7 @@ func (b *Builder) Shell() []string {
 // Note: this setting is not present in the OCIv1 image format, so it is
 // discarded when writing images using OCIv1 formats.
 func (b *Builder) SetShell(shell []string) {
-	if len(shell) > 0 && b.Format != Dockerv2ImageManifest {
+	if len(shell) > 0 && b.Format != bopts.Dockerv2ImageManifest {
 		logrus.Errorf("SHELL is not supported for OCI image format, %s will be ignored. Must use `docker` format", shell)
 	}
 
@@ -488,7 +489,7 @@ func (b *Builder) Domainname() string {
 // Note: this setting is not present in the OCIv1 image format, so it is
 // discarded when writing images using OCIv1 formats.
 func (b *Builder) SetDomainname(name string) {
-	if name != "" && b.Format != Dockerv2ImageManifest {
+	if name != "" && b.Format != bopts.Dockerv2ImageManifest {
 		logrus.Errorf("DOMAINNAME is not supported for OCI image format, domainname %s will be ignored. Must use `docker` format", name)
 	}
 	b.Docker.Config.Domainname = name
@@ -510,7 +511,7 @@ func (b *Builder) Comment() string {
 // Note: this setting is not present in the OCIv1 image format, so it is
 // discarded when writing images using OCIv1 formats.
 func (b *Builder) SetComment(comment string) {
-	if comment != "" && b.Format != Dockerv2ImageManifest {
+	if comment != "" && b.Format != bopts.Dockerv2ImageManifest {
 		logrus.Errorf("COMMENT is not supported for OCI image format, comment %s will be ignored. Must use `docker` format", comment)
 	}
 	b.Docker.Comment = comment

--- a/image.go
+++ b/image.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/containers/buildah/docker"
+	bopts "github.com/containers/buildah/pkg/options"
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/image"
 	"github.com/containers/image/manifest"
@@ -26,17 +27,6 @@ import (
 	"github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-)
-
-const (
-	// OCIv1ImageManifest is the MIME type of an OCIv1 image manifest,
-	// suitable for specifying as a value of the PreferredManifestType
-	// member of a CommitOptions structure.  It is also the default.
-	OCIv1ImageManifest = v1.MediaTypeImageManifest
-	// Dockerv2ImageManifest is the MIME type of a Docker v2s2 image
-	// manifest, suitable for specifying as a value of the
-	// PreferredManifestType member of a CommitOptions structure.
-	Dockerv2ImageManifest = manifest.DockerV2Schema2MediaType
 )
 
 type containerImageRef struct {
@@ -648,7 +638,7 @@ func (b *Builder) makeImageRef(manifestType string, exporting bool, squash bool,
 		}
 	}
 	if manifestType == "" {
-		manifestType = OCIv1ImageManifest
+		manifestType = bopts.OCIv1ImageManifest
 	}
 	oconfig, err := json.Marshal(&b.OCIv1)
 	if err != nil {

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/containers/buildah"
 	buildahdocker "github.com/containers/buildah/docker"
+	bopts "github.com/containers/buildah/pkg/options"
 	"github.com/containers/buildah/util"
 	cp "github.com/containers/image/copy"
 	"github.com/containers/image/docker/reference"
@@ -116,7 +117,7 @@ type BuildOptions struct {
 	SystemContext *types.SystemContext
 	// NamespaceOptions controls how we set up namespaces processes that we
 	// might need when handling RUN instructions.
-	NamespaceOptions []buildah.NamespaceOption
+	NamespaceOptions []bopts.NamespaceOption
 	// ConfigureNetwork controls whether or not network interfaces and
 	// routing are configured for a new network namespace (i.e., when not
 	// joining another's namespace and not just using the host's
@@ -139,7 +140,7 @@ type BuildOptions struct {
 	// when handling RUN instructions. If a capability appears in both lists, it
 	// will be dropped.
 	DropCapabilities []string
-	CommonBuildOpts  *buildah.CommonBuildOptions
+	CommonBuildOpts  *bopts.CommonBuildOptions
 	// DefaultMountsFilePath is the file path holding the mounts to be mounted in "host-path:container-path" format
 	DefaultMountsFilePath string
 	// IIDFile tells the builder to write the image ID to the specified file
@@ -196,12 +197,12 @@ type Executor struct {
 	systemContext                  *types.SystemContext
 	reportWriter                   io.Writer
 	isolation                      buildah.Isolation
-	namespaceOptions               []buildah.NamespaceOption
+	namespaceOptions               []bopts.NamespaceOption
 	configureNetwork               buildah.NetworkConfigurationPolicy
 	cniPluginPath                  string
 	cniConfigDir                   string
 	idmappingOptions               *buildah.IDMappingOptions
-	commonBuildOptions             *buildah.CommonBuildOptions
+	commonBuildOptions             *bopts.CommonBuildOptions
 	defaultMountsFilePath          string
 	iidfile                        string
 	squash                         bool
@@ -1480,7 +1481,7 @@ func (s *StageExecutor) commit(ctx context.Context, ib *imagebuilder.Builder, cr
 	if s.executor.layers || !s.executor.useCache {
 		writer = nil
 	}
-	options := buildah.CommitOptions{
+	options := bopts.CommitOptions{
 		Compression:           s.executor.compression,
 		SignaturePolicyPath:   s.executor.signaturePolicyPath,
 		AdditionalTags:        s.executor.additionalTags,

--- a/import.go
+++ b/import.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/containers/buildah/docker"
+	bopts "github.com/containers/buildah/pkg/options"
 	"github.com/containers/buildah/util"
 	is "github.com/containers/image/storage"
 	"github.com/containers/image/types"
@@ -47,7 +48,7 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 		}
 	}
 
-	defaultNamespaceOptions, err := DefaultNamespaceOptions()
+	defaultNamespaceOptions, err := bopts.DefaultNamespaceOptions()
 	if err != nil {
 		return nil, err
 	}

--- a/new.go
+++ b/new.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"strings"
 
+	bopts "github.com/containers/buildah/pkg/options"
 	"github.com/containers/buildah/util"
 	"github.com/containers/image/pkg/sysregistries"
 	is "github.com/containers/image/storage"
@@ -314,7 +315,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 
 	uidmap, gidmap := convertStorageIDMaps(container.UIDMap, container.GIDMap)
 
-	defaultNamespaceOptions, err := DefaultNamespaceOptions()
+	defaultNamespaceOptions, err := bopts.DefaultNamespaceOptions()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/containers/buildah"
+	bopts "github.com/containers/buildah/pkg/options"
 	"github.com/containers/buildah/util"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -217,7 +217,7 @@ func DefaultFormat() string {
 	if format != "" {
 		return format
 	}
-	return buildah.OCI
+	return bopts.OCI
 }
 
 // DefaultIsolation returns the default image format
@@ -226,7 +226,7 @@ func DefaultIsolation() string {
 	if isolation != "" {
 		return isolation
 	}
-	return buildah.OCI
+	return bopts.OCI
 }
 
 // DefaultHistory returns the default add-history setting

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -1,0 +1,251 @@
+package options
+
+import (
+	"io"
+	"time"
+
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/types"
+	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/archive"
+	"github.com/opencontainers/image-spec/specs-go/v1"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/pkg/errors"
+)
+
+const (
+	// DOCKER used to define the "docker" image format
+	DOCKER = "docker"
+	// OCI used to define the "oci" image format
+	OCI = "oci"
+
+	// Dockerv2ImageManifest is the MIME type of a Docker v2s2 image
+	// manifest, suitable for specifying as a value of the
+	// PreferredManifestType member of a CommitOptions structure.
+	Dockerv2ImageManifest = manifest.DockerV2Schema2MediaType
+	// OCIv1ImageManifest is the MIME type of an OCIv1 image manifest,
+	// suitable for specifying as a value of the PreferredManifestType
+	// member of a CommitOptions structure.  It is also the default.
+	OCIv1ImageManifest = v1.MediaTypeImageManifest
+)
+
+// CommitOptions can be used to alter how an image is committed.
+type CommitOptions struct {
+	// PreferredManifestType is the preferred type of image manifest.  The
+	// image configuration format will be of a compatible type.
+	PreferredManifestType string
+	// Compression specifies the type of compression which is applied to
+	// layer blobs.  The default is to not use compression, but
+	// archive.Gzip is recommended.
+	Compression archive.Compression
+	// SignaturePolicyPath specifies an override location for the signature
+	// policy which should be used for verifying the new image as it is
+	// being written.  Except in specific circumstances, no value should be
+	// specified, indicating that the shared, system-wide default policy
+	// should be used.
+	SignaturePolicyPath string
+	// AdditionalTags is a list of additional names to add to the image, if
+	// the transport to which we're writing the image gives us a way to add
+	// them.
+	AdditionalTags []string
+	// ReportWriter is an io.Writer which will be used to log the writing
+	// of the new image.
+	ReportWriter io.Writer
+	// HistoryTimestamp is the timestamp used when creating new items in the
+	// image's history.  If unset, the current time will be used.
+	HistoryTimestamp *time.Time
+	// github.com/containers/image/types SystemContext to hold credentials
+	// and other authentication/authorization information.
+	SystemContext *types.SystemContext
+	// IIDFile tells the builder to write the image ID to the specified file
+	IIDFile string
+	// Squash tells the builder to produce an image with a single layer
+	// instead of with possibly more than one layer.
+	Squash bool
+	// BlobDirectory is the name of a directory in which we'll look for
+	// prebuilt copies of layer blobs that we might otherwise need to
+	// regenerate from on-disk layers.  If blobs are available, the
+	// manifest of the new image will reference the blobs rather than
+	// on-disk layers.
+	BlobDirectory string
+
+	// OnBuild is a list of commands to be run by images based on this image
+	OnBuild []string
+
+	// OmitTimestamp forces epoch 0 as created timestamp to allow for
+	// deterministic, content-addressable builds.
+	OmitTimestamp bool
+}
+
+// CommonBuildOptions are resources that can be defined by flags for both buildah from and build-using-dockerfile
+type CommonBuildOptions struct {
+	// AddHost is the list of hostnames to add to the build container's /etc/hosts.
+	AddHost []string
+	// CgroupParent is the path to cgroups under which the cgroup for the container will be created.
+	CgroupParent string
+	// CPUPeriod limits the CPU CFS (Completely Fair Scheduler) period
+	CPUPeriod uint64
+	// CPUQuota limits the CPU CFS (Completely Fair Scheduler) quota
+	CPUQuota int64
+	// CPUShares (relative weight
+	CPUShares uint64
+	// CPUSetCPUs in which to allow execution (0-3, 0,1)
+	CPUSetCPUs string
+	// CPUSetMems memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
+	CPUSetMems string
+	// HTTPProxy determines whether *_proxy env vars from the build host are passed into the container.
+	HTTPProxy bool
+	// Memory is the upper limit (in bytes) on how much memory running containers can use.
+	Memory int64
+	// DNSSearch is the list of DNS search domains to add to the build container's /etc/resolv.conf
+	DNSSearch []string
+	// DNSServers is the list of DNS servers to add to the build container's /etc/resolv.conf
+	DNSServers []string
+	// DNSOptions is the list of DNS
+	DNSOptions []string
+	// MemorySwap limits the amount of memory and swap together.
+	MemorySwap int64
+	// LabelOpts is the a slice of fields of an SELinux context, given in "field:pair" format, or "disable".
+	// Recognized field names are "role", "type", and "level".
+	LabelOpts []string
+	// SeccompProfilePath is the pathname of a seccomp profile.
+	SeccompProfilePath string
+	// ApparmorProfile is the name of an apparmor profile.
+	ApparmorProfile string
+	// ShmSize is the "size" value to use when mounting an shmfs on the container's /dev/shm directory.
+	ShmSize string
+	// Ulimit specifies resource limit options, in the form type:softlimit[:hardlimit].
+	// These types are recognized:
+	// "core": maximimum core dump size (ulimit -c)
+	// "cpu": maximum CPU time (ulimit -t)
+	// "data": maximum size of a process's data segment (ulimit -d)
+	// "fsize": maximum size of new files (ulimit -f)
+	// "locks": maximum number of file locks (ulimit -x)
+	// "memlock": maximum amount of locked memory (ulimit -l)
+	// "msgqueue": maximum amount of data in message queues (ulimit -q)
+	// "nice": niceness adjustment (nice -n, ulimit -e)
+	// "nofile": maximum number of open files (ulimit -n)
+	// "nproc": maximum number of processes (ulimit -u)
+	// "rss": maximum size of a process's (ulimit -m)
+	// "rtprio": maximum real-time scheduling priority (ulimit -r)
+	// "rttime": maximum amount of real-time execution between blocking syscalls
+	// "sigpending": maximum number of pending signals (ulimit -i)
+	// "stack": maximum stack size (ulimit -s)
+	Ulimit []string
+	// Volumes to bind mount into the container
+	Volumes []string
+}
+
+// NamespaceOption controls how we set up a namespace when launching processes.
+type NamespaceOption struct {
+	// Name specifies the type of namespace, typically matching one of the
+	// ...Namespace constants defined in
+	// github.com/opencontainers/runtime-spec/specs-go.
+	Name string
+	// Host is used to force our processes to use the host's namespace of
+	// this type.
+	Host bool
+	// Path is the path of the namespace to attach our process to, if Host
+	// is not set.  If Host is not set and Path is also empty, a new
+	// namespace will be created for the process that we're starting.
+	// If Name is specs.NetworkNamespace, if Path doesn't look like an
+	// absolute path, it is treated as a comma-separated list of CNI
+	// configuration names which will be selected from among all of the CNI
+	// network configurations which we find.
+	Path string
+}
+
+// NamespaceOptions provides some helper methods for a slice of NamespaceOption
+// structs.
+type NamespaceOptions []NamespaceOption
+
+// DefaultNamespaceOptions returns the default namespace settings from the
+// runtime-tools generator library.
+func DefaultNamespaceOptions() (NamespaceOptions, error) {
+	options := NamespaceOptions{
+		{Name: string(specs.CgroupNamespace), Host: true},
+		{Name: string(specs.IPCNamespace), Host: true},
+		{Name: string(specs.MountNamespace), Host: true},
+		{Name: string(specs.NetworkNamespace), Host: true},
+		{Name: string(specs.PIDNamespace), Host: true},
+		{Name: string(specs.UserNamespace), Host: true},
+		{Name: string(specs.UTSNamespace), Host: true},
+	}
+	g, err := generate.New("linux")
+	if err != nil {
+		return options, errors.Wrapf(err, "error generating new 'linux' runtime spec")
+	}
+	spec := g.Config
+	if spec.Linux != nil {
+		for _, ns := range spec.Linux.Namespaces {
+			options.AddOrReplace(NamespaceOption{
+				Name: string(ns.Type),
+				Path: ns.Path,
+			})
+		}
+	}
+	return options, nil
+}
+
+// AddOrReplace either adds or replaces the configuration for a given namespace.
+func (n *NamespaceOptions) AddOrReplace(options ...NamespaceOption) {
+nextOption:
+	for _, option := range options {
+		for i := range *n {
+			j := len(*n) - 1 - i
+			if (*n)[j].Name == option.Name {
+				(*n)[j] = option
+				continue nextOption
+			}
+		}
+		*n = append(*n, option)
+	}
+}
+
+// Find the configuration for the namespace of the given type.  If there are
+// duplicates, find the _last_ one of the type, since we assume it was appended
+// more recently.
+func (n *NamespaceOptions) Find(namespace string) *NamespaceOption {
+	for i := range *n {
+		j := len(*n) - 1 - i
+		if (*n)[j].Name == namespace {
+			return &((*n)[j])
+		}
+	}
+	return nil
+}
+
+// PushOptions can be used to alter how an image is copied somewhere.
+type PushOptions struct {
+	// Compression specifies the type of compression which is applied to
+	// layer blobs.  The default is to not use compression, but
+	// archive.Gzip is recommended.
+	Compression archive.Compression
+	// SignaturePolicyPath specifies an override location for the signature
+	// policy which should be used for verifying the new image as it is
+	// being written.  Except in specific circumstances, no value should be
+	// specified, indicating that the shared, system-wide default policy
+	// should be used.
+	SignaturePolicyPath string
+	// ReportWriter is an io.Writer which will be used to log the writing
+	// of the new image.
+	ReportWriter io.Writer
+	// Store is the local storage store which holds the source image.
+	Store storage.Store
+	// github.com/containers/image/types SystemContext to hold credentials
+	// and other authentication/authorization information.
+	SystemContext *types.SystemContext
+	// ManifestType is the format to use when saving the imge using the 'dir' transport
+	// possible options are oci, v2s1, and v2s2
+	ManifestType string
+	// BlobDirectory is the name of a directory in which we'll look for
+	// prebuilt copies of layer blobs that we might otherwise need to
+	// regenerate from on-disk layers, substituting them in the list of
+	// blobs to copy whenever possible.
+	BlobDirectory string
+	// Quiet is a boolean value that determines if minimal output to
+	// the user will be displayed, this is best used for logging.
+	// The default is false.
+	Quiet bool
+}

--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/docker"
+	bopts "github.com/containers/buildah/pkg/options"
 	"github.com/containers/buildah/util"
 	"github.com/containers/image/manifest"
 	is "github.com/containers/image/storage"
@@ -35,7 +36,7 @@ func main() {
 	driver := flag.String("storage-driver", storeOptions.GraphDriverName, "storage driver")
 	opts := flag.String("storage-opts", "", "storage option list (comma separated)")
 	policy := flag.String("signature-policy", "", "signature policy file")
-	mtype := flag.String("expected-manifest-type", buildah.OCIv1ImageManifest, "expected manifest type")
+	mtype := flag.String("expected-manifest-type", bopts.OCIv1ImageManifest, "expected manifest type")
 	showm := flag.Bool("show-manifest", false, "output the manifest JSON")
 	rebuildm := flag.Bool("rebuild-manifest", false, "rebuild the manifest JSON")
 	showc := flag.Bool("show-config", false, "output the configuration JSON")
@@ -46,10 +47,10 @@ func main() {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 	switch *mtype {
-	case buildah.OCIv1ImageManifest:
+	case bopts.OCIv1ImageManifest:
 		expectedManifestType = *mtype
 		expectedConfigType = v1.MediaTypeImageConfig
-	case buildah.Dockerv2ImageManifest:
+	case bopts.Dockerv2ImageManifest:
 		expectedManifestType = *mtype
 		expectedConfigType = manifest.DockerV2Schema2ConfigMediaType
 	case "*":
@@ -57,7 +58,7 @@ func main() {
 		expectedConfigType = ""
 	default:
 		logrus.Errorf("unknown -expected-manifest-type value, expected either %q or %q or %q",
-			buildah.OCIv1ImageManifest, buildah.Dockerv2ImageManifest, "*")
+			bopts.OCIv1ImageManifest, bopts.Dockerv2ImageManifest, "*")
 		return
 	}
 	if root != nil {
@@ -138,7 +139,7 @@ func main() {
 		}
 
 		switch expectedManifestType {
-		case buildah.OCIv1ImageManifest:
+		case bopts.OCIv1ImageManifest:
 			err = json.Unmarshal(manifest, &oManifest)
 			if err != nil {
 				logrus.Errorf("error parsing manifest from %q: %v", image, err)
@@ -153,7 +154,7 @@ func main() {
 			}
 			manifestType = v1.MediaTypeImageManifest
 			configType = oManifest.Config.MediaType
-		case buildah.Dockerv2ImageManifest:
+		case bopts.Dockerv2ImageManifest:
 			err = json.Unmarshal(manifest, &dManifest)
 			if err != nil {
 				logrus.Errorf("error parsing manifest from %q: %v", image, err)
@@ -175,7 +176,7 @@ func main() {
 			continue
 		}
 		switch manifestType {
-		case buildah.OCIv1ImageManifest:
+		case bopts.OCIv1ImageManifest:
 			if rebuildm != nil && *rebuildm {
 				err = json.Unmarshal(manifest, &oManifest)
 				if err != nil {
@@ -204,7 +205,7 @@ func main() {
 					continue
 				}
 			}
-		case buildah.Dockerv2ImageManifest:
+		case bopts.Dockerv2ImageManifest:
 			if rebuildm != nil && *rebuildm {
 				err = json.Unmarshal(manifest, &dManifest)
 				if err != nil {


### PR DESCRIPTION
Currently the podman-remote command needs access to the build options and the commit
options in the client.  Since these options are defined in buildah main line code, go
ends up sucking in the code and it makes it very difficult to compile this out on
Windows and Mac Platforms.

Bu moving the code to buildah/util subdir, we should be able to avoid these problems.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>