### PR TITLE
Update docker/libnetwork to get rid of outdated sctp package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/docker/distribution v0.0.0-20170817175659-5f6282db7d65
 	github.com/docker/docker-credential-helpers v0.6.1 // indirect
 	github.com/docker/go-units v0.3.3
-	github.com/docker/libnetwork v0.8.0-dev.2.0.20180608203834-19279f049241
+	github.com/docker/libnetwork v0.8.0-dev.2.0.20190625141545-5a177b73e316
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/etcd-io/bbolt v1.3.2
 	github.com/fsouza/go-dockerclient v1.3.0
@@ -24,7 +24,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/ishidawataru/sctp v0.0.0-20180213033435-07191f837fed // indirect
+	github.com/ishidawataru/sctp v0.0.0-20180918013207-6e2cb1366111 // indirect
 	github.com/klauspost/compress v1.4.1 // indirect
 	github.com/klauspost/cpuid v1.2.0 // indirect
 	github.com/klauspost/pgzip v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libnetwork v0.8.0-dev.2.0.20180608203834-19279f049241 h1:+ebE/hCU02srkeIg8Vp/vlUp182JapYWtXzV+bCeR2I=
 github.com/docker/libnetwork v0.8.0-dev.2.0.20180608203834-19279f049241/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
+github.com/docker/libnetwork v0.8.0-dev.2.0.20190625141545-5a177b73e316 h1:moehPjPiGUaWdwgOl92xRyFHJyaqXDHcCyW9M6nmCK4=
+github.com/docker/libnetwork v0.8.0-dev.2.0.20190625141545-5a177b73e316/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU5CAUmr9zpesgbU6SWc8/B4mflAE4=
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/etcd-io/bbolt v1.3.2 h1:RLRQ0TKLX7DlBRXAJHvbmXL17Q3KNnTBtZ9B6Qo+/Y0=
@@ -66,6 +68,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20180213033435-07191f837fed h1:3MJOWnAfq3T9eoCQTarEY2DMlUWYcBkBLf03dAMvEb8=
 github.com/ishidawataru/sctp v0.0.0-20180213033435-07191f837fed/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
+github.com/ishidawataru/sctp v0.0.0-20180918013207-6e2cb1366111 h1:NAAiV9ass6VReWFjuxqrMIq12WKlSULI6Gs3PxQghLA=
+github.com/ishidawataru/sctp v0.0.0-20180918013207-6e2cb1366111/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/klauspost/compress v1.4.1 h1:8VMb5+0wMgdBykOV96DwNwKFQ+WTI4pzYURP99CcB9E=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v1.2.0 h1:NMpwD2G9JSFOE1/TJjGSo5zG7Yb2bTe7eq1jH+irmeE=

