### PR TITLE
config: expand variables only at the command line

### DIFF
--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -179,6 +180,19 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 		for _, envSpec := range iopts.env {
 			env := strings.SplitN(envSpec, "=", 2)
 			if len(env) > 1 {
+				var unexpanded []string
+				getenv := func(name string) string {
+					for _, envvar := range builder.Env() {
+						val := strings.SplitN(envvar, "=", 2)
+						if len(val) == 2 && val[0] == name {
+							return val[1]
+						}
+					}
+					logrus.Errorf("error expanding variable %q: no value set in configuration", name)
+					unexpanded = append(unexpanded, name)
+					return name
+				}
+				env[1] = os.Expand(env[1], getenv)
 				builder.SetEnv(env[0], env[1])
 			} else {
 				builder.UnsetEnv(env[0])

--- a/config.go
+++ b/config.go
@@ -3,7 +3,6 @@ package buildah
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -269,16 +268,6 @@ func (b *Builder) Env() []string {
 // built using an image built from this container.
 func (b *Builder) SetEnv(k string, v string) {
 	reset := func(s *[]string) {
-		getenv := func(name string) string {
-			for i := range *s {
-				val := strings.SplitN((*s)[i], "=", 2)
-				if len(val) == 2 && val[0] == name {
-					return val[1]
-				}
-			}
-			return name
-		}
-		v = os.Expand(v, getenv)
 		n := []string{}
 		for i := range *s {
 			if !strings.HasPrefix((*s)[i], k+"=") {

--- a/config.go
+++ b/config.go
@@ -278,12 +278,12 @@ func (b *Builder) SetEnv(k string, v string) {
 			}
 			return name
 		}
+		v = os.Expand(v, getenv)
 		n := []string{}
 		for i := range *s {
 			if !strings.HasPrefix((*s)[i], k+"=") {
 				n = append(n, (*s)[i])
 			}
-			v = os.Expand(v, getenv)
 		}
 		n = append(n, k+"="+v)
 		*s = n


### PR DESCRIPTION
Skip our own attempt to expand variables in the `SetEnv()` API, since we need to let the Dockerfile parser be the only place that happens when we're building using a Dockerfile in order to fix https://bugzilla.redhat.com/show_bug.cgi?id=1712245.

Move the expansion logic introduced in #931 from `SetEnv()` to the CLI, and have it log an error when it encounters a variable that it can't expand.