### PR TITLE
Avoid including linux/memfd.h

### DIFF
--- a/pkg/unshare/unshare.c
+++ b/pkg/unshare/unshare.c
@@ -3,7 +3,7 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
-#include <linux/memfd.h>
+#include <sys/mman.h>
 #include <fcntl.h>
 #include <grp.h>
 #include <sched.h>


### PR DESCRIPTION
The file is not available on older distros.

xref:  #1600, containers/skopeo#643