### PR TITLE
remove --> before imgageID on build

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -992,7 +992,7 @@ func (s *StageExecutor) Execute(ctx context.Context, stage imagebuilder.Stage, b
 	}
 	logImageID := func(imgID string) {
 		if s.executor.iidfile == "" {
-			fmt.Fprintf(s.executor.out, "--> %s\n", imgID)
+			fmt.Fprintf(s.executor.out, "%s\n", imgID)
 		}
 	}
 

--- a/tests/conformance/bud_test.go
+++ b/tests/conformance/bud_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Buildah build conformance test", func() {
 		},
 		Entry("shell test", BuildTest{
 			Dockerfile:   "Dockerfile.shell",
-			BuildahRegex: "(?s)--> [0-9a-z]+(.*)--",
+			BuildahRegex: "(?s)[0-9a-z]+(.*)--",
 			DockerRegex:  "(?s)RUN env.*?Running in [0-9a-z]+(.*?)---",
 			IsFile:       true,
 			ExtraOptions: []string{"--no-cache"},


### PR DESCRIPTION
Remove the `-->` from in front of the imageID that's printed in
the last line of output from a `buildah bud` command.

Fixes: https://github.com/containers/libpod/issues/3191

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>