### PR TITLE
Test bud copying from rootdir

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -278,8 +278,8 @@ load helpers
 
 @test "bud-from-scratch-iid" {
   target=scratch-image
-  buildah bud --iidfile output.iid --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
-  iid=$(cat output.iid)
+  buildah bud --iidfile ${TESTDIR}/output.iid --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  iid=$(cat ${TESTDIR}/output.iid)
   cid=$(buildah from ${iid})
   buildah rm ${cid}
   buildah rmi $(buildah --debug=false images -q)

--- a/tests/bud/use-layers/Dockerfile.7
+++ b/tests/bud/use-layers/Dockerfile.7
@@ -1,0 +1,2 @@
+FROM alpine
+COPY . world/


### PR DESCRIPTION
Following up on #1511 with a test. (Thanks for merging 1511 by the way!)

Verified to fail prior to #1511 merging, and to pass after it was merged.

Also updated an unrelated test to put it's `output.iid` scratch file into TESTDIR. This both seemed like a common pattern for these tests and avoids leaving around a scratch file to dirty up the working directory after running tests locally.

Also unrelated, but it was a bit tricky to get these tests running. It wasn't clear how to run them or what dependencies needed to be installed (to further complicate things I'm using Fedora Silverblue where `go` and other build tools are inside a toolbox podman container). If I have some time I'll try to PR a testing section for  `CONTRIBUTING.md`