### PR TITLE
Use content digests in ADD/COPY history entries

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -196,6 +196,8 @@ type Builder struct {
 	Format string
 	// TempVolumes are temporary mount points created during container runs
 	TempVolumes map[string]bool
+	// ContentDigester counts the digest of all Add()ed content
+	ContentDigester CompositeDigester
 }
 
 // BuilderInfo are used as objects to display container information

--- a/digester.go
+++ b/digester.go
@@ -1,0 +1,64 @@
+package buildah
+
+import (
+	"hash"
+	"strings"
+
+	digest "github.com/opencontainers/go-digest"
+)
+
+type singleDigester struct {
+	digester digest.Digester
+	prefix   string
+}
+
+// CompositeDigester can compute a digest over multiple items.
+type CompositeDigester struct {
+	digesters []singleDigester
+}
+
+// Restart clears all state, so that the composite digester can start over.
+func (c *CompositeDigester) Restart() {
+	c.digesters = nil
+}
+
+// Start starts recording the digest for a new item.  The caller should call
+// Hash() immediately after to retrieve the new io.Writer.
+func (c *CompositeDigester) Start(prefix string) {
+	prefix = strings.TrimSuffix(prefix, ":")
+	c.digesters = append(c.digesters, singleDigester{digester: digest.Canonical.Digester(), prefix: prefix})
+}
+
+// Hash returns the hasher for the current item.
+func (c *CompositeDigester) Hash() hash.Hash {
+	num := len(c.digesters)
+	if num == 0 {
+		return nil
+	}
+	return c.digesters[num-1].digester.Hash()
+}
+
+// Digest returns the prefix and a composite digest over everything that's been
+// digested.
+func (c *CompositeDigester) Digest() (string, digest.Digest) {
+	num := len(c.digesters)
+	switch num {
+	case 0:
+		return "", ""
+	case 1:
+		return c.digesters[0].prefix, c.digesters[0].digester.Digest()
+	default:
+		content := ""
+		for i, digester := range c.digesters {
+			if i > 0 {
+				content += ","
+			}
+			prefix := digester.prefix
+			if digester.prefix != "" {
+				digester.prefix += ":"
+			}
+			content += prefix + digester.digester.Digest().Encoded()
+		}
+		return "multi", digest.Canonical.FromString(content)
+	}
+}

--- a/imagebuildah/errors.go
+++ b/imagebuildah/errors.go
@@ -1,7 +1,0 @@
-package imagebuildah
-
-import "errors"
-
-var (
-	errDanglingSymlink = errors.New("error evaluating dangling symlink")
-)

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -42,8 +42,8 @@ var builtinAllowedBuildArgs = map[string]bool{
 }
 
 // Executor is a buildah-based implementation of the imagebuilder.Executor
-// interface.  It coordinates the entire build by using one StageExecutors to
-// handle each stage of the build.
+// interface.  It coordinates the entire build by using one or more
+// StageExecutors to handle each stage of the build.
 type Executor struct {
 	stages                         map[string]*StageExecutor
 	store                          storage.Store
@@ -248,26 +248,36 @@ func (b *Executor) getImageHistory(ctx context.Context, imageID string) ([]v1.Hi
 	return oci.History, nil
 }
 
-// getCreatedBy returns the command the image at node will be created by.
-func (b *Executor) getCreatedBy(node *parser.Node) string {
+// getCreatedBy returns the command the image at node will be created by.  If
+// the passed-in CompositeDigester is not nil, it is assumed to have the digest
+// information for the content if the node is ADD or COPY.
+func (b *Executor) getCreatedBy(node *parser.Node, addedContentDigest string) string {
 	if node == nil {
 		return "/bin/sh"
 	}
-	if node.Value == "run" {
+	switch strings.ToUpper(node.Value) {
+	case "RUN":
 		buildArgs := b.getBuildArgs()
 		if buildArgs != "" {
 			return "|" + strconv.Itoa(len(strings.Split(buildArgs, " "))) + " " + buildArgs + " /bin/sh -c " + node.Original[4:]
 		}
 		return "/bin/sh -c " + node.Original[4:]
+	case "ADD", "COPY":
+		destination := node
+		for destination.Next != nil {
+			destination = destination.Next
+		}
+		return "/bin/sh -c #(nop) " + strings.ToUpper(node.Value) + " " + addedContentDigest + " in " + destination.Value + " "
+	default:
+		return "/bin/sh -c #(nop) " + node.Original
 	}
-	return "/bin/sh -c #(nop) " + node.Original
 }
 
 // historyMatches returns true if a candidate history matches the history of our
 // base image (if we have one), plus the current instruction.
 // Used to verify whether a cache of the intermediate image exists and whether
 // to run the build again.
-func (b *Executor) historyMatches(baseHistory []v1.History, child *parser.Node, history []v1.History) bool {
+func (b *Executor) historyMatches(baseHistory []v1.History, child *parser.Node, history []v1.History, addedContentDigest string) bool {
 	if len(baseHistory) >= len(history) {
 		return false
 	}
@@ -297,7 +307,7 @@ func (b *Executor) historyMatches(baseHistory []v1.History, child *parser.Node, 
 			return false
 		}
 	}
-	return history[len(baseHistory)].CreatedBy == b.getCreatedBy(child)
+	return history[len(baseHistory)].CreatedBy == b.getCreatedBy(child, addedContentDigest)
 }
 
 // getBuildArgs returns a string of the build-args specified during the build process

--- a/run_linux.go
+++ b/run_linux.go
@@ -431,7 +431,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 
 	// Add temporary copies of the contents of volume locations at the
 	// volume locations, unless we already have something there.
-	copyWithTar := b.copyWithTar(nil, nil, nil)
+	copyWithTar := b.copyWithTar(nil, nil, nil, false)
 	builtins, err := runSetupBuiltinVolumes(b.MountLabel, mountPoint, cdir, copyWithTar, builtinVolumes, int(rootUID), int(rootGID))
 	if err != nil {
 		return err

--- a/tests/bud/dest-symlink-dangling/Dockerfile
+++ b/tests/bud/dest-symlink-dangling/Dockerfile
@@ -3,3 +3,4 @@ FROM ubuntu
 RUN mkdir /symlink
 RUN ln -s /symlink /src && rm -rf /symlink
 COPY Dockerfile /src/
+RUN test -s /symlink/Dockerfile


### PR DESCRIPTION
Use digests of the added content in history entries that we create for ADD and COPY instructions, tightening up cache checking just a little bit more.  This should fix #1780.