### PR TITLE
Update shebangs to take env into consideration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ From [`./examples/lighttpd.sh`](examples/lighttpd.sh):
 
 ```bash
 $ cat > lighttpd.sh <<"EOF"
-#!/bin/bash -x
+#!/usr/bin/env bash -x
 
 ctr1=$(buildah from "${1:-fedora}")
 

--- a/btrfs_installed_tag.sh
+++ b/btrfs_installed_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cc -E - > /dev/null 2> /dev/null << EOF
 #include <btrfs/ioctl.h>
 EOF

--- a/btrfs_tag.sh
+++ b/btrfs_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cc -E - > /dev/null 2> /dev/null << EOF
 #include <btrfs/version.h>
 EOF

--- a/contrib/cirrus/build_and_test.sh
+++ b/contrib/cirrus/build_and_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/lib.sh.t
+++ b/contrib/cirrus/lib.sh.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Unit tests for some functions in lib.sh
 #

--- a/contrib/cirrus/ooe.sh
+++ b/contrib/cirrus/ooe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script executes a command while logging all output to a temporary
 # file.  If the command exits non-zero, then all output is sent to the console,

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/demos/buildah-bud-demo.sh
+++ b/demos/buildah-bud-demo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
 
 # buildah-bud-demo.sh
 # author : ipbabble

--- a/demos/buildah-scratch-demo.sh
+++ b/demos/buildah-scratch-demo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # author : ipbabble
 # Assumptions install buildah and podman
@@ -53,7 +53,7 @@ buildah run $newcontainer bash
 read -p "${cyan}Let's look at the program${yellow}"
 FILE=./runecho.sh
 /bin/cat <<EOM >$FILE
-#!/bin/bash
+#!/usr/bin/env bash
 for i in {1..9};
 do
     echo "This is a new cloud native container using Buildah [" \$i "]"

--- a/demos/buildah_multi_stage.sh
+++ b/demos/buildah_multi_stage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
 
 # author : tsweeney (based on ipbabble's other demos) 
 # Based on Alex Ellis blog (https://blog.alexellis.io/mutli-stage-docker-builds)

--- a/demos/docker-compatibility-demo.sh
+++ b/demos/docker-compatibility-demo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
 
 # docker-compatibility-demo.sh
 # author : ipbabble

--- a/docs/tutorials/01-intro.md
+++ b/docs/tutorials/01-intro.md
@@ -110,7 +110,7 @@ Let's try it out (showing the prompt in this example to demonstrate the differen
 
 Notice we have a `/usr/bin` directory in the newcontainer's image layer. Let's first copy a simple file from our host into the container. Create a file called runecho.sh which contains the following:
 
-    #!/bin/bash
+    #!/usr/bin/env bash
     for i in `seq 0 9`;
     do
     	echo "This is a new container from ipbabble [" $i "]"

--- a/docs/tutorials/03-on-build.md
+++ b/docs/tutorials/03-on-build.md
@@ -119,7 +119,7 @@ result-container
 For this example the ONBUILD instructions in the primary container image will be used to copy a shell script and then run it in the secondary container image.  For the script, we'll make use of the shell script from the [Introduction Tutorial][].  First create a file in the local directory called `runecho.sh` containing the following:
 
 ```
-#!/bin/bash
+#!/usr/bin/env bash
 
 for i in `seq 0 9`;
 do

--- a/examples/all-the-things.sh
+++ b/examples/all-the-things.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash -x
 set -e
 read
 export PATH=`pwd`:$PATH

--- a/examples/copy.sh
+++ b/examples/copy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash -x
 set -e
 : "[1m Build a temporary directory; make sure ocid is running.[0m"
 export PATH=`pwd`:$PATH

--- a/examples/lighttpd.sh
+++ b/examples/lighttpd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash -x
 
 ctr1=$(buildah from "${1:-fedora}")
 

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/run_build.sh
+++ b/hack/run_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/spc_build.sh
+++ b/hack/spc_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/tree_status.sh
+++ b/hack/tree_status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 STATUS=$(git status --porcelain)

--- a/libdm_tag.sh
+++ b/libdm_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT

--- a/ostree_tag.sh
+++ b/ostree_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if pkg-config ostree-1 2> /dev/null ; then
 	echo containers_image_ostree
 else

--- a/selinux_tag.sh
+++ b/selinux_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if pkg-config libselinux 2> /dev/null ; then
 	echo selinux
 fi

--- a/tests/conformance/testdata/copy/script
+++ b/tests/conformance/testdata/copy/script
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0

--- a/tests/conformance/testdata/copyrename/file1
+++ b/tests/conformance/testdata/copyrename/file1
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILDAH_BINARY=${BUILDAH_BINARY:-$(dirname ${BASH_SOURCE})/../buildah}
 IMGTYPE_BINARY=${IMGTYPE_BINARY:-$(dirname ${BASH_SOURCE})/../imgtype}

--- a/tests/test_buildah_authentication.sh
+++ b/tests/test_buildah_authentication.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # test_buildah_authentication
 # A script to be run at the command line with Buildah installed.
 # This currently needs to be run as root and Docker must be

--- a/tests/test_buildah_baseline.sh
+++ b/tests/test_buildah_baseline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # test_buildah_baseline.sh 
 # A script to be run at the command line with Buildah installed.
 # This should be run against a new kit to provide base level testing
@@ -104,7 +104,7 @@ buildah run $newcontainer -- ls -alF /usr/bin
 ########
 FILE=./runecho.sh
 /bin/cat <<EOM >$FILE
-#!/bin/bash
+#!/usr/bin/env bash
 for i in {1..9};
 do
     echo "This is a new container from ipbabble [" \$i "]"

--- a/tests/test_buildah_build_rpm.sh
+++ b/tests/test_buildah_build_rpm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # test_buildah_build_rpm.sh
 #

--- a/tests/validate/git-validation.sh
+++ b/tests/validate/git-validation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export PATH=tests/tools/build:${PATH}
 if ! which git-validation > /dev/null 2> /dev/null ; then
 	echo git-validation is not in PATH.

--- a/tests/validate/gofmt.sh
+++ b/tests/validate/gofmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if test $(find . -name "*.go" -not -path "*/vendor/*" -print0 | xargs -n 1 -0 gofmt -s -l | wc -l) -ne 0 ; then
 	echo Error: source files are not formatted according to recommendations.  Run \"gofmt -s -w\" on:
 	find . -name "*.go" -not -path "*/vendor/*" -print0 | xargs -n 1 -0 gofmt -s -l

--- a/tests/validate/govet.sh
+++ b/tests/validate/govet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 while ! test -x ./btrfs_tag.sh ; do
 	cd ..
 done


### PR DESCRIPTION
Some operating systems don’t have `bash` in `/bin`, so we should take the
`$PATH` into consideration for searching it.