### PR TITLE
buildah-run: fix-out-of-range panic (2)

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -1134,8 +1134,14 @@ func runCopyStdio(stdio *sync.WaitGroup, copyPipes bool, stdioPipe [][]int, copy
 		setNonblock(wfd, writeDesc[wfd], false)
 	}
 
-	setNonblock(stdioPipe[unix.Stdin][1], writeDesc[stdioPipe[unix.Stdin][1]], true)
+	if copyPipes {
+		setNonblock(stdioPipe[unix.Stdin][1], writeDesc[stdioPipe[unix.Stdin][1]], true)
+	}
 
+	runCopyStdioPassData(stdio, copyPipes, stdioPipe, copyConsole, consoleListener, finishCopy, finishedCopy, spec, relayMap, relayBuffer, readDesc, writeDesc)
+}
+
+func runCopyStdioPassData(stdio *sync.WaitGroup, copyPipes bool, stdioPipe [][]int, copyConsole bool, consoleListener *net.UnixListener, finishCopy []int, finishedCopy chan struct{}, spec *specs.Spec, relayMap map[int]int, relayBuffer map[int]*bytes.Buffer, readDesc map[int]string, writeDesc map[int]string) {
 	closeStdin := false
 
 	// Pass data back and forth.


### PR DESCRIPTION
Fix an out-of-range panic in buildah-run by moving the call to
setNonbloc() to the appropriate place (i.e., only when the copyPipes
parameter is set).

Replaces #1672.  Needed to make two smaller functions to make gofmt
happy.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>