### PR TITLE
Show total number of steps when building images with bud

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -729,7 +729,7 @@ func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Nod
 		stepCounter := 0
 		exec.log = func(format string, args ...interface{}) {
 			stepCounter++
-			prefix := fmt.Sprintf("STEP %d: ", stepCounter)
+			prefix := fmt.Sprintf("STEP %d/%d: ", stepCounter, len(mainNode.Children)+1)
 			suffix := "\n"
 			fmt.Fprintf(exec.err, prefix+format+suffix, args...)
 		}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1327,8 +1327,8 @@ load helpers
 @test "bud-target" {
   target=target
   run_buildah bud --debug=false --signature-policy ${TESTSDIR}/policy.json -t ${target} --target mytarget ${TESTSDIR}/bud/target
-  expect_output --substring "STEP 1: FROM ubuntu:latest"
-  expect_output --substring "STEP 3: FROM alpine:latest AS mytarget"
+  expect_output --substring "STEP 1/7: FROM ubuntu:latest"
+  expect_output --substring "STEP 3/7: FROM alpine:latest AS mytarget"
   cid=$(buildah from ${target})
   root=$(buildah mount ${cid})
   run ls ${root}/2
@@ -1373,7 +1373,7 @@ load helpers
   target=alpine-image
   ctr=alpine-ctr
   run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-symlink
-  expect_output --substring "STEP 5: RUN ln -s "
+  expect_output --substring "STEP 5/7: RUN ln -s "
 
   run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
   expect_output --substring ${ctr}
@@ -1389,7 +1389,7 @@ load helpers
   target=ubuntu-image
   ctr=ubuntu-ctr
   run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-symlink-dangling
-  expect_output --substring "STEP 3: RUN ln -s "
+  expect_output --substring "STEP 3/5: RUN ln -s "
 
   run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
   expect_output --substring ${ctr}
@@ -1405,7 +1405,7 @@ load helpers
   target=alpine-image
   ctr=alpine-ctr
   run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/workdir-symlink
-  expect_output --substring "STEP 3: RUN ln -sf "
+  expect_output --substring "STEP 3/7: RUN ln -sf "
 
   run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
   expect_output --substring ${ctr}
@@ -1421,7 +1421,7 @@ load helpers
   target=alpine-image
   ctr=alpine-ctr
   run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile-2 ${TESTSDIR}/bud/workdir-symlink
-  expect_output --substring "STEP 2: RUN ln -sf "
+  expect_output --substring "STEP 2/7: RUN ln -sf "
 
   run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
   expect_output --substring ${ctr}
@@ -1440,7 +1440,7 @@ load helpers
   target=alpine-image
   ctr=alpine-ctr
   run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile-3 ${TESTSDIR}/bud/workdir-symlink
-  expect_output --substring "STEP 2: RUN ln -sf "
+  expect_output --substring "STEP 2/10: RUN ln -sf "
 
   run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
   expect_output --substring ${ctr}


### PR DESCRIPTION
Closes https://github.com/containers/buildah/issues/1681

When building images with `bud`, buildah now shows the total number of steps remaining, for example:
```
[root@080ea3d07748 microclimateGoTemplate]# buildah bud --storage-driver=vfs -t goproject .
STEP 1/8: FROM golang:latest
STEP 2/8: RUN mkdir /app 
STEP 3/8: ADD . /app/ 
STEP 4/8: WORKDIR /app 
STEP 5/8: RUN go build -o main . 
STEP 6/8: CMD ["/app/main"]
STEP 7/8: EXPOSE 8000
STEP 8/8: COMMIT goproject
Getting image source signatures
Copying blob 0db06dff9d9a skipped: already exists
Copying blob f32868cde90b skipped: already exists
Copying blob 7b76d801397d skipped: already exists
Copying blob 2c8d31157b81 skipped: already exists
Copying blob 510e5f32af35 skipped: already exists
Copying blob 56df4f4c91ea skipped: already exists
Copying blob 39ba5a88a3c4 skipped: already exists
Copying blob c09a626e77bb done
Copying config ec4bc6fcb6 done
Writing manifest to image destination
Storing signatures
ec4bc6fcb62c6a0c3ea11dacda323841f6f4369d6c894fac0e394c08ae7533cc
```

I've also updated the tests under bud.bats to account for the change in the output now (STEP X -> STEP X/Y). Output from buds.bats:
```
[root@080ea3d07748 tests]# bats bud.bats 
 ✓ bud with --dns* flags
 ✓ bud with .dockerignore
 ✓ bud-flags-order-verification
 ✓ bud with --layers and --no-cache flags
 ✓ bud with --layers and single and two line Dockerfiles
 ✓ bud with --layers, multistage, and COPY with --from
 ✓ bud-multistage-copy-final-slash
 ✓ bud-multistage-reused
 ✓ bud-multistage-cache
 ✓ bud with --layers and symlink file
 ✓ bud with --layers and dangling symlink
 ✓ bud with --layers and --build-args
 ✓ bud with --rm flag
 ✓ bud with --force-rm flag
 ✓ bud --layers with non-existent/down registry
 ✓ bud from base image should have base image ENV also
 ✓ bud-from-scratch
 ✓ bud-from-scratch-iid
 ✓ bud-from-scratch-label
 ✓ bud-from-scratch-annotation
 ✓ bud-from-scratch-layers
 ✓ bud-from-multiple-files-one-from
 ✓ bud-from-multiple-files-two-froms
 ✓ bud-multi-stage-builds
 ✓ bud-multi-stage-builds-small-as
 - bud-preserve-subvolumes (skipped: no runc in PATH)
 ✓ bud-http-Dockerfile
 ✓ bud-http-context-with-Dockerfile
 ✓ bud-http-context-dir-with-Dockerfile-pre
 ✓ bud-http-context-dir-with-Dockerfile-post
 - bud-git-context (skipped: no git in PATH)
 ✓ bud-github-context
 ✓ bud-additional-tags
 ✓ bud-additional-tags-cached
 - bud-volume-perms (skipped: no runc in PATH)
 ✓ bud-from-glob
 ✓ bud-maintainer
 ✓ bud-unrecognized-instruction
 ✓ bud-shell
 ✓ bud-shell during build in Docker format
 ✓ bud-shell during build in OCI format
 ✓ bud-shell changed during build in Docker format
 ✓ bud-shell changed during build in OCI format
 ✓ bud with symlinks
 ✓ bud with symlinks to relative path
 ✓ bud with multiple symlinks in a path
 ✓ bud with multiple symlink pointing to itself
 ✓ bud multi-stage with symlink to absolute path
 ✓ bud multi-stage with dir symlink to absolute path
 ✓ bud with ENTRYPOINT and RUN
 ✓ bud with ENTRYPOINT and empty RUN
 ✓ bud with CMD and RUN
 ✓ bud with CMD and empty RUN
 ✓ bud with ENTRYPOINT, CMD and RUN
 ✓ bud with ENTRYPOINT, CMD and empty RUN
 ✓ bud access ENV variable defined in same source file
 ✓ bud access ENV variable defined in FROM image
 ✓ bud ENV preserves special characters after commit
 ✓ bud with Dockerfile from valid URL
 ✓ bud with Dockerfile from invalid URL
 ✓ bud with -f flag, alternate Dockerfile name
 ✓ bud with --cache-from noop flag
 ✓ bud with --compress noop flag
 ✓ bud with --cpu-shares flag, no argument
 ✓ bud with --cpu-shares flag, invalid argument
 ✓ bud with --cpu-shares flag, valid argument
 ✓ bud with --cpu-shares short flag (-c), no argument
 ✓ bud with --cpu-shares short flag (-c), invalid argument
 ✓ bud with --cpu-shares short flag (-c), valid argument
 ✓ bud-onbuild
 ✓ bud-onbuild-layers
 ✓ bud-logfile
 ✓ bud with ARGS
 ✓ bud with unused ARGS
 ✓ bud with multi-value ARGS
 ✓ bud-from-stdin
 ✓ bud with preprocessor
 ✓ bud with preprocessor error
 ✓ bud-with-rejected-name
 ✓ bud with chown copy
 ✓ bud with chown add
 ✓ bud with ADD file construct
 ✓ bud with COPY of single file creates absolute path with correct permissions
 ✓ bud with COPY of single file creates relative path with correct permissions
 ✓ bud with ADD of single file creates absolute path with correct permissions
 ✓ bud with ADD of single file creates relative path with correct permissions
 ✓ bud multi-stage COPY creates absolute path with correct permissions
 ✓ bud multi-stage COPY creates relative path with correct permissions
 ✓ bud COPY to root succeeds
 ✓ bud with FROM AS construct
 ✓ bud with FROM AS construct with layers
 ✓ bud with FROM AS skip FROM construct
 ✓ bud with symlink Dockerfile not specified in file
 ✓ bud with dir for file but no Dockerfile in dir
 ✓ bud with bad dir Dockerfile
 ✓ bud with ARG before FROM default value
 ✓ bud with ARG before FROM
 ✓ bud-with-healthcheck
 ✓ bud with unused build arg
 ✓ bud with copy-from and cache
 ✓ bud with copy-from in Dockerfile no prior FROM
 ✓ bud-target
 ✓ bud-no-target-name
 ✓ bud-multi-stage-nocache-nocommit
 ✓ bud-multi-stage-cache-nocontainer
 ✓ bud copy to symlink
 ✓ bud copy to dangling symlink
 ✓ bud WORKDIR isa symlink
 ✓ bud WORKDIR isa symlink no target dir
 ✓ bud WORKDIR isa symlink no target dir and follow on dir
 ✓ buidah bud --volume
 ✓ bud-copy-dot with --layers picks up changed file
 ✓ buildah-bud-policy
 ✓ bud-copy-replace-symlink
 ✓ bud-copy-recurse
 ✓ bud-copy-workdir
 ✓ bud-build-arg-cache

117 tests, 0 failures, 3 skipped
```
Signed-off-by: John Collier <John.J.Collier@ibm.com>