### PR TITLE
Support --dns=none like podman

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -189,6 +189,10 @@ soley for scripting compatibility.
 
 Set custom DNS servers
 
+This option can be used to override the DNS configuration passed to the container. Typically this is necessary when the host DNS configuration is invalid for the container (e.g., 127.0.0.1). When this is the case the `--dns` flag is necessary for every run.
+
+The special value **none** can be specified to disable creation of /etc/resolv.conf in the container by Buildah. The /etc/resolv.conf file in the image will be used without changes.
+
 **--dns-option**=[]
 
 Set custom DNS options

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -171,6 +171,22 @@ The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
 
+**--dns**=[]
+
+Set custom DNS servers
+
+This option can be used to override the DNS configuration passed to the container. Typically this is necessary when the host DNS configuration is invalid for the container (e.g., 127.0.0.1). When this is the case the `--dns` flag is necessary for every run.
+
+The special value **none** can be specified to disable creation of /etc/resolv.conf in the container by Buildah. The /etc/resolv.conf file in the image will be used without changes.
+
+**--dns-option**=[]
+
+Set custom DNS options
+
+**--dns-search**=[]
+
+Set custom DNS search domains
+
 **--http-proxy**
 
 By default proxy environment variables are passed into the container if set

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -37,6 +37,7 @@ func CommonBuildOptions(c *cobra.Command) (*buildah.CommonBuildOptions, error) {
 	var (
 		memoryLimit int64
 		memorySwap  int64
+		noDNS       bool
 		err         error
 	)
 
@@ -67,9 +68,26 @@ func CommonBuildOptions(c *cobra.Command) (*buildah.CommonBuildOptions, error) {
 		}
 	}
 
+	noDNS = false
 	dnsServers, _ := c.Flags().GetStringSlice("dns")
+	for _, server := range dnsServers {
+		if strings.ToLower(server) == "none" {
+			noDNS = true
+		}
+	}
+	if noDNS && len(dnsServers) > 1 {
+		return nil, errors.Errorf("invalid --dns, --dns=none may not be used with any other --dns options")
+	}
+
 	dnsSearch, _ := c.Flags().GetStringSlice("dns-search")
+	if noDNS && len(dnsSearch) > 0 {
+		return nil, errors.Errorf("invalid --dns-search, --dns-search may not be used with --dns=none")
+	}
+
 	dnsOptions, _ := c.Flags().GetStringSlice("dns-option")
+	if noDNS && len(dnsOptions) > 0 {
+		return nil, errors.Errorf("invalid --dns-option, --dns-option may not be used with --dns=none")
+	}
 
 	if _, err := units.FromHumanSize(c.Flag("shm-size").Value.String()); err != nil {
 		return nil, errors.Wrapf(err, "invalid --shm-size")

--- a/run_linux.go
+++ b/run_linux.go
@@ -174,7 +174,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		bindFiles["/etc/hosts"] = hostFile
 	}
 
-	if !contains(volumes, "/etc/resolv.conf") {
+	if !(contains(volumes, "/etc/resolv.conf") || (len(b.CommonBuildOpts.DNSServers) == 1 && strings.ToLower(b.CommonBuildOpts.DNSServers[0]) == "none")) {
 		resolvFile, err := b.addNetworkConfig(path, "/etc/resolv.conf", rootIDPair, b.CommonBuildOpts.DNSServers, b.CommonBuildOpts.DNSSearch, b.CommonBuildOpts.DNSOptions)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR adds support for `--dns=none`, which will avoid setting up a bind mount for `/etc/resolv.conf`. This is equivalent to podman's `--dns=none`, which was added in https://github.com/containers/libpod/pull/2747

It looks like it was possible at one point to avoid a bind mount on `/etc/resolv.conf` as a side-effect of passing network configuration options in https://github.com/containers/buildah/pull/1146 but it appears this way has been factored out of the code since then. This gives "I don't want resolv.conf" a dedicated knob to twist, which is shaped and labeled identically to the knob in podman :)

I may eventually want to add an equivalent podman's of `--no-hosts` in a separate PR, but I left that off for now since it would be a bit more involved and since I don't personally need it just yet.