### PR TITLE
Add gomod instructions and mailing list links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,11 +118,18 @@ commit automatically with `git commit -s`.
 
 ## Communications
 
-For general questions, or discussions, please use the
+For general questions or discussions, please use the
 IRC group on `irc.freenode.net` called `buildah`
 that has been setup.
 
-For discussions around issues/bugs and features, you can use the github
+### For discussions around issues/bugs and features:
+
+#### Buildah Mailing List
+
+You can join the Buildah mailing list by sending an email to `buildah-join@lists.buildah.io` with the word `subscribe` in the subject.  You can also go to this [page](https://lists.podman.io/admin/lists/buildah.lists.buildah.io/), then scroll down to the bottom of the page and enter your email and optionally name, then click on the "Subscribe" buton.
+
+#### GitHub
+You can also use the github
 [issues](https://github.com/containers/buildah/issues)
 and
 [PRs](https://github.com/containers/buildah/pulls)

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ install.tools:
 	env GO111MODULE=off \
 		$(GO) get -u gopkg.in/alecthomas/gometalinter.v1
 	env GO111MODULE=off \
-		gometalinter.v1 -i
+		$(GOPATH)/bin/gometalinter.v1 -i
 	make build -C tests/tools
 
 .PHONY: runc

--- a/install.md
+++ b/install.md
@@ -374,3 +374,14 @@ cat /etc/containers/policy.json
 	}
 }
 ```
+
+## Vendoring
+
+Buildah uses Go Modules for vendoring purposes.  If you need to update or add a vendored package into Buildah, please follow this proceedure:
+ * Enter into your sandbox `src/github.com/containers/buildah` and ensure that he GOPATH variable is set to the directory prior as noted above.
+ * `export GO111MODULE=on`
+ * Assuming you want to 'bump' the `github.com/containers/storage` package to version 1.12.13, use this command: `go get github.com/containers/storage@v1.12.13`
+ * `make vendor`
+ * `make`
+ * `make install`
+ * Then add any updated or added files with `git add` then do a `git commit` and create a PR.


### PR DESCRIPTION
Added instructions for how to use go mod to vendor in the contributing.md file.

Also added a few links to the Buildah mailing list.



Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>