### PR TITLE
Bump 1.8

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -26,7 +26,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.8-dev"
+	Version = "1.8"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/buildah.go
+++ b/buildah.go
@@ -26,7 +26,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.8"
+	Version = "1.9-dev"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,26 @@
+- Changelog for v1.8 (2019-04-25)
+  * Resolve symlink when checking container path
+  * commit: commit on every instruction, but not always with layers
+  * CommitOptions: drop the unused OnBuild field
+  * makeImageRef: pass in the whole CommitOptions structure
+  * cmd: API cleanup: stores before images
+  * run: check if SELinux is enabled
+  * Fix buildahimages Dockerfiles to include support for additionalimages mounted from host.
+  * Detect changes in rootdir
+  * Fix typo in buildah-pull(1)
+  * Vendor in latest containers/storage
+  * Keep track of any build-args used during buildah bud --layers
+  * commit: always set a parent ID
+  * imagebuildah: rework unused-argument detection
+  * fix bug dest path when COPY .dockerignore
+  * Move Host IDMAppings code from util to unshare
+  * Add BUILDAH_ISOLATION rootless back
+  * Travis CI: fail fast, upon error in any step
+  * imagebuildah: only commit images for intermediate stages if we have to
+  * Use errors.Cause() when checking for IsNotExist errors
+  * auto pass http_proxy to container
+  * Bump back to 1.8-dev
+
 - Changelog for v1.7.3 (2019-04-16)
   * imagebuildah: don't leak image structs
   * Add Dockerfiles for buildahimages

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in buildah.go too
-Version:        1.8
+Version:        1.9-dev
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,7 +100,9 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
-* Thu Apr 25, 2019 Tom Sweeney <tsweeney@redhat.com> 1.8-1
+* Thu Apr 25, 2019 Tom Sweeney <tsweeney@redhat.com> 1.9-dev-1
+
+* Thu Apr 25, 2019 Tom Sweeney <tsweeney@redhat.com> 1.8
   * Resolve symlink when checking container path
   * commit: commit on every instruction, but not always with layers
   * CommitOptions: drop the unused OnBuild field

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in buildah.go too
-Version:        1.8-dev
+Version:        1.8
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,7 +100,28 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
-* Tue Apr 16, 2019 Tom Sweeney <tsweeney@redhat.com> 1.8-dev-1
+* Thu Apr 25, 2019 Tom Sweeney <tsweeney@redhat.com> 1.8-1
+  * Resolve symlink when checking container path
+  * commit: commit on every instruction, but not always with layers
+  * CommitOptions: drop the unused OnBuild field
+  * makeImageRef: pass in the whole CommitOptions structure
+  * cmd: API cleanup: stores before images
+  * run: check if SELinux is enabled
+  * Fix buildahimages Dockerfiles to include support for additionalimages mounted from host.
+  * Detect changes in rootdir
+  * Fix typo in buildah-pull(1)
+  * Vendor in latest containers/storage
+  * Keep track of any build-args used during buildah bud --layers
+  * commit: always set a parent ID
+  * imagebuildah: rework unused-argument detection
+  * fix bug dest path when COPY .dockerignore
+  * Move Host IDMAppings code from util to unshare
+  * Add BUILDAH_ISOLATION rootless back
+  * Travis CI: fail fast, upon error in any step
+  * imagebuildah: only commit images for intermediate stages if we have to
+  * Use errors.Cause() when checking for IsNotExist errors
+  * auto pass http_proxy to container
+  * Bump back to 1.8-dev
 
 * Tue Apr 16, 2019 Tom Sweeney <tsweeney@redhat.com> 1.7.3
 - imagebuildah: don't leak image structs


### PR DESCRIPTION
Bump to 1.8.  I'd thought about 1.7.4, but given the Fedora 30 packaging and the change to c/storage here, I went to 1.8.