--- a/vendor/github.com/docker/libnetwork/ipamutils/utils.go
+++ b/vendor/github.com/docker/libnetwork/ipamutils/utils.go
@@ -5,23 +5,20 @@ import (
 	"fmt"
 	"net"
 	"sync"
-
-	"github.com/sirupsen/logrus"
 )
 
 var (
-	// PredefinedBroadNetworks contains a list of 31 IPv4 private networks with host size 16 and 12
-	// (172.17-31.x.x/16, 192.168.x.x/20) which do not overlap with the networks in `PredefinedGranularNetworks`
-	PredefinedBroadNetworks []*net.IPNet
-	// PredefinedGranularNetworks contains a list of 64K IPv4 private networks with host size 8
-	// (10.x.x.x/24) which do not overlap with the networks in `PredefinedBroadNetworks`
-	PredefinedGranularNetworks []*net.IPNet
-	initNetworksOnce           sync.Once
-
-	defaultBroadNetwork = []*NetworkToSplit{{"172.17.0.0/16", 16}, {"172.18.0.0/16", 16}, {"172.19.0.0/16", 16},
+	// PredefinedLocalScopeDefaultNetworks contains a list of 31 IPv4 private networks with host size 16 and 12
+	// (172.17-31.x.x/16, 192.168.x.x/20) which do not overlap with the networks in `PredefinedGlobalScopeDefaultNetworks`
+	PredefinedLocalScopeDefaultNetworks []*net.IPNet
+	// PredefinedGlobalScopeDefaultNetworks contains a list of 64K IPv4 private networks with host size 8
+	// (10.x.x.x/24) which do not overlap with the networks in `PredefinedLocalScopeDefaultNetworks`
+	PredefinedGlobalScopeDefaultNetworks []*net.IPNet
+	mutex                                sync.Mutex
+	localScopeDefaultNetworks            = []*NetworkToSplit{{"172.17.0.0/16", 16}, {"172.18.0.0/16", 16}, {"172.19.0.0/16", 16},
 		{"172.20.0.0/14", 16}, {"172.24.0.0/14", 16}, {"172.28.0.0/14", 16},
 		{"192.168.0.0/16", 20}}
-	defaultGranularNetwork = []*NetworkToSplit{{"10.0.0.0/8", 24}}
+	globalScopeDefaultNetworks = []*NetworkToSplit{{"10.0.0.0/8", 24}}
 )
 
 // NetworkToSplit represent a network that has to be split in chunks with mask length Size.
@@ -34,19 +31,61 @@ type NetworkToSplit struct {
 	Size int    `json:"size"`
 }
 
-// InitNetworks initializes the broad network pool and the granular network pool
-func InitNetworks(defaultAddressPool []*NetworkToSplit) {
-	initNetworksOnce.Do(func() {
-		// error ingnored should never fail
-		PredefinedGranularNetworks, _ = splitNetworks(defaultGranularNetwork)
-		if defaultAddressPool == nil {
-			defaultAddressPool = defaultBroadNetwork
-		}
-		var err error
-		if PredefinedBroadNetworks, err = splitNetworks(defaultAddressPool); err != nil {
-			logrus.WithError(err).Error("InitAddressPools failed to initialize the default address pool")
-		}
-	})
+func init() {
+	var err error
+	if PredefinedGlobalScopeDefaultNetworks, err = splitNetworks(globalScopeDefaultNetworks); err != nil {
+		//we are going to panic in case of error as we should never get into this state
+		panic("InitAddressPools failed to initialize the global scope default address pool")
+	}
+
+	if PredefinedLocalScopeDefaultNetworks, err = splitNetworks(localScopeDefaultNetworks); err != nil {
+		//we are going to panic in case of error as we should never get into this state
+		panic("InitAddressPools failed to initialize the local scope default address pool")
+	}
+}
+
+// configDefaultNetworks configures local as well global default pool based on input
+func configDefaultNetworks(defaultAddressPool []*NetworkToSplit, result *[]*net.IPNet) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+	defaultNetworks, err := splitNetworks(defaultAddressPool)
+	if err != nil {
+		return err
+	}
+	*result = defaultNetworks
+	return nil
+}
+
+// GetGlobalScopeDefaultNetworks returns PredefinedGlobalScopeDefaultNetworks
+func GetGlobalScopeDefaultNetworks() []*net.IPNet {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return PredefinedGlobalScopeDefaultNetworks
+}
+
+// GetLocalScopeDefaultNetworks returns PredefinedLocalScopeDefaultNetworks
+func GetLocalScopeDefaultNetworks() []*net.IPNet {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return PredefinedLocalScopeDefaultNetworks
+}
+
+// ConfigGlobalScopeDefaultNetworks configures global default pool.
+// Ideally this will be called from SwarmKit as part of swarm init
+func ConfigGlobalScopeDefaultNetworks(defaultAddressPool []*NetworkToSplit) error {
+	if defaultAddressPool == nil {
+		defaultAddressPool = globalScopeDefaultNetworks
+	}
+	return configDefaultNetworks(defaultAddressPool, &PredefinedGlobalScopeDefaultNetworks)
+}
+
+// ConfigLocalScopeDefaultNetworks configures local default pool.
+// Ideally this will be called during libnetwork init
+func ConfigLocalScopeDefaultNetworks(defaultAddressPool []*NetworkToSplit) error {
+	if defaultAddressPool == nil {
+		return nil
+	}
+	return configDefaultNetworks(defaultAddressPool, &PredefinedLocalScopeDefaultNetworks)
 }
 
 // splitNetworks takes a slice of networks, split them accordingly and returns them

--- a/vendor/github.com/docker/libnetwork/resolvconf/resolvconf.go
+++ b/vendor/github.com/docker/libnetwork/resolvconf/resolvconf.go
@@ -14,6 +14,45 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// defaultPath is the default path to the resolv.conf that contains information to resolve DNS. See Path().
+	defaultPath = "/etc/resolv.conf"
+	// alternatePath is a path different from defaultPath, that may be used to resolve DNS. See Path().
+	alternatePath = "/run/systemd/resolve/resolv.conf"
+)
+
+var (
+	detectSystemdResolvConfOnce sync.Once
+	pathAfterSystemdDetection   = defaultPath
+)
+
+// Path returns the path to the resolv.conf file that libnetwork should use.
+//
+// When /etc/resolv.conf contains 127.0.0.53 as the only nameserver, then
+// it is assumed systemd-resolved manages DNS. Because inside the container 127.0.0.53
+// is not a valid DNS server, Path() returns /run/systemd/resolve/resolv.conf
+// which is the resolv.conf that systemd-resolved generates and manages.
+// Otherwise Path() returns /etc/resolv.conf.
+//
+// Errors are silenced as they will inevitably resurface at future open/read calls.
+//
+// More information at https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html#/etc/resolv.conf
+func Path() string {
+	detectSystemdResolvConfOnce.Do(func() {
+		candidateResolvConf, err := ioutil.ReadFile(defaultPath)
+		if err != nil {
+			// silencing error as it will resurface at next calls trying to read defaultPath
+			return
+		}
+		ns := GetNameservers(candidateResolvConf, types.IP)
+		if len(ns) == 1 && ns[0] == "127.0.0.53" {
+			pathAfterSystemdDetection = alternatePath
+			logrus.Infof("detected 127.0.0.53 nameserver, assuming systemd-resolved, so using resolv.conf: %s", alternatePath)
+		}
+	})
+	return pathAfterSystemdDetection
+}
+
 var (
 	// Note: the default IPv4 & IPv6 resolvers are set to Google's Public DNS
 	defaultIPv4Dns = []string{"nameserver 8.8.8.8", "nameserver 8.8.4.4"}
@@ -50,15 +89,7 @@ type File struct {
 
 // Get returns the contents of /etc/resolv.conf and its hash
 func Get() (*File, error) {
-	resolv, err := ioutil.ReadFile("/etc/resolv.conf")
-	if err != nil {
-		return nil, err
-	}
-	hash, err := ioutils.HashData(bytes.NewReader(resolv))
-	if err != nil {
-		return nil, err
-	}
-	return &File{Content: resolv, Hash: hash}, nil
+	return GetSpecific(Path())
 }
 
 // GetSpecific returns the contents of the user specified resolv.conf file and its hash
@@ -81,7 +112,7 @@ func GetIfChanged() (*File, error) {
 	lastModified.Lock()
 	defer lastModified.Unlock()
 
-	resolv, err := ioutil.ReadFile("/etc/resolv.conf")
+	resolv, err := ioutil.ReadFile(Path())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/docker/libnetwork/types/types.go
+++ b/vendor/github.com/docker/libnetwork/types/types.go
@@ -99,7 +99,7 @@ func (p PortBinding) HostAddr() (net.Addr, error) {
 	case TCP:
 		return &net.TCPAddr{IP: p.HostIP, Port: int(p.HostPort)}, nil
 	case SCTP:
-		return &sctp.SCTPAddr{IP: []net.IP{p.HostIP}, Port: int(p.HostPort)}, nil
+		return &sctp.SCTPAddr{IPAddrs: []net.IPAddr{{IP: p.HostIP}}, Port: int(p.HostPort)}, nil
 	default:
 		return nil, ErrInvalidProtocolBinding(p.Proto.String())
 	}
@@ -113,7 +113,7 @@ func (p PortBinding) ContainerAddr() (net.Addr, error) {
 	case TCP:
 		return &net.TCPAddr{IP: p.IP, Port: int(p.Port)}, nil
 	case SCTP:
-		return &sctp.SCTPAddr{IP: []net.IP{p.IP}, Port: int(p.Port)}, nil
+		return &sctp.SCTPAddr{IPAddrs: []net.IPAddr{{IP: p.IP}}, Port: int(p.Port)}, nil
 	default:
 		return nil, ErrInvalidProtocolBinding(p.Proto.String())
 	}
@@ -145,7 +145,12 @@ func (p *PortBinding) String() string {
 	return ret
 }
 
-// FromString reads the PortBinding structure from string
+// FromString reads the PortBinding structure from string s.
+// String s is a triple of "protocol/containerIP:port/hostIP:port"
+// containerIP and hostIP can be in dotted decimal ("192.0.2.1") or IPv6 ("2001:db8::68") form.
+// Zoned addresses ("169.254.0.23%eth0" or "fe80::1ff:fe23:4567:890a%eth0") are not supported.
+// If string s is incorrectly formatted or the IP addresses or ports cannot be parsed, FromString
+// returns an error.
 func (p *PortBinding) FromString(s string) error {
 	ps := strings.Split(s, "/")
 	if len(ps) != 3 {
@@ -167,21 +172,19 @@ func (p *PortBinding) FromString(s string) error {
 }
 
 func parseIPPort(s string) (net.IP, uint16, error) {
-	pp := strings.Split(s, ":")
-	if len(pp) != 2 {
-		return nil, 0, BadRequestErrorf("invalid format: %s", s)
-	}
-
-	var ip net.IP
-	if pp[0] != "" {
-		if ip = net.ParseIP(pp[0]); ip == nil {
-			return nil, 0, BadRequestErrorf("invalid ip: %s", pp[0])
-		}
-	}
-
-	port, err := strconv.ParseUint(pp[1], 10, 16)
+	hoststr, portstr, err := net.SplitHostPort(s)
 	if err != nil {
-		return nil, 0, BadRequestErrorf("invalid port: %s", pp[1])
+		return nil, 0, err
+	}
+
+	ip := net.ParseIP(hoststr)
+	if ip == nil {
+		return nil, 0, BadRequestErrorf("invalid ip: %s", hoststr)
+	}
+
+	port, err := strconv.ParseUint(portstr, 10, 16)
+	if err != nil {
+		return nil, 0, BadRequestErrorf("invalid port: %s", portstr)
 	}
 
 	return ip, uint16(port), nil
@@ -329,6 +332,8 @@ func CompareIPNet(a, b *net.IPNet) bool {
 }
 
 // GetMinimalIP returns the address in its shortest form
+// If ip contains an IPv4-mapped IPv6 address, the 4-octet form of the IPv4 address will be returned.
+// Otherwise ip is returned unchanged.
 func GetMinimalIP(ip net.IP) net.IP {
 	if ip != nil && ip.To4() != nil {
 		return ip.To4()

--- a/vendor/github.com/ishidawataru/sctp/.gitignore
+++ b/vendor/github.com/ishidawataru/sctp/.gitignore
@@ -12,3 +12,5 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+example/example

--- a/vendor/github.com/ishidawataru/sctp/.travis.yml
+++ b/vendor/github.com/ishidawataru/sctp/.travis.yml
@@ -4,6 +4,7 @@ go:
  - 1.7
  - 1.8
  - 1.9
+ - "1.10"
 
 script:
  - go test -v -race ./...

--- a/vendor/github.com/ishidawataru/sctp/GO_LICENSE
+++ b/vendor/github.com/ishidawataru/sctp/GO_LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/ishidawataru/sctp/ipsock_linux.go
+++ b/vendor/github.com/ishidawataru/sctp/ipsock_linux.go
@@ -1,0 +1,218 @@
+package sctp
+
+import (
+	"net"
+	"os"
+	"sync"
+	"syscall"
+)
+
+//from https://github.com/golang/go
+// Boolean to int.
+func boolint(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+//from https://github.com/golang/go
+func ipToSockaddr(family int, ip net.IP, port int, zone string) (syscall.Sockaddr, error) {
+	switch family {
+	case syscall.AF_INET:
+		if len(ip) == 0 {
+			ip = net.IPv4zero
+		}
+		ip4 := ip.To4()
+		if ip4 == nil {
+			return nil, &net.AddrError{Err: "non-IPv4 address", Addr: ip.String()}
+		}
+		sa := &syscall.SockaddrInet4{Port: port}
+		copy(sa.Addr[:], ip4)
+		return sa, nil
+	case syscall.AF_INET6:
+		// In general, an IP wildcard address, which is either
+		// "0.0.0.0" or "::", means the entire IP addressing
+		// space. For some historical reason, it is used to
+		// specify "any available address" on some operations
+		// of IP node.
+		//
+		// When the IP node supports IPv4-mapped IPv6 address,
+		// we allow an listener to listen to the wildcard
+		// address of both IP addressing spaces by specifying
+		// IPv6 wildcard address.
+		if len(ip) == 0 || ip.Equal(net.IPv4zero) {
+			ip = net.IPv6zero
+		}
+		// We accept any IPv6 address including IPv4-mapped
+		// IPv6 address.
+		ip6 := ip.To16()
+		if ip6 == nil {
+			return nil, &net.AddrError{Err: "non-IPv6 address", Addr: ip.String()}
+		}
+		//we set ZoneId to 0, as currently we use this functon only to probe the IP capabilities of the host
+		//if real Zone handling is required, the zone cache implementation in golang/net should be pulled here
+		sa := &syscall.SockaddrInet6{Port: port, ZoneId: 0}
+		copy(sa.Addr[:], ip6)
+		return sa, nil
+	}
+	return nil, &net.AddrError{Err: "invalid address family", Addr: ip.String()}
+}
+
+//from https://github.com/golang/go
+func sockaddr(a *net.TCPAddr, family int) (syscall.Sockaddr, error) {
+	if a == nil {
+		return nil, nil
+	}
+	return ipToSockaddr(family, a.IP, a.Port, a.Zone)
+}
+
+//from https://github.com/golang/go
+type ipStackCapabilities struct {
+	sync.Once             // guards following
+	ipv4Enabled           bool
+	ipv6Enabled           bool
+	ipv4MappedIPv6Enabled bool
+}
+
+//from https://github.com/golang/go
+var ipStackCaps ipStackCapabilities
+
+//from https://github.com/golang/go
+// supportsIPv4 reports whether the platform supports IPv4 networking
+// functionality.
+func supportsIPv4() bool {
+	ipStackCaps.Once.Do(ipStackCaps.probe)
+	return ipStackCaps.ipv4Enabled
+}
+
+//from https://github.com/golang/go
+// supportsIPv6 reports whether the platform supports IPv6 networking
+// functionality.
+func supportsIPv6() bool {
+	ipStackCaps.Once.Do(ipStackCaps.probe)
+	return ipStackCaps.ipv6Enabled
+}
+
+//from https://github.com/golang/go
+// supportsIPv4map reports whether the platform supports mapping an
+// IPv4 address inside an IPv6 address at transport layer
+// protocols. See RFC 4291, RFC 4038 and RFC 3493.
+func supportsIPv4map() bool {
+	ipStackCaps.Once.Do(ipStackCaps.probe)
+	return ipStackCaps.ipv4MappedIPv6Enabled
+}
+
+//from https://github.com/golang/go
+// Probe probes IPv4, IPv6 and IPv4-mapped IPv6 communication
+// capabilities which are controlled by the IPV6_V6ONLY socket option
+// and kernel configuration.
+//
+// Should we try to use the IPv4 socket interface if we're only
+// dealing with IPv4 sockets? As long as the host system understands
+// IPv4-mapped IPv6, it's okay to pass IPv4-mapeed IPv6 addresses to
+// the IPv6 interface. That simplifies our code and is most
+// general. Unfortunately, we need to run on kernels built without
+// IPv6 support too. So probe the kernel to figure it out.
+func (p *ipStackCapabilities) probe() {
+	s, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, syscall.IPPROTO_TCP)
+	switch err {
+	case syscall.EAFNOSUPPORT, syscall.EPROTONOSUPPORT:
+	case nil:
+		syscall.Close(s)
+		p.ipv4Enabled = true
+	}
+	var probes = []struct {
+		laddr net.TCPAddr
+		value int
+	}{
+		// IPv6 communication capability
+		{laddr: net.TCPAddr{IP: net.IPv6loopback}, value: 1},
+		// IPv4-mapped IPv6 address communication capability
+		{laddr: net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)}, value: 0},
+	}
+
+	for i := range probes {
+		s, err := syscall.Socket(syscall.AF_INET6, syscall.SOCK_STREAM, syscall.IPPROTO_TCP)
+		if err != nil {
+			continue
+		}
+		defer syscall.Close(s)
+		syscall.SetsockoptInt(s, syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY, probes[i].value)
+		sa, err := sockaddr(&(probes[i].laddr), syscall.AF_INET6)
+		if err != nil {
+			continue
+		}
+		if err := syscall.Bind(s, sa); err != nil {
+			continue
+		}
+		if i == 0 {
+			p.ipv6Enabled = true
+		} else {
+			p.ipv4MappedIPv6Enabled = true
+		}
+	}
+}
+
+//from https://github.com/golang/go
+//Change: we check the first IP address in the list of candidate SCTP IP addresses
+func (a *SCTPAddr) isWildcard() bool {
+	if a == nil {
+		return true
+	}
+	if 0 == len(a.IPAddrs) {
+		return true
+	}
+
+	return a.IPAddrs[0].IP.IsUnspecified()
+}
+
+func (a *SCTPAddr) family() int {
+	if a != nil {
+		for _, ip := range a.IPAddrs {
+			if ip.IP.To4() == nil {
+				return syscall.AF_INET6
+			}
+		}
+	}
+	return syscall.AF_INET
+}
+
+//from https://github.com/golang/go
+func favoriteAddrFamily(network string, laddr *SCTPAddr, raddr *SCTPAddr, mode string) (family int, ipv6only bool) {
+	switch network[len(network)-1] {
+	case '4':
+		return syscall.AF_INET, false
+	case '6':
+		return syscall.AF_INET6, true
+	}
+
+	if mode == "listen" && (laddr == nil || laddr.isWildcard()) {
+		if supportsIPv4map() || !supportsIPv4() {
+			return syscall.AF_INET6, false
+		}
+		if laddr == nil {
+			return syscall.AF_INET, false
+		}
+		return laddr.family(), false
+	}
+
+	if (laddr == nil || laddr.family() == syscall.AF_INET) &&
+		(raddr == nil || raddr.family() == syscall.AF_INET) {
+		return syscall.AF_INET, false
+	}
+	return syscall.AF_INET6, false
+}
+
+//from https://github.com/golang/go
+//Changes: it is for SCTP only
+func setDefaultSockopts(s int, family int, ipv6only bool) error {
+	if family == syscall.AF_INET6 {
+		// Allow both IP versions even if the OS default
+		// is otherwise. Note that some operating systems
+		// never admit this option.
+		syscall.SetsockoptInt(s, syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY, boolint(ipv6only))
+	}
+	// Allow broadcast.
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(s, syscall.SOL_SOCKET, syscall.SO_BROADCAST, 1))
+}

--- a/vendor/github.com/ishidawataru/sctp/sctp.go
+++ b/vendor/github.com/ishidawataru/sctp/sctp.go
@@ -197,37 +197,58 @@ func htons(h uint16) uint16 {
 
 var ntohs = htons
 
-func setNumOstreams(fd, num int) error {
-	param := InitMsg{
-		NumOstreams: uint16(num),
-	}
-	optlen := unsafe.Sizeof(param)
-	_, _, err := setsockopt(fd, SCTP_INITMSG, uintptr(unsafe.Pointer(&param)), uintptr(optlen))
+// setInitOpts sets options for an SCTP association initialization
+// see https://tools.ietf.org/html/rfc4960#page-25
+func setInitOpts(fd int, options InitMsg) error {
+	optlen := unsafe.Sizeof(options)
+	_, _, err := setsockopt(fd, SCTP_INITMSG, uintptr(unsafe.Pointer(&options)), uintptr(optlen))
 	return err
 }
 
+func setNumOstreams(fd, num int) error {
+	return setInitOpts(fd, InitMsg{NumOstreams: uint16(num)})
+}
+
 type SCTPAddr struct {
-	IP   []net.IP
-	Port int
+	IPAddrs []net.IPAddr
+	Port    int
 }
 
 func (a *SCTPAddr) ToRawSockAddrBuf() []byte {
-	buf := []byte{}
 	p := htons(uint16(a.Port))
-	for _, ip := range a.IP {
-		if ip.To4() != nil {
+	if len(a.IPAddrs) == 0 { // if a.IPAddrs list is empty - fall back to IPv4 zero addr
+		s := syscall.RawSockaddrInet4{
+			Family: syscall.AF_INET,
+			Port:   p,
+		}
+		copy(s.Addr[:], net.IPv4zero)
+		return toBuf(s)
+	}
+	buf := []byte{}
+	for _, ip := range a.IPAddrs {
+		ipBytes := ip.IP
+		if len(ipBytes) == 0 {
+			ipBytes = net.IPv4zero
+		}
+		if ip4 := ipBytes.To4(); ip4 != nil {
 			s := syscall.RawSockaddrInet4{
 				Family: syscall.AF_INET,
 				Port:   p,
 			}
-			copy(s.Addr[:], ip.To4())
+			copy(s.Addr[:], ip4)
 			buf = append(buf, toBuf(s)...)
 		} else {
-			s := syscall.RawSockaddrInet6{
-				Family: syscall.AF_INET6,
-				Port:   p,
+			var scopeid uint32
+			ifi, err := net.InterfaceByName(ip.Zone)
+			if err == nil {
+				scopeid = uint32(ifi.Index)
 			}
-			copy(s.Addr[:], ip)
+			s := syscall.RawSockaddrInet6{
+				Family:   syscall.AF_INET6,
+				Port:     p,
+				Scope_id: scopeid,
+			}
+			copy(s.Addr[:], ipBytes)
 			buf = append(buf, toBuf(s)...)
 		}
 	}
@@ -237,15 +258,15 @@ func (a *SCTPAddr) ToRawSockAddrBuf() []byte {
 func (a *SCTPAddr) String() string {
 	var b bytes.Buffer
 
-	for n, i := range a.IP {
-		if a.IP[n].To4() != nil {
+	for n, i := range a.IPAddrs {
+		if i.IP.To4() != nil {
 			b.WriteString(i.String())
-		} else if a.IP[n].To16() != nil {
+		} else if i.IP.To16() != nil {
 			b.WriteRune('[')
 			b.WriteString(i.String())
 			b.WriteRune(']')
 		}
-		if n < len(a.IP)-1 {
+		if n < len(a.IPAddrs)-1 {
 			b.WriteRune('/')
 		}
 	}
@@ -260,6 +281,7 @@ func ResolveSCTPAddr(network, addrs string) (*SCTPAddr, error) {
 	tcpnet := ""
 	switch network {
 	case "", "sctp":
+		tcpnet = "tcp"
 	case "sctp4":
 		tcpnet = "tcp4"
 	case "sctp6":
@@ -271,26 +293,26 @@ func ResolveSCTPAddr(network, addrs string) (*SCTPAddr, error) {
 	if len(elems) == 0 {
 		return nil, fmt.Errorf("invalid input: %s", addrs)
 	}
-	ipaddrs := make([]net.IP, 0, len(elems))
+	ipaddrs := make([]net.IPAddr, 0, len(elems))
 	for _, e := range elems[:len(elems)-1] {
 		tcpa, err := net.ResolveTCPAddr(tcpnet, e+":")
 		if err != nil {
 			return nil, err
 		}
-		ipaddrs = append(ipaddrs, tcpa.IP)
+		ipaddrs = append(ipaddrs, net.IPAddr{IP: tcpa.IP, Zone: tcpa.Zone})
 	}
 	tcpa, err := net.ResolveTCPAddr(tcpnet, elems[len(elems)-1])
 	if err != nil {
 		return nil, err
 	}
 	if tcpa.IP != nil {
-		ipaddrs = append(ipaddrs, tcpa.IP)
+		ipaddrs = append(ipaddrs, net.IPAddr{IP: tcpa.IP, Zone: tcpa.Zone})
 	} else {
 		ipaddrs = nil
 	}
 	return &SCTPAddr{
-		IP:   ipaddrs,
-		Port: tcpa.Port,
+		IPAddrs: ipaddrs,
+		Port:    tcpa.Port,
 	}, nil
 }
 
@@ -357,15 +379,12 @@ func (c *SCTPConn) Read(b []byte) (int, error) {
 }
 
 func (c *SCTPConn) SetInitMsg(numOstreams, maxInstreams, maxAttempts, maxInitTimeout int) error {
-	param := InitMsg{
+	return setInitOpts(c.fd(), InitMsg{
 		NumOstreams:    uint16(numOstreams),
 		MaxInstreams:   uint16(maxInstreams),
 		MaxAttempts:    uint16(maxAttempts),
 		MaxInitTimeout: uint16(maxInitTimeout),
-	}
-	optlen := unsafe.Sizeof(param)
-	_, _, err := setsockopt(c.fd(), SCTP_INITMSG, uintptr(unsafe.Pointer(&param)), uintptr(optlen))
-	return err
+	})
 }
 
 func (c *SCTPConn) SubscribeEvents(flags int) error {
@@ -473,7 +492,7 @@ func (c *SCTPConn) GetDefaultSentParam() (*SndRcvInfo, error) {
 
 func resolveFromRawAddr(ptr unsafe.Pointer, n int) (*SCTPAddr, error) {
 	addr := &SCTPAddr{
-		IP: make([]net.IP, n),
+		IPAddrs: make([]net.IPAddr, n),
 	}
 
 	switch family := (*(*syscall.RawSockaddrAny)(ptr)).Addr.Family; family {
@@ -484,7 +503,7 @@ func resolveFromRawAddr(ptr unsafe.Pointer, n int) (*SCTPAddr, error) {
 		for i := 0; i < n; i++ {
 			a := *(*syscall.RawSockaddrInet4)(unsafe.Pointer(
 				uintptr(ptr) + size*uintptr(i)))
-			addr.IP[i] = a.Addr[:]
+			addr.IPAddrs[i] = net.IPAddr{IP: a.Addr[:]}
 		}
 	case syscall.AF_INET6:
 		addr.Port = int(ntohs(uint16((*(*syscall.RawSockaddrInet4)(ptr)).Port)))
@@ -493,7 +512,12 @@ func resolveFromRawAddr(ptr unsafe.Pointer, n int) (*SCTPAddr, error) {
 		for i := 0; i < n; i++ {
 			a := *(*syscall.RawSockaddrInet6)(unsafe.Pointer(
 				uintptr(ptr) + size*uintptr(i)))
-			addr.IP[i] = a.Addr[:]
+			var zone string
+			ifi, err := net.InterfaceByIndex(int(a.Scope_id))
+			if err == nil {
+				zone = ifi.Name
+			}
+			addr.IPAddrs[i] = net.IPAddr{IP: a.Addr[:], Zone: zone}
 		}
 	default:
 		return nil, fmt.Errorf("unknown address family: %d", family)

--- a/vendor/github.com/ishidawataru/sctp/sctp_linux.go
+++ b/vendor/github.com/ishidawataru/sctp/sctp_linux.go
@@ -3,7 +3,6 @@
 package sctp
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"sync/atomic"
@@ -115,31 +114,14 @@ func (c *SCTPConn) Close() error {
 	return syscall.EBADF
 }
 
+// ListenSCTP - start listener on specified address/port
 func ListenSCTP(net string, laddr *SCTPAddr) (*SCTPListener, error) {
-	af := syscall.AF_INET
-	switch net {
-	case "sctp":
-		hasv6 := func(addr *SCTPAddr) bool {
-			if addr == nil {
-				return false
-			}
-			for _, ip := range addr.IP {
-				if ip.To4() == nil {
-					return true
-				}
-			}
-			return false
-		}
-		if hasv6(laddr) {
-			af = syscall.AF_INET6
-		}
-	case "sctp4":
-	case "sctp6":
-		af = syscall.AF_INET6
-	default:
-		return nil, fmt.Errorf("invalid net: %s", net)
-	}
+	return ListenSCTPExt(net, laddr, InitMsg{NumOstreams: SCTP_MAX_STREAM})
+}
 
+// ListenSCTPExt - start listener on specified address/port with given SCTP options
+func ListenSCTPExt(network string, laddr *SCTPAddr, options InitMsg) (*SCTPListener, error) {
+	af, ipv6only := favoriteAddrFamily(network, laddr, nil, "listen")
 	sock, err := syscall.Socket(
 		af,
 		syscall.SOCK_STREAM,
@@ -148,11 +130,30 @@ func ListenSCTP(net string, laddr *SCTPAddr) (*SCTPListener, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = setNumOstreams(sock, SCTP_MAX_STREAM)
+
+	// close socket on error
+	defer func() {
+		if err != nil {
+			syscall.Close(sock)
+		}
+	}()
+	if err = setDefaultSockopts(sock, af, ipv6only); err != nil {
+		return nil, err
+	}
+	err = setInitOpts(sock, options)
 	if err != nil {
 		return nil, err
 	}
-	if laddr != nil && len(laddr.IP) != 0 {
+
+	if laddr != nil {
+		// If IP address and/or port was not provided so far, let's use the unspecified IPv4 or IPv6 address
+		if len(laddr.IPAddrs) == 0 {
+			if af == syscall.AF_INET {
+				laddr.IPAddrs = append(laddr.IPAddrs, net.IPAddr{IP: net.IPv4zero})
+			} else if af == syscall.AF_INET6 {
+				laddr.IPAddrs = append(laddr.IPAddrs, net.IPAddr{IP: net.IPv6zero})
+			}
+		}
 		err := SCTPBind(sock, laddr, SCTP_BINDX_ADD_ADDR)
 		if err != nil {
 			return nil, err
@@ -167,9 +168,15 @@ func ListenSCTP(net string, laddr *SCTPAddr) (*SCTPListener, error) {
 	}, nil
 }
 
-func (ln *SCTPListener) Accept() (net.Conn, error) {
+// AcceptSCTP waits for and returns the next SCTP connection to the listener.
+func (ln *SCTPListener) AcceptSCTP() (*SCTPConn, error) {
 	fd, _, err := syscall.Accept4(ln.fd, 0)
 	return NewSCTPConn(fd, nil), err
+}
+
+// Accept waits for and returns the next connection connection to the listener.
+func (ln *SCTPListener) Accept() (net.Conn, error) {
+	return ln.AcceptSCTP()
 }
 
 func (ln *SCTPListener) Close() error {
@@ -177,30 +184,14 @@ func (ln *SCTPListener) Close() error {
 	return syscall.Close(ln.fd)
 }
 
+// DialSCTP - bind socket to laddr (if given) and connect to raddr
 func DialSCTP(net string, laddr, raddr *SCTPAddr) (*SCTPConn, error) {
-	af := syscall.AF_INET
-	switch net {
-	case "sctp":
-		hasv6 := func(addr *SCTPAddr) bool {
-			if addr == nil {
-				return false
-			}
-			for _, ip := range addr.IP {
-				if ip.To4() == nil {
-					return true
-				}
-			}
-			return false
-		}
-		if hasv6(laddr) || hasv6(raddr) {
-			af = syscall.AF_INET6
-		}
-	case "sctp4":
-	case "sctp6":
-		af = syscall.AF_INET6
-	default:
-		return nil, fmt.Errorf("invalid net: %s", net)
-	}
+	return DialSCTPExt(net, laddr, raddr, InitMsg{NumOstreams: SCTP_MAX_STREAM})
+}
+
+// DialSCTPExt - same as DialSCTP but with given SCTP options
+func DialSCTPExt(network string, laddr, raddr *SCTPAddr, options InitMsg) (*SCTPConn, error) {
+	af, ipv6only := favoriteAddrFamily(network, laddr, raddr, "dial")
 	sock, err := syscall.Socket(
 		af,
 		syscall.SOCK_STREAM,
@@ -209,11 +200,29 @@ func DialSCTP(net string, laddr, raddr *SCTPAddr) (*SCTPConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = setNumOstreams(sock, SCTP_MAX_STREAM)
+
+	// close socket on error
+	defer func() {
+		if err != nil {
+			syscall.Close(sock)
+		}
+	}()
+	if err = setDefaultSockopts(sock, af, ipv6only); err != nil {
+		return nil, err
+	}
+	err = setInitOpts(sock, options)
 	if err != nil {
 		return nil, err
 	}
 	if laddr != nil {
+		// If IP address and/or port was not provided so far, let's use the unspecified IPv4 or IPv6 address
+		if len(laddr.IPAddrs) == 0 {
+			if af == syscall.AF_INET {
+				laddr.IPAddrs = append(laddr.IPAddrs, net.IPAddr{IP: net.IPv4zero})
+			} else if af == syscall.AF_INET6 {
+				laddr.IPAddrs = append(laddr.IPAddrs, net.IPAddr{IP: net.IPv6zero})
+			}
+		}
 		err := SCTPBind(sock, laddr, SCTP_BINDX_ADD_ADDR)
 		if err != nil {
 			return nil, err

--- a/vendor/github.com/ishidawataru/sctp/sctp_unsupported.go
+++ b/vendor/github.com/ishidawataru/sctp/sctp_unsupported.go
@@ -34,7 +34,15 @@ func ListenSCTP(net string, laddr *SCTPAddr) (*SCTPListener, error) {
 	return nil, ErrUnsupported
 }
 
+func ListenSCTPExt(net string, laddr *SCTPAddr, options InitMsg) (*SCTPListener, error) {
+	return nil, ErrUnsupported
+}
+
 func (ln *SCTPListener) Accept() (net.Conn, error) {
+	return nil, ErrUnsupported
+}
+
+func (ln *SCTPListener) AcceptSCTP() (*SCTPConn, error) {
 	return nil, ErrUnsupported
 }
 
@@ -43,5 +51,9 @@ func (ln *SCTPListener) Close() error {
 }
 
 func DialSCTP(net string, laddr, raddr *SCTPAddr) (*SCTPConn, error) {
+	return nil, ErrUnsupported
+}
+
+func DialSCTPExt(network string, laddr, raddr *SCTPAddr, options InitMsg) (*SCTPConn, error) {
 	return nil, ErrUnsupported
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -164,7 +164,7 @@ github.com/docker/go-connections/sockets
 github.com/docker/go-connections/nat
 # github.com/docker/go-units v0.3.3
 github.com/docker/go-units
-# github.com/docker/libnetwork v0.8.0-dev.2.0.20180608203834-19279f049241
+# github.com/docker/libnetwork v0.8.0-dev.2.0.20190625141545-5a177b73e316
 github.com/docker/libnetwork/resolvconf
 github.com/docker/libnetwork/types
 github.com/docker/libnetwork/resolvconf/dns
@@ -200,7 +200,7 @@ github.com/hpcloud/tail/winfile
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/ishidawataru/sctp v0.0.0-20180213033435-07191f837fed
+# github.com/ishidawataru/sctp v0.0.0-20180918013207-6e2cb1366111
 github.com/ishidawataru/sctp
 # github.com/klauspost/compress v1.4.1
 github.com/klauspost/compress/flate


### PR DESCRIPTION
After the merge of https://github.com/docker/libnetwork/pull/2403, we're now able to update the outdated SCTP package as well.