### PR TITLE
Improve tests/tools/Makefile parallelism and abstraction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,8 @@ script:
     - docker images
     - docker rmi localhost:5000/my-alpine
     # Setting up  Docker Registry is complete, let's do Buildah testing!
-    - make install.tools install.libseccomp.sudo all runc validate lint SECURITYTAGS="apparmor seccomp"
+    - make install.tools -j4
+    - make install.libseccomp.sudo all runc validate lint SECURITYTAGS="apparmor seccomp"
     - go test -c -tags "apparmor seccomp `./btrfs_tag.sh` `./libdm_tag.sh` `./ostree_tag.sh` `./selinux_tag.sh`" ./cmd/buildah
     - tmp=`mktemp -d`; mkdir $tmp/root $tmp/runroot; sudo PATH="$PATH" ./buildah.test -test.v --root $tmp/root --runroot $tmp/runroot --storage-driver vfs --signature-policy `pwd`/tests/policy.json --registries-conf `pwd`/tests/registries.conf
     - cd tests; sudo PATH="$PATH" ./test_runner.sh

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ endif
 
 .PHONY: install.tools
 install.tools:
-	make build -C tests/tools
+	make -C tests/tools
 
 .PHONY: runc
 runc: gopath

--- a/tests/tools/Makefile
+++ b/tests/tools/Makefile
@@ -2,15 +2,38 @@ GO := go
 
 BUILDDIR := build
 
+all: $(BUILDDIR)
+
 .PHONY: vendor
 vendor:
 	export GO111MODULE=on \
 		$(GO) mod tidy && \
 		$(GO) mod vendor && \
 		$(GO) mod verify
-.PHONY: build
-build:
-	$(GO) build -o $(BUILDDIR)/go-md2man ./vendor/github.com/cpuguy83/go-md2man
-	$(GO) build -o $(BUILDDIR)/git-validation ./vendor/github.com/vbatts/git-validation
-	$(GO) build -o $(BUILDDIR)/ginkgo ./vendor/github.com/onsi/ginkgo/ginkgo
-	$(GO) build -o $(BUILDDIR)/golangci-lint ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint
+
+define go-build
+	$(shell cd `pwd` && $(GO) build -o $(BUILDDIR)/$(shell basename $(1)) $(1))
+	@echo > /dev/null
+endef
+
+.PHONY: clean
+clean:
+	rm -rf $(BUILDDIR)
+
+$(BUILDDIR): \
+	$(BUILDDIR)/ginkgo \
+	$(BUILDDIR)/git-validation \
+	$(BUILDDIR)/go-md2man \
+	$(BUILDDIR)/golangci-lint
+
+$(BUILDDIR)/ginkgo:
+	$(call go-build,./vendor/github.com/onsi/ginkgo/ginkgo)
+
+$(BUILDDIR)/git-validation:
+	$(call go-build,./vendor/github.com/vbatts/git-validation)
+
+$(BUILDDIR)/go-md2man:
+	$(call go-build,./vendor/github.com/cpuguy83/go-md2man)
+
+$(BUILDDIR)/golangci-lint:
+	$(call go-build,./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint)


### PR DESCRIPTION
Update the Makefile to be less repeatable in terms of targets to be
built. With that change, a parallel build of all targets is possible as
well, which has been changed in the CI too. A `clean` and `all` target
has to be added for convenience.