### PR TITLE
Fix possible runtime panic on bud

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1619,3 +1619,25 @@ load helpers
   cd $(mktemp -d)
   run_buildah 1 bud
 }
+
+@test "bud with specified context should fail if directory contains no Dockerfile" {
+  DIR=$(mktemp -d)
+  run_buildah 1 bud "$DIR"
+}
+
+@test "bud with specified context should fail if assumed Dockerfile is a directory" {
+  DIR=$(mktemp -d)
+  mkdir -p "$DIR"/Dockerfile
+  run_buildah 1 bud "$DIR"
+}
+
+@test "bud with specified context should fail if context contains not-existing Dockerfile" {
+  DIR=$(mktemp -d)
+  run_buildah 1 bud "$DIR"/Dockerfile
+}
+
+@test "bud with specified context should succeed if context contains existing Dockerfile" {
+  DIR=$(mktemp -d)
+  touch "$DIR"/Dockerfile
+  run_buildah 0 bud "$DIR"/Dockerfile
+}


### PR DESCRIPTION
The current code triggers a runtime panic in `imagebuildah/build.go:201`
if buildah is specifying a file as build context, which will be
interpreted wrongly as `Dockerfile`.

Reproduce with:
```
> buildah bud <any exinsting file>
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x561c1706f0a5]

goroutine 1 [running]:
github.com/containers/buildah/imagebuildah.BuildDockerfiles(0x561c17513b00, 0xc0000ba038, 0x561c1751bd60, 0xc00075a360, 0x7ffebb358667, 0x18, 0x0, 0x0, 0x0, 0x0, ...)
        /home/abuild/go/src/github.com/containers/buildah/imagebuildah/build.go:201 +0xd85
main.budCmd(0xc000173400, 0xc0000afce0, 0x1, 0x1, 0xc0006e3da8, 0xc000098f00, 0xc0003b8b40, 0xc000099080, 0xc0003b8ba0, 0x0, ...)
        /home/abuild/go/src/github.com/containers/buildah/cmd/buildah/bud.go:292 +0x12e6
main.init.1.func1(0xc000173400, 0xc0000afce0, 0x1, 0x1, 0x0, 0x0)
        /home/abuild/go/src/github.com/containers/buildah/cmd/buildah/bud.go:50 +0xd8
github.com/spf13/cobra.(*Command).execute(0xc000173400, 0xc0000afca0, 0x1, 0x1, 0xc000173400, 0xc0000afca0)
        /home/abuild/go/src/github.com/containers/buildah/vendor/github.com/spf13/cobra/command.go:762 +0x475
github.com/spf13/cobra.(*Command).ExecuteC(0x561c17a8f700, 0xc000721f18, 0x561c17039a74, 0xc000721f00)
        /home/abuild/go/src/github.com/containers/buildah/vendor/github.com/spf13/cobra/command.go:852 +0x2ff
github.com/spf13/cobra.(*Command).Execute(0x561c17a8f700, 0x1, 0xc000721f88)
        /home/abuild/go/src/github.com/containers/buildah/vendor/github.com/spf13/cobra/command.go:800 +0x2d
main.main()
        /home/abuild/go/src/github.com/containers/buildah/cmd/buildah/main.go:125 +0x42
```

We now check if the file exists before passing the Dockerfile around.
For this we introduce a new function `discoverDockerfile`, which tries
to find a corresponding Dockerfile for a given directory.

All possible integration test scenarios have been added as well.