### PR TITLE
addHelperSymlink: clear the destination on os.IsExist errors

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1358,3 +1358,18 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/deny.json -t dir:${TESTDIR}/mount -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
   run_buildah rmi -a -f
 }
+
+@test "bud-copy-replace-symlink" {
+  mkdir -p ${TESTDIR}/top
+  cp ${TESTSDIR}/bud/symlink/Dockerfile.replace-symlink ${TESTDIR}/top/
+  ln -s Dockerfile.replace-symlink ${TESTDIR}/top/symlink
+  echo foo > ${TESTDIR}/top/.dockerignore
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/top/Dockerfile.replace-symlink ${TESTDIR}/top
+}
+
+@test "bud-copy-recurse" {
+  mkdir -p ${TESTDIR}/recurse
+  cp ${TESTSDIR}/bud/recurse/Dockerfile ${TESTDIR}/recurse
+  echo foo > ${TESTDIR}/recurse/.dockerignore
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTDIR}/recurse
+}

--- a/tests/bud/recurse/Dockerfile
+++ b/tests/bud/recurse/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY . .
+COPY . .

--- a/tests/bud/symlink/Dockerfile.replace-symlink
+++ b/tests/bud/symlink/Dockerfile.replace-symlink
@@ -1,0 +1,3 @@
+FROM scratch
+COPY ./ ./
+COPY ./ ./


### PR DESCRIPTION
If we fail to create a symbolic link because the destination already exists, attempt to remove the destination.  This should help with #1598.
