### PR TITLE
Remove outdated deps Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,6 @@ docs: install.tools ## build the docs on the host
 gopath:
 	test $(shell pwd) = $(shell cd ../../../../src/github.com/containers/buildah ; pwd)
 
-# We use https://github.com/lk4d4/vndr to manage dependencies.
-.PHONY: deps
-deps: gopath
-	env GOPATH=$(shell cd ../../../.. ; pwd) vndr
-
 .PHONY: validate
 validate: install.tools
 	# Run gofmt on version 1.11 and higher


### PR DESCRIPTION
We don’t use vendor any more so we can remove the `deps` Makefile
target.
