### PR TITLE
Add security-related volume options to validator

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -462,25 +462,40 @@ func ValidateVolumeCtrDir(ctrDir string) error {
 
 // ValidateVolumeOpts validates a volume's options
 func ValidateVolumeOpts(options []string) ([]string, error) {
-	var foundRootPropagation, foundRWRO, foundLabelChange, bindType int
+	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid int
 	finalOpts := make([]string, 0, len(options))
 	for _, opt := range options {
 		switch opt {
+		case "noexec", "exec":
+			foundExec++
+			if foundExec > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'noexec' or 'exec' option", strings.Join(options, ", "))
+			}
+		case "nodev", "dev":
+			foundDev++
+			if foundDev > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'nodev' or 'dev' option", strings.Join(options, ", "))
+			}
+		case "nosuid", "suid":
+			foundSuid++
+			if foundSuid > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'nosuid' or 'suid' option", strings.Join(options, ", "))
+			}
 		case "rw", "ro":
+			foundRWRO++
 			if foundRWRO > 1 {
 				return nil, errors.Errorf("invalid options %q, can only specify 1 'rw' or 'ro' option", strings.Join(options, ", "))
 			}
-			foundRWRO++
 		case "z", "Z", "O":
+			foundLabelChange++
 			if foundLabelChange > 1 {
 				return nil, errors.Errorf("invalid options %q, can only specify 1 'z', 'Z', or 'O' option", strings.Join(options, ", "))
 			}
-			foundLabelChange++
 		case "private", "rprivate", "shared", "rshared", "slave", "rslave", "unbindable", "runbindable":
+			foundRootPropagation++
 			if foundRootPropagation > 1 {
 				return nil, errors.Errorf("invalid options %q, can only specify 1 '[r]shared', '[r]private', '[r]slave' or '[r]unbindable' option", strings.Join(options, ", "))
 			}
-			foundRootPropagation++
 		case "bind", "rbind":
 			bindType++
 			if bindType > 1 {


### PR DESCRIPTION
Also, ensure ordering is correct on other entries. The current code will increment *after* checking for validity in some cases, which allows such options as '-v /tmp:/test1:ro,rw' to pass validation when they obviously don't make much sense.

Inspired by https://github.com/containers/libpod/issues/3819 on the Podman side