### PR TITLE
Add automatic apparmor tag discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SELINUXTAG := $(shell ./selinux_tag.sh)
+APPARMORTAG := $(shell hack/apparmor_tag.sh)
 STORAGETAGS := $(shell ./btrfs_tag.sh) $(shell ./btrfs_installed_tag.sh) $(shell ./libdm_tag.sh) $(shell ./ostree_tag.sh)
-SECURITYTAGS ?= seccomp $(SELINUXTAG)
+SECURITYTAGS ?= seccomp $(SELINUXTAG) $(APPARMORTAG)
 TAGS ?= $(SECURITYTAGS) $(STORAGETAGS)
 BUILDTAGS += $(TAGS)
 PREFIX := /usr/local

--- a/hack/apparmor_tag.sh
+++ b/hack/apparmor_tag.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+if pkg-config libapparmor 2>/dev/null; then
+    echo apparmor
+fi


### PR DESCRIPTION
The 'apparmor' build tag is now added if libappamor was found on the
local system.
