### PR TITLE
run.bats: skip the "z" flag when testing --mount

### DIFF
--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -107,6 +107,7 @@ Current supported mount TYPES are bind, and tmpfs.
        Options specific to bind:
 
               · bind-propagation: shared, slave, private, rshared, rslave, or rprivate(default). See also mount(2).
+
               . bind-nonrecursive: do not setup a recursive bind mount.  By default it is recursive.
 
        Options specific to tmpfs:

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -272,12 +272,12 @@ function configure_and_check_user() {
 	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
 	mkdir -p ${TESTDIR}/was:empty
 	# As a baseline, this should succeed.
-	run_buildah --debug=false run --mount type=tmpfs,dst=/var/tmpfs-not-empty${zflag:+,${zflag}}     $cid touch /var/tmpfs-not-empty/testfile
-	run_buildah --debug=false run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/not-empty${zflag:+,${zflag}}     $cid touch /var/not-empty/testfile
+	run_buildah --debug=false run --mount type=tmpfs,dst=/var/tmpfs-not-empty                                           $cid touch /var/tmpfs-not-empty/testfile
+	run_buildah --debug=false run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/not-empty${zflag:+,${zflag}}      $cid touch /var/not-empty/testfile
 	# If we're parsing the options at all, this should be read-only, so it should fail.
 	run_buildah 1 --debug=false run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/not-empty,ro${zflag:+,${zflag}} $cid touch /var/not-empty/testfile
 	# Even if the parent directory doesn't exist yet, this should succeed.
-	run_buildah --debug=false run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/multi-level/subdirectory        $cid touch /var/multi-level/subdirectory/testfile
+	run_buildah --debug=false run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/multi-level/subdirectory          $cid touch /var/multi-level/subdirectory/testfile
 	# And check the same for file volumes.
 	run_buildah --debug=false run --mount type=bind,src=${TESTDIR}/was:empty/testfile,dst=/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
 }


### PR DESCRIPTION
When testing the --mount flag, don't add the "z" flag as a mount option when mounting a tmpfs, since relabeling the "source" for that case isn't supported.