### PR TITLE
fix bug --cpu-shares parsing typo

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -80,7 +80,7 @@ func CommonBuildOptions(c *cobra.Command) (*buildah.CommonBuildOptions, error) {
 	}
 	cpuPeriod, _ := c.Flags().GetUint64("cpu-period")
 	cpuQuota, _ := c.Flags().GetInt64("cpu-quota")
-	cpuShares, _ := c.Flags().GetUint64("cpu-shared")
+	cpuShares, _ := c.Flags().GetUint64("cpu-shares")
 	httpProxy, _ := c.Flags().GetBool("http-proxy")
 	ulimit, _ := c.Flags().GetStringSlice("ulimit")
 	commonOpts := &buildah.CommonBuildOptions{

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -244,7 +244,7 @@ load helpers
   fi
   cid=$(buildah from --cpu-shares=2 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah --debug=false run $cid cat /sys/fs/cgroup/cpu/cpu.shares
-  expect_output "1024"
+  expect_output "2"
   buildah rm $cid
 }
 


### PR DESCRIPTION
close #1464

fix the paring typo cpu-shared of --cpu-shares.
fix expect value in from.bats

Signed-off-by: Qi Wang <qiwan@redhat.com>