### PR TITLE
imagebuildah: use a stable sort for comparing build args

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1355,6 +1355,7 @@ func (b *Executor) getBuildArgs() string {
 			buildArgs = append(buildArgs, k+"="+v)
 		}
 	}
+	sort.Strings(buildArgs)
 	return strings.Join(buildArgs, " ")
 }
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -1340,26 +1340,8 @@ func (b *Executor) historyMatches(baseHistory []v1.History, child *parser.Node, 
 			return false
 		}
 	}
-	instruction := child.Original
-	switch strings.ToUpper(child.Value) {
-	case "RUN":
-		instruction = instruction[4:]
-		buildArgs := b.getBuildArgs()
-		// If a previous image was built with some build-args but the new build process doesn't have any build-args
-		// specified, the command might be expanded differently, so compare the lengths of the old instruction with
-		// the current one.  11 is the length of "/bin/sh -c " that is used to run the run commands.
-		if buildArgs == "" && len(history[len(baseHistory)].CreatedBy) > len(instruction)+11 {
-			return false
-		}
-		// There are build-args, so check if anything with the build-args has changed
-		if buildArgs != "" && !strings.Contains(history[len(baseHistory)].CreatedBy, buildArgs) {
-			return false
-		}
-		fallthrough
-	default:
-		if !strings.Contains(history[len(baseHistory)].CreatedBy, instruction) {
-			return false
-		}
+	if history[len(baseHistory)].CreatedBy != b.getCreatedBy(child) {
+		return false
 	}
 	return true
 }

--- a/tests/bud/build-arg/Dockerfile3
+++ b/tests/bud/build-arg/Dockerfile3
@@ -1,0 +1,13 @@
+FROM busybox
+MAINTAINER jdoe <jdoe@example.com>
+ENV container="docker"
+
+RUN echo this-should-be-cached-but-it-s-not
+
+ARG USERNAME
+ARG UID
+ARG CODE
+ARG PGDATA
+ARG PORT=55555
+
+CMD ["/container-run"]


### PR DESCRIPTION
When checking if a history entry in a candidate image that represents a RUN instruction matches what we'll do if the image is not a valid cached image, sort the arguments.  This should fix https://github.com/containers/buildah/issues/1635.
