### PR TITLE
 Add unconvert, stylecheck, goimports and misspell linter and apply fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - nakedret
     - staticcheck
     - structcheck
+    - stylecheck
     - typecheck
     - unconvert
     - unparam
@@ -41,4 +42,3 @@ linters:
     # - misspell
     # - prealloc
     # - scopelint
-    # - stylecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - misspell
     - nakedret
     - staticcheck
     - structcheck
@@ -39,6 +40,5 @@ linters:
     # - interfacer
     # - lll
     # - maligned
-    # - misspell
     # - prealloc
     # - scopelint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - dupl
     - errcheck
     - gofmt
+    - goimports
     - gosimple
     - govet
     - ineffassign
@@ -33,7 +34,6 @@ linters:
     # - goconst
     # - gocritic
     # - gocyclo
-    # - goimports
     # - golint
     # - gosec
     # - interfacer

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - staticcheck
     - structcheck
     - typecheck
+    - unconvert
     - unparam
     - unused
     - varcheck
@@ -41,4 +42,3 @@ linters:
     # - prealloc
     # - scopelint
     # - stylecheck
-    # - unconvert

--- a/buildah.go
+++ b/buildah.go
@@ -15,7 +15,7 @@ import (
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/ioutils"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/chroot/run.go
+++ b/chroot/run.go
@@ -569,7 +569,7 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 	cmd.UnshareFlags = syscall.CLONE_NEWUTS | syscall.CLONE_NEWNS
 	requestedUserNS := false
 	for _, ns := range spec.Linux.Namespaces {
-		if ns.Type == specs.LinuxNamespaceType(specs.UserNamespace) {
+		if ns.Type == specs.UserNamespace {
 			requestedUserNS = true
 		}
 	}

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -220,7 +220,7 @@ func setFilterDate(ctx context.Context, store storage.Store, images []storage.Im
 			}
 		}
 	}
-	return time.Time{}, fmt.Errorf("Could not locate image %q", imgName)
+	return time.Time{}, fmt.Errorf("could not locate image %q", imgName)
 }
 
 func outputHeader(opts imageOptions) string {

--- a/commit.go
+++ b/commit.go
@@ -184,8 +184,8 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 	}
 	// In case we're using caching, decide how to handle compression for a cache.
 	// If we're using blob caching, set it up for the source.
-	var maybeCachedSrc = types.ImageReference(src)
-	var maybeCachedDest = types.ImageReference(dest)
+	maybeCachedSrc := src
+	maybeCachedDest := dest
 	if options.BlobDirectory != "" {
 		compress := types.PreserveOriginal
 		if options.Compression != archive.Uncompressed {
@@ -301,7 +301,7 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 	if err != nil {
 		return nil, "", err
 	}
-	var maybeCachedSrc = types.ImageReference(src)
+	maybeCachedSrc := src
 	if options.BlobDirectory != "" {
 		compress := types.PreserveOriginal
 		if options.Compression != archive.Uncompressed {

--- a/config.go
+++ b/config.go
@@ -565,7 +565,7 @@ func (b *Builder) SetHealthcheck(config *docker.HealthConfig) {
 }
 
 // AddPrependedEmptyLayer adds an item to the history that we'll create when
-// commiting the image, after any history we inherit from the base image, but
+// committing the image, after any history we inherit from the base image, but
 // before the history item that we'll use to describe the new layer that we're
 // adding.
 func (b *Builder) AddPrependedEmptyLayer(created *time.Time, createdBy, author, comment string) {
@@ -589,7 +589,7 @@ func (b *Builder) ClearPrependedEmptyLayers() {
 }
 
 // AddAppendedEmptyLayer adds an item to the history that we'll create when
-// commiting the image, after the history item that we'll use to describe the
+// committing the image, after the history item that we'll use to describe the
 // new layer that we're adding.
 func (b *Builder) AddAppendedEmptyLayer(created *time.Time, createdBy, author, comment string) {
 	if created != nil {

--- a/image.go
+++ b/image.go
@@ -23,7 +23,7 @@ import (
 	"github.com/containers/storage/pkg/ioutils"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/blobcache/blobcache.go
+++ b/pkg/blobcache/blobcache.go
@@ -83,7 +83,7 @@ func makeFilename(blobSum digest.Digest, isConfig bool) string {
 
 // NewBlobCache creates a new blob cache that wraps an image reference.  Any blobs which are
 // written to the destination image created from the resulting reference will also be stored
-// as-is to the specifed directory or a temporary directory.  The cache directory's contents
+// as-is to the specified directory or a temporary directory.  The cache directory's contents
 // can be cleared by calling the returned BlobCache()'s ClearCache() method.
 // The compress argument controls whether or not the cache will try to substitute a compressed
 // or different version of a blob when preparing the list of layers when reading an image.

--- a/pkg/blobcache/blobcache_test.go
+++ b/pkg/blobcache/blobcache_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/parse/parse_unix.go
+++ b/pkg/parse/parse_unix.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+
 	"golang.org/x/sys/unix"
 )
 

--- a/tests/conformance/conformance_suite_test.go
+++ b/tests/conformance/conformance_suite_test.go
@@ -411,7 +411,7 @@ func diffDebug(k string, a, b interface{}) string {
 	return fmt.Sprintf("%v\t\t%v\t\t%v\n", k, a, b)
 }
 
-// InspectCompareResult give the compare results from inpsect.
+// InspectCompareResult give the compare results from inspect.
 func InspectCompareResult(miss, left, diff []string) string {
 	msg := `Inspect Error Messages:
 	Item missing in buildah output: MISSKEYS

--- a/util.go
+++ b/util.go
@@ -18,7 +18,7 @@ import (
 	"github.com/containers/storage/pkg/pools"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/containers/storage/pkg/system"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"


### PR DESCRIPTION
This PR fixes some more linting issues reported by golangci-lint and enabled them within the CI.