### PR TITLE
Don't create directory on container

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1816,25 +1816,13 @@ func (b *Executor) deleteSuccessfulIntermediateCtrs() error {
 }
 
 func (s *StageExecutor) EnsureContainerPath(path string) error {
-	// Check the path to see if it's a symlink, if
-	// so convert it to it's target for processing.
 	targetPath := filepath.Join(s.mountPoint, path)
-	fileDest, _ := os.Lstat(targetPath)
-	if fileDest != nil {
-		if fileDest.Mode()&os.ModeSymlink != 0 {
-			if symLink, err := resolveSymlink(s.mountPoint, path); err == nil {
-				targetPath = symLink
-			} else {
-				return errors.Wrapf(err, "error reading symbolic link to %q", targetPath)
-			}
-		}
-	}
-	_, err := os.Stat(targetPath)
+	_, err := os.Lstat(targetPath)
 	if err != nil && os.IsNotExist(err) {
 		err = os.MkdirAll(targetPath, 0755)
 	}
 	if err != nil {
-		return errors.Wrapf(err, "error ensuring container path %q", targetPath)
+		return errors.Wrapf(err, "error ensuring container path %q", path)
 	}
 	return nil
 }

--- a/run_linux.go
+++ b/run_linux.go
@@ -142,7 +142,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	g = nil
 
 	logrus.Debugf("ensuring working directory %q exists", filepath.Join(mountPoint, spec.Process.Cwd))
-	if err = os.MkdirAll(filepath.Join(mountPoint, spec.Process.Cwd), 0755); err != nil {
+	if err = os.MkdirAll(filepath.Join(mountPoint, spec.Process.Cwd), 0755); err != nil && !os.IsExist(err) {
 		return errors.Wrapf(err, "error ensuring working directory %q exists", spec.Process.Cwd)
 	}
 

--- a/tests/bud/copy-from/Dockerfile
+++ b/tests/bud/copy-from/Dockerfile
@@ -1,2 +1,2 @@
-FROM php:7.2 
+FROM php:7.2
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer


### PR DESCRIPTION
In a prior PR, we were creating the directory from the
translated symlink onto the host container.  Instead
try to create that in the container and if it exists
already, just continue.

Fixes: #1562

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>