### PR TITLE
Makefile: set GO111MODULE=off

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+export GO111MODULE=off
+
 SELINUXTAG := $(shell ./selinux_tag.sh)
 STORAGETAGS := $(shell ./btrfs_tag.sh) $(shell ./btrfs_installed_tag.sh) $(shell ./libdm_tag.sh) $(shell ./ostree_tag.sh)
 SECURITYTAGS ?= seccomp $(SELINUXTAG)


### PR DESCRIPTION
Turn of go modules to avoid breaking build environments to accidentally
try pulling the dependencies instead of using the ./vendor directory.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>