### PR TITLE
Make buildah run --isolation follow BUILDAH_ISOLATION environment

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -59,7 +59,7 @@ func init() {
 	flags.StringSliceVar(&opts.capAdd, "cap-add", []string{}, "add the specified capability (default []")
 	flags.StringSliceVar(&opts.capDrop, "cap-drop", []string{}, "drop the specified capability (default [])")
 	flags.StringVar(&opts.hostname, "hostname", "", "set the hostname inside of the container")
-	flags.StringVar(&opts.isolation, "isolation", "", "which process isolation `type` to use")
+	flags.StringVar(&opts.isolation, "isolation", buildahcli.DefaultIsolation(), "`type` of process isolation to use. Use BUILDAH_ISOLATION environment variable to override.")
 	flags.StringVar(&opts.runtime, "runtime", util.Runtime(), "`path` to an alternate OCI runtime")
 	flags.StringSliceVar(&opts.runtimeFlag, "runtime-flag", []string{}, "add global flags for the container runtime")
 	flags.BoolVar(&opts.noPivot, "no-pivot", false, "do not use pivot root to jail process inside rootfs")
@@ -103,12 +103,9 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 		return errors.Wrapf(err, "error reading build container %q", name)
 	}
 
-	isolation := builder.Isolation
-	if c.Flag("isolation").Changed {
-		isolation, err = parse.IsolationOption(c)
-		if err != nil {
-			return err
-		}
+	isolation, err := parse.IsolationOption(c)
+	if err != nil {
+		return err
 	}
 
 	runtimeFlags := []string{}


### PR DESCRIPTION
Currently buildah run ignores the variable.

Closes: https://github.com/containers/buildah/issues/1584

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>