### PR TITLE
Fix rootless handling of /dev/shm size

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -214,7 +214,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		if options.NoPivot {
 			moreCreateArgs = append(moreCreateArgs, "--no-pivot")
 		}
-		if err := setupRootlessSpecChanges(spec, path, rootUID, rootGID); err != nil {
+		if err := setupRootlessSpecChanges(spec, path, rootUID, rootGID, b.CommonBuildOpts.ShmSize); err != nil {
 			return err
 		}
 		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, configureNetworks, moreCreateArgs, spec, mountPoint, path, Package+"-"+filepath.Base(path))
@@ -1809,7 +1809,7 @@ func (b *Builder) configureEnvironment(g *generate.Generator, options RunOptions
 	}
 }
 
-func setupRootlessSpecChanges(spec *specs.Spec, bundleDir string, rootUID, rootGID uint32) error {
+func setupRootlessSpecChanges(spec *specs.Spec, bundleDir string, rootUID, rootGID uint32, shmSize string) error {
 	spec.Hostname = ""
 	spec.Process.User.AdditionalGids = nil
 	spec.Linux.Resources = nil
@@ -1843,7 +1843,7 @@ func setupRootlessSpecChanges(spec *specs.Spec, bundleDir string, rootUID, rootG
 			Source:      "shm",
 			Destination: "/dev/shm",
 			Type:        "tmpfs",
-			Options:     []string{"private", "nodev", "noexec", "nosuid", "mode=1777", "size=65536k"},
+			Options:     []string{"private", "nodev", "noexec", "nosuid", "mode=1777", fmt.Sprintf("size=%s", shmSize)},
 		},
 		{
 			Source:      "/proc",

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -311,14 +311,14 @@ load helpers
 }
 
 @test "from shm-size test" {
-  if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
+  if test "$BUILDAH_ISOLATION" = "chroot"; then
     skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION"
   fi
   if ! which runc ; then
     skip "no runc in PATH"
   fi
   cid=$(buildah from --shm-size=80m --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false run $cid -- df -h
+  run_buildah --debug=false run $cid -- df -h /dev/shm
   expect_output --substring " 80.0M "
   buildah rm $cid
 }


### PR DESCRIPTION
Rootless mode was ignoreing the --shm-size option.
For some reason the test that would have caught this was disabled.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>