### PR TITLE
add exit code for buildah pull network error

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -44,6 +44,7 @@ var rootCmd = &cobra.Command{
 
 var (
 	globalFlagResults globalFlags
+	exitCode          = 1
 )
 
 func init() {

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/containers/buildah"
@@ -9,6 +10,10 @@ import (
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+)
+
+var (
+	errTlsUnexpectedMsg = errors.New("tls: unexpected message")
 )
 
 type pullResults struct {
@@ -100,6 +105,11 @@ func pullCmd(c *cobra.Command, args []string, iopts pullResults) error {
 
 	id, err := buildah.Pull(getContext(), args[0], options)
 	if err != nil {
+		cause := errors.Cause(err)
+		_, isNetErr := cause.(net.Error)
+		if isNetErr || cause == errTlsUnexpectedMsg {
+			exitCode = 129
+		}
 		return err
 	}
 	fmt.Printf("%s\n", id)


### PR DESCRIPTION
Close #1499

Add different exit code for buildah pull network failures. Check net.Error or defined network error.

Signed-off-by: Qi Wang <qiwan@redhat.com>