### PR TITLE
Update buildah-login.md

### DIFF
--- a/docs/buildah-login.md
+++ b/docs/buildah-login.md
@@ -74,7 +74,7 @@ Login Succeeded!
 ```
 
 ```
-$ $ buildah login --authfile ./auth.json docker.io
+$ buildah login --authfile ./auth.json docker.io
 Username: qiwanredhat
 Password:
 Login Succeeded!


### PR DESCRIPTION
Fix typo in man page.

Thanks to @lukeyeager for finding this.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>