### PR TITLE
image: make sure we don't try to use zstd compression

### DIFF
--- a/image.go
+++ b/image.go
@@ -128,6 +128,10 @@ func computeLayerMIMEType(what string, layerCompression archive.Compression) (om
 			// Until the image specs define a media type for xz-compressed layers, even if we know
 			// how to decompress them, we can't try to compress layers with xz.
 			return "", "", errors.New("media type for xz-compressed layers is not defined")
+		case archive.Zstd:
+			// Until the image specs define a media type for zstd-compressed layers, even if we know
+			// how to decompress them, we can't try to compress layers with zstd.
+			return "", "", errors.New("media type for zstd-compressed layers is not defined")
 		default:
 			logrus.Debugf("compressing %s with unknown compressor(?)", what)
 		}

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -31,6 +31,7 @@ const (
 	Gzip         = archive.Gzip
 	Bzip2        = archive.Bzip2
 	Xz           = archive.Xz
+	Zstd         = archive.Zstd
 	Uncompressed = archive.Uncompressed
 )
 


### PR DESCRIPTION
Don't try to use zstd to compress layers until we know what MIME type to use to describe layers that are compressed with zstd.