### PR TITLE
Remove gofmt.sh in favor of golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,6 @@ deps: gopath
 
 .PHONY: validate
 validate: install.tools
-	# Run gofmt on version 1.11 and higher
-ifneq ($(GO110),$(GOVERSION))
-	@./tests/validate/gofmt.sh
-endif
 	@./tests/validate/whitespace.sh
 	@./tests/validate/govet.sh
 	@./tests/validate/git-validation.sh

--- a/tests/validate/gofmt.sh
+++ b/tests/validate/gofmt.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-if test $(find . -name "*.go" -not -path "*/vendor/*" -print0 | xargs -n 1 -0 gofmt -s -l | wc -l) -ne 0 ; then
-	echo Error: source files are not formatted according to recommendations.  Run \"gofmt -s -w\" on:
-	find . -name "*.go" -not -path "*/vendor/*" -print0 | xargs -n 1 -0 gofmt -s -l
-	exit 1
-fi
-exit 0


### PR DESCRIPTION
golangci-lint already checks via gofmt so we can safely remove the
additional linting step.
