### PR TITLE
Fix directory pull image names

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -102,19 +102,11 @@ func localImageNameForReference(ctx context.Context, store storage.Store, srcRef
 		}
 	case directory.Transport.Name():
 		// supports pull from a directory
-		name = srcRef.StringWithinTransport()
-		// remove leading "/"
-		if name[:1] == "/" {
-			name = name[1:]
-		}
+		name = toLocalImageName(srcRef.StringWithinTransport())
 	case oci.Transport.Name():
 		// supports pull from a directory
 		split := strings.SplitN(srcRef.StringWithinTransport(), ":", 2)
-		name = split[0]
-		// remove leading "/"
-		if name[:1] == "/" {
-			name = name[1:]
-		}
+		name = toLocalImageName(split[0])
 	default:
 		ref := srcRef.DockerReference()
 		if ref == nil {
@@ -286,4 +278,9 @@ func getImageDigest(ctx context.Context, src types.ImageReference, sc *types.Sys
 		return "", errors.Wrapf(err, "error getting config info from image %q", transports.ImageName(src))
 	}
 	return "@" + digest.Hex(), nil
+}
+
+// toLocalImageName converts an image name into a 'localhost/' prefixed one
+func toLocalImageName(imageName string) string {
+	return "localhost/" + strings.TrimLeft(imageName, "/")
 }

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -75,7 +75,7 @@ load helpers
   run_buildah rmi alpine
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json dir:${TESTDIR}/buildahtest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
-  expect_output --substring "buildahtest"
+  expect_output --substring "localhost${TESTDIR}/buildahtest:latest"
   run_buildah 1 pull --all-tags --signature-policy ${TESTSDIR}/policy.json dir:${TESTDIR}/buildahtest
   run rm -rf ${TESTDIR}/buildahtest
   echo "$output"
@@ -139,7 +139,7 @@ load helpers
   run_buildah rmi alpine
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json oci:${TESTDIR}/alpine
   run_buildah images --format "{{.Name}}:{{.Tag}}"
-  expect_output --substring "alpine"
+  expect_output --substring "localhost${TESTDIR}/alpine:latest"
   run_buildah 1 pull --all-tags --signature-policy ${TESTSDIR}/policy.json oci:${TESTDIR}/alpine
   run rm -rf ${TESTDIR}/alpine
   echo "$output"


### PR DESCRIPTION
This is a breaking change and modifies the resulting image name when
pull from an directory via `oci:...` or `dir:...`.

Without this patch, the image names pulled via a local directory got
prefixed with `docker.io/{library/}`, which is not correct.

We now use either the full path to the image, or the relative path as
image name, but prefixed with `localhost` to indicate that the image is
not being pulled from a remote location.

Closes: https://github.com/containers/buildah/issues/1797