### PR TITLE
allow 32bit builds

### DIFF
--- a/add.go
+++ b/add.go
@@ -293,8 +293,8 @@ func addHelper(excludes *fileutils.PatternMatcher, extract bool, dest string, de
 					mtime := info.ModTime()
 					atime := mtime
 					times := []syscall.Timespec{
-						{Sec: atime.Unix(), Nsec: atime.UnixNano() % 1000000000},
-						{Sec: mtime.Unix(), Nsec: mtime.UnixNano() % 1000000000},
+						syscall.NsecToTimespec(atime.Unix()),
+						syscall.NsecToTimespec(mtime.Unix()),
 					}
 					if info.IsDir() {
 						return addHelperDirectory(esrc, path, filepath.Join(dest, fpath), info, hostOwner, times)


### PR DESCRIPTION
on 32-bit systems, we had type mismatches when creating a
syscall.timespec.

resolves #1629

Signed-off-by: baude <bbaude@redhat.com>