### PR TITLE
imagebuilder: fix detection of referenced stage roots

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -406,13 +406,12 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 							// arg expansion, so if the previous stage
 							// was named using argument values, we might
 							// not record the right value here.
-							rootfs := flag[7:]
+							rootfs := strings.TrimPrefix(flag, "--from=")
 							b.rootfsMap[rootfs] = true
 							logrus.Debugf("rootfs: %q", rootfs)
 						}
 					}
 				}
-				break
 			}
 			node = node.Next // next line
 		}

--- a/tests/bud/cache-stages/Dockerfile.1
+++ b/tests/bud/cache-stages/Dockerfile.1
@@ -1,0 +1,2 @@
+FROM alpine AS builder
+RUN touch /tmpfile

--- a/tests/bud/cache-stages/Dockerfile.2
+++ b/tests/bud/cache-stages/Dockerfile.2
@@ -1,0 +1,5 @@
+FROM alpine AS builder
+RUN touch /tmpfile
+FROM alpine AS base
+COPY --from=builder /tmpfile /
+RUN stat /tmpfile


### PR DESCRIPTION
Fix detection of when we need to have an up-to-date copy of a stage's root filesystem for later stages.  ADD and COPY instructions aren't the first lines in their stages, so we can't stop parsing a stage's lines after its first line.  This should fix #1782.