### PR TITLE
Remove GO111MODULE in favor of `-mod=vendor`

### DIFF
--- a/install.md
+++ b/install.md
@@ -378,7 +378,7 @@ cat /etc/containers/policy.json
 ## Vendoring
 
 Buildah uses Go Modules for vendoring purposes.  If you need to update or add a vendored package into Buildah, please follow this proceedure:
- * Enter into your sandbox `src/github.com/containers/buildah` and ensure that he GOPATH variable is set to the directory prior as noted above.
+ * Enter into your sandbox `src/github.com/containers/buildah` and ensure that the GOPATH variable is set to the directory prior as noted above.
  * `export GO111MODULE=on`
  * Assuming you want to 'bump' the `github.com/containers/storage` package to version 1.12.13, use this command: `go get github.com/containers/storage@v1.12.13`
  * `make vendor`

--- a/tests/tools/Makefile
+++ b/tests/tools/Makefile
@@ -1,6 +1,10 @@
-export GO111MODULE=off
-
 GO := go
+# test for go module support
+ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
+export GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
+else
+export GO_BUILD=$(GO) build
+endif
 
 BUILDDIR := build
 
@@ -14,7 +18,7 @@ vendor:
 		$(GO) mod verify
 
 define go-build
-	$(shell cd `pwd` && $(GO) build -o $(BUILDDIR)/$(shell basename $(1)) $(1))
+	$(shell cd `pwd` && $(GO_BUILD) -o $(BUILDDIR)/$(shell basename $(1)) $(1))
 	@echo > /dev/null
 endef
 


### PR DESCRIPTION
When building buildah outside of the `$GOPATH`, then we should stick to
the `-mod=vendor` approach. Other go versions than 1.11 will build on
the classic way, whereas other targets should not be affected at all.
The documentation has been updated as well.