### PR TITLE
Cirrus: Update VM images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,10 +19,10 @@ env:
     ####
     # GCE project where images live
     IMAGE_PROJECT: "libpod-218412"
-    FEDORA_CACHE_IMAGE_NAME: "fedora-cloud-base-30-1-2-1559164849"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-cloud-base-29-1-2-1559164849"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-1904-disco-v20190514"         # Latest
-    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "ubuntu-1804-bionic-v20190530"  # LTS
+    FEDORA_CACHE_IMAGE_NAME: "fedora-cloud-base-30-1-2-1565360543"
+    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-cloud-base-29-1-2-1565360543"
+    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-1904-disco-v20190724"          # Latest
+    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "ubuntu-1804-bionic-v20190722a"  # LTS
 
     ####
     #### Command variables to help avoid duplication


### PR DESCRIPTION
These were produced as an intended byproduct of:
https://github.com/containers/libpod/pull/3754

Where 'systemd_banish.sh' was run during base-image production.
Therefor, during run-time there should no longer be interference
of testing by background/periodic processes.

Signed-off-by: Chris Evich <cevich@redhat.com>