### PR TITLE
add: handle hard links when copying with .dockerignore

### DIFF
--- a/tests/bud/hardlink/Dockerfile
+++ b/tests/bud/hardlink/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY . .
+COPY . .

--- a/util/util_not_uint64.go
+++ b/util/util_not_uint64.go
@@ -1,0 +1,14 @@
+// +build darwin
+
+package util
+
+import (
+	"syscall"
+)
+
+func makeHardlinkDeviceAndInode(st *syscall.Stat_t) hardlinkDeviceAndInode {
+	return hardlinkDeviceAndInode{
+		device: uint64(st.Dev),
+		inode:  uint64(st.Ino),
+	}
+}

--- a/util/util_uint64.go
+++ b/util/util_uint64.go
@@ -1,0 +1,14 @@
+// +build linux
+
+package util
+
+import (
+	"syscall"
+)
+
+func makeHardlinkDeviceAndInode(st *syscall.Stat_t) hardlinkDeviceAndInode {
+	return hardlinkDeviceAndInode{
+		device: st.Dev,
+		inode:  st.Ino,
+	}
+}

--- a/util/util_unix.go
+++ b/util/util_unix.go
@@ -1,0 +1,31 @@
+// +build linux darwin
+
+package util
+
+import (
+	"os"
+	"sync"
+	"syscall"
+)
+
+type hardlinkDeviceAndInode struct {
+	device, inode uint64
+}
+
+type HardlinkChecker struct {
+	hardlinks sync.Map
+}
+
+func (h *HardlinkChecker) Check(fi os.FileInfo) string {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok && fi.Mode().IsRegular() && st.Nlink > 1 {
+		if name, ok := h.hardlinks.Load(makeHardlinkDeviceAndInode(st)); ok && name.(string) != "" {
+			return name.(string)
+		}
+	}
+	return ""
+}
+func (h *HardlinkChecker) Add(fi os.FileInfo, name string) {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok && fi.Mode().IsRegular() && st.Nlink > 1 {
+		h.hardlinks.Store(makeHardlinkDeviceAndInode(st), name)
+	}
+}

--- a/util/util_windows.go
+++ b/util/util_windows.go
@@ -1,0 +1,16 @@
+// +build !linux,!darwin
+
+package util
+
+import (
+	"os"
+)
+
+type HardlinkChecker struct {
+}
+
+func (h *HardlinkChecker) Check(fi os.FileInfo) string {
+	return ""
+}
+func (h *HardlinkChecker) Add(fi os.FileInfo, name string) {
+}


### PR DESCRIPTION
Detect files that are hard linked together, and use that information to avoid copying their contents more often than we have to.