### PR TITLE
Apply SHELL during image build time

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -589,7 +589,11 @@ func (s *StageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 
 	args := run.Args
 	if run.Shell {
-		args = append([]string{"/bin/sh", "-c"}, args...)
+		if len(config.Shell) > 0 && s.builder.Format == buildah.Dockerv2ImageManifest {
+			args = append(config.Shell, args...)
+		} else {
+			args = append([]string{"/bin/sh", "-c"}, args...)
+		}
 	}
 	if err := s.volumeCacheSave(); err != nil {
 		return err

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -635,6 +635,42 @@ load helpers
   expect_output ""
 }
 
+@test "bud-shell during build in Docker format" {
+  target=alpine-image
+  run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
+  expect_output --substring "SHELL=/bin/sh"
+  buildah rmi -a
+  run_buildah --debug=false images -q
+  expect_output ""
+}
+
+@test "bud-shell during build in OCI format" {
+  target=alpine-image
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
+  expect_output --substring "SHELL=/bin/sh"
+  buildah rmi -a
+  run_buildah --debug=false images -q
+  expect_output ""
+}
+
+@test "bud-shell changed during build in Docker format" {
+  target=ubuntu-image
+  run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
+  expect_output --substring "SHELL=/bin/bash"
+  buildah rmi -a
+  run_buildah --debug=false images -q
+  expect_output ""
+}
+
+@test "bud-shell changed during build in OCI format" {
+  target=ubuntu-image
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
+  expect_output --substring "SHELL=/bin/sh"
+  buildah rmi -a
+  run_buildah --debug=false images -q
+  expect_output ""
+}
+
 @test "bud with symlinks" {
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/symlink

--- a/tests/bud/shell/Dockerfile.build-shell-custom
+++ b/tests/bud/shell/Dockerfile.build-shell-custom
@@ -1,0 +1,3 @@
+FROM ubuntu
+SHELL [ "/bin/bash", "-c" ]
+RUN echo "SHELL=$0"

--- a/tests/bud/shell/Dockerfile.build-shell-default
+++ b/tests/bud/shell/Dockerfile.build-shell-default
@@ -1,0 +1,2 @@
+FROM alpine
+RUN echo "SHELL=$0"


### PR DESCRIPTION
# Overview
This PR fixes the behaviour of `SHELL` by making sure that it applies during image build time in addition to existing functionality. Resolves #1581.

# Testing
4 new tests added:
- default shell + OCI format
- default shell + Docker format
- custom shell + OCI format
- custom shell + Docker format

Output:
```
 ✓ bud-shell during build in Docker format
 ✓ bud-shell during build in OCI format
 ✓ bud-shell changed during build in Docker format
 ✓ bud-shell changed during build in OCI format
...
296 tests, 10 failures, 5 skipped
```
10 tests that are failing (as far as I can see) rely on an image registry being setup at `localhost`. Therefore, I don't think they're caused by my changes.

# Signing
Signed-off-by: Eric Hripko <ehripko@bloomberg.net>