### PR TITLE
fix --volume splits comma delimited option

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -71,7 +71,7 @@ func init() {
 	if err := flags.MarkHidden("tty"); err != nil {
 		panic(fmt.Sprintf("error marking tty flag as hidden: %v", err))
 	}
-	flags.StringSliceVarP(&opts.volumes, "volume", "v", []string{}, "bind mount a host location into the container while running the command")
+	flags.StringArrayVarP(&opts.volumes, "volume", "v", []string{}, "bind mount a host location into the container while running the command")
 
 	userFlags := getUserFlags()
 	namespaceFlags := buildahcli.GetNameSpaceFlags(&namespaceResults)

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -248,6 +248,8 @@ function configure_and_check_user() {
 	mkdir -p ${TESTDIR}/was-empty
 	# As a baseline, this should succeed.
 	run_buildah --debug=false run -v ${TESTDIR}/was-empty:/var/not-empty${zflag:+:${zflag}}     $cid touch /var/not-empty/testfile
+	# Parsing options that with comma, this should succeed.
+	run_buildah --debug=false run -v ${TESTDIR}/was-empty:/var/not-empty:rw,rshared${zflag:+,${zflag}}     $cid touch /var/not-empty/testfile
 	# If we're parsing the options at all, this should be read-only, so it should fail.
 	run_buildah 1 --debug=false run -v ${TESTDIR}/was-empty:/var/not-empty:ro${zflag:+,${zflag}} $cid touch /var/not-empty/testfile
 	# Even if the parent directory doesn't exist yet, this should succeed.


### PR DESCRIPTION
close #1685 use StringArrayVarP to avoid splitting arguements since the option part of --volume is comma delimited
Signed-off-by: Qi Wang <qiwan@redhat.com>