### PR TITLE
store auth to authfile file if 'nokeyring' specified

### DIFF
--- a/cmd/buildah/login.go
+++ b/cmd/buildah/login.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/image/docker"
 	"github.com/containers/image/pkg/docker/config"
@@ -43,7 +42,7 @@ func init() {
 
 	flags := loginCommand.Flags()
 	flags.SetInterspersed(false)
-	flags.StringVar(&opts.authfile, "authfile", buildahcli.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	flags.StringVar(&opts.authfile, "authfile", "", "path of the authentication file or 'nokeyring'. Use REGISTRY_AUTH_FILE environment variable to override")
 	flags.StringVar(&opts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	flags.StringVarP(&opts.password, "password", "p", "", "Password for registry")
 	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -40,8 +40,10 @@ Note: this information is not present in Docker image formats, so it is discarde
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Buildah will use the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--build-arg** *arg=value*
 

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -18,8 +18,10 @@ The image ID of the image that was created.  On error, 1 is returned and errno i
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Buildah will use the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login --authfile nokeyring`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--cert-dir** *path*
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -54,8 +54,10 @@ Add a line to /etc/hosts. The format is hostname:ip. The **--add-host** option c
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Buildah will use the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--cap-add**=*CAP\_xxx*
 

--- a/docs/buildah-login.md
+++ b/docs/buildah-login.md
@@ -10,8 +10,13 @@ buildah\-login - Login to a container registry
 **buildah login** logs into a specified registry server with the correct username
 and password. **buildah login** reads in the username and password from STDIN.
 The username and password can also be set using the **username** and **password** flags.
-The path of the authentication file can be specified by the user by setting the **authfile**
-flag. The default path used is **${XDG\_RUNTIME_DIR}/containers/auth.json**.
+The authentication storage can be set by the **authfile** option.
+By default, the authentication storage is the kernel keyring. If the system does not
+support kernel keyring, Buildah will use the authentication file.
+The path of the authentication file can be specified by the user by setting the **authfile** option
+or REGISTRY\_AUTH\_FILE environment variable. The default path used is **${XDG\_RUNTIME_DIR}/containers/auth.json**.
+If the **authfile** is set to "nokeyring", Buildah will use the default authentication path or the
+file set by REGISTRY\_AUTH\_FILE environment variable.
 
 **buildah [GLOBAL OPTIONS]**
 
@@ -35,10 +40,9 @@ Username for registry
 
 **--authfile**
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
+Path of the authentication file or "nokeyring". By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Buildah will use the authentication file.  If **authfile** is set to "nokeyring", Buildah will use the default authentication file ${XDG_\RUNTIME\_DIR}/containers/auth.json or the value of REGISTRY\_AUTH\_FILE environment variable
 
-Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
-environment variable. `export REGISTRY_AUTH_FILE=path`
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--get-login**
 

--- a/docs/buildah-logout.md
+++ b/docs/buildah-logout.md
@@ -7,10 +7,11 @@ buildah\-logout - Logout of a container registry
 **buildah logout** [*options*] *registry*
 
 ## DESCRIPTION
-**buildah logout** logs out of a specified registry server by deleting the cached credentials
-stored in the **auth.json** file. The path of the authentication file can be overridden by the user by setting the **authfile** flag.
+**buildah logout** logs out of a specified registry server by deleting the cached credentials stored in the kernel keyring.
+If the system does not support kernel keyring or the authorization state is not found there, Buildah will check the authentication file.
+The path of the authentication file can be overridden by the user by setting the **authfile** option.
 The default path used is **${XDG\_RUNTIME_DIR}/containers/auth.json**.
-All the cached credentials can be removed by setting the **all** flag.
+All the authentication file cached credentials can be removed by setting the **all** option.
 
 **buildah [GLOBAL OPTIONS]**
 
@@ -22,10 +23,10 @@ All the cached credentials can be removed by setting the **all** flag.
 
 **--authfile**
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Buildah will use the authentication file.Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
-Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
-environment variable. `export REGISTRY_AUTH_FILE=path`
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--all, -a**
 

--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -51,8 +51,10 @@ All tagged images in the repository will be pulled.
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Buildah will use the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--cert-dir** *path*
 

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -47,8 +47,10 @@ If the transport part of DESTINATION is omitted, "docker://" is assumed.
 
 **--authfile** *path*
 
-Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Buildah will use the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--cert-dir** *path*
 


### PR DESCRIPTION
This PR allows the value of --authfile to be "nokeyring".
Returns empty string if both --authfile and REGISTRY_AUTH_FILE are not set.
Returns filepath if one of --authfile or REGISTRY_AUTH_FILE is set to a filepath. If --authfile and REGISTRY_AUTH_FILE are filepath, we respect --authfile

Signed-off-by: Qi Wang <qiwan@redhat.com>