### PR TITLE
run_linux: fix mounting /sys in a userns

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -343,7 +343,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 	net := namespaceOptions.Find(string(specs.NetworkNamespace))
 	hostNetwork := net == nil || net.Host
 	user := namespaceOptions.Find(string(specs.UserNamespace))
-	hostUser := user == nil || user.Host
+	hostUser := (user == nil || user.Host) && !unshare.IsRootless()
 
 	// Copy mounts from the generated list.
 	mountCgroups := true

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -2,6 +2,20 @@
 
 load helpers
 
+@test "already-in-userns" {
+  if test "$BUILDAH_ISOLATION" != "rootless" -o $UID == 0 ; then
+    skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION"
+  fi
+
+  run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --quiet alpine
+  [ "$output" != "" ]
+  ctr="$output"
+
+  run_buildah unshare buildah run --isolation=oci "$ctr" echo hello
+  [ $status -eq 0 ]
+  [ "$output" == "hello" ]
+}
+
 @test "user-and-network-namespace" {
   if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
     skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION"


### PR DESCRIPTION
fix the detection code for running in a user namespace.  When buildah
is running in rootless mode, a user namespace is automatically created
even if there are no mappings configured.

Closes: https://github.com/containers/libpod/issues/2972

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>