### PR TITLE
Fix bug whereby --get-login doesn't do anything

### DIFF
--- a/cmd/buildah/login.go
+++ b/cmd/buildah/login.go
@@ -70,7 +70,7 @@ func loginCmd(c *cobra.Command, args []string, iopts *loginReply) error {
 	if err != nil {
 		return errors.Wrapf(err, "error reading auth file")
 	}
-	if !iopts.getLogin {
+	if c.Flag("get-login").Changed {
 		if userFromAuthFile == "" {
 			return errors.Errorf("not logged into %s", server)
 		}


### PR DESCRIPTION
The  `--get-login` option for `buildah login` doesn't work because it incorrectly defaults to true and the if statement that performs the action checks the value is false.  This fix swaps them round so it defaults to false and the if statement checks it's true.

Test case:

buildah login --get-login *registry*


Signed-off-by: Paul Urwin <register@paulurwin.com>