### PR TITLE
Add support for file secret mounts

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -190,58 +190,79 @@ func addSecretsFromMountsFile(filePath, mountLabel, containerWorkingDir, mountPr
 	var mounts []rspec.Mount
 	defaultMountsPaths := getMounts(filePath)
 	for _, path := range defaultMountsPaths {
-		hostDir, ctrDir, err := getMountsMap(path)
+		hostDirOrFile, ctrDirOrFile, err := getMountsMap(path)
 		if err != nil {
 			return nil, err
 		}
-		// skip if the hostDir path doesn't exist
-		if _, err = os.Stat(hostDir); err != nil {
+		// skip if the hostDirOrFile path doesn't exist
+		fileInfo, err := os.Stat(hostDirOrFile)
+		if err != nil {
 			if os.IsNotExist(err) {
-				logrus.Warnf("Path %q from %q doesn't exist, skipping", hostDir, filePath)
+				logrus.Warnf("Path %q from %q doesn't exist, skipping", hostDirOrFile, filePath)
 				continue
 			}
-			return nil, errors.Wrapf(err, "failed to stat %q", hostDir)
+			return nil, errors.Wrapf(err, "failed to stat %q", hostDirOrFile)
 		}
 
-		ctrDirOnHost := filepath.Join(containerWorkingDir, ctrDir)
+		ctrDirOrFileOnHost := filepath.Join(containerWorkingDir, ctrDirOrFile)
 
-		// In the event of a restart, don't want to copy secrets over again as they already would exist in ctrDirOnHost
-		_, err = os.Stat(ctrDirOnHost)
+		// In the event of a restart, don't want to copy secrets over again as they already would exist in ctrDirOrFileOnHost
+		_, err = os.Stat(ctrDirOrFileOnHost)
 		if os.IsNotExist(err) {
-			if err = os.MkdirAll(ctrDirOnHost, 0755); err != nil {
-				return nil, errors.Wrapf(err, "making container directory %q failed", ctrDirOnHost)
-			}
-			hostDir, err = resolveSymbolicLink(hostDir)
+
+			hostDirOrFile, err = resolveSymbolicLink(hostDirOrFile)
 			if err != nil {
 				return nil, err
 			}
 
-			data, err := getHostSecretData(hostDir)
-			if err != nil {
-				return nil, errors.Wrapf(err, "getting host secret data failed")
-			}
-			for _, s := range data {
-				if err := s.saveTo(ctrDirOnHost); err != nil {
-					return nil, errors.Wrapf(err, "error saving data to container filesystem on host %q", ctrDirOnHost)
+			switch mode := fileInfo.Mode(); {
+			case mode.IsDir():
+				if err = os.MkdirAll(ctrDirOrFileOnHost, 0755); err != nil {
+					return nil, errors.Wrapf(err, "making container directory %q failed", ctrDirOrFileOnHost)
 				}
+				data, err := getHostSecretData(hostDirOrFile)
+				if err != nil {
+					return nil, errors.Wrapf(err, "getting host secret data failed")
+				}
+				for _, s := range data {
+					if err := s.saveTo(ctrDirOrFileOnHost); err != nil {
+						return nil, errors.Wrapf(err, "error saving data to container filesystem on host %q", ctrDirOrFileOnHost)
+					}
+				}
+			case mode.IsRegular():
+				data, err := readFile("", hostDirOrFile)
+				if err != nil {
+					return nil, errors.Wrapf(err, "error reading file %q", hostDirOrFile)
+
+				}
+				for _, s := range data {
+					if err := os.MkdirAll(filepath.Dir(ctrDirOrFileOnHost), 0700); err != nil {
+						return nil, err
+					}
+					if err := ioutil.WriteFile(ctrDirOrFileOnHost, s.data, 0700); err != nil {
+						return nil, errors.Wrapf(err, "error saving data to container filesystem on host %q", ctrDirOrFileOnHost)
+					}
+				}
+			default:
+				return nil, errors.Errorf("unsupported file type for: %q", hostDirOrFile)
 			}
 
-			err = label.Relabel(ctrDirOnHost, mountLabel, false)
+			err = label.Relabel(ctrDirOrFileOnHost, mountLabel, false)
 			if err != nil {
 				return nil, errors.Wrap(err, "error applying correct labels")
 			}
 			if uid != 0 || gid != 0 {
-				if err := rchown(ctrDirOnHost, uid, gid); err != nil {
+				if err := rchown(ctrDirOrFileOnHost, uid, gid); err != nil {
 					return nil, err
 				}
 			}
 		} else if err != nil {
-			return nil, errors.Wrapf(err, "error getting status of %q", ctrDirOnHost)
+			return nil, errors.Wrapf(err, "error getting status of %q", ctrDirOrFileOnHost)
 		}
 
 		m := rspec.Mount{
-			Source:      filepath.Join(mountPrefix, ctrDir),
-			Destination: ctrDir,
+			Source:      filepath.Join(mountPrefix, ctrDirOrFile),
+			Destination: ctrDirOrFile,
 			Type:        "bind",
 			Options:     []string{"bind", "rprivate"},
 		}


### PR DESCRIPTION
The current implementation supports only specified directories within a
mounts file like `/etc/containers/mounts.conf`. We now separate the code
paths to pre-check if it's a file or directory and create only the
secret file if necessary.