### PR TITLE
COPY: Fix the handling of symlinks to absolute paths

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -547,6 +547,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 						if err := s.builder.Add(filepath.Join(copy.Dest, srcName), copy.Download, options, srcSecure); err != nil {
 							return err
 						}
+						continue
 					}
 				}
 				sources = append(sources, srcSecure)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -782,6 +782,22 @@ load helpers
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.symlink-points-to-itself ${TESTSDIR}/bud/symlink
 }
 
+@test "bud multi-stage with symlink to absolute path" {
+  target=ubuntu-image
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.absolute-symlink ${TESTSDIR}/bud/symlink
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
+  root=$(buildah mount ${cid})
+  run ls $root/bin
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ myexe ]]
+  run cat $root/bin/myexe
+  [ "$status" -eq 0 ]
+  [[ "$output" == "symlink-test" ]]
+  buildah rm ${cid}
+  buildah rmi ${target}
+}
+
 @test "bud with ENTRYPOINT and RUN" {
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.entrypoint-run ${TESTSDIR}/bud/run-scenarios

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -798,6 +798,19 @@ load helpers
   buildah rmi ${target}
 }
 
+@test "bud multi-stage with dir symlink to absolute path" {
+  target=ubuntu-image
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.absolute-dir-symlink ${TESTSDIR}/bud/symlink
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
+  root=$(buildah mount ${cid})
+  run ls $root/data
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ myexe ]]
+  buildah rm ${cid}
+  buildah rmi ${target}
+}
+
 @test "bud with ENTRYPOINT and RUN" {
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.entrypoint-run ${TESTSDIR}/bud/run-scenarios

--- a/tests/bud/symlink/Dockerfile.absolute-dir-symlink
+++ b/tests/bud/symlink/Dockerfile.absolute-dir-symlink
@@ -1,0 +1,6 @@
+FROM ubuntu as builder
+RUN mkdir -p /my/data && touch /my/data/myexe && ln -s /my/data /data
+
+FROM ubuntu
+COPY --from=builder /data /data
+VOLUME [ "/data" ]

--- a/tests/bud/symlink/Dockerfile.absolute-symlink
+++ b/tests/bud/symlink/Dockerfile.absolute-symlink
@@ -1,0 +1,6 @@
+FROM ubuntu as builder
+RUN echo "symlink-test" > /bin/myexe.1 && ln -s /bin/myexe.1 /bin/myexe
+
+FROM ubuntu
+COPY --from=builder /bin/myexe /bin/
+VOLUME [ "/bin" ]


### PR DESCRIPTION
# Overview
This PR changes the behaviour of multi-stage `COPY` to handle symlinks to absolute paths. Partially resolves #1610.

It doesn't fully solve it, because new logic relies on trailing slash to indicate a directory whilst `docker` happily passes this test without a trailing slash. The reason I couldn't make a better implementation is because there's no right place for it in `buildah`. The logic would need to know the original root+source (before symlink resolution) whilst also knowing that destination is a folder (based on file info, not relying on trailing slash like here). Will happily welcome suggestions if maintainers have any ideas :+1: 

# Testing
1 new test added:
- `bud` multi-stage `COPY` with symlink to absolute path

All `bud` tests pass, output:
```
 ✓ bud with --dns* flags
 ✓ bud with .dockerignore
 ✓ bud-flags-order-verification
 ✓ bud with --layers and --no-cache flags
 ✓ bud with --layers and single and two line Dockerfiles
 ✓ bud with --layers, multistage, and COPY with --from
 ✓ bud-multistage-copy-final-slash
 ✓ bud-multistage-reused
 ✓ bud-multistage-cache
 ✓ bud with --layers and symlink file
 ✓ bud with --layers and dangling symlink
 ✓ bud with --layers and --build-args
 ✓ bud with --rm flag
 ✓ bud with --force-rm flag
 ✓ bud --layers with non-existent/down registry
 ✓ bud from base image should have base image ENV also
 ✓ bud-from-scratch
 ✓ bud-from-scratch-iid
 ✓ bud-from-scratch-label
 ✓ bud-from-scratch-annotation
 ✓ bud-from-scratch-layers
 ✓ bud-from-multiple-files-one-from
 ✓ bud-from-multiple-files-two-froms
 ✓ bud-multi-stage-builds
 ✓ bud-multi-stage-builds-small-as
 ✓ bud-preserve-subvolumes
 ✓ bud-http-Dockerfile
 ✓ bud-http-context-with-Dockerfile
 ✓ bud-http-context-dir-with-Dockerfile-pre
 ✓ bud-http-context-dir-with-Dockerfile-post
 ✓ bud-git-context
 ✓ bud-github-context
 ✓ bud-additional-tags
 ✓ bud-volume-perms
 ✓ bud-from-glob
 ✓ bud-maintainer
 ✓ bud-unrecognized-instruction
 ✓ bud-shell
 ✓ bud-shell during build in Docker format
 ✓ bud-shell during build in OCI format
 ✓ bud-shell changed during build in Docker format
 ✓ bud-shell changed during build in OCI format
 ✓ bud with symlinks
 ✓ bud with symlinks to relative path
 ✓ bud with multiple symlinks in a path
 ✓ bud with multiple symlink pointing to itself
 ✓ bud multi-stage with symlink to absolute path
 ✓ bud with ENTRYPOINT and RUN
 ✓ bud with ENTRYPOINT and empty RUN
 ✓ bud with CMD and RUN
 ✓ bud with CMD and empty RUN
 ✓ bud with ENTRYPOINT, CMD and RUN
 ✓ bud with ENTRYPOINT, CMD and empty RUN
 ✓ bud access ENV variable defined in same source file
 ✓ bud access ENV variable defined in FROM image
 ✓ bud ENV preserves special characters after commit
 ✓ bud with Dockerfile from valid URL
 ✓ bud with Dockerfile from invalid URL
 ✓ bud with -f flag, alternate Dockerfile name
 ✓ bud with --cache-from noop flag
 ✓ bud with --compress noop flag
 ✓ bud with --cpu-shares flag, no argument
 ✓ bud with --cpu-shares flag, invalid argument
 ✓ bud with --cpu-shares flag, valid argument
 ✓ bud with --cpu-shares short flag (-c), no argument
 ✓ bud with --cpu-shares short flag (-c), invalid argument
 ✓ bud with --cpu-shares short flag (-c), valid argument
 ✓ bud-onbuild
 ✓ bud-onbuild-layers
 ✓ bud-logfile
 ✓ bud with ARGS
 ✓ bud with unused ARGS
 ✓ bud with multi-value ARGS
 ✓ bud-from-stdin
 ✓ bud with preprocessor
 ✓ bud with preprocessor error
 ✓ bud-with-rejected-name
 ✓ bud with chown copy
 ✓ bud with chown add
 ✓ bud with ADD file construct
 ✓ bud with FROM AS construct
 ✓ bud with FROM AS construct with layers
 ✓ bud with FROM AS skip FROM construct
 ✓ bud with symlink Dockerfile not specified in file
 ✓ bud with dir for file but no Dockerfile in dir
 ✓ bud with bad dir Dockerfile
 ✓ bud with ARG before FROM default value
 ✓ bud with ARG before FROM
 ✓ bud-with-healthcheck
 ✓ bud with unused build arg
 ✓ bud with copy-from and cache
 ✓ bud with copy-from in Dockerfile no prior FROM
 ✓ bud-target
 ✓ bud-no-target-name
 ✓ bud-multi-stage-nocache-nocommit
 ✓ bud-multi-stage-cache-nocontainer
 ✓ bud copy to symlink
 ✓ bud WORKDIR isa symlink
 ✓ bud WORKDIR isa symlink no target dir
 ✓ bud WORKDIR isa symlink no target dir and follow on dir
 ✓ buidah bud --volume
 ✓ bud-copy-dot with --layers picks up changed file
 ✓ buildah-bud-policy
 ✓ bud-copy-replace-symlink
 ✓ bud-copy-recurse

105 tests, 0 failures
```

# Signing
Signed-off-by: Eric Hripko <ehripko@bloomberg.net>