### PR TITLE
[WIP] Make chown tolerant of errors when doing single user mapping

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -15,6 +15,7 @@ import (
 
 type globalFlags struct {
 	Debug             bool
+	SingleUserMap     bool
 	Root              string
 	RunRoot           string
 	StorageDriver     string
@@ -67,6 +68,7 @@ func init() {
 	//rootCmd.TraverseChildren = true
 	rootCmd.Version = fmt.Sprintf("%s (image-spec %s, runtime-spec %s)", buildah.Version, ispecs.Version, rspecs.Version)
 	rootCmd.PersistentFlags().BoolVar(&globalFlagResults.Debug, "debug", false, "print debugging information")
+	rootCmd.PersistentFlags().BoolVar(&globalFlagResults.SingleUserMap, "single-user-mapping", false, "avoids using uidmap tools by doing single user mapping")
 	// TODO Need to allow for environment variable
 	rootCmd.PersistentFlags().StringVar(&globalFlagResults.RegistriesConf, "registries-conf", "", "path to registries.conf file (not usually used)")
 	rootCmd.PersistentFlags().StringVar(&globalFlagResults.RegistriesConfDir, "registries-conf-dir", "", "path to registries.conf.d directory (not usually used)")
@@ -103,7 +105,7 @@ func before(cmd *cobra.Command, args []string) error {
 	case "", "help", "version", "mount":
 		return nil
 	}
-	unshare.MaybeReexecUsingUserNamespace(false)
+	unshare.MaybeReexecUsingUserNamespace(false, globalFlagResults.SingleUserMap)
 	return nil
 }
 

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -42,7 +42,7 @@ func unshareCmd(c *cobra.Command, args []string) error {
 	}
 
 	// force reexec using the configured ID mappings
-	unshare.MaybeReexecUsingUserNamespace(true)
+	unshare.MaybeReexecUsingUserNamespace(true, globalFlagResults.SingleUserMap)
 	// exec the specified command, if there is one
 	if len(args) < 1 {
 		// try to exec the shell, if one's set

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -54,6 +54,10 @@ Default root dir is configured in /etc/containers/storage.conf
 Storage state dir (default: "/var/run/containers/storage" for UID 0, "/var/run/user/$UID" for other users)
 Default state dir is configured in /etc/containers/storage.conf
 
+**--single-user-mapping**
+
+Avoids using uidmap tools and will only map the current user to root in the container. Note that this does not work if running buildah as root already.
+
 **--storage-driver** **value**
 
 Storage driver.  The default storage driver for UID 0 is configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode), and is *vfs* for other users.  The `STORAGE_DRIVER` environment variable overrides the default.  The --storage-driver specified driver overrides all.

--- a/pkg/unshare/unshare_unsupported.go
+++ b/pkg/unshare/unshare_unsupported.go
@@ -30,7 +30,7 @@ func RootlessEnv() []string {
 }
 
 // MaybeReexecUsingUserNamespace re-exec the process in a new namespace
-func MaybeReexecUsingUserNamespace(evenForRoot bool) {
+func MaybeReexecUsingUserNamespace(evenForRoot bool, singleUserMap bool) {
 }
 
 // GetHostIDMappings reads mappings for the specified process (or the current


### PR DESCRIPTION
**Linked to this PR:** https://github.com/containers/storage/pull/358

### Problem:
When building a container as an unprivileged user and without uidmap tools, buildah will fail when chowning system files. This patch ignores those chown errors if buildah has fallen back to single user mapping mode.

### What this patch changes:
**Buildah side:** 
unshare.go checks if newuidmap and newgidmap is installed by running "which newuidmap". If uidmap tools are not installed it sets an environment variable to pass down to the child.

**containers/storage side:**
diff_unix.go passes in the hosts environment variables (including the single user mapping environment variable) to the "storage-applyLayer" command. This allows checkChownErr in idtools.go to check if it needs to ignore the chown errors.

### Notes:
I'm not completely sure if using environment variables is the best way to get this information down to checkChownErr, but it seemed to work best in terms minimal code change. I would love to hear feedback on better solutions.

