### PR TITLE
unshare: add a --mount flag

### DIFF
--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -3,10 +3,14 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/containers/buildah/pkg/unshare"
+	"github.com/containers/storage"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -22,13 +26,68 @@ var (
   buildah unshare cat /proc/self/uid_map,
   buildah unshare buildah-script.sh`,
 	}
+	unshareMounts []string
 )
 
 func init() {
 	unshareCommand.SetUsageTemplate(UsageTemplate())
 	flags := unshareCommand.Flags()
 	flags.SetInterspersed(false)
+	flags.StringSliceVar(&unshareMounts, "mount", []string{}, "mount the specified containers (default [])")
 	rootCmd.AddCommand(unshareCommand)
+}
+
+func unshareMount(c *cobra.Command, mounts []string) ([]string, func(), error) {
+	var store storage.Store
+	var mountedContainers, env []string
+	if len(mounts) == 0 {
+		return nil, nil, nil
+	}
+	unmount := func() {
+		for _, mounted := range mountedContainers {
+			builder, err := openBuilder(getContext(), store, mounted)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, errors.Wrapf(err, "error loading information about build container %q", mounted))
+				continue
+			}
+			err = builder.Unmount()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, errors.Wrapf(err, "error unmounting build container %q", mounted))
+				continue
+			}
+		}
+	}
+	store, err := getStore(c)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, mountSpec := range mounts {
+		mount := strings.SplitN(mountSpec, "=", 2)
+		container := mountSpec
+		envVar := container
+		if len(mount) == 2 {
+			envVar = mount[0]
+			container = mount[1]
+		}
+		builder, err := openBuilder(getContext(), store, container)
+		if err != nil {
+			unmount()
+			return nil, nil, errors.Wrapf(err, "error loading information about build container %q", container)
+		}
+		mountPoint, err := builder.Mount(builder.MountLabel)
+		if err != nil {
+			unmount()
+			return nil, nil, errors.Wrapf(err, "error mounting build container %q", container)
+		}
+		logrus.Debugf("mounted container %q at %q", container, mountPoint)
+		mountedContainers = append(mountedContainers, container)
+		if envVar != "" {
+			envSpec := fmt.Sprintf("%s=%s", envVar, mountPoint)
+			logrus.Debugf("adding %q to environment", envSpec)
+			env = append(env, envSpec)
+		}
+	}
+	return env, unmount, nil
 }
 
 // unshareCmd execs whatever using the ID mappings that we want to use for ourselves
@@ -58,7 +117,12 @@ func unshareCmd(c *cobra.Command, args []string) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	unshare.ExecRunnable(cmd)
+	mountEnvs, unmountMounts, err := unshareMount(c, unshareMounts)
+	if err != nil {
+		return err
+	}
+	cmd.Env = append(cmd.Env, mountEnvs...)
+	unshare.ExecRunnable(cmd, unmountMounts)
 	os.Exit(1)
 	return nil
 }

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -894,6 +894,7 @@ _buildah_containers() {
      "
 
      local options_with_args="
+     --mount
      "
  }
 

--- a/docs/buildah-unshare.md
+++ b/docs/buildah-unshare.md
@@ -19,6 +19,14 @@ manually clearing storage and other data related to images and containers.
 It is also useful if you want to use the `buildah mount` command.  If an unprivileged users wants to mount and work with a container, then they need to execute
 buildah unshare.  Executing `buildah mount` fails for unprivileged users unless the user is running inside a `buildah unshare` session.
 
+## OPTIONS
+**--mount** [*VARIABLE=]containerNameOrID*
+
+Mount the *containerNameOrID* container while running *command*, and set the
+environment variable *VARIABLE* to the path of the mountpoint.  If *VARIABLE*
+is not specified, it defaults to *containerNameOrID*, which may not be a valid
+name for an environment variable.
+
 ## EXAMPLE
 
 buildah unshare id
@@ -28,6 +36,8 @@ buildah unshare pwd
 buildah unshare cat /proc/self/uid\_map /proc/self/gid\_map
 
 buildah unshare rm -fr $HOME/.local/share/containers/storage /var/run/user/\`id -u\`/run
+
+buildah unshare --mount containerID sh -c 'cat ${containerID}/etc/os-release'
 
 If you want to use buildah with a mount command then you can create a script that looks something like:
 

--- a/pkg/unshare/unshare.go
+++ b/pkg/unshare/unshare.go
@@ -459,32 +459,38 @@ func MaybeReexecUsingUserNamespace(evenForRoot bool) {
 
 	// Finish up.
 	logrus.Debugf("running %+v with environment %+v, UID map %+v, and GID map %+v", cmd.Cmd.Args, os.Environ(), cmd.UidMappings, cmd.GidMappings)
-	ExecRunnable(cmd)
+	ExecRunnable(cmd, nil)
 }
 
 // ExecRunnable runs the specified unshare command, captures its exit status,
 // and exits with the same status.
-func ExecRunnable(cmd Runnable) {
+func ExecRunnable(cmd Runnable, cleanup func()) {
+	exit := func(status int) {
+		if cleanup != nil {
+			cleanup()
+		}
+		os.Exit(status)
+	}
 	if err := cmd.Run(); err != nil {
 		if exitError, ok := errors.Cause(err).(*exec.ExitError); ok {
 			if exitError.ProcessState.Exited() {
 				if waitStatus, ok := exitError.ProcessState.Sys().(syscall.WaitStatus); ok {
 					if waitStatus.Exited() {
 						logrus.Errorf("%v", exitError)
-						os.Exit(waitStatus.ExitStatus())
+						exit(waitStatus.ExitStatus())
 					}
 					if waitStatus.Signaled() {
 						logrus.Errorf("%v", exitError)
-						os.Exit(int(waitStatus.Signal()) + 128)
+						exit(int(waitStatus.Signal()) + 128)
 					}
 				}
 			}
 		}
 		logrus.Errorf("%v", err)
 		logrus.Errorf("(unable to determine exit status)")
-		os.Exit(1)
+		exit(1)
 	}
-	os.Exit(0)
+	exit(0)
 }
 
 // getHostIDMappings reads mappings from the named node under /proc.


### PR DESCRIPTION
Add a `--mount` flag to `buildah unshare`, so that the command it runs can have a container's root filesystem mounted, and the location where it's mounted provided in its environment.

This is primarily aimed at cases where `buildah unshare` is used to run one-liner commands, as proper scripts can simply call `buildah mount` themselves.

Users still have to be careful about quoting references to the environment if the command needs to be executed by a shell (for example, if it's run as `buildah unshare --mount foo sh -c 'ls $foo'`), so that the shell that's invoking `buildah unshare` doesn't try to expand the variable's value first.

My use case was primarily mucking around in https://github.com/containers/BuildSourceImage, and if it's useful for me there, hopefully it will be for others.