### PR TITLE
Add upstream buildahimage

### DIFF
--- a/buildahimage/README.md
+++ b/buildahimage/README.md
@@ -11,7 +11,7 @@ resulting containers can run safely with privileges within the container.  The c
 using the latest Fedora and then Buildah is installed into them:
 
   * quay.io/buildah/buildahimage - This image is built using the latest stable version of Buildah in a Fedora based container.  Built with buildahimage/stable/Dockerfile.
-  * quay.io/buildah/buildahimagegit - This image is built using the latest code found in this GitHub repository.  When someone creates a commit and pushes it, the image is created.  Due to that the image changes frequently and is not guaranteed to be stable.  Containers built with this imsage have a Buildah development environment set up in the directory /root/buildah.  Built with buildahimage/git/Dockerfile.
+  * quay.io/buildah/buildahimageupstream - This image is built using the latest code found in this GitHub repository.  When someone creates a commit and pushes it, the image is created.  Due to that the image changes frequently and is not guaranteed to be stable.  Built with buildahimage/upstream/Dockerfile.
   * quay.io/buildah/buildahimagetesting - This image is built using the latest version of Buildah that is or was in updates testing for Fedora.  At times this may be the same as the stable image.  This container image will primarily be used by the development teams for verification testing when a new package is created.  Built with buildahimage/testing/Dockerfile.
 
 ## Sample Usage
@@ -40,8 +40,6 @@ podman exec -it  buildahctr /bin/sh
 buildah from alpine
 
 buildah images
-
-cd /root/buildah
 
 exit
 ```

--- a/buildahimage/stable/Dockerfile
+++ b/buildahimage/stable/Dockerfile
@@ -6,7 +6,7 @@
 # This image can be used to create a secured container
 # that runs safely with privileges within the container.
 #
-FROM fedora
+FROM fedora:latest
 
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking

--- a/buildahimage/testing/Dockerfile
+++ b/buildahimage/testing/Dockerfile
@@ -8,7 +8,7 @@
 # This image can be used to create a secured container
 # that runs safely with privileges within the container.
 #
-FROM fedora
+FROM fedora:latest
 
 # Don't include container-selinux and remove 
 # directories used by dnf that are just taking

--- a/buildahimage/upstream/Dockerfile
+++ b/buildahimage/upstream/Dockerfile
@@ -8,11 +8,16 @@
 # The containers created by this image also come with a
 # Buildah development environment in /root/buildah.
 #
-FROM fedora
+FROM fedora:latest
 ENV GOPATH=/root/buildah
 
 # Install the software required to build Buildah.
-RUN dnf -y install --enablerepo=updates-testing --exclude=container-selinux \
+# Then create a directory and clone from the Buildah
+# GitHub repository, make and install Buildah
+# to the container.
+# Finally remove the buildah directory and a few other packages
+# that are needed for building but not running Buildah
+RUN dnf -y install --enablerepo=updates-testing \
      make \
      golang \
      bats \
@@ -29,16 +34,15 @@ RUN dnf -y install --enablerepo=updates-testing --exclude=container-selinux \
      runc \
      fuse-overlayfs \
      fuse3 \
-     containers-common;
-
-# Create a directory and clone from the Buildah
-# GitHub repository, then make and install Buildah
-# to the container.
-RUN mkdir /root/buildah; \
+     containers-common; \
+     mkdir /root/buildah; \
      git clone https://github.com/containers/buildah /root/buildah/src/github.com/containers/buildah; \
      cd /root/buildah/src/github.com/containers/buildah; \
      make;\
-     make install
+     make install;\
+     rm -rf /root/buildah/*; \
+     dnf -y remove bats git golang go-md2man make; \
+     dnf clean all;
 
 # Adjust storage.conf to enable Fuse storage.
 RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
@@ -52,4 +56,3 @@ RUN mkdir /root/.config && ln -s /etc/containers /root/.config/containers
 # not starting with usernamespace and default to 
 # isolate the filesystem with chroot.
 ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
-


### PR DESCRIPTION
Add an upstream buildahimage, built like the git variant, but
remove the /root/buildah directory and packages required for
building but not running buildah.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>