### PR TITLE
Avoid fmt.Printf() in the library

### DIFF
--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/containers/buildah"
@@ -93,5 +94,10 @@ func pullCmd(c *cobra.Command, args []string, iopts pullResults) error {
 		options.ReportWriter = nil // Turns off logging output
 	}
 
-	return buildah.Pull(getContext(), args[0], options)
+	id, err := buildah.Pull(getContext(), args[0], options)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", id)
+	return nil
 }

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -169,6 +169,7 @@ func pushCmd(c *cobra.Command, args []string, iopts pushResults) error {
 	} else {
 		logrus.Debugf("pushed image with digest %s", digest.String())
 	}
+	fmt.Printf("Successfully pushed %s@%s\n", dest.StringWithinTransport(), digest.String())
 
 	return nil
 }

--- a/commit.go
+++ b/commit.go
@@ -338,6 +338,5 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 			logrus.Warnf("error generating canonical reference with name %q and digest %s: %v", name, manifestDigest.String(), err)
 		}
 	}
-	fmt.Printf("Successfully pushed %s@%s\n", dest.StringWithinTransport(), manifestDigest.String())
 	return ref, manifestDigest, nil
 }


### PR DESCRIPTION
Avoid calling fmt.Printf() to print things in library logic, which can't be controlled or suppressed by callers.  Prefer returning values and printing them in our CLI wrapper, as callers would.