### PR TITLE
Fix Transient Mounts

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -235,6 +235,16 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budResults) error {
 	namespaceOptions.AddOrReplace(usernsOption...)
 
 	defaultsMountFile, _ := c.PersistentFlags().GetString("defaults-mount-file")
+	transientMounts := []imagebuildah.Mount{}
+	for _, volume := range iopts.Volumes {
+		mount, err := parse.ParseVolume(volume)
+		if err != nil {
+			return err
+		}
+
+		transientMounts = append(transientMounts, imagebuildah.Mount(mount))
+	}
+
 	options := imagebuildah.BuildOptions{
 		ContextDirectory:        contextDir,
 		PullPolicy:              pullPolicy,
@@ -272,6 +282,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budResults) error {
 		ForceRmIntermediateCtrs: iopts.ForceRm,
 		BlobDirectory:           iopts.BlobCache,
 		Target:                  iopts.Target,
+		TransientMounts:         transientMounts,
 	}
 
 	if iopts.Quiet {

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -10,7 +10,6 @@ import (
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -153,21 +152,11 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 	}
 
 	for _, volumeSpec := range iopts.volumes {
-		volSpec := strings.Split(volumeSpec, ":")
-		if len(volSpec) >= 2 {
-			var mountOptions string
-			if len(volSpec) >= 3 {
-				mountOptions = volSpec[2]
-			}
-			mountOpts := strings.Split(mountOptions, ",")
-			mount := specs.Mount{
-				Source:      volSpec[0],
-				Destination: volSpec[1],
-				Type:        "bind",
-				Options:     mountOpts,
-			}
-			options.Mounts = append(options.Mounts, mount)
+		mount, err := parse.ParseVolume(volumeSpec)
+		if err != nil {
+			return err
 		}
+		options.Mounts = append(options.Mounts, mount)
 	}
 	runerr := builder.Run(args, options)
 	if runerr != nil {

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -96,7 +96,7 @@ type FromAndBudResults struct {
 	SecurityOpt  []string
 	ShmSize      string
 	Ulimit       []string
-	Volume       []string
+	Volumes      []string
 }
 
 // GetUserNSFlags returns the common flags for usernamespace
@@ -190,7 +190,7 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 	fs.StringArrayVar(&flags.SecurityOpt, "security-opt", []string{}, "security options (default [])")
 	fs.StringVar(&flags.ShmSize, "shm-size", "65536k", "size of '/dev/shm'. The format is `<number><unit>`.")
 	fs.StringSliceVar(&flags.Ulimit, "ulimit", []string{}, "ulimit options (default [])")
-	fs.StringSliceVarP(&flags.Volume, "volume", "v", []string{}, "bind mount a volume into the container (default [])")
+	fs.StringSliceVarP(&flags.Volumes, "volume", "v", []string{}, "bind mount a volume into the container (default [])")
 
 	// Add in the usernamespace and namespaceflags
 	usernsFlags := GetUserNSFlags(usernsResults)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1180,3 +1180,8 @@ load helpers
   run_buildah --debug=false run ${ctr} ls -alF /etc/notareal.conf 
   expect_output --substring "\-rw\-rw\-r\-\-"
 }
+
+@test "buidah bud --volume" {
+  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
+  expect_output --substring "/testdir"
+}

--- a/tests/bud/mount/Dockerfile
+++ b/tests/bud/mount/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine
+RUN mount

--- a/vendor/github.com/fsouza/go-dockerclient/go.mod
+++ b/vendor/github.com/fsouza/go-dockerclient/go.mod
@@ -1,0 +1,42 @@
+module github.com/fsouza/go-dockerclient
+
+require (
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+	github.com/Microsoft/go-winio v0.4.11
+	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5
+	github.com/containerd/continuity v0.0.0-20180814194400-c7c5070e6f6e // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/docker v0.7.3-0.20180827131323-0c5f8d2b9b23
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.3.3
+	github.com/docker/libnetwork v0.8.0-dev.2.0.20180608203834-19279f049241 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/gogo/protobuf v1.1.1 // indirect
+	github.com/golang/protobuf v1.2.0 // indirect
+	github.com/google/go-cmp v0.2.0
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/mux v1.6.2
+	github.com/hpcloud/tail v1.0.0 // indirect
+	github.com/onsi/ginkgo v1.6.0 // indirect
+	github.com/onsi/gomega v1.4.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/opencontainers/runc v0.1.1 // indirect
+	github.com/pkg/errors v0.8.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.0.6
+	github.com/stretchr/testify v1.2.2 // indirect
+	github.com/vishvananda/netlink v1.0.0 // indirect
+	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
+	golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac // indirect
+	golang.org/x/net v0.0.0-20180826012351-8a410e7b638d // indirect
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
+	golang.org/x/sys v0.0.0-20180824143301-4910a1d54f87
+	golang.org/x/text v0.3.0 // indirect
+	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
+	gopkg.in/fsnotify.v1 v1.4.7 // indirect
+	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.2.1 // indirect
+	gotest.tools v2.1.0+incompatible // indirect
+)

--- a/vendor/github.com/hashicorp/errwrap/go.mod
+++ b/vendor/github.com/hashicorp/errwrap/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/errwrap

--- a/vendor/github.com/hashicorp/go-multierror/go.mod
+++ b/vendor/github.com/hashicorp/go-multierror/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/go-multierror
+
+require github.com/hashicorp/errwrap v1.0.0

--- a/vendor/golang.org/x/text/go.mod
+++ b/vendor/golang.org/x/text/go.mod
@@ -1,0 +1,3 @@
+module golang.org/x/text
+
+require golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e

--- a/vendor/gopkg.in/yaml.v2/go.mod
+++ b/vendor/gopkg.in/yaml.v2/go.mod
@@ -1,0 +1,5 @@
+module "gopkg.in/yaml.v2"
+
+require (
+	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+)


### PR DESCRIPTION
buildah bud is ignoring --volumes flag.

This patch parses the volumes and then passes them into the builder to be used.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>