### PR TITLE
fix tutorial instructions

### DIFF
--- a/docs/tutorials/01-intro.md
+++ b/docs/tutorials/01-intro.md
@@ -99,7 +99,7 @@ Notice that the overlay image is under `/var/lib/containers/storage` as one woul
 
 Now that we have a new empty container we can install or remove software packages or simply copy content into that container. So let's install `bash` and `coreutils` so that we can run bash scripts. This could easily be `nginx` or other packages needed for your container.
 
-    # dnf install --installroot $scratchmnt --releasever 29 bash coreutils --setopt install_weak_deps=false -y
+    # dnf install --installroot $scratchmnt --releasever 30 bash coreutils --setopt install_weak_deps=false -y
 
 Let's try it out (showing the prompt in this example to demonstrate the difference):
 
@@ -127,6 +127,7 @@ With `buildah` files can be copied into the new image.  We can then use `buildah
     # dnf -y install podman
     # buildah copy $newcontainer ./runecho.sh /usr/bin
     # buildah config --cmd /usr/bin/runecho.sh $newcontainer
+    # buildah commit $newcontainer newimage
 
 Now run the command in the container with Buildah specifying the command to run in the container:
 
@@ -144,7 +145,7 @@ Now run the command in the container with Buildah specifying the command to run 
 
 Now run the command in the container with Podman (no command required):
 
-    # podman run $newcontainer
+    # podman run -t --rm newimage
     This is a new container from ipbabble [ 0 ]
     This is a new container from ipbabble [ 1 ]
     This is a new container from ipbabble [ 2 ]
@@ -161,7 +162,7 @@ It works! Congratulations, you have built a new OCI container from scratch that 
 Back to Buildah, let's add some more configuration information.
 
     # buildah config --created-by "ipbabble"  $newcontainer
-    # buildah config --author "wgh at redhat.com @ipbabble" --label name=fedora29-bashecho $newcontainer
+    # buildah config --author "wgh at redhat.com @ipbabble" --label name=fedora30-bashecho $newcontainer
 
 We can inspect the container's metadata using the `inspect` command:
 


### PR DESCRIPTION
Before, there is no `$newcontainer` image committed thus
`podman run $newcontainer` attempts to pull `$newcontainer` from the various
container registries.

I have followed the tutorials but I have encountered an issue similar to [here](https://www.reddit.com/r/podman/comments/bp3sdq/buildah_tutorial_issue_with_podman_on_centos_7/).