### PR TITLE
add: fix slow copy with no excludes

### DIFF
--- a/add.go
+++ b/add.go
@@ -278,7 +278,7 @@ func addHelper(excludes *fileutils.PatternMatcher, extract bool, dest string, de
 					return errors.Wrapf(err, "error creating directory %q", dest)
 				}
 				logrus.Debugf("copying %q to %q", esrc+string(os.PathSeparator)+"*", dest+string(os.PathSeparator)+"*")
-				if excludes == nil {
+				if excludes == nil || !excludes.Exclusions() {
 					if err = copyWithTar(esrc, dest); err != nil {
 						return errors.Wrapf(err, "error copying %q to %q", esrc, dest)
 					}


### PR DESCRIPTION
when there are excludes defined (such as from .dockerignore), we take
a slow path and walk each file in the directory.  If the files doesn't
match any exclusion pattern then it is copied into the container.
This is slow as each file requires buildah to re-exec and copy it from
a chroot environment.

When there are no excludes defined we can take a faster path and copy
the entire directory as a single re-exec operation.

Closes: https://github.com/containers/buildah/issues/1714

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>