### PR TITLE
Added '-' syntax to remove volume config option

### DIFF
--- a/config.go
+++ b/config.go
@@ -440,8 +440,14 @@ func (b *Builder) AddVolume(v string) {
 // mounted from outside of the container when a container based on an image
 // built from this container is run.
 func (b *Builder) RemoveVolume(v string) {
-	delete(b.OCIv1.Config.Volumes, v)
-	delete(b.Docker.Config.Volumes, v)
+	_, OCIv1Volume := b.OCIv1.Config.Volumes[v]
+	_, DockerVolume := b.Docker.Config.Volumes[v]
+	if !OCIv1Volume && !DockerVolume {
+		logrus.Errorf("Volume \"%s\" cannot be removed from config because it was not set.", v)
+	} else {
+		delete(b.OCIv1.Config.Volumes, v)
+		delete(b.Docker.Config.Volumes, v)
+	}
 }
 
 // ClearVolumes removes all locations from the image's list of locations which

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -180,7 +180,7 @@ If names are used, the container should include entries for those names in its
 
 **--volume** *volume*
 
-Add a location in the directory tree which should be marked as a *volume* in any images which will be built using the specified container. Can be used multiple times.
+Add a location in the directory tree which should be marked as a *volume* in any images which will be built using the specified container. Can be used multiple times. If *volume* has a trailing `-`, and does not exist on disk, then the volume is removed from the config.
 
 **--workingdir** *directory*
 


### PR DESCRIPTION
When using the --volume flag, putting a '-' after the volume removes the volume from the config. 
`--volume /testvol-` removes /testvol from the config. 
Only implemented on Volume flag as a test. 

#1399 
