### PR TITLE
Add bud test for RUN with a priv'd command

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1563,3 +1563,12 @@ load helpers
   run_buildah --debug=false inspect -f '{{.FromImageID}}' ${target}
   [[ "$output" == "$argsid" ]]
 }
+
+@test "bud test RUN with a priv'd command" {
+  target=alpinepriv
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-privd/Dockerfile ${TESTSDIR}/bud/run-privd
+  [ "${status}" -eq 0 ]
+  expect_output --substring "STEP 3: COMMIT"
+  run_buildah --debug=false images -q
+  expect_line_count 2 
+}

--- a/tests/bud/run-privd/Dockerfile
+++ b/tests/bud/run-privd/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine
+RUN apk add nginx 


### PR DESCRIPTION
In Buildah v1.8.4 we had an error that occured when a
RUN command in a Dockerfile did a privileged command
such as yum, dnf, apk, etc. This test will cover the
scenario reported in #1679

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>