### PR TITLE
Handle WORKDIRs that are symlinks

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1164,3 +1164,19 @@ load helpers
   run_buildah --debug=false run ${ctr} ls -alF /usr/local/hbase 
   expect_output --substring "Dockerfile"
 }
+
+@test "bud WORKDIR isa symlink" {
+  target=alpine-image
+  ctr=alpine-ctr
+  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/workdir-symlink
+  expect_output --substring "STEP 3: RUN ln -sf "
+
+  run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
+  expect_output --substring ${ctr}
+
+  run_buildah --debug=false run ${ctr} ls -alF /tempest
+  expect_output --substring "/tempest -> /var/lib/tempest/"
+
+  run_buildah --debug=false run ${ctr} ls -alF /etc/notareal.conf 
+  expect_output --substring "\-rw\-rw\-r\-\-"
+}

--- a/tests/bud/workdir-symlink/Dockerfile
+++ b/tests/bud/workdir-symlink/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine 
+RUN mkdir /var/lib/tempest
+RUN ln -sf /var/lib/tempest /tempest
+WORKDIR /tempest
+RUN touch /etc/notareal.conf
+RUN chmod 664 /etc/notareal.conf


### PR DESCRIPTION
When a Dockerfile specified a WORKDIR that was
a symlink, the EnsureContainerPath() function
did not resolve the link to it's target and
caused failures.

Fixes: #1537

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>