### PR TITLE
Add errcheck linter and fix missing error check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - deadcode
     - depguard
     - dupl
+    - errcheck
     - gofmt
     - gosimple
     - govet
@@ -24,7 +25,6 @@ linters:
     - typecheck
     - unused
     - varcheck
-    # - errcheck
     # - gochecknoglobals
     # - gochecknoinits
     # - goconst

--- a/chroot/run.go
+++ b/chroot/run.go
@@ -987,7 +987,10 @@ func isDevNull(dev os.FileInfo) bool {
 	if dev.Mode()&os.ModeCharDevice != 0 {
 		stat, _ := dev.Sys().(*syscall.Stat_t)
 		nullStat := syscall.Stat_t{}
-		syscall.Stat(os.DevNull, &nullStat)
+		if err := syscall.Stat(os.DevNull, &nullStat); err != nil {
+			logrus.Warnf("unable to stat /dev/null: %v", err)
+			return false
+		}
 		if stat.Rdev == nullStat.Rdev {
 			return true
 		}

--- a/tests/tools/Makefile
+++ b/tests/tools/Makefile
@@ -1,3 +1,5 @@
+export GO111MODULE=off
+
 GO := go
 
 BUILDDIR := build


### PR DESCRIPTION
This commit enabled the errcheck linter and fixes an uncovered stat to
`os.DevNull`. Beside this, we disable go modules within the
`tests/tools/Makefile` to allow independent offline builds.