### PR TITLE
imagebuildah: fix handling of destinations that end with '/'

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -487,6 +487,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 		// Check the file and see if part of it is a symlink.
 		// Convert it to the target if so.  To be ultrasafe
 		// do the same for the mountpoint.
+		hadFinalPathSeparator := len(copy.Dest) > 0 && copy.Dest[len(copy.Dest)-1] == os.PathSeparator
 		secureMountPoint, err := securejoin.SecureJoin("", s.mountPoint)
 		finalPath, err := securejoin.SecureJoin(secureMountPoint, copy.Dest)
 		if err != nil {
@@ -496,6 +497,11 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 			return errors.Wrapf(err, "error resolving copy destination %s", copy.Dest)
 		}
 		copy.Dest = strings.TrimPrefix(finalPath, secureMountPoint)
+		if len(copy.Dest) == 0 || copy.Dest[len(copy.Dest)-1] != os.PathSeparator {
+			if hadFinalPathSeparator {
+				copy.Dest += string(os.PathSeparator)
+			}
+		}
 
 		if copy.Download {
 			logrus.Debugf("ADD %#v, %#v", excludes, copy)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -149,6 +149,14 @@ load helpers
   buildah rmi -a -f
 }
 
+@test "bud-multistage-copy-final-slash" {
+  target=foo
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-final-slash
+  run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid="$output"
+  run_buildah run ${cid} /test/ls -lR /test/ls
+}
+
 @test "bud-multistage-reused" {
   target=foo
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds

--- a/tests/bud/dest-final-slash/Dockerfile
+++ b/tests/bud/dest-final-slash/Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox AS base
+FROM scratch
+COPY --from=base /bin/ls /test/
+COPY --from=base /bin/sh /bin/
+RUN /test/ls -lR /test/ls


### PR DESCRIPTION
Don't lose track of whether or not the specified destination for an ADD or COPY instruction ends with the path separator, which is important.