### PR TITLE
imagebuildah: tighten cache checking back up

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1218,6 +1218,13 @@ func (s *StageExecutor) layerExists(ctx context.Context, currNode *parser.Node, 
 	if err != nil {
 		return "", errors.Wrap(err, "error getting image list from store")
 	}
+	var baseHistory []v1.History
+	if s.builder.FromImageID != "" {
+		baseHistory, err = s.executor.getImageHistory(ctx, s.builder.FromImageID)
+		if err != nil {
+			return "", errors.Wrapf(err, "error getting history of base image %q", s.builder.FromImageID)
+		}
+	}
 	for _, image := range images {
 		var imageTopLayer *storage.Layer
 		if image.TopLayer != "" {
@@ -1236,7 +1243,7 @@ func (s *StageExecutor) layerExists(ctx context.Context, currNode *parser.Node, 
 				return "", errors.Wrapf(err, "error getting history of %q", image.ID)
 			}
 			// children + currNode is the point of the Dockerfile we are currently at.
-			if s.executor.historyMatches(append(children, currNode), history) {
+			if s.executor.historyMatches(baseHistory, currNode, history) {
 				// This checks if the files copied during build have been changed if the node is
 				// a COPY or ADD command.
 				filesMatch, err := s.copiedFilesMatch(currNode, history[len(history)-1].Created)
@@ -1285,32 +1292,60 @@ func (b *Executor) getCreatedBy(node *parser.Node) string {
 	return "/bin/sh -c #(nop) " + node.Original
 }
 
-// historyMatches returns true if the history of the image matches the lines
-// in the Dockerfile till the point of build we are at.
+// historyMatches returns true if a candidate history matches the history of our
+// base image (if we have one), plus the current instruction.
 // Used to verify whether a cache of the intermediate image exists and whether
 // to run the build again.
-func (b *Executor) historyMatches(children []*parser.Node, history []v1.History) bool {
-	i := len(history) - 1
-	for j := len(children) - 1; j >= 0; j-- {
-		instruction := children[j].Original
-		if children[j].Value == "run" {
-			instruction = instruction[4:]
-			buildArgs := b.getBuildArgs()
-			// If a previous image was built with some build-args but the new build process doesn't have any build-args
-			// specified, so compare the lengths of the old instruction with the current one
-			// 11 is the length of "/bin/sh -c " that is used to run the run commands
-			if buildArgs == "" && len(history[i].CreatedBy) > len(instruction)+11 {
-				return false
-			}
-			// There are build-args, so check if anything with the build-args has changed
-			if buildArgs != "" && !strings.Contains(history[i].CreatedBy, buildArgs) {
-				return false
-			}
-		}
-		if !strings.Contains(history[i].CreatedBy, instruction) {
+func (b *Executor) historyMatches(baseHistory []v1.History, child *parser.Node, history []v1.History) bool {
+	if len(baseHistory) >= len(history) {
+		return false
+	}
+	if len(history)-len(baseHistory) != 1 {
+		return false
+	}
+	for i := range baseHistory {
+		if baseHistory[i].CreatedBy != history[i].CreatedBy {
 			return false
 		}
-		i--
+		if baseHistory[i].Comment != history[i].Comment {
+			return false
+		}
+		if baseHistory[i].Author != history[i].Author {
+			return false
+		}
+		if baseHistory[i].EmptyLayer != history[i].EmptyLayer {
+			return false
+		}
+		if baseHistory[i].Created != nil && history[i].Created == nil {
+			return false
+		}
+		if baseHistory[i].Created == nil && history[i].Created != nil {
+			return false
+		}
+		if baseHistory[i].Created != nil && history[i].Created != nil && *baseHistory[i].Created != *history[i].Created {
+			return false
+		}
+	}
+	instruction := child.Original
+	switch strings.ToUpper(child.Value) {
+	case "RUN":
+		instruction = instruction[4:]
+		buildArgs := b.getBuildArgs()
+		// If a previous image was built with some build-args but the new build process doesn't have any build-args
+		// specified, the command might be expanded differently, so compare the lengths of the old instruction with
+		// the current one.  11 is the length of "/bin/sh -c " that is used to run the run commands.
+		if buildArgs == "" && len(history[len(baseHistory)].CreatedBy) > len(instruction)+11 {
+			return false
+		}
+		// There are build-args, so check if anything with the build-args has changed
+		if buildArgs != "" && !strings.Contains(history[len(baseHistory)].CreatedBy, buildArgs) {
+			return false
+		}
+		fallthrough
+	default:
+		if !strings.Contains(history[len(baseHistory)].CreatedBy, instruction) {
+			return false
+		}
 	}
 	return true
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -158,6 +158,19 @@ load helpers
   run_buildah from --signature-policy ${TESTSDIR}/policy.json ${target}
 }
 
+@test "bud-multistage-cache" {
+  target=foo
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.extended ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid="$output"
+  run_buildah --debug=false mount "$cid"
+  root="$output"
+  # cache should have used this one
+  test -r "$root"/tmp/preCommit
+  # cache should not have used this one
+  ! test -r "$root"/tmp/postCommit
+}
+
 @test "bud with --layers and symlink file" {
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
   echo 'echo "Hello World!"' > ${TESTDIR}/use-layers/hello.sh

--- a/tests/bud/multi-stage-builds/Dockerfile.extended
+++ b/tests/bud/multi-stage-builds/Dockerfile.extended
@@ -1,0 +1,13 @@
+FROM busybox:latest AS builder
+ENV "BUILD_LOGLEVEL"="5"
+RUN touch /tmp/preCommit
+ENTRYPOINT /bin/sleep 600
+ENV "OPENSHIFT_BUILD_NAME"="mydockertest-1" "OPENSHIFT_BUILD_NAMESPACE"="default"
+LABEL "io.openshift.build.name"="mydockertest-1" "io.openshift.build.namespace"="default"
+
+FROM builder
+ENV "BUILD_LOGLEVEL"="5"
+RUN touch /tmp/postCommit
+
+FROM builder
+ENV "BUILD_LOGLEVEL"="5"


### PR DESCRIPTION
Since we started adding layers for only certain instructions (somewhere around 74a319586ecbf3207c6bb18e83cfc0557ca47368), history matching for cached images hasn't been precise enough.  Since we now include a full image history, though, we can compare a candidate cache image's history with our base image's exactly, and then check if the current instruction would produce its final history entry.