### PR TITLE
fix push check image name is not empty

### DIFF
--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -97,6 +97,9 @@ func pushCmd(c *cobra.Command, args []string, iopts pushResults) error {
 	case 2:
 		src = args[0]
 		destSpec = args[1]
+		if src == "" {
+			return errors.Errorf(`Invalid image name "%s"`, args[0])
+		}
 	default:
 		return errors.New("Only two arguments are necessary to push: source and destination")
 	}


### PR DESCRIPTION
Close #1708

This PR checks the input image name is not a nil string if both image name and registry are provided. Avoid triggering go segmentation violation later in the code.

Signed-off-by: Qi Wang <qiwan@redhat.com>