### PR TITLE
Bug fix for volume minus syntax

### DIFF
--- a/config.go
+++ b/config.go
@@ -422,6 +422,16 @@ func (b *Builder) Volumes() []string {
 	return nil
 }
 
+// CheckVolume returns True if the location exists in the image's list of locations
+// which should be mounted from outside of the container when a container
+// based on an image built from this container is run
+
+func (b *Builder) CheckVolume(v string) bool {
+	_, OCIv1Volume := b.OCIv1.Config.Volumes[v]
+	_, DockerVolume := b.Docker.Config.Volumes[v]
+	return OCIv1Volume || DockerVolume
+}
+
 // AddVolume adds a location to the image's list of locations which should be
 // mounted from outside of the container when a container based on an image
 // built from this container is run.
@@ -440,14 +450,8 @@ func (b *Builder) AddVolume(v string) {
 // mounted from outside of the container when a container based on an image
 // built from this container is run.
 func (b *Builder) RemoveVolume(v string) {
-	_, OCIv1Volume := b.OCIv1.Config.Volumes[v]
-	_, DockerVolume := b.Docker.Config.Volumes[v]
-	if !OCIv1Volume && !DockerVolume {
-		logrus.Errorf("Volume \"%s\" cannot be removed from config because it was not set.", v)
-	} else {
-		delete(b.OCIv1.Config.Volumes, v)
-		delete(b.Docker.Config.Volumes, v)
-	}
+	delete(b.OCIv1.Config.Volumes, v)
+	delete(b.Docker.Config.Volumes, v)
 }
 
 // ClearVolumes removes all locations from the image's list of locations which

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -183,7 +183,7 @@ If names are used, the container should include entries for those names in its
 
 **--volume** *volume*
 
-Add a location in the directory tree which should be marked as a *volume* in any images which will be built using the specified container. Can be used multiple times. If *volume* has a trailing `-`, and does not exist on disk, then the *volume* is removed from the config.
+Add a location in the directory tree which should be marked as a *volume* in any images which will be built using the specified container. Can be used multiple times. If *volume* has a trailing `-`, and is already set, then the *volume* is removed from the config.
 
 **--workingdir** *directory*
 


### PR DESCRIPTION
Do not check disk for existence of volume.
If volume that ends with `-` is set in config, remove it.
If not, add it into config.

https://github.com/containers/buildah/pull/1670#issuecomment-517969058

Signed-off-by: Ashley Cui <ashleycui16@gmail.com>