### PR TITLE
Add ability to skip secrets in mounts file

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -117,7 +117,12 @@ func getMounts(filePath string) []string {
 	}
 	var mounts []string
 	for scanner.Scan() {
-		mounts = append(mounts, scanner.Text())
+		if strings.HasPrefix(strings.TrimSpace(scanner.Text()), "/") {
+			mounts = append(mounts, scanner.Text())
+		} else {
+			logrus.Debugf("skipping unrecognized mount in %v: %q",
+				filePath, scanner.Text())
+		}
 	}
 	return mounts
 }


### PR DESCRIPTION
This commit changes the behavior for mounting secrets from a file like
`/etc/containers/mounts.conf`.

Before this commit, lines which do not contain a possible mount (like
comments) where included in the the returned slice of `getMounts()`.
This means that the returned result is not correct and higher level
functions like `addSecretsFromMountsFile()` fail because of that
comment.

Now, invalid lines are simply skipped, which allows the end-user to keep
their additional information within the mounts files.