### PR TITLE
imagebuildah: handle ID mappings for COPY --from

### DIFF
--- a/add.go
+++ b/add.go
@@ -34,10 +34,14 @@ type AddAndCopyOptions struct {
 	// If the sources include directory trees, Hasher will be passed
 	// tar-format archives of the directory trees.
 	Hasher io.Writer
-	// Exludes contents in the .dockerignore file
+	// Excludes is the contents of the .dockerignore file
 	Excludes []string
-	// current directory on host
+	// The base directory for Excludes and data to copy in
 	ContextDir string
+	// ID mapping options to use when contents to be copied are part of
+	// another container, and need ownerships to be mapped from the host to
+	// that container's values before copying them into the container.
+	IDMappingOptions *IDMappingOptions
 }
 
 // addURL copies the contents of the source URL to the destination.  This is
@@ -146,8 +150,8 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	if len(source) > 1 && (destfi == nil || !destfi.IsDir()) {
 		return errors.Errorf("destination %q is not a directory", dest)
 	}
-	copyFileWithTar := b.copyFileWithTar(&containerOwner, options.Hasher)
-	copyWithTar := b.copyWithTar(&containerOwner, options.Hasher)
+	copyFileWithTar := b.copyFileWithTar(options.IDMappingOptions, &containerOwner, options.Hasher)
+	copyWithTar := b.copyWithTar(options.IDMappingOptions, &containerOwner, options.Hasher)
 	untarPath := b.untarPath(nil, options.Hasher)
 	err = addHelper(excludes, extract, dest, destfi, hostOwner, options, copyFileWithTar, copyWithTar, untarPath, source...)
 	if err != nil {

--- a/image.go
+++ b/image.go
@@ -707,7 +707,7 @@ func (b *Builder) makeImageRef(options CommitOptions, exporting bool) (types.Ima
 		exporting:             exporting,
 		squash:                options.Squash,
 		emptyLayer:            options.EmptyLayer,
-		tarPath:               b.tarPath(),
+		tarPath:               b.tarPath(&b.IDMappingOptions),
 		parent:                parent,
 		blobDirectory:         options.BlobDirectory,
 		preEmptyLayers:        b.PrependedEmptyLayers,

--- a/run_linux.go
+++ b/run_linux.go
@@ -434,7 +434,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 
 	// Add temporary copies of the contents of volume locations at the
 	// volume locations, unless we already have something there.
-	copyWithTar := b.copyWithTar(nil, nil)
+	copyWithTar := b.copyWithTar(nil, nil, nil)
 	builtins, err := runSetupBuiltinVolumes(b.MountLabel, mountPoint, cdir, copyWithTar, builtinVolumes, int(rootUID), int(rootGID))
 	if err != nil {
 		return err

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -350,6 +350,7 @@ general_namespace() {
 	createrandom ${TESTDIR}/randomfile
 	cid=$(buildah from --userns-uid-map 0:32:16 --userns-gid-map 0:48:16 scratch)
 	buildah copy "$cid" ${TESTDIR}/randomfile /
+	buildah copy --chown 1:1 "$cid" ${TESTDIR}/randomfile /randomfile2
 	buildah commit --squash --signature-policy ${TESTSDIR}/policy.json --rm "$cid" squashed
 	cid=$(buildah from squashed)
 	mountpoint=$(buildah mount $cid)
@@ -357,4 +358,8 @@ general_namespace() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	[ "$output" = 0:0 ]
+	run stat -c %u:%g $mountpoint/randomfile2
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "$output" = 1:1 ]
 }

--- a/util/util.go
+++ b/util/util.go
@@ -257,6 +257,36 @@ func StringInSlice(s string, slice []string) bool {
 	return false
 }
 
+// GetContainerIDs uses ID mappings to compute the container-level IDs that will
+// correspond to a UID/GID pair on the host.
+func GetContainerIDs(uidmap, gidmap []specs.LinuxIDMapping, uid, gid uint32) (uint32, uint32, error) {
+	uidMapped := true
+	for _, m := range uidmap {
+		uidMapped = false
+		if uid >= m.HostID && uid < m.HostID+m.Size {
+			uid = (uid - m.HostID) + m.ContainerID
+			uidMapped = true
+			break
+		}
+	}
+	if !uidMapped {
+		return 0, 0, errors.Errorf("container uses ID mappings (%#v), but doesn't map UID %d", uidmap, uid)
+	}
+	gidMapped := true
+	for _, m := range gidmap {
+		gidMapped = false
+		if gid >= m.HostID && gid < m.HostID+m.Size {
+			gid = (gid - m.HostID) + m.ContainerID
+			gidMapped = true
+			break
+		}
+	}
+	if !gidMapped {
+		return 0, 0, errors.Errorf("container uses ID mappings (%#v), but doesn't map GID %d", gidmap, gid)
+	}
+	return uid, gid, nil
+}
+
 // GetHostIDs uses ID mappings to compute the host-level IDs that will
 // correspond to a UID/GID pair in the container.
 func GetHostIDs(uidmap, gidmap []specs.LinuxIDMapping, uid, gid uint32) (uint32, uint32, error) {
@@ -270,7 +300,7 @@ func GetHostIDs(uidmap, gidmap []specs.LinuxIDMapping, uid, gid uint32) (uint32,
 		}
 	}
 	if !uidMapped {
-		return 0, 0, errors.Errorf("container uses ID mappings, but doesn't map UID %d", uid)
+		return 0, 0, errors.Errorf("container uses ID mappings (%#v), but doesn't map UID %d", uidmap, uid)
 	}
 	gidMapped := true
 	for _, m := range gidmap {
@@ -282,7 +312,7 @@ func GetHostIDs(uidmap, gidmap []specs.LinuxIDMapping, uid, gid uint32) (uint32,
 		}
 	}
 	if !gidMapped {
-		return 0, 0, errors.Errorf("container uses ID mappings, but doesn't map GID %d", gid)
+		return 0, 0, errors.Errorf("container uses ID mappings (%#v), but doesn't map GID %d", gidmap, gid)
 	}
 	return uid, gid, nil
 }


### PR DESCRIPTION
Fix handling of ID mapping for COPY: when copying from other containers, use their mappings, and when copying from the host, use host mappings.