### PR TITLE
commit/push: use an everything-allowed policy

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -106,6 +106,22 @@ type PushOptions struct {
 	Quiet bool
 }
 
+var (
+	// commitPolicy bypasses any signing requirements when committing containers to images
+	commitPolicy = &signature.Policy{
+		Default: []signature.PolicyRequirement{signature.NewPRReject()},
+		Transports: map[string]signature.PolicyTransportScopes{
+			is.Transport.Name(): {
+				"": []signature.PolicyRequirement{
+					signature.NewPRInsecureAcceptAnything(),
+				},
+			},
+		},
+	}
+	// pushPolicy bypasses any signing requirements when pushing (copying) images from local storage
+	pushPolicy = commitPolicy
+)
+
 // Commit writes the contents of the container, along with its updated
 // configuration, to a new image in the specified location, and if we know how,
 // add any additional tags that were specified. Returns the ID of the new image
@@ -141,11 +157,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 		return "", nil, "", errors.Errorf("commit access to registry for %q is blocked by configuration", transports.ImageName(dest))
 	}
 
-	policy, err := signature.DefaultPolicy(systemContext)
-	if err != nil {
-		return imgID, nil, "", errors.Wrapf(err, "error obtaining default signature policy")
-	}
-	policyContext, err := signature.NewPolicyContext(policy)
+	policyContext, err := signature.NewPolicyContext(commitPolicy)
 	if err != nil {
 		return imgID, nil, "", errors.Wrapf(err, "error creating new signature policy context")
 	}
@@ -280,11 +292,7 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 		return nil, "", errors.Errorf("push access to registry for %q is blocked by configuration", transports.ImageName(dest))
 	}
 
-	policy, err := signature.DefaultPolicy(systemContext)
-	if err != nil {
-		return nil, "", errors.Wrapf(err, "error obtaining default signature policy")
-	}
-	policyContext, err := signature.NewPolicyContext(policy)
+	policyContext, err := signature.NewPolicyContext(pushPolicy)
 	if err != nil {
 		return nil, "", errors.Wrapf(err, "error creating new signature policy context")
 	}

--- a/tests/deny.json
+++ b/tests/deny.json
@@ -1,0 +1,7 @@
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ]
+}

--- a/tests/docker.json
+++ b/tests/docker.json
@@ -1,0 +1,6 @@
+{
+    "default": [ { "type": "reject" } ],
+    "transports": {
+        "docker": { "": [ { "type": "insecureAcceptAnything" } ] }
+    }
+}


### PR DESCRIPTION
Ignore the global signature policy, which is used to control whether or not we can trust an image, when we're attempting to commit an image from a container, or pushing an image.  The global policy still affects pulling of base images at the time when we pull them, which I _think_ is correct.