### PR TITLE
Add default /root if empty on chroot iso

### DIFF
--- a/add.go
+++ b/add.go
@@ -100,7 +100,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		}
 	}()
 	// Find out which user (and group) the destination should belong to.
-	user, err := b.user(mountPoint, options.Chown)
+	user, _, err := b.user(mountPoint, options.Chown)
 	if err != nil {
 		return err
 	}
@@ -153,12 +153,12 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 }
 
 // user returns the user (and group) information which the destination should belong to.
-func (b *Builder) user(mountPoint string, userspec string) (specs.User, error) {
+func (b *Builder) user(mountPoint string, userspec string) (specs.User, string, error) {
 	if userspec == "" {
 		userspec = b.User()
 	}
 
-	uid, gid, err := chrootuser.GetUser(mountPoint, userspec)
+	uid, gid, homeDir, err := chrootuser.GetUser(mountPoint, userspec)
 	u := specs.User{
 		UID:      uid,
 		GID:      gid,
@@ -175,7 +175,7 @@ func (b *Builder) user(mountPoint string, userspec string) (specs.User, error) {
 		}
 
 	}
-	return u, err
+	return u, homeDir, err
 }
 
 // dockerIgnore struct keep info from .dockerignore

--- a/chroot/run.go
+++ b/chroot/run.go
@@ -84,9 +84,18 @@ type runUsingChrootExecSubprocOptions struct {
 // RunUsingChroot runs a chrooted process, using some of the settings from the
 // passed-in spec, and using the specified bundlePath to hold temporary files,
 // directories, and mountpoints.
-func RunUsingChroot(spec *specs.Spec, bundlePath string, stdin io.Reader, stdout, stderr io.Writer) (err error) {
+func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reader, stdout, stderr io.Writer) (err error) {
 	var confwg sync.WaitGroup
-
+	var homeFound bool
+	for _, env := range spec.Process.Env {
+		if strings.HasPrefix(env, "HOME=") {
+			homeFound = true
+			break
+		}
+	}
+	if !homeFound {
+		spec.Process.Env = append(spec.Process.Env, fmt.Sprintf("HOME=%s", homeDir))
+	}
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 

--- a/chroot/run_test.go
+++ b/chroot/run_test.go
@@ -90,7 +90,7 @@ func testMinimal(t *testing.T, modify func(g *generate.Generator, rootDir, bundl
 	}
 
 	output := new(bytes.Buffer)
-	if err := RunUsingChroot(g.Config, bundleDir, new(bytes.Buffer), output, output); err != nil {
+	if err := RunUsingChroot(g.Config, bundleDir, "/", new(bytes.Buffer), output, output); err != nil {
 		t.Fatalf("run: %v: %s", err, output.String())
 	}
 

--- a/pkg/chrootuser/user.go
+++ b/pkg/chrootuser/user.go
@@ -18,7 +18,7 @@ var (
 // it will use the /etc/passwd and /etc/group files inside of the rootdir
 // to return this information.
 // userspec format [user | user:group | uid | uid:gid | user:gid | uid:group ]
-func GetUser(rootdir, userspec string) (uint32, uint32, error) {
+func GetUser(rootdir, userspec string) (uint32, uint32, string, error) {
 	var gid64 uint64
 	var gerr error = user.UnknownGroupError("error looking up group")
 
@@ -26,7 +26,7 @@ func GetUser(rootdir, userspec string) (uint32, uint32, error) {
 	userspec = spec[0]
 	groupspec := ""
 	if userspec == "" {
-		return 0, 0, nil
+		return 0, 0, "/", nil
 	}
 	if len(spec) > 1 {
 		groupspec = spec[1]
@@ -65,15 +65,21 @@ func GetUser(rootdir, userspec string) (uint32, uint32, error) {
 		}
 	}
 
-	if uerr == nil && gerr == nil {
-		return uint32(uid64), uint32(gid64), nil
+	homedir, err := lookupHomedirInContainer(rootdir, uid64)
+	if err != nil {
+		homedir = "/"
 	}
 
-	err := errors.Wrapf(uerr, "error determining run uid")
+	if uerr == nil && gerr == nil {
+		return uint32(uid64), uint32(gid64), homedir, nil
+	}
+
+	err = errors.Wrapf(uerr, "error determining run uid")
 	if uerr == nil {
 		err = errors.Wrapf(gerr, "error determining run gid")
 	}
-	return 0, 0, err
+
+	return 0, 0, homedir, err
 }
 
 // GetGroup returns the gid by looking it up in the /etc/group file

--- a/pkg/chrootuser/user_basic.go
+++ b/pkg/chrootuser/user_basic.go
@@ -25,3 +25,7 @@ func lookupAdditionalGroupsForUIDInContainer(rootdir string, userid uint64) (gid
 func lookupUIDInContainer(rootdir string, uid uint64) (string, uint64, error) {
 	return "", 0, errors.New("UID lookup not supported")
 }
+
+func lookupHomedirInContainer(rootdir string, uid uint64) (string, error) {
+	return "", errors.New("Home directory lookup not supported")
+}

--- a/run_linux.go
+++ b/run_linux.go
@@ -131,7 +131,8 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		return err
 	}
 
-	if err := b.configureUIDGID(g, mountPoint, options); err != nil {
+	homeDir, err := b.configureUIDGID(g, mountPoint, options)
+	if err != nil {
 		return err
 	}
 
@@ -210,7 +211,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		}
 		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, configureNetworks, moreCreateArgs, spec, mountPoint, path, Package+"-"+filepath.Base(path))
 	case IsolationChroot:
-		err = chroot.RunUsingChroot(spec, path, options.Stdin, options.Stdout, options.Stderr)
+		err = chroot.RunUsingChroot(spec, path, homeDir, options.Stdin, options.Stdout, options.Stderr)
 	case IsolationOCIRootless:
 		moreCreateArgs := []string{"--no-new-keyring"}
 		if options.NoPivot {
@@ -1775,14 +1776,14 @@ func getDNSIP(dnsServers []string) (dns []net.IP, err error) {
 	return dns, nil
 }
 
-func (b *Builder) configureUIDGID(g *generate.Generator, mountPoint string, options RunOptions) error {
+func (b *Builder) configureUIDGID(g *generate.Generator, mountPoint string, options RunOptions) (string, error) {
 	// Set the user UID/GID/supplemental group list/capabilities lists.
-	user, err := b.user(mountPoint, options.User)
+	user, homeDir, err := b.user(mountPoint, options.User)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if err := setupCapabilities(g, b.AddCapabilities, b.DropCapabilities, options.AddCapabilities, options.DropCapabilities); err != nil {
-		return err
+		return "", err
 	}
 	g.SetProcessUID(user.UID)
 	g.SetProcessGID(user.GID)
@@ -1797,7 +1798,7 @@ func (b *Builder) configureUIDGID(g *generate.Generator, mountPoint string, opti
 		g.Config.Process.Capabilities.Bounding = bounding
 	}
 
-	return nil
+	return homeDir, nil
 }
 
 func (b *Builder) configureEnvironment(g *generate.Generator, options RunOptions) {


### PR DESCRIPTION
Checks to see if the $HOME envvar has been set
and if not, trys to set it as best as possible.

Fixes: #1592

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>