### PR TITLE
Fix typo in buildah-pull(1)

### DIFF
--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -1,7 +1,7 @@
 # buildah-pull "1" "July 2018" "buildah"
 
 ## NAME
-buildah\-pull - Creates a new working container using a specified image as a starting point.
+buildah\-pull - Pull an image from a registry.
 
 ## SYNOPSIS
 **buildah pull** [*options*] *image*


### PR DESCRIPTION
'buildah pull' doesn't create a working container. It only pulls an
image from a registry.

Fixes: 834a6c848ceae3c2 ("Create buildah pull command")

Signed-off-by: Debarshi Ray <rishi@fedoraproject.org>