### PR TITLE
Fix response body not closed resource leak

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ run:
 linters:
   disable-all: true
   enable:
+    - bodyclose
     - deadcode
     - depguard
     - dupl
@@ -23,7 +24,6 @@ linters:
     - typecheck
     - unused
     - varcheck
-    # - bodyclose
     # - errcheck
     # - gochecknoglobals
     # - gochecknoinits

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1143,6 +1143,7 @@ func urlContentModified(url string, historyTime *time.Time) (bool, error) {
 	if err != nil {
 		return false, errors.Wrapf(err, "error getting %q", url)
 	}
+	defer resp.Body.Close()
 	if lastModified := resp.Header.Get("Last-Modified"); lastModified != "" {
 		lastModifiedTime, err := time.Parse(time.RFC1123, lastModified)
 		if err != nil {


### PR DESCRIPTION
This enabled the `bodyclose` linter and fixes the reported response body
resource leak.