### PR TITLE
Add a test for ENV special chars behaviour

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -832,6 +832,16 @@ load helpers
   buildah rmi -a -f
 }
 
+@test "bud ENV preserves special characters after commit" {
+  from_target=special-chars
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${from_target} -f ${TESTSDIR}/bud/env/Dockerfile.special-chars ${TESTSDIR}/bud/env
+  cid=$(buildah from ${from_target})
+  run_buildah run ${cid} env
+  expect_output --substring "LIB=\\$\(PREFIX\)/lib"
+  buildah rm ${cid}
+  buildah rmi -a -f
+}
+
 @test "bud with Dockerfile from valid URL" {
   target=url-image
   url=https://raw.githubusercontent.com/containers/buildah/master/tests/bud/from-scratch/Dockerfile

--- a/tests/bud/env/Dockerfile.special-chars
+++ b/tests/bud/env/Dockerfile.special-chars
@@ -1,0 +1,3 @@
+FROM docker.io/ubuntu
+ENV LIB="$(PREFIX)/lib"
+


### PR DESCRIPTION
# Overview
This PR adds a test to ensure that special characters in `ENV` are preserved after the commit. Combined with #1607, this resolves #1556.

Output:
```
 ✓ bud ENV preserves special characters after commit
```

# Signing
Signed-off-by: Eric Hripko <ehripko@bloomberg.net>