### PR TITLE
imagebuildah: don't remove intermediate images if we need them

### DIFF
--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -32,48 +32,48 @@ func TestSizeFormatting(t *testing.T) {
 }
 
 func TestMatchWithTag(t *testing.T) {
-	isMatch := matchesReference("docker.io/kubernetes/pause:latest", "pause:latest")
+	isMatch := matchesReference("gcr.io/pause:latest", "pause:latest")
 	if !isMatch {
 		t.Error("expected match, got not match")
 	}
 
-	isMatch = matchesReference("docker.io/kubernetes/pause:latest", "kubernetes/pause:latest")
-	if !isMatch {
-		t.Error("expected match, got no match")
+	isMatch = matchesReference("gcr.io/pause:latest", "kubernetes/pause:latest")
+	if isMatch {
+		t.Error("expected not match, got match")
 	}
 }
 
 func TestNoMatchesReferenceWithTag(t *testing.T) {
-	isMatch := matchesReference("docker.io/kubernetes/pause:latest", "redis:latest")
+	isMatch := matchesReference("gcr.io/pause:latest", "redis:latest")
 	if isMatch {
 		t.Error("expected no match, got match")
 	}
 
-	isMatch = matchesReference("docker.io/kubernetes/pause:latest", "kubernetes/redis:latest")
+	isMatch = matchesReference("gcr.io/pause:latest", "kubernetes/redis:latest")
 	if isMatch {
 		t.Error("expected no match, got match")
 	}
 }
 
 func TestMatchesReferenceWithoutTag(t *testing.T) {
-	isMatch := matchesReference("docker.io/kubernetes/pause:latest", "pause")
+	isMatch := matchesReference("gcr.io/pause:latest", "pause")
 	if !isMatch {
 		t.Error("expected match, got not match")
 	}
 
-	isMatch = matchesReference("docker.io/kubernetes/pause:latest", "kubernetes/pause")
-	if !isMatch {
-		t.Error("expected match, got no match")
+	isMatch = matchesReference("gcr.io/pause:latest", "kubernetes/pause")
+	if isMatch {
+		t.Error("expected not match, got match")
 	}
 }
 
 func TestNoMatchesReferenceWithoutTag(t *testing.T) {
-	isMatch := matchesReference("docker.io/kubernetes/pause:latest", "redis")
+	isMatch := matchesReference("gcr.io/pause:latest", "redis")
 	if isMatch {
 		t.Error("expected no match, got match")
 	}
 
-	isMatch = matchesReference("docker.io/kubernetes/pause:latest", "kubernetes/redis")
+	isMatch = matchesReference("gcr.io/pause:latest", "kubernetes/redis")
 	if isMatch {
 		t.Error("expected no match, got match")
 	}

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1558,6 +1558,9 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 		// stages.
 		for i := range cleanupImages {
 			removeID := cleanupImages[len(cleanupImages)-i-1]
+			if removeID == imageID {
+				continue
+			}
 			if _, err := b.store.DeleteImage(removeID, true); err != nil {
 				logrus.Debugf("failed to remove intermediate image %q: %v", removeID, err)
 				if b.forceRmIntermediateCtrs || errors.Cause(err) != storage.ErrImageUsedByContainer {
@@ -1663,6 +1666,7 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 			if !b.layers {
 				cleanupImages = append(cleanupImages, imageID)
 			}
+			imageID = ""
 		}
 	}
 

--- a/tests/blobcache.bats
+++ b/tests/blobcache.bats
@@ -6,7 +6,7 @@ load helpers
 	blobcachedir=${TESTDIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah pull --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json docker.io/kubernetes/pause
+	run_buildah pull --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
 	# Check that we dropped some files in there.
 	run find ${blobcachedir} -type f
 	echo "$output"
@@ -18,7 +18,7 @@ load helpers
 	blobcachedir=${TESTDIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah from --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json docker.io/kubernetes/pause
+	run_buildah from --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
 	# Check that we dropped some files in there.
 	run find ${blobcachedir} -type f
 	echo "$output"
@@ -30,7 +30,7 @@ load helpers
 	blobcachedir=${TESTDIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah --debug=false from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json docker.io/kubernetes/pause
+	run_buildah --debug=false from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
 	ctr="$output"
 	run_buildah add ${ctr} ${TESTSDIR}/bud/add-file/file /
 	# Commit the image without using the blob cache, using compression so that uncompressed blobs
@@ -97,7 +97,7 @@ load helpers
 	blobcachedir=${TESTDIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah --debug=false from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json docker.io/kubernetes/pause
+	run_buildah --debug=false from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
 	ctr="$output"
 	run_buildah add ${ctr} ${TESTSDIR}/bud/add-file/file /
 	# Commit the image using the blob cache.

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -147,6 +147,15 @@ load helpers
   buildah rmi -a -f
 }
 
+@test "bud-multistage-reused" {
+  target=foo
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah rmi -f ${target}
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --layers -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json ${target}
+}
+
 @test "bud with --layers and symlink file" {
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
   echo 'echo "Hello World!"' > ${TESTDIR}/use-layers/hello.sh

--- a/tests/bud/multi-stage-builds/Dockerfile.reused
+++ b/tests/bud/multi-stage-builds/Dockerfile.reused
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN pwd
+FROM base
+RUN pwd
+FROM base

--- a/tests/byid.bats
+++ b/tests/byid.bats
@@ -55,7 +55,7 @@ load helpers
 }
 
 @test "push-by-id" {
-  for image in busybox kubernetes/pause ; do
+  for image in busybox k8s.gcr.io/pause ; do
     echo pulling/pushing image $image
 
     TARGET=${TESTDIR}/subdir-$(basename $image)

--- a/tests/digest.bats
+++ b/tests/digest.bats
@@ -16,7 +16,7 @@ fromreftest() {
 }
 
 @test "from-by-digest-s1" {
-  fromreftest kubernetes/pause@sha256:f8cd50c5a287dd8c5f226cf69c60c737d34ed43726c14b8a746d9de2d23eda2b
+  fromreftest k8s.gcr.io/pause@sha256:bbeaef1d40778579b7b86543fe03e1ec041428a50d21f7a7b25630e357ec9247
 }
 
 @test "from-by-digest-s1-a-discarded-layer" {
@@ -24,11 +24,7 @@ fromreftest() {
 }
 
 @test "from-by-tag-s1" {
-  fromreftest kubernetes/pause:go
-}
-
-@test "from-by-repo-only-s1" {
-  fromreftest kubernetes/pause
+  fromreftest k8s.gcr.io/pause:0.8.0
 }
 
 @test "from-by-digest-s2" {

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -41,9 +41,9 @@ load helpers
 }
 
 @test "images filter test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json kubernetes/pause)
+  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false images --noheading --filter since=kubernetes/pause
+  run_buildah --debug=false images --noheading --filter since=k8s.gcr.io/pause
   expect_line_count 1
   buildah rm -a
   buildah rmi -a -f

--- a/util/util.go
+++ b/util/util.go
@@ -197,7 +197,7 @@ func FindImage(store storage.Store, firstRegistry string, systemContext *types.S
 		break
 	}
 	if ref == nil || img == nil {
-		return nil, nil, errors.Wrapf(err, "error locating image with name %q", image)
+		return nil, nil, errors.Wrapf(err, "error locating image with name %q (%v)", image, names)
 	}
 	return ref, img, nil
 }


### PR DESCRIPTION
In multistage builds without caching, if an intermediate stage's image ended up being the final image (i.e., when the last instruction in the Dockerfile is a FROM instruction that references a previous stage), we would remove it when we finished building.  Fix that by modifying the cleanup logic to compare the ID of an image that it's about to delete to the final image's ID, if it has one, and skipping it if they match.