### PR TITLE
Add '-' minus syntax for removal of config values

### DIFF
--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -194,8 +194,11 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 				}
 				env[1] = os.Expand(env[1], getenv)
 				builder.SetEnv(env[0], env[1])
-			} else {
+			} else if strings.HasSuffix(env[0], "-") {
+				env[0] = strings.TrimSuffix(env[0], "-")
 				builder.UnsetEnv(env[0])
+			} else {
+				logrus.Errorf("error setting variable %q: no value given.", env[0])
 			}
 		}
 		conditionallyAddHistory(builder, c, "/bin/sh -c #(nop) ENV %s", strings.Join(iopts.env, " "))
@@ -237,8 +240,11 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 			label := strings.SplitN(labelSpec, "=", 2)
 			if len(label) > 1 {
 				builder.SetLabel(label[0], label[1])
-			} else {
+			} else if strings.HasSuffix(label[0], "-") {
+				label[0] = strings.TrimSuffix(label[0], "-")
 				builder.UnsetLabel(label[0])
+			} else {
+				logrus.Errorf("error adding label %q: no value given", label[0])
 			}
 		}
 		conditionallyAddHistory(builder, c, "/bin/sh -c #(nop) LABEL %s", strings.Join(iopts.label, " "))
@@ -270,13 +276,17 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 			conditionallyAddHistory(builder, c, "/bin/sh -c #(nop) ONBUILD %s", onbuild)
 		}
 	}
+
 	if c.Flag("annotation").Changed {
 		for _, annotationSpec := range iopts.annotation {
 			annotation := strings.SplitN(annotationSpec, "=", 2)
 			if len(annotation) > 1 {
 				builder.SetAnnotation(annotation[0], annotation[1])
-			} else {
+			} else if strings.HasSuffix(annotation[0], "-") {
+				annotation[0] = strings.TrimSuffix(annotation[0], "-")
 				builder.UnsetAnnotation(annotation[0])
+			} else {
+				logrus.Errorf("error adding annotation %q: no value given", annotation[0])
 			}
 		}
 	}

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -22,10 +22,11 @@ Defaults to false.
 Note: You can also override the default value of --add-history by setting the
 BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
 
-**--annotation** *annotation*
+**--annotation** *annotation*=*annotation*
 
 Add an image *annotation* (e.g. annotation=*annotation*) to the image manifest
 of any images which will be built using the specified container. Can be used multiple times.
+If *annotation* has a trailing `-`, then the *annotation* is removed from the config.
 
 **--arch** *architecture*
 
@@ -75,10 +76,11 @@ ignore the `cmd` value of the container image.  However if you use the array
 form, then the cmd will be appended onto the end of the entrypoint cmd and be
 executed together.
 
-**--env** *var=value*
+**--env** *env=value*
 
-Add a value (e.g. name=*value*) to the environment for containers based on any
+Add a value (e.g. env=*value*) to the environment for containers based on any
 images which will be built using the specified container. Can be used multiple times.
+If *env* has a trailing `-`, then the *env* is removed from the config.
 
 **--healthcheck** *command*
 
@@ -136,10 +138,11 @@ the specified container.
 
 Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
 
-**--label** *label*
+**--label** *label*=*value*
 
 Add an image *label* (e.g. label=*value*) to the image configuration of any
 images which will be built using the specified container. Can be used multiple times.
+If *label* has a trailing `-`, then the *label* is removed from the config.
 
 **--onbuild** *onbuild command*
 
@@ -180,7 +183,7 @@ If names are used, the container should include entries for those names in its
 
 **--volume** *volume*
 
-Add a location in the directory tree which should be marked as a *volume* in any images which will be built using the specified container. Can be used multiple times. If *volume* has a trailing `-`, and does not exist on disk, then the volume is removed from the config.
+Add a location in the directory tree which should be marked as a *volume* in any images which will be built using the specified container. Can be used multiple times. If *volume* has a trailing `-`, and does not exist on disk, then the *volume* is removed from the config.
 
 **--workingdir** *directory*
 
@@ -197,7 +200,20 @@ buildah config --entrypoint '[ "/entrypoint.sh", "dev" ]' containerID
 
 buildah config --env foo=bar --env PATH=$PATH containerID
 
+buildah config --env foo- containerID
+
 buildah config --label Name=Mycontainer --label  Version=1.0 containerID
+
+buildah config --label Name- containerID
+
+buildah config --annotation note=myNote containerID
+
+buildah config --annotation note-
+
+buildah config --volume /usr/myvol containerID
+
+buildah config --volume /usr/myvol- containerID
+
 
 ## SEE ALSO
 buildah(1)


### PR DESCRIPTION
Minus syntax for `--env`, `--label`, and `-annotation` flags for `buildah config` subcommand.
 #1399,  #1670

Signed-off-by: Ashley Cui <ashleycui16@gmail.com>