### PR TITLE
buildah-run: fix out-of-range panic

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -1134,7 +1134,9 @@ func runCopyStdio(stdio *sync.WaitGroup, copyPipes bool, stdioPipe [][]int, copy
 		setNonblock(wfd, writeDesc[wfd], false)
 	}
 
-	setNonblock(stdioPipe[unix.Stdin][1], writeDesc[stdioPipe[unix.Stdin][1]], true)
+	if copyPipes {
+		setNonblock(stdioPipe[unix.Stdin][1], writeDesc[stdioPipe[unix.Stdin][1]], true)
+	}
 
 	closeStdin := false
 


### PR DESCRIPTION
Fix an out-of-range panic in buildah-run by moving the call to
setNonbloc() to the appropriate place (i.e., only when the copyPipes
parameter is set).

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>