### PR TITLE
Add `--log-level` command line option and deprecate `--debug`

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -54,7 +54,7 @@ __buildah_pos_first_nonflag() {
     fi
 
     # Bash splits words at "=", retaining "=" as a word, examples:
-    # "--debug=false" => 3 words, "--log-opt syslog-facility=daemon" => 4 words
+    # "--log-level=error" => 3 words, "--log-opt syslog-facility=daemon" => 4 words
     while [ "${words[$counter + 1]}" = "=" ] ; do
       counter=$(( counter + 2))
     done
@@ -157,7 +157,6 @@ return 1
  # global options that may appear after the buildah command
  _buildah_buildah() {
      local boolean_options="
-         --debug
          --help -h
          --version -v
          "
@@ -783,7 +782,7 @@ _buildah_containers() {
 
  _buildah_info() {
      local options_with_args="
-       --debug
+       --log-level
        --D
        --format
      "

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -272,7 +272,7 @@ Add an image *label* (e.g. label=*value*) to the image metadata. Can be used mul
 **--loglevel** *number*
 
 Adjust the logging level up or down.  Valid option values range from -2 to 3,
-with 3 being roughly equivalent to using the global *--debug* option, and
+with 3 being roughly equivalent to using the global *--log-level=debug* option, and
 values below 0 omitting even error messages which accompany fatal errors.
 
 **--layers** *bool-value*

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -20,9 +20,9 @@ The Buildah package provides a command line tool which can be used to:
 
 ## OPTIONS
 
-**--debug**
+**--log-level** **value**
 
-Print debugging information
+The log level to be used. Either "debug", "info", "warn" or "error", per default "error".
 
 **--help, -h**
 

--- a/docs/tutorials/02-registries-repositories.md
+++ b/docs/tutorials/02-registries-repositories.md
@@ -21,9 +21,9 @@ Then we need to start the registry. You should start the registry in a separate 
 
 If you would like to see more details as to what is going on inside the registry, especially if you are having problems with the registry, you can run the registry container in debug mode as follows:
 
-    # buildah --debug run $registry
+    # buildah --log-level=debug run $registry
 
-You can use `--debug` on any Buildah command.
+You can use `--log-level=debug` on any Buildah command.
 
 The registry is running and is waiting for requests to process. Notice that this registry is a Docker registry that we pulled from Docker hub and we are running it for this example using `buildah run`. There is no Docker daemon running at this time.
 

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -102,9 +102,9 @@ load helpers
   run_buildah rmi remove-container-image
   run_buildah rmi containers-storage:other-new-image
   run_buildah rmi another-new-image
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   [ "$output" != "" ]
   run_buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }

--- a/tests/blobcache.bats
+++ b/tests/blobcache.bats
@@ -30,7 +30,7 @@ load helpers
 	blobcachedir=${TESTDIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah --debug=false from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
+	run_buildah --log-level=error from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
 	ctr="$output"
 	run_buildah add ${ctr} ${TESTSDIR}/bud/add-file/file /
 	# Commit the image without using the blob cache, using compression so that uncompressed blobs
@@ -97,7 +97,7 @@ load helpers
 	blobcachedir=${TESTDIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah --debug=false from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
+	run_buildah --log-level=error from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
 	ctr="$output"
 	run_buildah add ${ctr} ${TESTSDIR}/bud/add-file/file /
 	# Commit the image using the blob cache.

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3,7 +3,7 @@
 load helpers
 
 @test "bud with --dns* flags" {
-  run buildah bud --debug=false --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc  --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/dns/Dockerfile  ${TESTSDIR}/bud/dns
+  run buildah bud --log-level=error --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc  --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/dns/Dockerfile  ${TESTSDIR}/bud/dns
   echo "$output"
   [[ "$output" =~ "search example.com" ]]
   [[ "$output" =~ "nameserver 223.5.5.5" ]]
@@ -61,40 +61,40 @@ load helpers
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 8
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 10
-  run_buildah --debug=false inspect --format "{{index .Docker.ContainerConfig.Env 1}}" test1
+  run_buildah --log-level=error inspect --format "{{index .Docker.ContainerConfig.Env 1}}" test1
   expect_output "foo=bar"
-  run_buildah --debug=false inspect --format "{{index .Docker.ContainerConfig.Env 1}}" test2
+  run_buildah --log-level=error inspect --format "{{index .Docker.ContainerConfig.Env 1}}" test2
   expect_output "foo=bar"
-  run_buildah --debug=false inspect --format "{{.Docker.ContainerConfig.ExposedPorts}}" test1
+  run_buildah --log-level=error inspect --format "{{.Docker.ContainerConfig.ExposedPorts}}" test1
   expect_output "map[8080/tcp:{}]"
-  run_buildah --debug=false inspect --format "{{.Docker.ContainerConfig.ExposedPorts}}" test2
+  run_buildah --log-level=error inspect --format "{{.Docker.ContainerConfig.ExposedPorts}}" test2
   expect_output "map[8080/tcp:{}]"
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 12
 
   mkdir -p ${TESTDIR}/use-layers/mount/subdir
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test4 -f Dockerfile.3 ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 14
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test5 -f Dockerfile.3 ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 15
 
   touch ${TESTDIR}/use-layers/mount/subdir/file.txt
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test6 -f Dockerfile.3 ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 17
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --no-cache -t test7 -f Dockerfile.2 ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 18
 
   buildah rmi -a -f
@@ -102,11 +102,11 @@ load helpers
 
 @test "bud with --layers and single and two line Dockerfiles" {
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test -f Dockerfile.5 ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 3
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 -f Dockerfile.6 ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 4
 
   buildah rmi -a -f
@@ -121,31 +121,31 @@ load helpers
   date > ${TESTDIR}/use-layers/date/data
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 6
   [ "${status}" -eq 0 ]
   # The second time through, the layers should all get reused.
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 6
   # The third time through, the layers should all get reused, but we'll have a new line of output for the new name.
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 7
 
   # Both interim images will be different, and all of the layers in the final image will be different.
   uuidgen > ${TESTDIR}/use-layers/uuid/data
   date > ${TESTDIR}/use-layers/date/data
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 11
   # No leftover containers, just the header line.
-  run_buildah --debug=false containers
+  run_buildah --log-level=error containers
   expect_line_count 1
 
-  ctr=$(buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json test3)
-  mnt=$(buildah --debug=false mount ${ctr})
+  ctr=$(buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json test3)
+  mnt=$(buildah --log-level=error mount ${ctr})
   run test -e $mnt/uuid
   [ "${status}" -eq 0 ]
   run test -e $mnt/date
@@ -153,7 +153,7 @@ load helpers
 
   # Layers won't get reused because this build won't use caching.
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t test4 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 12
 
   buildah rmi -a -f
@@ -164,19 +164,19 @@ load helpers
   # build the first stage
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -f ${TESTSDIR}/bud/cache-stages/Dockerfile.1 ${TESTSDIR}/bud/cache-stages
   # expect alpine + 1 image record for the first stage
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 3
   # build the second stage, itself not cached, when the first stage is found in the cache
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -f ${TESTSDIR}/bud/cache-stages/Dockerfile.2 -t ${target} ${TESTSDIR}/bud/cache-stages
   # expect alpine + 1 image record for the first stage, then two more image records for the second stage
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 5
 }
 
 @test "bud-multistage-copy-final-slash" {
   target=foo
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-final-slash
-  run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json ${target}
   cid="$output"
   run_buildah run ${cid} /test/ls -lR /test/ls
 }
@@ -193,9 +193,9 @@ load helpers
 @test "bud-multistage-cache" {
   target=foo
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.extended ${TESTSDIR}/bud/multi-stage-builds
-  run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json ${target}
   cid="$output"
-  run_buildah --debug=false mount "$cid"
+  run_buildah --log-level=error mount "$cid"
   root="$output"
   # cache should have used this one
   test -r "$root"/tmp/preCommit
@@ -208,16 +208,16 @@ load helpers
   echo 'echo "Hello World!"' > ${TESTDIR}/use-layers/hello.sh
   ln -s hello.sh ${TESTDIR}/use-layers/hello_world.sh
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test -f Dockerfile.4 ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 4
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 -f Dockerfile.4 ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 5
 
   echo 'echo "Hello Cache!"' > ${TESTDIR}/use-layers/hello.sh
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.4 ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 7
 
   buildah rmi -a -f
@@ -229,15 +229,15 @@ load helpers
   ln -s ${TESTSDIR}/policy.json ${TESTDIR}/use-layers/blah/policy.json
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test -f Dockerfile.dangling-symlink ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 3
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 -f Dockerfile.dangling-symlink ${TESTDIR}/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 4
 
   cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json test)
-  run_buildah --debug=false run $cid ls /tmp
+  run_buildah --log-level=error run $cid ls /tmp
   expect_output "policy.json"
 
   buildah rm -a
@@ -248,22 +248,22 @@ load helpers
 @test "bud with --layers and --build-args" {
   # base plus 3, plus the header line
   buildah bud --signature-policy ${TESTSDIR}/policy.json --build-arg=user=0 --layers -t test -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 5
 
   # two more, starting at the "echo $user" instruction
   buildah bud --signature-policy ${TESTSDIR}/policy.json --build-arg=user=1 --layers -t test1 -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 7
 
   # one more, because we added a new name to the same image
   buildah bud --signature-policy ${TESTSDIR}/policy.json --build-arg=user=1 --layers -t test2 -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 8
 
   # two more, starting at the "echo $user" instruction
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 10
 
   buildah rmi -a -f
@@ -271,11 +271,11 @@ load helpers
 
 @test "bud with --rm flag" {
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false containers
+  run_buildah --log-level=error containers
   expect_line_count 1
 
   buildah bud --signature-policy ${TESTSDIR}/policy.json --rm=false --layers -t test2 ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false containers
+  run_buildah --log-level=error containers
   expect_line_count 7
 
   buildah rm -a
@@ -284,11 +284,11 @@ load helpers
 
 @test "bud with --force-rm flag" {
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --force-rm --layers -t test1 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false containers
+  run_buildah --log-level=error containers
   expect_line_count 1
 
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false containers
+  run_buildah --log-level=error containers
   expect_line_count 2
 
   buildah rm -a
@@ -305,9 +305,9 @@ load helpers
   cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json test)
   buildah config --env random=hello,goodbye ${cid}
   buildah commit --signature-policy ${TESTSDIR}/policy.json ${cid} test1
-  run_buildah --debug=false inspect --format '{{index .Docker.ContainerConfig.Env 1}}' test1
+  run_buildah --log-level=error inspect --format '{{index .Docker.ContainerConfig.Env 1}}' test1
   expect_output "foo=bar"
-  run_buildah --debug=false inspect --format '{{index .Docker.ContainerConfig.Env 2}}' test1
+  run_buildah --log-level=error inspect --format '{{index .Docker.ContainerConfig.Env 2}}' test1
   expect_output "random=hello,goodbye"
   buildah rm ${cid}
   buildah rmi -a -f
@@ -318,8 +318,8 @@ load helpers
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
   cid=$(buildah from ${target})
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -329,15 +329,15 @@ load helpers
   iid=$(cat ${TESTDIR}/output.iid)
   cid=$(buildah from ${iid})
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
 @test "bud-from-scratch-label" {
   target=scratch-image
   buildah bud --label "test=label" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
-  run_buildah --debug=false inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
+  run_buildah --log-level=error inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output 'map["test":"label"]'
 
   buildah rmi ${target}
@@ -346,7 +346,7 @@ load helpers
 @test "bud-from-scratch-annotation" {
   target=scratch-image
   buildah bud --annotation "test=annotation1,annotation2=z" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
-  run_buildah --debug=false inspect --format '{{printf "%q" .ImageAnnotations}}' ${target}
+  run_buildah --log-level=error inspect --format '{{printf "%q" .ImageAnnotations}}' ${target}
   expect_output 'map["test":"annotation1,annotation2=z"]'
   buildah rmi ${target}
 }
@@ -356,7 +356,7 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -f  ${TESTSDIR}/bud/from-scratch/Dockerfile2 -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -f  ${TESTSDIR}/bud/from-scratch/Dockerfile2 -t ${target} ${TESTSDIR}/bud/from-scratch
   cid=$(buildah from ${target})
-  run_buildah --debug=false images
+  run_buildah --log-level=error images
   run_buildah rm ${cid}
   expect_line_count 2
 }
@@ -372,8 +372,8 @@ load helpers
   echo "$output"
   [ "$status" -ne 0 ]
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 
   target=alpine-image
@@ -387,7 +387,7 @@ load helpers
   [ "$status" -eq 0 ]
   buildah rm ${cid}
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -405,7 +405,7 @@ load helpers
   [ "$status" -eq 0 ]
   buildah rm ${cid}
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 
   target=alpine-image
@@ -421,7 +421,7 @@ load helpers
   [ "$status" -eq 0 ]
   buildah rm ${cid}
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   echo "$output"
   expect_output ""
 }
@@ -436,7 +436,7 @@ load helpers
   [ "$status" -eq 0 ]
   buildah rm ${cid}
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 
   target=multi-stage-name
@@ -447,8 +447,8 @@ load helpers
   run test -s $root/etc/passwd
   [ "$status" -ne 0 ]
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 
   target=multi-stage-mixed
@@ -459,8 +459,8 @@ load helpers
   cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index
   cmp $root/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.mixed
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -474,7 +474,7 @@ load helpers
   [ "$status" -eq 0 ]
   buildah rm ${cid}
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 
   target=multi-stage-name
@@ -485,8 +485,8 @@ load helpers
   run test -s $root/etc/passwd
   [ "$status" -ne 0 ]
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 
   target=multi-stage-mixed
@@ -497,8 +497,8 @@ load helpers
   cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index
   cmp $root/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.mixed
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -521,7 +521,7 @@ load helpers
   [ "$status" -ne 0 ]
   buildah rm ${cid}
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -532,8 +532,8 @@ load helpers
   stophttpd
   cid=$(buildah from ${target})
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -544,8 +544,8 @@ load helpers
   stophttpd
   cid=$(buildah from ${target})
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -556,8 +556,8 @@ load helpers
   stophttpd
   cid=$(buildah from ${target})
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -568,8 +568,8 @@ load helpers
   stophttpd
   cid=$(buildah from ${target})
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -587,8 +587,8 @@ load helpers
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} "${gitrepo}"
   cid=$(buildah from ${target})
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -599,9 +599,9 @@ load helpers
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} "${gitrepo}"
   cid=$(buildah from ${target})
   buildah rm ${cid}
-  buildah --debug=false images -q
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah --log-level=error images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -610,15 +610,15 @@ load helpers
   target2=another-scratch-image
   target3=so-many-scratch-images
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -t docker.io/${target2} -t ${target3} ${TESTSDIR}/bud/from-scratch
-  run_buildah --debug=false images
+  run_buildah --log-level=error images
   cid=$(buildah from ${target})
   buildah rm ${cid}
   cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json library/${target2})
   buildah rm ${cid}
   cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target3}:latest)
   buildah rm ${cid}
-  buildah rmi -f $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi -f $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -629,18 +629,18 @@ load helpers
   target4=still-another-tagged-image
   run_buildah bud --layers --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/addtl-tags
   run_buildah bud --layers --signature-policy ${TESTSDIR}/policy.json -t ${target2} -t ${target3} -t ${target4} ${TESTSDIR}/bud/addtl-tags
-  run_buildah --debug=false inspect -f '{{.FromImageID}}' busybox
+  run_buildah --log-level=error inspect -f '{{.FromImageID}}' busybox
   busyboxid="$output"
-  run_buildah --debug=false inspect -f '{{.FromImageID}}' ${target}
+  run_buildah --log-level=error inspect -f '{{.FromImageID}}' ${target}
   targetid="$output"
   [ "$targetid" != "$busyboxid" ]
-  run_buildah --debug=false inspect -f '{{.FromImageID}}' ${target2}
+  run_buildah --log-level=error inspect -f '{{.FromImageID}}' ${target2}
   targetid2="$output"
   [ "$targetid2" = "$targetid" ]
-  run_buildah --debug=false inspect -f '{{.FromImageID}}' ${target3}
+  run_buildah --log-level=error inspect -f '{{.FromImageID}}' ${target3}
   targetid3="$output"
   [ "$targetid3" = "$targetid2" ]
-  run_buildah --debug=false inspect -f '{{.FromImageID}}' ${target4}
+  run_buildah --log-level=error inspect -f '{{.FromImageID}}' ${target4}
   targetid4="$output"
   [ "$targetid4" = "$targetid3" ]
 }
@@ -662,7 +662,7 @@ load helpers
   [ "$output" = 41ed ]
   buildah rm ${cid}
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -675,19 +675,19 @@ load helpers
   cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
   buildah rm ${cid}
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
 @test "bud-maintainer" {
   target=alpine-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/maintainer
-  run_buildah --debug=false inspect --type=image --format '{{.Docker.Author}}' ${target}
+  run_buildah --log-level=error inspect --type=image --format '{{.Docker.Author}}' ${target}
   expect_output "kilroy"
-  run_buildah --debug=false inspect --type=image --format '{{.OCIv1.Author}}' ${target}
+  run_buildah --log-level=error inspect --type=image --format '{{.OCIv1.Author}}' ${target}
   expect_output "kilroy"
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -695,23 +695,23 @@ load helpers
   target=alpine-image
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/unrecognized
   expect_output --substring "BOGUS"
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
 @test "bud-shell" {
   target=alpine-image
   buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/shell
-  run_buildah --debug=false inspect --type=image --format '{{printf "%q" .Docker.Config.Shell}}' ${target}
+  run_buildah --log-level=error inspect --type=image --format '{{printf "%q" .Docker.Config.Shell}}' ${target}
   expect_output '["/bin/sh" "-c"]' ".Docker.Config.Shell (original)"
   ctr=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
-  run_buildah --debug=false config --shell "/bin/bash -c" ${ctr}
-  run_buildah --debug=false inspect --type=container --format '{{printf "%q" .Docker.Config.Shell}}' ${ctr}
+  run_buildah --log-level=error config --shell "/bin/bash -c" ${ctr}
+  run_buildah --log-level=error inspect --type=container --format '{{printf "%q" .Docker.Config.Shell}}' ${ctr}
   expect_output '["/bin/bash" "-c"]' ".Docker.Config.Shell (changed)"
   buildah rm ${ctr}
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -720,7 +720,7 @@ load helpers
   run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/sh"
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -729,7 +729,7 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/sh"
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -738,7 +738,7 @@ load helpers
   run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/bash"
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -747,7 +747,7 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/sh"
   buildah rmi -a
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -1008,7 +1008,7 @@ load helpers
 @test "bud-onbuild" {
   target=onbuild
   buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/onbuild
-  run_buildah --debug=false inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
+  run_buildah --log-level=error inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild1" "RUN touch /onbuild2"]'
   cid=$(buildah from ${target})
   root=$(buildah mount ${cid})
@@ -1020,7 +1020,7 @@ load helpers
 
   target=onbuild-image2
   buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1 ${TESTSDIR}/bud/onbuild
-  run_buildah --debug=false inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
+  run_buildah --log-level=error inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild3"]'
   cid=$(buildah from ${target})
   root=$(buildah mount ${cid})
@@ -1029,11 +1029,11 @@ load helpers
   [ "$status" -eq 0 ]
   buildah umount ${cid}
 
-  run_buildah --debug=false config --onbuild "RUN touch /onbuild4" ${cid}
+  run_buildah --log-level=error config --onbuild "RUN touch /onbuild4" ${cid}
 
   target=onbuild-image3
   buildah commit --signature-policy ${TESTSDIR}/policy.json --format docker ${cid} ${target}
-  run_buildah --debug=false inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
+  run_buildah --log-level=error inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild4"]'
   buildah rm ${cid}
   buildah rmi --all
@@ -1042,7 +1042,7 @@ load helpers
 @test "bud-onbuild-layers" {
   target=onbuild
   buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile2 ${TESTSDIR}/bud/onbuild
-  run_buildah --debug=false inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
+  run_buildah --log-level=error inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild1" "RUN touch /onbuild2"]'
 }
 
@@ -1055,23 +1055,23 @@ load helpers
 
 @test "bud with ARGS" {
   target=alpine-image
-  run_buildah --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.args ${TESTSDIR}/bud/run-scenarios
+  run_buildah --log-level=error bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.args ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "arg_value"
 }
 
 @test "bud with unused ARGS" {
   target=alpine-image
-  run_buildah --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE ${TESTSDIR}/bud/run-scenarios
+  run_buildah --log-level=error bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "USED_VALUE"
   [[ ! "$output" =~ "one or more build args were not consumed: [UNUSED_ARG]" ]]
-  run_buildah --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE --build-arg UNUSED_ARG=whaaaat ${TESTSDIR}/bud/run-scenarios
+  run_buildah --log-level=error bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE --build-arg UNUSED_ARG=whaaaat ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "USED_VALUE"
   expect_output --substring "one or more build args were not consumed: \[UNUSED_ARG\]"
 }
 
 @test "bud with multi-value ARGS" {
   target=alpine-image
-  run_buildah --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=plugin1,plugin2,plugin3 ${TESTSDIR}/bud/run-scenarios
+  run_buildah --log-level=error bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=plugin1,plugin2,plugin3 ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "plugin1,plugin2,plugin3"
   [[ ! "$output" =~ "one or more build args were not consumed: [UNUSED_ARG]" ]]
 }
@@ -1085,38 +1085,38 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   buildah rm ${cid}
-  buildah rmi $(buildah --debug=false images -q)
-  run_buildah --debug=false images -q
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
 @test "bud with preprocessor" {
   target=alpine-image
-  run_buildah --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Decomposed.in ${TESTSDIR}/bud/preprocess
+  run_buildah --log-level=error bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Decomposed.in ${TESTSDIR}/bud/preprocess
 }
 
 @test "bud with preprocessor error" {
   target=alpine-image
-  run_buildah 1 --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Error.in ${TESTSDIR}/bud/preprocess
+  run_buildah 1 --log-level=error bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Error.in ${TESTSDIR}/bud/preprocess
 }
 
 @test "bud-with-rejected-name" {
   target=ThisNameShouldBeRejected
-  run_buildah 1 --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah 1 --log-level=error bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
   expect_output --substring "must be lower"
 }
 
 @test "bud with chown copy" {
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-chown
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-chown
   expect_output --substring "user:2367 group:3267"
-  run_buildah --debug=false from --name ${ctrName} ${imgName}
-  run_buildah --debug=false run alpine-chown -- stat -c '%u' /tmp/copychown.txt
+  run_buildah --log-level=error from --name ${ctrName} ${imgName}
+  run_buildah --log-level=error run alpine-chown -- stat -c '%u' /tmp/copychown.txt
   # Validate that output starts with "2367"
   expect_output --substring "2367"
 
-  run_buildah --debug=false run alpine-chown -- stat -c '%g' /tmp/copychown.txt
+  run_buildah --log-level=error run alpine-chown -- stat -c '%g' /tmp/copychown.txt
   # Validate that output starts with "3267"
   expect_output --substring "3267"
 }
@@ -1124,108 +1124,108 @@ load helpers
 @test "bud with chown add" {
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-chown
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-chown
   expect_output --substring "user:2367 group:3267"
-  run_buildah --debug=false from --name ${ctrName} ${imgName}
-  run_buildah --debug=false run alpine-chown -- stat -c '%u' /tmp/addchown.txt
+  run_buildah --log-level=error from --name ${ctrName} ${imgName}
+  run_buildah --log-level=error run alpine-chown -- stat -c '%u' /tmp/addchown.txt
   # Validate that output starts with "2367"
   expect_output --substring "2367"
 
-  run_buildah --debug=false run alpine-chown -- stat -c '%g' /tmp/addchown.txt
+  run_buildah --log-level=error run alpine-chown -- stat -c '%g' /tmp/addchown.txt
   # Validate that output starts with "3267"
   expect_output --substring "3267"
 }
 
 @test "bud with ADD file construct" {
-  buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/add-file
-  run_buildah --debug=false images -a
+  buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/add-file
+  run_buildah --log-level=error images -a
   expect_output --substring "test1"
 
-  ctr=$(buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json test1)
-  run_buildah --debug=false containers -a
+  ctr=$(buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json test1)
+  run_buildah --log-level=error containers -a
   expect_output --substring "test1"
 
-  run_buildah --debug=false run $ctr ls /var/file2
+  run_buildah --log-level=error run $ctr ls /var/file2
   expect_output --substring "/var/file2"
 }
 
 @test "bud with COPY of single file creates absolute path with correct permissions" {
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-create-absolute-path
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-create-absolute-path
   expect_output --substring "permissions=755"
 
-  run_buildah --debug=false from --name ${ctrName} ${imgName}
-  run_buildah --debug=false run ${ctrName} -- stat -c "%a" /usr/lib/python3.7/distutils
+  run_buildah --log-level=error from --name ${ctrName} ${imgName}
+  run_buildah --log-level=error run ${ctrName} -- stat -c "%a" /usr/lib/python3.7/distutils
   expect_output --substring "755"
 }
 
 @test "bud with COPY of single file creates relative path with correct permissions" {
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-create-relative-path
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-create-relative-path
   expect_output --substring "permissions=755"
 
-  run_buildah --debug=false from --name ${ctrName} ${imgName}
-  run_buildah --debug=false run ${ctrName} -- stat -c "%a" lib/custom
+  run_buildah --log-level=error from --name ${ctrName} ${imgName}
+  run_buildah --log-level=error run ${ctrName} -- stat -c "%a" lib/custom
   expect_output --substring "755"
 }
 
 @test "bud with ADD of single file creates absolute path with correct permissions" {
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-create-absolute-path
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-create-absolute-path
   expect_output --substring "permissions=755"
 
-  run_buildah --debug=false from --name ${ctrName} ${imgName}
-  run_buildah --debug=false run ${ctrName} -- stat -c "%a" /usr/lib/python3.7/distutils
+  run_buildah --log-level=error from --name ${ctrName} ${imgName}
+  run_buildah --log-level=error run ${ctrName} -- stat -c "%a" /usr/lib/python3.7/distutils
   expect_output --substring "755"
 }
 
 @test "bud with ADD of single file creates relative path with correct permissions" {
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-create-relative-path
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-create-relative-path
   expect_output --substring "permissions=755"
 
-  run_buildah --debug=false from --name ${ctrName} ${imgName}
-  run_buildah --debug=false run ${ctrName} -- stat -c "%a" lib/custom
+  run_buildah --log-level=error from --name ${ctrName} ${imgName}
+  run_buildah --log-level=error run ${ctrName} -- stat -c "%a" lib/custom
   expect_output --substring "755"
 }
 
 @test "bud multi-stage COPY creates absolute path with correct permissions" {
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.absolute -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.absolute -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
   expect_output --substring "permissions=755"
 
-  run_buildah --debug=false from --name ${ctrName} ${imgName}
-  run_buildah --debug=false run ${ctrName} -- stat -c "%a" /my/bin
+  run_buildah --log-level=error from --name ${ctrName} ${imgName}
+  run_buildah --log-level=error run ${ctrName} -- stat -c "%a" /my/bin
   expect_output --substring "755"
 }
 
 @test "bud multi-stage COPY creates relative path with correct permissions" {
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.relative -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.relative -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
   expect_output --substring "permissions=755"
 
-  run_buildah --debug=false from --name ${ctrName} ${imgName}
-  run_buildah --debug=false run ${ctrName} -- stat -c "%a" my/bin
+  run_buildah --log-level=error from --name ${ctrName} ${imgName}
+  run_buildah --log-level=error run ${ctrName} -- stat -c "%a" my/bin
   expect_output --substring "755"
 }
 
 @test "bud COPY to root succeeds" {
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/copy-root
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/copy-root
 }
 
 @test "bud with FROM AS construct" {
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_output --substring "test1"
 
-  ctr=$(buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json test1)
-  run_buildah --debug=false containers -a
+  ctr=$(buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json test1)
+  run_buildah --log-level=error containers -a
   expect_output --substring "test1"
 
   run_buildah inspect --format "{{.Docker.ContainerConfig.Env}}" --type image test1
@@ -1234,11 +1234,11 @@ load helpers
 
 @test "bud with FROM AS construct with layers" {
   buildah bud --layers --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_output --substring "test1"
 
-  ctr=$(buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json test1)
-  run_buildah --debug=false containers -a
+  ctr=$(buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json test1)
+  run_buildah --log-level=error containers -a
   expect_output --substring "test1"
 
   run_buildah inspect --format "{{.Docker.ContainerConfig.Env}}" --type image test1
@@ -1246,15 +1246,15 @@ load helpers
 }
 
 @test "bud with FROM AS skip FROM construct" {
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t test1 -f ${TESTSDIR}/bud/from-as/Dockerfile.skip ${TESTSDIR}/bud/from-as
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t test1 -f ${TESTSDIR}/bud/from-as/Dockerfile.skip ${TESTSDIR}/bud/from-as
   expect_output --substring "LOCAL=/1"
   expect_output --substring "LOCAL2=/2"
 
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_output --substring "test1"
 
-  ctr=$(buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json test1)
-  run_buildah --debug=false containers -a
+  ctr=$(buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json test1)
+  run_buildah --log-level=error containers -a
   expect_output --substring "test1"
 
   mnt=$(buildah mount $ctr)
@@ -1263,7 +1263,7 @@ load helpers
   run test -e $mnt/2
   [ "${status}" -ne 0 ]
 
-  run_buildah --debug=false inspect --format "{{.Docker.ContainerConfig.Env}}" --type image test1
+  run_buildah --log-level=error inspect --format "{{.Docker.ContainerConfig.Env}}" --type image test1
   expect_output "[PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin LOCAL=/1]"
 }
 
@@ -1297,8 +1297,8 @@ load helpers
 
 @test "bud-with-healthcheck" {
   target=alpine-image
-  buildah --debug=false bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} --format docker ${TESTSDIR}/bud/healthcheck
-  run_buildah --debug=false inspect -f '{{printf "%q" .Docker.Config.Healthcheck.Test}} {{printf "%d" .Docker.Config.Healthcheck.StartPeriod}} {{printf "%d" .Docker.Config.Healthcheck.Interval}} {{printf "%d" .Docker.Config.Healthcheck.Timeout}} {{printf "%d" .Docker.Config.Healthcheck.Retries}}' ${target}
+  buildah --log-level=error bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} --format docker ${TESTSDIR}/bud/healthcheck
+  run_buildah --log-level=error inspect -f '{{printf "%q" .Docker.Config.Healthcheck.Test}} {{printf "%d" .Docker.Config.Healthcheck.StartPeriod}} {{printf "%d" .Docker.Config.Healthcheck.Interval}} {{printf "%d" .Docker.Config.Healthcheck.Timeout}} {{printf "%d" .Docker.Config.Healthcheck.Retries}}' ${target}
   second=1000000000
   threeseconds=$(( 3 * $second ))
   fiveminutes=$(( 5 * 60 * $second ))
@@ -1330,8 +1330,8 @@ load helpers
   target=php-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy-from ${TESTSDIR}/bud/copy-from
 
-  ctr=$(buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json ${target})
-  mnt=$(buildah --debug=false mount ${ctr})
+  ctr=$(buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json ${target})
+  mnt=$(buildah --log-level=error mount ${ctr})
 
   run test -e $mnt/usr/local/bin/composer
   echo "$output"
@@ -1340,7 +1340,7 @@ load helpers
 
 @test "bud-target" {
   target=target
-  run_buildah bud --debug=false --signature-policy ${TESTSDIR}/policy.json -t ${target} --target mytarget ${TESTSDIR}/bud/target
+  run_buildah bud --log-level=error --signature-policy ${TESTSDIR}/policy.json -t ${target} --target mytarget ${TESTSDIR}/bud/target
   expect_output --substring "STEP 1: FROM ubuntu:latest"
   expect_output --substring "STEP 3: FROM alpine:latest AS mytarget"
   cid=$(buildah from ${target})
@@ -1386,94 +1386,94 @@ load helpers
 @test "bud copy to symlink" {
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-symlink
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-symlink
   expect_output --substring "STEP 5: RUN ln -s "
 
-  run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
+  run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
   expect_output --substring ${ctr}
 
-  run_buildah --debug=false run ${ctr} ls -alF /etc/hbase
+  run_buildah --log-level=error run ${ctr} ls -alF /etc/hbase
   expect_output --substring "/etc/hbase -> /usr/local/hbase/"
 
-  run_buildah --debug=false run ${ctr} ls -alF /usr/local/hbase
+  run_buildah --log-level=error run ${ctr} ls -alF /usr/local/hbase
   expect_output --substring "Dockerfile"
 }
 
 @test "bud copy to dangling symlink" {
   target=ubuntu-image
   ctr=ubuntu-ctr
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-symlink-dangling
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-symlink-dangling
   expect_output --substring "STEP 3: RUN ln -s "
 
-  run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
+  run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
   expect_output --substring ${ctr}
 
-  run_buildah --debug=false run ${ctr} ls -alF /src
+  run_buildah --log-level=error run ${ctr} ls -alF /src
   expect_output --substring "/src -> /symlink"
 
-  run_buildah --debug=false run ${ctr} ls -alF /symlink
+  run_buildah --log-level=error run ${ctr} ls -alF /symlink
   expect_output --substring "Dockerfile"
 }
 
 @test "bud WORKDIR isa symlink" {
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/workdir-symlink
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/workdir-symlink
   expect_output --substring "STEP 3: RUN ln -sf "
 
-  run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
+  run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
   expect_output --substring ${ctr}
 
-  run_buildah --debug=false run ${ctr} ls -alF /tempest
+  run_buildah --log-level=error run ${ctr} ls -alF /tempest
   expect_output --substring "/tempest -> /var/lib/tempest/"
 
-  run_buildah --debug=false run ${ctr} ls -alF /etc/notareal.conf
+  run_buildah --log-level=error run ${ctr} ls -alF /etc/notareal.conf
   expect_output --substring "\-rw\-rw\-r\-\-"
 }
 
 @test "bud WORKDIR isa symlink no target dir" {
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile-2 ${TESTSDIR}/bud/workdir-symlink
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile-2 ${TESTSDIR}/bud/workdir-symlink
   expect_output --substring "STEP 2: RUN ln -sf "
 
-  run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
+  run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
   expect_output --substring ${ctr}
 
-  run_buildah --debug=false run ${ctr} ls -alF /tempest
+  run_buildah --log-level=error run ${ctr} ls -alF /tempest
   expect_output --substring "/tempest -> /var/lib/tempest/"
 
-  run_buildah --debug=false run ${ctr} ls /tempest
+  run_buildah --log-level=error run ${ctr} ls /tempest
   expect_output --substring "Dockerfile-2"
 
-  run_buildah --debug=false run ${ctr} ls -alF /etc/notareal.conf
+  run_buildah --log-level=error run ${ctr} ls -alF /etc/notareal.conf
   expect_output --substring "\-rw\-rw\-r\-\-"
 }
 
 @test "bud WORKDIR isa symlink no target dir and follow on dir" {
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile-3 ${TESTSDIR}/bud/workdir-symlink
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile-3 ${TESTSDIR}/bud/workdir-symlink
   expect_output --substring "STEP 2: RUN ln -sf "
 
-  run_buildah --debug=false from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
+  run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
   expect_output --substring ${ctr}
 
-  run_buildah --debug=false run ${ctr} ls -alF /tempest
+  run_buildah --log-level=error run ${ctr} ls -alF /tempest
   expect_output --substring "/tempest -> /var/lib/tempest/"
 
-  run_buildah --debug=false run ${ctr} ls /tempest
+  run_buildah --log-level=error run ${ctr} ls /tempest
   expect_output --substring "Dockerfile-3"
 
-  run_buildah --debug=false run ${ctr} ls /tempest/lowerdir
+  run_buildah --log-level=error run ${ctr} ls /tempest/lowerdir
   expect_output --substring "Dockerfile-3"
 
-  run_buildah --debug=false run ${ctr} ls -alF /etc/notareal.conf
+  run_buildah --log-level=error run ${ctr} ls -alF /etc/notareal.conf
   expect_output --substring "\-rw\-rw\-r\-\-"
 }
 
 @test "buidah bud --volume" {
-  run_buildah --debug=false bud --signature-policy ${TESTSDIR}/policy.json -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
   expect_output --substring "/testdir"
 }
 
@@ -1539,9 +1539,9 @@ load helpers
 @test "bud-copy-workdir" {
   target=testimage
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/copy-workdir
-  run_buildah --debug=false from ${target}
+  run_buildah --log-level=error from ${target}
   cid="$output"
-  run_buildah --debug=false mount "${cid}"
+  run_buildah --log-level=error mount "${cid}"
   root="$output"
   test -s "${root}"/file1.txt
   test -d "${root}"/subdir
@@ -1551,30 +1551,30 @@ load helpers
 @test "bud-build-arg-cache" {
   target=derived-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 ${TESTSDIR}/bud/build-arg
-  run_buildah --debug=false inspect -f '{{.FromImageID}}' ${target}
+  run_buildah --log-level=error inspect -f '{{.FromImageID}}' ${target}
   targetid="$output"
 
   # With build args, we should not find the previous build as a cached result.
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata ${TESTSDIR}/bud/build-arg
-  run_buildah --debug=false inspect -f '{{.FromImageID}}' ${target}
+  run_buildah --log-level=error inspect -f '{{.FromImageID}}' ${target}
   argsid="$output"
   [[ "$argsid" != "$targetid" ]]
 
   # With build args, even in a different order, we should end up using the previous build as a cached result.
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata ${TESTSDIR}/bud/build-arg
-  run_buildah --debug=false inspect -f '{{.FromImageID}}' ${target}
+  run_buildah --log-level=error inspect -f '{{.FromImageID}}' ${target}
   [[ "$output" == "$argsid" ]]
 
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata --build-arg=UID=17122 ${TESTSDIR}/bud/build-arg
-  run_buildah --debug=false inspect -f '{{.FromImageID}}' ${target}
+  run_buildah --log-level=error inspect -f '{{.FromImageID}}' ${target}
   [[ "$output" == "$argsid" ]]
 
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend ${TESTSDIR}/bud/build-arg
-  run_buildah --debug=false inspect -f '{{.FromImageID}}' ${target}
+  run_buildah --log-level=error inspect -f '{{.FromImageID}}' ${target}
   [[ "$output" == "$argsid" ]]
 
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 --build-arg=PGDATA=/pgdata --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup ${TESTSDIR}/bud/build-arg
-  run_buildah --debug=false inspect -f '{{.FromImageID}}' ${target}
+  run_buildah --log-level=error inspect -f '{{.FromImageID}}' ${target}
   [[ "$output" == "$argsid" ]]
 }
 
@@ -1583,7 +1583,7 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-privd/Dockerfile ${TESTSDIR}/bud/run-privd
   [ "${status}" -eq 0 ]
   expect_output --substring "STEP 3: COMMIT"
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_line_count 2
 }
 
@@ -1597,9 +1597,9 @@ load helpers
   ln ${TESTDIR}/hardlinks/subdir/test2.txt ${TESTDIR}/hardlinks/test3.txt
   ln ${TESTDIR}/hardlinks/test3.txt ${TESTDIR}/hardlinks/test4.txt
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTDIR}/hardlinks
-  run_buildah --debug=false from ${target}
+  run_buildah --log-level=error from ${target}
   ctrid="$output"
-  run_buildah --debug=false mount "$ctrid"
+  run_buildah --log-level=error mount "$ctrid"
   root="$output"
   id1=$(stat -c "%d:%i" ${root}/subdir/test1.txt)
   id2=$(stat -c "%d:%i" ${root}/subdir/test2.txt)

--- a/tests/byid.bats
+++ b/tests/byid.bats
@@ -6,24 +6,24 @@ load helpers
   image=busybox
 
   # Pull down the image, if we have to.
-  cid=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+  cid=$(buildah --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json $image)
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
   buildah rm $cid
 
   # Get the image's ID.
-  run_buildah --debug=false images -q $image
+  run_buildah --log-level=error images -q $image
   expect_line_count 1
   iid="$output"
 
   # Use the image's ID to create a container.
-  run_buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json ${iid}
+  run_buildah --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json ${iid}
   expect_line_count 1
   cid="$output"
   buildah rm $cid
 
   # Use a truncated form of the image's ID to create a container.
-  run_buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json ${iid:0:6}
+  run_buildah --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json ${iid:0:6}
   expect_line_count 1
   cid="$output"
   buildah rm $cid
@@ -35,21 +35,21 @@ load helpers
   image=busybox
 
   # Pull down the image, if we have to.
-  cid=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+  cid=$(buildah --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json $image)
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
   buildah rm $cid
 
   # Get the image's ID.
-  run_buildah --debug=false images -q $image
+  run_buildah --log-level=error images -q $image
   expect_line_count 1
   iid="$output"
 
   # Use the image's ID to inspect it.
-  run_buildah --debug=false inspect --type=image ${iid}
+  run_buildah --log-level=error inspect --type=image ${iid}
 
   # Use a truncated copy of the image's ID to inspect it.
-  run_buildah --debug=false inspect --type=image ${iid:0:6}
+  run_buildah --log-level=error inspect --type=image ${iid:0:6}
 
   buildah rmi $iid
 }
@@ -62,13 +62,13 @@ load helpers
     mkdir -p $TARGET $TARGET-truncated
 
     # Pull down the image, if we have to.
-    cid=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+    cid=$(buildah --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json $image)
     [ $? -eq 0 ]
     [ $(wc -l <<< "$cid") -eq 1 ]
     buildah rm $cid
 
     # Get the image's ID.
-    run_buildah --debug=false images -q $IMAGE
+    run_buildah --log-level=error images -q $IMAGE
     expect_line_count 1
     iid="$output"
 
@@ -87,16 +87,16 @@ load helpers
   image=busybox
 
   # Pull down the image, if we have to.
-  cid=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+  cid=$(buildah --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json $image)
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
   buildah rm $cid
 
   # Get the image's ID.
-  run_buildah --debug=false images -q $image
+  run_buildah --log-level=error images -q $image
   expect_line_count 1
   iid="$output"
 
   # Use a truncated copy of the image's ID to remove it.
-  run_buildah --debug=false rmi ${iid:0:6}
+  run_buildah --log-level=error rmi ${iid:0:6}
 }

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -29,15 +29,15 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-oci
   buildah commit --format docker --disable-compression=false --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-docker
 
-  buildah --debug=false inspect --type=image --format '{{.Manifest}}' alpine-image-oci | grep "application/vnd.oci.image.layer.v1.tar"
-  buildah --debug=false inspect --type=image --format '{{.Manifest}}' alpine-image-docker | grep "application/vnd.docker.image.rootfs.diff.tar.gzip"
+  buildah --log-level=error inspect --type=image --format '{{.Manifest}}' alpine-image-oci | grep "application/vnd.oci.image.layer.v1.tar"
+  buildah --log-level=error inspect --type=image --format '{{.Manifest}}' alpine-image-docker | grep "application/vnd.docker.image.rootfs.diff.tar.gzip"
   buildah rm $cid
   buildah rmi -a
 }
 
 @test "commit quiet test" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false commit --iidfile /dev/null --signature-policy ${TESTSDIR}/policy.json -q $cid alpine-image
+  run_buildah --log-level=error commit --iidfile /dev/null --signature-policy ${TESTSDIR}/policy.json -q $cid alpine-image
   expect_output ""
   buildah rm $cid
   buildah rmi -a
@@ -46,7 +46,7 @@ load helpers
 @test "commit rm test" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah commit --signature-policy ${TESTSDIR}/policy.json --rm $cid alpine-image
-  run_buildah 1 --debug=false rm $cid
+  run_buildah 1 --log-level=error rm $cid
   expect_output --substring "error removing container \"alpine-working-container\": error reading build container: container not known"
   buildah rmi -a
 }
@@ -62,7 +62,7 @@ load helpers
 
 @test "commit-rejected-name" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah 1 --debug=false commit --signature-policy ${TESTSDIR}/policy.json $cid ThisNameShouldBeRejected
+  run_buildah 1 --log-level=error commit --signature-policy ${TESTSDIR}/policy.json $cid ThisNameShouldBeRejected
   expect_output --substring "must be lower"
 }
 
@@ -73,18 +73,18 @@ load helpers
   target=new-image
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
 
-  run_buildah --debug=false config --created-by "untracked actions" $cid
-  run_buildah --debug=false commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
-  run_buildah --debug=false inspect --format '{{.Config}}' ${target}
+  run_buildah --log-level=error config --created-by "untracked actions" $cid
+  run_buildah --log-level=error commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
+  run_buildah --log-level=error inspect --format '{{.Config}}' ${target}
   config="$output"
   run python3 -c 'import json, sys; config = json.load(sys.stdin); print(config["history"][len(config["history"])-1]["created_by"])' <<< "$config"
   echo "$output"
   [ "${status}" -eq 0 ]
   [ "$output" == "untracked actions" ]
 
-  run_buildah --debug=false config --created-by "" $cid
-  run_buildah --debug=false commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
-  run_buildah --debug=false inspect --format '{{.Config}}' ${target}
+  run_buildah --log-level=error config --created-by "" $cid
+  run_buildah --log-level=error commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
+  run_buildah --log-level=error inspect --format '{{.Config}}' ${target}
   config="$output"
   run python3 -c 'import json, sys; config = json.load(sys.stdin); print(config["history"][len(config["history"])-1]["created_by"])' <<< "$config"
   echo "$output"

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -23,7 +23,7 @@ function check_matrix() {
   # matrix test: all permutations of .Docker.* and .OCIv1.* in all image types
   for image in docker oci; do
       for which in Docker OCIv1; do
-        run_buildah --debug=false inspect --type=image --format "{{.$which.$setting}}" scratch-image-$image
+        run_buildah --log-level=error inspect --type=image --format "{{.$which.$setting}}" scratch-image-$image
         expect_output "$expect"
     done
   done
@@ -143,7 +143,7 @@ function check_matrix() {
   check_matrix 'Architecture' 'SOMEARCH'
   check_matrix 'OS'           'SOMEOS'
 
-  buildah --debug=false inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+  buildah --log-level=error inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
 
   check_matrix 'Config.Cmd'          '[COMMAND-OR-ARGS]'
   check_matrix 'Config.Entrypoint'   '[/bin/sh -c /ENTRYPOINT]'
@@ -156,23 +156,23 @@ function check_matrix() {
   check_matrix 'Config.Volumes'      "map[/VOLUME:{}]"
   check_matrix 'Config.WorkingDir'   '/tmp'
 
-  buildah --debug=false inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-docker | grep PROBABLY-EMPTY
-  buildah --debug=false inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-docker | grep PROBABLY-EMPTY
-  buildah --debug=false inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-oci | grep PROBABLY-EMPTY
-  buildah --debug=false inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-oci | grep PROBABLY-EMPTY
+  buildah --log-level=error inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-docker | grep PROBABLY-EMPTY
+  buildah --log-level=error inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-docker | grep PROBABLY-EMPTY
+  buildah --log-level=error inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-oci | grep PROBABLY-EMPTY
+  buildah --log-level=error inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-oci | grep PROBABLY-EMPTY
 
   # The following aren't part of the Docker v2 spec, so they're discarded when we save to Docker format.
-  buildah --debug=false inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep ANNOTATION:VALUE1,VALUE2
-  buildah --debug=false inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep ANNOTATION:VALUE1,VALUE2
-  buildah --debug=false inspect --type=image --format '{{.Docker.Comment}}'                        scratch-image-docker | grep INFORMATIVE
-  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Domainname}}'              scratch-image-docker | grep mydomain.local
-  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Hostname}}'                scratch-image-docker | grep cleverhostname
-  buildah --debug=false inspect --type=image --format '{{.Docker.Config.Shell}}'                   scratch-image-docker | grep /bin/arbitrarysh
-  buildah --debug=false inspect               -f      '{{.Docker.Config.Healthcheck.Test}}'        scratch-image-docker | grep true
-  buildah --debug=false inspect               -f      '{{.Docker.Config.Healthcheck.StartPeriod}}' scratch-image-docker | grep 5
-  buildah --debug=false inspect               -f      '{{.Docker.Config.Healthcheck.Interval}}'    scratch-image-docker | grep 6
-  buildah --debug=false inspect               -f      '{{.Docker.Config.Healthcheck.Timeout}}'     scratch-image-docker | grep 7
-  buildah --debug=false inspect               -f      '{{.Docker.Config.Healthcheck.Retries}}'     scratch-image-docker | grep 8
+  buildah --log-level=error inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep ANNOTATION:VALUE1,VALUE2
+  buildah --log-level=error inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep ANNOTATION:VALUE1,VALUE2
+  buildah --log-level=error inspect --type=image --format '{{.Docker.Comment}}'                        scratch-image-docker | grep INFORMATIVE
+  buildah --log-level=error inspect --type=image --format '{{.Docker.Config.Domainname}}'              scratch-image-docker | grep mydomain.local
+  buildah --log-level=error inspect --type=image --format '{{.Docker.Config.Hostname}}'                scratch-image-docker | grep cleverhostname
+  buildah --log-level=error inspect --type=image --format '{{.Docker.Config.Shell}}'                   scratch-image-docker | grep /bin/arbitrarysh
+  buildah --log-level=error inspect               -f      '{{.Docker.Config.Healthcheck.Test}}'        scratch-image-docker | grep true
+  buildah --log-level=error inspect               -f      '{{.Docker.Config.Healthcheck.StartPeriod}}' scratch-image-docker | grep 5
+  buildah --log-level=error inspect               -f      '{{.Docker.Config.Healthcheck.Interval}}'    scratch-image-docker | grep 6
+  buildah --log-level=error inspect               -f      '{{.Docker.Config.Healthcheck.Timeout}}'     scratch-image-docker | grep 7
+  buildah --log-level=error inspect               -f      '{{.Docker.Config.Healthcheck.Retries}}'     scratch-image-docker | grep 8
   rm -rf /VOLUME
 }
 
@@ -183,10 +183,10 @@ function check_matrix() {
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid env-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid env-image-oci
 
-  run_buildah --debug=false inspect --type=image --format '{{.Docker.Config.Env}}' env-image-docker
+  run_buildah --log-level=error inspect --type=image --format '{{.Docker.Config.Env}}' env-image-docker
   expect_output --substring "combined=bar/bar1"
 
-  run_buildah --debug=false inspect --type=image --format '{{.OCIv1.Config.Env}}' env-image-docker
+  run_buildah --log-level=error inspect --type=image --format '{{.OCIv1.Config.Env}}' env-image-docker
   expect_output --substring "combined=bar/bar1"
 
   buildah rm $cid
@@ -195,15 +195,15 @@ function check_matrix() {
 
 @test "user" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  bndoutput=$(buildah --debug=false run $cid grep CapBnd /proc/self/status)
+  bndoutput=$(buildah --log-level=error run $cid grep CapBnd /proc/self/status)
   buildah config --user 1000 $cid
-  run_buildah --debug=false run $cid id -u
+  run_buildah --log-level=error run $cid id -u
   expect_output "1000"
 
-  run_buildah --debug=false run $cid sh -c "grep CapEff /proc/self/status | cut -f2"
+  run_buildah --log-level=error run $cid sh -c "grep CapEff /proc/self/status | cut -f2"
   expect_output "0000000000000000"
 
-  run_buildah --debug=false run $cid grep CapBnd /proc/self/status
+  run_buildah --log-level=error run $cid grep CapBnd /proc/self/status
   expect_output "$bndoutput"
 
   buildah rm $cid
@@ -221,13 +221,13 @@ function check_matrix() {
 
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
-  buildah --debug=false inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+  buildah --log-level=error inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
 
   check_matrix 'Config.Volumes'      "map[/VOLUME:{}]"
   check_matrix 'Config.Env'          '[VARIABLE=VALUE1,VALUE2]'
   check_matrix 'Config.Labels.LABEL' 'VALUE'
-  buildah --debug=false inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep ANNOTATION:VALUE1,VALUE2
-  buildah --debug=false inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep ANNOTATION:VALUE1,VALUE2
+  buildah --log-level=error inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep ANNOTATION:VALUE1,VALUE2
+  buildah --log-level=error inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep ANNOTATION:VALUE1,VALUE2
 
   buildah config \
    --created-by COINCIDENCE \
@@ -239,12 +239,12 @@ function check_matrix() {
 
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
-  buildah --debug=false inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+  buildah --log-level=error inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
   check_matrix 'Config.Volumes'      'map[]'
   check_matrix 'Config.Env'          '[]'
   check_matrix 'Config.Labels.LABEL' '<no value>'
-  buildah --debug=false inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep "map\[\]"
-  buildah --debug=false inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep "map\[\]"
+  buildah --log-level=error inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep "map\[\]"
+  buildah --log-level=error inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep "map\[\]"
 
 
 
@@ -258,7 +258,7 @@ function check_matrix() {
 
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
-  buildah --debug=false inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+  buildah --log-level=error inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
 
   check_matrix 'Config.Volumes'      "map[/VOLUME-:{}]"
 

--- a/tests/containers.bats
+++ b/tests/containers.bats
@@ -5,7 +5,7 @@ load helpers
 @test "containers" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false containers
+  run_buildah --log-level=error containers
   expect_line_count 3
 
   buildah rm -a
@@ -15,7 +15,7 @@ load helpers
 @test "containers filter test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false containers --filter name=$cid1
+  run_buildah --log-level=error containers --filter name=$cid1
   expect_line_count 2
 
   buildah rm -a
@@ -25,7 +25,7 @@ load helpers
 @test "containers format test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false containers --format "{{.ContainerName}}"
+  run_buildah --log-level=error containers --format "{{.ContainerName}}"
   expect_line_count 2
 
   buildah rm -a
@@ -34,7 +34,7 @@ load helpers
 
 @test "containers json test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  out=$(buildah --debug=false containers --json | grep "{" | wc -l)
+  out=$(buildah --log-level=error containers --json | grep "{" | wc -l)
   [ "$out" -ne "0" ]
   buildah rm -a
   buildah rmi -a -f
@@ -43,7 +43,7 @@ load helpers
 @test "containers noheading test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false containers --noheading
+  run_buildah --log-level=error containers --noheading
   expect_line_count 2
 
   buildah rm -a
@@ -53,7 +53,7 @@ load helpers
 @test "containers quiet test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false containers --quiet
+  run_buildah --log-level=error containers --quiet
   expect_line_count 2
 
   buildah rm -a

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -66,7 +66,7 @@ load helpers
 
 #  ctrid=$(buildah from localhost:5000/my-alpine --cert-dir ${TESTDIR}/auth)
 #  buildah rm $ctrid
-#  buildah rmi -f $(buildah --debug=false images -q)
+#  buildah rmi -f $(buildah --log-level=error images -q)
 
   # This should work
 #  ctrid=$(buildah from localhost:5000/my-alpine --cert-dir ${TESTDIR}/auth  --tls-verify true)
@@ -82,7 +82,7 @@ load helpers
 #  docker rmi -f localhost:5000/my-alpine
 #  docker rmi -f $(docker images -q)
 #  buildah rm $ctrid
-#  buildah rmi -f $(buildah --debug=false images -q)
+#  buildah rmi -f $(buildah --log-level=error images -q)
 }
 
 @test "from-authenticate-cert-and-creds" {
@@ -105,7 +105,7 @@ load helpers
 
 #  ctrid=$(buildah from localhost:5000/my-alpine --cert-dir ${TESTDIR}/auth)
 #  buildah rm $ctrid
-#  buildah rmi -f $(buildah --debug=false images -q)
+#  buildah rmi -f $(buildah --log-level=error images -q)
 
 #  docker logout localhost:5000
 
@@ -122,7 +122,7 @@ load helpers
 #  docker rmi -f localhost:5000/my-alpine
 #  docker rmi -f $(docker images -q)
 #  buildah rm $ctrid
-#  buildah rmi -f $(buildah --debug=false images -q)
+#  buildah rmi -f $(buildah --log-level=error images -q)
 }
 
 @test "from-tagged-image" {
@@ -217,7 +217,7 @@ load helpers
     skip "no runc in PATH"
   fi
   cid=$(buildah from --cpu-period=5000 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
+  run_buildah --log-level=error run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
   expect_output "5000"
   buildah rm $cid
 }
@@ -230,7 +230,7 @@ load helpers
     skip "no runc in PATH"
   fi
   cid=$(buildah from --cpu-quota=5000 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
+  run_buildah --log-level=error run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
   expect_output "5000"
   buildah rm $cid
 }
@@ -243,7 +243,7 @@ load helpers
     skip "no runc in PATH"
   fi
   cid=$(buildah from --cpu-shares=2 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false run $cid cat /sys/fs/cgroup/cpu/cpu.shares
+  run_buildah --log-level=error run $cid cat /sys/fs/cgroup/cpu/cpu.shares
   expect_output "2"
   buildah rm $cid
 }
@@ -256,7 +256,7 @@ load helpers
     skip "no runc in PATH"
   fi
   cid=$(buildah from --cpuset-cpus=0 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false run $cid cat /sys/fs/cgroup/cpuset/cpuset.cpus
+  run_buildah --log-level=error run $cid cat /sys/fs/cgroup/cpuset/cpuset.cpus
   expect_output "0"
   buildah rm $cid
 }
@@ -269,7 +269,7 @@ load helpers
     skip "no runc in PATH"
   fi
   cid=$(buildah from --cpuset-mems=0 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false run $cid cat /sys/fs/cgroup/cpuset/cpuset.mems
+  run_buildah --log-level=error run $cid cat /sys/fs/cgroup/cpuset/cpuset.mems
   expect_output "0"
   buildah rm $cid
 }
@@ -282,7 +282,7 @@ load helpers
     skip "no runc in PATH"
   fi
   cid=$(buildah from --memory=40m --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false run $cid cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+  run_buildah --log-level=error run $cid cat /sys/fs/cgroup/memory/memory.limit_in_bytes
   expect_output "41943040"
   buildah rm $cid
 }
@@ -292,7 +292,7 @@ load helpers
     skip "no runc in PATH"
   fi
   cid=$(buildah from --volume=${TESTDIR}:/myvol --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false run $cid -- cat /proc/mounts
+  run_buildah --log-level=error run $cid -- cat /proc/mounts
   expect_output --substring " /myvol "
   buildah rm $cid
 }
@@ -305,7 +305,7 @@ load helpers
     skip "no runc in PATH"
   fi
   cid=$(buildah from --volume=${TESTDIR}:/myvol:ro --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false run $cid -- cat /proc/mounts
+  run_buildah --log-level=error run $cid -- cat /proc/mounts
   expect_output --substring " /myvol "
   buildah rm $cid
 }
@@ -318,7 +318,7 @@ load helpers
     skip "no runc in PATH"
   fi
   cid=$(buildah from --shm-size=80m --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false run $cid -- df -h /dev/shm
+  run_buildah --log-level=error run $cid -- df -h /dev/shm
   expect_output --substring " 80.0M "
   buildah rm $cid
 }
@@ -336,12 +336,12 @@ load helpers
 @test "from name test" {
   container_name=mycontainer
   cid=$(buildah from --name=${container_name} --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  buildah --debug=false inspect --format '{{.Container}}' ${container_name}
+  buildah --log-level=error inspect --format '{{.Container}}' ${container_name}
 }
 
 @test "from cidfile test" {
   buildah from --cidfile output.cid --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$(cat output.cid)
-  run_buildah --debug=false containers -f id=${cid}
+  run_buildah --log-level=error containers -f id=${cid}
   buildah rm ${cid}
 }

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -44,7 +44,7 @@ function createrandom() {
 }
 
 function buildah() {
-	${BUILDAH_BINARY} --debug --registries-conf ${TESTSDIR}/registries.conf --root ${TESTDIR}/root --runroot ${TESTDIR}/runroot --storage-driver ${STORAGE_DRIVER} "$@"
+	${BUILDAH_BINARY} --log-level=debug --registries-conf ${TESTSDIR}/registries.conf --root ${TESTDIR}/root --runroot ${TESTDIR}/runroot --storage-driver ${STORAGE_DRIVER} "$@"
 }
 
 function imgtype() {
@@ -85,7 +85,7 @@ function run_buildah() {
 
     # stdout is only emitted upon error; this echo is to help a debugger
     echo "\$ $BUILDAH_BINARY $*"
-    run timeout --foreground --kill=10 $BUILDAH_TIMEOUT ${BUILDAH_BINARY} --debug --registries-conf ${TESTSDIR}/registries.conf --root ${TESTDIR}/root --runroot ${TESTDIR}/runroot --storage-driver ${STORAGE_DRIVER} "$@"
+    run timeout --foreground --kill=10 $BUILDAH_TIMEOUT ${BUILDAH_BINARY} --log-level=debug --registries-conf ${TESTSDIR}/registries.conf --root ${TESTDIR}/root --runroot ${TESTDIR}/runroot --storage-driver ${STORAGE_DRIVER} "$@"
     # without "quotes", multiple lines are glommed together into one
     if [ -n "$output" ]; then
         echo "$output"

--- a/tests/history.bats
+++ b/tests/history.bats
@@ -86,7 +86,7 @@ function testconfighistory() {
 @test "history-copy" {
   createrandom ${TESTDIR}/randomfile
   buildah from --name copyctr --format docker scratch
-  run_buildah --debug=false copy --add-history copyctr ${TESTDIR}/randomfile
+  run_buildah --log-level=error copy --add-history copyctr ${TESTDIR}/randomfile
   digest="$output"
   buildah commit --signature-policy ${TESTSDIR}/policy.json copyctr copyimg
   buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -18,7 +18,7 @@ load helpers
 @test "images" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false images
+  run_buildah --log-level=error images
   expect_line_count 3
   buildah rm -a
   buildah rmi -a -f
@@ -26,15 +26,15 @@ load helpers
 
 @test "images all test" {
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false images
+  run_buildah --log-level=error images
   expect_line_count 3
 
-  run_buildah --debug=false images -a
+  run_buildah --log-level=error images -a
   expect_line_count 8
 
   # create a no name image which should show up when doing buildah images without the --all flag
   buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false images
+  run_buildah --log-level=error images
   expect_line_count 4
 
   buildah rmi -a -f
@@ -43,7 +43,7 @@ load helpers
 @test "images filter test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false images --noheading --filter since=k8s.gcr.io/pause
+  run_buildah --log-level=error images --noheading --filter since=k8s.gcr.io/pause
   expect_line_count 1
   buildah rm -a
   buildah rmi -a -f
@@ -52,7 +52,7 @@ load helpers
 @test "images format test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false images --format "{{.Name}}"
+  run_buildah --log-level=error images --format "{{.Name}}"
   expect_line_count 2
   buildah rm -a
   buildah rmi -a -f
@@ -61,7 +61,7 @@ load helpers
 @test "images noheading test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false images --noheading
+  run_buildah --log-level=error images --noheading
   expect_line_count 2
   buildah rm -a
   buildah rmi -a -f
@@ -70,7 +70,7 @@ load helpers
 @test "images quiet test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false images --quiet
+  run_buildah --log-level=error images --quiet
   expect_line_count 2
   buildah rm -a
   buildah rmi -a -f
@@ -79,7 +79,7 @@ load helpers
 @test "images no-trunc test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false images -q --no-trunc
+  run_buildah --log-level=error images -q --no-trunc
   expect_line_count 2
   expect_output --substring --from="${lines[0]}" "sha256"
   buildah rm -a
@@ -89,10 +89,10 @@ load helpers
 @test "images json test" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false images --json
+  run_buildah --log-level=error images --json
   expect_line_count 24
 
-  run_buildah --debug=false images --json alpine
+  run_buildah --log-level=error images --json alpine
   expect_line_count 13
   buildah rm -a
   buildah rmi -a -f
@@ -103,7 +103,7 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
   buildah tag test new-name
 
-  run_buildah --debug=false images --json
+  run_buildah --log-level=error images --json
   [ $(grep '"id": "' <<< "$output" | wc -l) -eq 1 ]
 
   buildah rm -a
@@ -116,7 +116,7 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid1 test
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid2 test2
 
-  run_buildah --debug=false images --json
+  run_buildah --log-level=error images --json
   run python3 -m json.tool <<< "$output"
   [ "${status}" -eq 0 ]
 
@@ -127,14 +127,14 @@ load helpers
 @test "specify an existing image" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false images alpine
+  run_buildah --log-level=error images alpine
   expect_line_count 2
   buildah rm -a
   buildah rmi -a -f
 }
 
 @test "specify a nonexistent image" {
-  run_buildah 1 --debug=false images alpine
+  run_buildah 1 --log-level=error images alpine
   expect_output --from="${lines[0]}" "No such image alpine"
   expect_line_count 1
 }
@@ -143,14 +143,14 @@ load helpers
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
-  run_buildah --debug=false images
+  run_buildah --log-level=error images
   expect_line_count 3
 
-  run_buildah --debug=false images --filter dangling=true
+  run_buildah --log-level=error images --filter dangling=true
   expect_output --substring " <none> "
   expect_line_count 2
 
-  run_buildah --debug=false images --filter dangling=false
+  run_buildah --log-level=error images --filter dangling=false
   expect_output --substring " latest "
   expect_line_count 2
 

--- a/tests/loglevel.bats
+++ b/tests/loglevel.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "log-level set to debug" {
+  run_buildah --log-level=error --log-level=debug images -q
+  expect_output --substring "level=debug "
+}
+
+@test "log-level set to info" {
+  run_buildah --log-level=error --log-level=info images -q
+  expect_output ""
+}
+
+@test "log-level set to warn" {
+  run_buildah --log-level=error --log-level=warn images -q
+  expect_output ""
+}
+
+@test "log-level set to error" {
+  run_buildah --log-level=error --log-level=error images -q
+  expect_output ""
+}
+
+@test "log-level set to invalid" {
+  run_buildah 1 --log-level=error --log-level=invalid images -q
+  expect_output --substring "unable to parse log level"
+}

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -15,13 +15,13 @@ load helpers
 
 @test "mount one container" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false mount "$cid"
+  run_buildah --log-level=error mount "$cid"
   buildah rm $cid
   buildah rmi -f alpine
 }
 
 @test "mount bad container" {
-  run_buildah 1 --debug=false mount badcontainer
+  run_buildah 1 --log-level=error mount badcontainer
 }
 
 @test "mount multi images" {
@@ -49,7 +49,7 @@ load helpers
   buildah mount "$cid2"
   cid3=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid3"
-  run_buildah --debug=false mount
+  run_buildah --log-level=error mount
   expect_output --from="${lines[0]}" --substring "/tmp" "mount line 1 of 3"
   expect_output --from="${lines[1]}" --substring "/tmp" "mount line 2 of 3"
   expect_output --from="${lines[2]}" --substring "/tmp" "mount line 3 of 3"

--- a/tests/overlay.bats
+++ b/tests/overlay.bats
@@ -10,17 +10,17 @@ load helpers
   mkdir ${TESTDIR}/lower
   touch ${TESTDIR}/lower/foo
 
-cid=$(buildah --debug=false from -v ${TESTDIR}/lower:/lower:O --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+cid=$(buildah --log-level=error from -v ${TESTDIR}/lower:/lower:O --quiet --signature-policy ${TESTSDIR}/policy.json $image)
 
   # This should succeed
-  run_buildah --debug=false run $cid ls /lower/foo
+  run_buildah --log-level=error run $cid ls /lower/foo
 
   # Create and remove content in the overlay directory, should succeed
-  run_buildah --debug=false run $cid touch /lower/bar
-  run_buildah --debug=false run $cid rm /lower/foo
+  run_buildah --log-level=error run $cid touch /lower/bar
+  run_buildah --log-level=error run $cid rm /lower/foo
 
   # This should fail, second runs of containers go back to original
-  run_buildah 1 --debug=false run $cid ls /lower/bar
+  run_buildah 1 --log-level=error run $cid ls /lower/bar
 
   # This should fail
   run ls ${TESTDIR}/lower/bar

--- a/tests/registries.bats
+++ b/tests/registries.bats
@@ -8,10 +8,10 @@ load helpers
     imagename=$2
 
     # Clean up.
-    for id in $(buildah --debug=false containers -q) ; do
+    for id in $(buildah --log-level=error containers -q) ; do
       buildah rm ${id}
     done
-    for id in $(buildah --debug=false images -q) ; do
+    for id in $(buildah --log-level=error images -q) ; do
       buildah rmi ${id}
     done
 
@@ -23,8 +23,8 @@ load helpers
 
     # Get their image IDs.  They should be the same one.
     lastid=
-    for cid in $(buildah --debug=false containers -q) ; do
-      run_buildah --debug=false inspect -f "{{.FromImageID}}" $cid
+    for cid in $(buildah --log-level=error containers -q) ; do
+      run_buildah --log-level=error inspect -f "{{.FromImageID}}" $cid
       expect_line_count 1
       if [ "$lastid" != "" ] ; then
         expect_output "$lastid"
@@ -36,10 +36,10 @@ load helpers
     run_buildah images
 
     # Clean up.
-    for id in $(buildah --debug=false containers -q) ; do
+    for id in $(buildah --log-level=error containers -q) ; do
       buildah rm ${id}
     done
-    for id in $(buildah --debug=false images -q) ; do
+    for id in $(buildah --log-level=error images -q) ; do
       buildah rmi ${id}
     done
   }

--- a/tests/rename.bats
+++ b/tests/rename.bats
@@ -11,7 +11,7 @@ load helpers
   run_buildah containers --format "{{.ContainerName}}"
   expect_output --substring "test-container"
 
-  run_buildah --debug=false containers --quiet -f name=${old_name}
+  run_buildah --log-level=error containers --quiet -f name=${old_name}
   expect_output ""
 
   buildah rm ${new_name}
@@ -20,7 +20,7 @@ load helpers
 
 @test "rename same name as current name" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah 1 --debug=false rename ${cid} ${cid}
+  run_buildah 1 --log-level=error rename ${cid} ${cid}
   expect_output 'renaming a container with the same name as its current name'
 
   buildah rm $cid
@@ -30,7 +30,7 @@ load helpers
 @test "rename same name as other container name" {
   cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah 1 --debug=false rename ${cid1} ${cid2}
+  run_buildah 1 --log-level=error rename ${cid1} ${cid2}
   expect_output --substring " already in use by "
 
   buildah rm $cid1 $cid2

--- a/tests/rm.bats
+++ b/tests/rm.bats
@@ -11,7 +11,7 @@ load helpers
 }
 
 @test "remove multiple containers errors" {
-  run_buildah 1 --debug=false rm mycontainer1 mycontainer2 mycontainer3
+  run_buildah 1 --log-level=error rm mycontainer1 mycontainer2 mycontainer3
   expect_output --from="${lines[0]}" "error removing container \"mycontainer1\": error reading build container: container not known" "output line 1"
   expect_output --from="${lines[1]}" "error removing container \"mycontainer2\": error reading build container: container not known" "output line 2"
   expect_output --from="${lines[2]}" "error removing container \"mycontainer3\": error reading build container: container not known" "output line 3"
@@ -20,14 +20,14 @@ load helpers
 
 @test "remove one container" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --debug=false rm "$cid"
+  run_buildah --log-level=error rm "$cid"
   run_buildah rmi alpine
 }
 
 @test "remove multiple containers" {
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false rm "$cid2" "$cid3"
+  run_buildah --log-level=error rm "$cid2" "$cid3"
   run_buildah rmi alpine busybox
 }
 
@@ -35,13 +35,13 @@ load helpers
   cid1=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --debug=false rm -a
+  run_buildah --log-level=error rm -a
   run_buildah rmi --all
 }
 
 @test "use conflicting commands to remove containers" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah 1 --debug=false rm -a "$cid"
+  run_buildah 1 --log-level=error rm -a "$cid"
   expect_output --substring "when using the --all switch, you may not pass any containers names or IDs"
   run_buildah rm "$cid"
   run_buildah rmi alpine

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -17,7 +17,7 @@ load helpers
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
   buildah rmi alpine
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -25,16 +25,16 @@ load helpers
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah 1 rmi alpine busybox
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   [ "$output" != "" ]
 
   buildah rmi -f alpine busybox
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
 @test "remove multiple non-existent images errors" {
-  run_buildah 1 --debug=false rmi image1 image2 image3
+  run_buildah 1 --log-level=error rmi image1 image2 image3
   expect_output --from="${lines[0]}" "could not get image \"image1\": identifier is not an image" "output line 1"
   expect_output --from="${lines[1]}" "could not get image \"image2\": identifier is not an image" "output line 2"
   expect_output --from="${lines[2]}" "could not get image \"image3\": identifier is not an image" "output line 3"
@@ -46,18 +46,18 @@ load helpers
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
   buildah rmi -a -f
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 
   cid1=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah 1 rmi --all
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   [ "$output" != "" ]
 
   buildah rmi --all --force
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
@@ -67,7 +67,7 @@ load helpers
 
   cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
 
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_line_count 1
 
   root=$(buildah mount $cid)
@@ -75,7 +75,7 @@ load helpers
   buildah unmount $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
 
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_line_count 2
 
   root=$(buildah mount $cid)
@@ -83,33 +83,33 @@ load helpers
   buildah unmount $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
 
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_line_count 3
 
   buildah rmi --prune
 
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_line_count 2
 
   buildah rmi --all --force
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
 @test "use conflicting commands to remove images" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
-  run_buildah 1 --debug=false rmi -a alpine
+  run_buildah 1 --log-level=error rmi -a alpine
   expect_output --substring "when using the --all switch, you may not pass any images names or IDs"
 
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
-  run_buildah 1 --debug=false rmi -p alpine
+  run_buildah 1 --log-level=error rmi -p alpine
   expect_output --substring "when using the --prune switch, you may not pass any images names or IDs"
 
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
-  run_buildah 1 --debug=false rmi -a -p
+  run_buildah 1 --log-level=error rmi -a -p
   expect_output --substring "when using the --all switch, you may not use --prune switch"
   buildah rmi --all
 }
@@ -120,36 +120,36 @@ load helpers
   buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid new-image
   buildah rm -a
-  run_buildah 1 --debug=false rmi alpine
+  run_buildah 1 --log-level=error rmi alpine
   expect_line_count 2
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error images -q
   expect_line_count 1
-  run_buildah --debug=false images -q -a
+  run_buildah --log-level=error images -q -a
   expect_line_count 2
-  my_images=( $(buildah --debug=false images -a -q) )
-  run_buildah 1 --debug=false rmi ${my_images[2]}
+  my_images=( $(buildah --log-level=error images -a -q) )
+  run_buildah 1 --log-level=error rmi ${my_images[2]}
   buildah rmi new-image
 }
 
 @test "rmi with cached images" {
   buildah rmi -a -f
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false images -a -q
+  run_buildah --log-level=error images -a -q
   expect_line_count 7
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
-  run_buildah --debug=false images -a -q
+  run_buildah --log-level=error images -a -q
   expect_line_count 9
-  run_buildah --debug=false rmi test2
-  run_buildah --debug=false images -a -q
+  run_buildah --log-level=error rmi test2
+  run_buildah --log-level=error images -a -q
   expect_line_count 7
-  run_buildah --debug=false rmi test1
-  run_buildah --debug=false images -a -q
+  run_buildah --log-level=error rmi test1
+  run_buildah --log-level=error images -a -q
   expect_line_count 1
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
-  run_buildah 1 --debug=false rmi alpine
+  run_buildah 1 --log-level=error rmi alpine
   expect_line_count 2
-  run_buildah --debug=false rmi test3
-  run_buildah --debug=false images -a -q
+  run_buildah --log-level=error rmi test3
+  run_buildah --log-level=error images -a -q
   expect_output ""
 }
 
@@ -162,7 +162,7 @@ load helpers
   buildah config --env 'foo=bar' $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid new-image-2
   buildah rm -a
-  run_buildah --debug=false rmi new-image-2
-  run_buildah --debug=false images -q
+  run_buildah --log-level=error rmi new-image-2
+  run_buildah --log-level=error images -q
   expect_line_count 2
 }

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -11,10 +11,10 @@ load helpers
 	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
 	root=$(buildah mount $cid)
 	buildah config --workingdir /tmp $cid
-	run_buildah --debug=false run $cid pwd
+	run_buildah --log-level=error run $cid pwd
 	expect_output "/tmp"
 	buildah config --workingdir /root $cid
-	run_buildah --debug=false run        $cid pwd
+	run_buildah --log-level=error run        $cid pwd
 	expect_output "/root"
 	cp ${TESTDIR}/randomfile $root/tmp/
 	buildah run        $cid cp /tmp/randomfile /tmp/other-randomfile
@@ -34,22 +34,22 @@ load helpers
 	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
 
 	# This should fail, because buildah run doesn't have a -n flag.
-	run_buildah 1 --debug=false run -n $cid echo test
+	run_buildah 1 --log-level=error run -n $cid echo test
 
 	# This should succeed, because buildah run stops caring at the --, which is preserved as part of the command.
-	run_buildah --debug=false run $cid echo -- -n test
+	run_buildah --log-level=error run $cid echo -- -n test
 	expect_output -- "-- -n test"
 
 	# This should succeed, because buildah run stops caring at the --, which is not part of the command.
-	run_buildah --debug=false run $cid -- echo -n -- test
+	run_buildah --log-level=error run $cid -- echo -n -- test
 	expect_output -- "-- test"
 
 	# This should succeed, because buildah run stops caring at the --.
-	run_buildah --debug=false run $cid -- echo -- -n test --
+	run_buildah --log-level=error run $cid -- echo -- -n test --
 	expect_output -- "-- -n test --"
 
 	# This should succeed, because buildah run stops caring at the --.
-	run_buildah --debug=false run $cid -- echo -n "test"
+	run_buildah --log-level=error run $cid -- echo -n "test"
 	expect_output "test"
 
 	buildah rm $cid
@@ -68,57 +68,57 @@ load helpers
 	# empty entrypoint, configured cmd, empty run arguments
 	buildah config --entrypoint "" $cid
 	buildah config --cmd pwd $cid
-	run_buildah 1 --debug=false run $cid
+	run_buildah 1 --log-level=error run $cid
 	expect_output --substring "command must be specified" "empty entrypoint, cmd, no args"
 
 	# empty entrypoint, configured cmd, empty run arguments, end parsing option
 	buildah config --entrypoint "" $cid
 	buildah config --cmd pwd $cid
-	run_buildah 1 --debug=false run $cid --
+	run_buildah 1 --log-level=error run $cid --
 	expect_output --substring "command must be specified" "empty entrypoint, cmd, no args, --"
 
 	# configured entrypoint, empty cmd, empty run arguments
 	buildah config --entrypoint pwd $cid
 	buildah config --cmd "" $cid
-	run_buildah 1 --debug=false run $cid
+	run_buildah 1 --log-level=error run $cid
 	expect_output --substring "command must be specified" "entrypoint, empty cmd, no args"
 
 	# configured entrypoint, empty cmd, empty run arguments, end parsing option
 	buildah config --entrypoint pwd $cid
 	buildah config --cmd "" $cid
-	run_buildah 1 --debug=false run $cid --
+	run_buildah 1 --log-level=error run $cid --
 	expect_output --substring "command must be specified" "entrypoint, empty cmd, no args, --"
 
 	# configured entrypoint only, empty run arguments
 	buildah config --entrypoint pwd $cid
-	run_buildah 1 --debug=false run $cid
+	run_buildah 1 --log-level=error run $cid
 	expect_output --substring "command must be specified" "entrypoint, no args"
 
 	# configured entrypoint only, empty run arguments, end parsing option
 	buildah config --entrypoint pwd $cid
-	run_buildah 1 --debug=false run $cid --
+	run_buildah 1 --log-level=error run $cid --
 	expect_output --substring "command must be specified" "entrypoint, no args, --"
 
 	# cofigured cmd only, empty run arguments
 	buildah config --cmd pwd $cid
-	run_buildah 1 --debug=false run $cid
+	run_buildah 1 --log-level=error run $cid
 	expect_output --substring "command must be specified" "cmd, no args"
 
 	# configured cmd only, empty run arguments, end parsing option
 	buildah config --cmd pwd $cid
-	run_buildah 1 --debug=false run $cid --
+	run_buildah 1 --log-level=error run $cid --
 	expect_output --substring "command must be specified" "cmd, no args, --"
 
 	# configured entrypoint, configured cmd, empty run arguments
 	buildah config --entrypoint "pwd" $cid
 	buildah config --cmd "whoami" $cid
-	run_buildah 1 --debug=false run $cid
+	run_buildah 1 --log-level=error run $cid
 	expect_output --substring "command must be specified" "entrypoint, cmd, no args"
 
 	# configured entrypoint, configured cmd, empty run arguments, end parsing option
 	buildah config --entrypoint "pwd" $cid
 	buildah config --cmd "whoami" $cid
-	run_buildah 1 --debug=false run $cid --
+	run_buildah 1 --log-level=error run $cid --
 	expect_output --substring "command must be specified"  "entrypoint, cmd, no args"
 
 
@@ -128,29 +128,29 @@ load helpers
 	# empty entrypoint, configured cmd, configured run arguments
 	buildah config --entrypoint "" $cid
 	buildah config --cmd "/invalid/cmd" $cid
-	run_buildah --debug=false run $cid -- pwd
+	run_buildah --log-level=error run $cid -- pwd
 	expect_output "/tmp" "empty entrypoint, invalid cmd, pwd"
 
         # configured entrypoint, empty cmd, configured run arguments
         buildah config --entrypoint "/invalid/entrypoint" $cid
         buildah config --cmd "" $cid
-        run_buildah --debug=false run $cid -- pwd
+        run_buildah --log-level=error run $cid -- pwd
 	expect_output "/tmp" "invalid entrypoint, empty cmd, pwd"
 
         # configured entrypoint only, configured run arguments
         buildah config --entrypoint "/invalid/entrypoint" $cid
-        run_buildah --debug=false run $cid -- pwd
+        run_buildah --log-level=error run $cid -- pwd
 	expect_output "/tmp" "invalid entrypoint, no cmd(??), pwd"
 
         # cofigured cmd only, configured run arguments
         buildah config --cmd "/invalid/cmd" $cid
-        run_buildah --debug=false run $cid -- pwd
+        run_buildah --log-level=error run $cid -- pwd
 	expect_output "/tmp" "invalid cmd, no entrypoint(??), pwd"
 
         # configured entrypoint, configured cmd, configured run arguments
         buildah config --entrypoint "/invalid/entrypoint" $cid
         buildah config --cmd "/invalid/cmd" $cid
-        run_buildah --debug=false run $cid -- pwd
+        run_buildah --log-level=error run $cid -- pwd
 	expect_output "/tmp" "invalid cmd & entrypoint, pwd"
 
 	buildah rm $cid
@@ -162,10 +162,10 @@ function configure_and_check_user() {
     local expect_g=$3
 
     run_buildah config -u "$setting" $cid
-    run_buildah --debug=false run -- $cid id -u
+    run_buildah --log-level=error run -- $cid id -u
     expect_output "$expect_u" "id -u ($setting)"
 
-    run_buildah --debug=false run -- $cid id -g
+    run_buildah --log-level=error run -- $cid id -g
     expect_output "$expect_g" "id -g ($setting)"
 }
 
@@ -202,14 +202,14 @@ function configure_and_check_user() {
         configure_and_check_user "${testuid}:${testgroupid}"    $testuid      $testgroupid
 
         buildah config -u ${testbogususer} $cid
-        run_buildah 1 --debug=false run -- $cid id -u
+        run_buildah 1 --log-level=error run -- $cid id -u
         expect_output --substring "unknown user" "id -u (bogus user)"
-        run_buildah 1 --debug=false run -- $cid id -g
+        run_buildah 1 --log-level=error run -- $cid id -g
         expect_output --substring "unknown user" "id -g (bogus user)"
 
 	ln -vsf /etc/passwd $root/etc/passwd
 	buildah config -u ${testuser}:${testgroup} $cid
-	run_buildah 1 --debug=false run -- $cid id -u
+	run_buildah 1 --log-level=error run -- $cid id -u
 	echo "$output"
 	expect_output --substring "unknown user" "run as unknown user"
 
@@ -226,9 +226,9 @@ function configure_and_check_user() {
 	fi
 	runc --version
 	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-	run_buildah --debug=false run $cid hostname
+	run_buildah --log-level=error run $cid hostname
 	[ "$output" != "foobar" ]
-	run_buildah --debug=false run --hostname foobar $cid hostname
+	run_buildah --log-level=error run --hostname foobar $cid hostname
 	expect_output "foobar"
 	buildah rm $cid
 }
@@ -247,15 +247,15 @@ function configure_and_check_user() {
 	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
 	mkdir -p ${TESTDIR}/was-empty
 	# As a baseline, this should succeed.
-	run_buildah --debug=false run -v ${TESTDIR}/was-empty:/var/not-empty${zflag:+:${zflag}}     $cid touch /var/not-empty/testfile
+	run_buildah --log-level=error run -v ${TESTDIR}/was-empty:/var/not-empty${zflag:+:${zflag}}     $cid touch /var/not-empty/testfile
 	# Parsing options that with comma, this should succeed.
-	run_buildah --debug=false run -v ${TESTDIR}/was-empty:/var/not-empty:rw,rshared${zflag:+,${zflag}}     $cid touch /var/not-empty/testfile
+	run_buildah --log-level=error run -v ${TESTDIR}/was-empty:/var/not-empty:rw,rshared${zflag:+,${zflag}}     $cid touch /var/not-empty/testfile
 	# If we're parsing the options at all, this should be read-only, so it should fail.
-	run_buildah 1 --debug=false run -v ${TESTDIR}/was-empty:/var/not-empty:ro${zflag:+,${zflag}} $cid touch /var/not-empty/testfile
+	run_buildah 1 --log-level=error run -v ${TESTDIR}/was-empty:/var/not-empty:ro${zflag:+,${zflag}} $cid touch /var/not-empty/testfile
 	# Even if the parent directory doesn't exist yet, this should succeed.
-	run_buildah --debug=false run -v ${TESTDIR}/was-empty:/var/multi-level/subdirectory        $cid touch /var/multi-level/subdirectory/testfile
+	run_buildah --log-level=error run -v ${TESTDIR}/was-empty:/var/multi-level/subdirectory        $cid touch /var/multi-level/subdirectory/testfile
 	# And check the same for file volumes.
-	run_buildah --debug=false run -v ${TESTDIR}/was-empty/testfile:/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
+	run_buildah --log-level=error run -v ${TESTDIR}/was-empty/testfile:/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
 }
 
 @test "run --mount" {
@@ -272,14 +272,14 @@ function configure_and_check_user() {
 	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
 	mkdir -p ${TESTDIR}/was:empty
 	# As a baseline, this should succeed.
-	run_buildah --debug=false run --mount type=tmpfs,dst=/var/tmpfs-not-empty                                           $cid touch /var/tmpfs-not-empty/testfile
-	run_buildah --debug=false run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/not-empty${zflag:+,${zflag}}      $cid touch /var/not-empty/testfile
+	run_buildah --log-level=error run --mount type=tmpfs,dst=/var/tmpfs-not-empty                                           $cid touch /var/tmpfs-not-empty/testfile
+	run_buildah --log-level=error run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/not-empty${zflag:+,${zflag}}      $cid touch /var/not-empty/testfile
 	# If we're parsing the options at all, this should be read-only, so it should fail.
-	run_buildah 1 --debug=false run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/not-empty,ro${zflag:+,${zflag}} $cid touch /var/not-empty/testfile
+	run_buildah 1 --log-level=error run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/not-empty,ro${zflag:+,${zflag}} $cid touch /var/not-empty/testfile
 	# Even if the parent directory doesn't exist yet, this should succeed.
-	run_buildah --debug=false run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/multi-level/subdirectory          $cid touch /var/multi-level/subdirectory/testfile
+	run_buildah --log-level=error run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/multi-level/subdirectory          $cid touch /var/multi-level/subdirectory/testfile
 	# And check the same for file volumes.
-	run_buildah --debug=false run --mount type=bind,src=${TESTDIR}/was:empty/testfile,dst=/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
+	run_buildah --log-level=error run --mount type=bind,src=${TESTDIR}/was:empty/testfile,dst=/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
 }
 
 @test "run symlinks" {
@@ -291,7 +291,7 @@ function configure_and_check_user() {
 	mkdir -p ${TESTDIR}/tmp
 	ln -s tmp ${TESTDIR}/tmp2
 	export TMPDIR=${TESTDIR}/tmp2
-	run_buildah --debug=false run $cid id
+	run_buildah --log-level=error run $cid id
 }
 
 @test "run --cap-add/--cap-drop" {
@@ -301,13 +301,13 @@ function configure_and_check_user() {
 	runc --version
 	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
 	# Try with default caps.
-	run_buildah --debug=false run $cid grep ^CapEff /proc/self/status
+	run_buildah --log-level=error run $cid grep ^CapEff /proc/self/status
 	defaultcaps="$output"
 	# Try adding DAC_OVERRIDE.
-	run_buildah --debug=false run --cap-add CAP_DAC_OVERRIDE $cid grep ^CapEff /proc/self/status
+	run_buildah --log-level=error run --cap-add CAP_DAC_OVERRIDE $cid grep ^CapEff /proc/self/status
 	addedcaps="$output"
 	# Try dropping DAC_OVERRIDE.
-	run_buildah --debug=false run --cap-drop CAP_DAC_OVERRIDE $cid grep ^CapEff /proc/self/status
+	run_buildah --log-level=error run --cap-drop CAP_DAC_OVERRIDE $cid grep ^CapEff /proc/self/status
 	droppedcaps="$output"
 	# Okay, now the "dropped" and "added" should be different.
 	test "$addedcaps" != "$droppedcaps"
@@ -325,23 +325,23 @@ function configure_and_check_user() {
 		skip "no runc in PATH"
 	fi
 	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-	run_buildah --debug=false run $cid awk '/open files/{print $4}' /proc/self/limits
+	run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output "1048576" "limits: open files (unlimited)"
-	run_buildah --debug=false run $cid awk '/processes/{print $3}' /proc/self/limits
+	run_buildah --log-level=error run $cid awk '/processes/{print $3}' /proc/self/limits
 	expect_output "1048576" "limits: processes (unlimited)"
 	buildah rm $cid
 
 	cid=$(buildah from --ulimit nofile=300:400 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-	run_buildah --debug=false run $cid awk '/open files/{print $4}' /proc/self/limits
+	run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output "300" "limits: open files (w/file limit)"
-	run_buildah --debug=false run $cid awk '/processes/{print $3}' /proc/self/limits
+	run_buildah --log-level=error run $cid awk '/processes/{print $3}' /proc/self/limits
 	expect_output "1048576" "limits: processes (w/file limit)"
 	buildah rm $cid
 
 	cid=$(buildah from --ulimit nproc=100:200 --ulimit nofile=300:400 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-	run_buildah --debug=false run $cid awk '/open files/{print $4}' /proc/self/limits
+	run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output "300" "limits: open files (w/file & proc limits)"
-	run_buildah --debug=false run $cid awk '/processes/{print $3}' /proc/self/limits
+	run_buildah --log-level=error run $cid awk '/processes/{print $3}' /proc/self/limits
 	expect_output "100" "limits: processes (w/file & proc limits)"
 	buildah rm $cid
 }
@@ -356,7 +356,7 @@ function configure_and_check_user() {
 	echo "$output"
 	[ "$status" -ne 0 ]
 	# We'll create the mountpoint for "run".
-	run_buildah --debug=false run $cid ls -1 /var/lib
+	run_buildah --log-level=error run $cid ls -1 /var/lib
         expect_output --substring "registry"
 
 	# Double-check that the mountpoint is there.

--- a/tests/secrets.bats
+++ b/tests/secrets.bats
@@ -27,10 +27,10 @@ function teardown() {
 		skip "no runc in PATH"
     fi
     runc --version
-    cid=$(buildah --default-mounts-file "$MOUNTS_PATH" --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-    run_buildah --debug=false run $cid ls /run/secrets
+    cid=$(buildah --default-mounts-file "$MOUNTS_PATH" --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+    run_buildah --log-level=error run $cid ls /run/secrets
     expect_output --substring "test.txt"
-    run_buildah --debug run $cid ls /run/secrets/mysymlink
+    run_buildah run $cid ls /run/secrets/mysymlink
     expect_output --substring "key.pem"
     buildah rm $cid
     rm -rf $TESTSDIR/containers

--- a/tests/selinux.bats
+++ b/tests/selinux.bats
@@ -12,18 +12,18 @@ load helpers
   image=alpine
 
   # Create a container and read its context as a baseline.
-  cid=$(buildah --debug=false from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
-  run_buildah --debug=false run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
+  cid=$(buildah --log-level=error from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah --log-level=error run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   [ "$output" != "" ]
   firstlabel="$output"
 
   # Ensure that we label the same container consistently across multiple "run" instructions.
-  run_buildah --debug=false run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
+  run_buildah --log-level=error run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   expect_output "$firstlabel" "label of second container == first"
 
   # Ensure that different containers get different labels.
-  cid1=$(buildah --debug=false from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
-  run_buildah --debug=false run $cid1 sh -c 'tr \\0 \\n < /proc/self/attr/current'
+  cid1=$(buildah --log-level=error from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah --log-level=error run $cid1 sh -c 'tr \\0 \\n < /proc/self/attr/current'
   if [ "$output" = "$firstlabel" ]; then
       die "Second container has the same label as first (both '$output')"
   fi
@@ -44,8 +44,8 @@ load helpers
       firstlabel="unconfined_u:system_r:spc_t:s0-s0:c0.c1023"
   fi
   # Create a container and read its context as a baseline.
-  cid=$(buildah --debug=false from --security-opt label=disable --quiet --signature-policy ${TESTSDIR}/policy.json $image)
-  run_buildah --debug=false run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
+  cid=$(buildah --log-level=error from --security-opt label=disable --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah --log-level=error run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   expect_output "$firstlabel" "container context matches our own"
 }
 
@@ -60,13 +60,13 @@ load helpers
 
   firstlabel="system_u:system_r:container_t:s0:c1,c2"
   # Create a container and read its context as a baseline.
-  cid=$(buildah --debug=false from --security-opt label="level:s0:c1,c2" --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  cid=$(buildah --log-level=error from --security-opt label="level:s0:c1,c2" --quiet --signature-policy ${TESTSDIR}/policy.json $image)
 
   # Inspect image
-  run_buildah --debug=false inspect  --format '{{.ProcessLabel}}' $cid
+  run_buildah --log-level=error inspect  --format '{{.ProcessLabel}}' $cid
   expect_output "$firstlabel"
 
   # Check actual running context
-  run_buildah --debug=false run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
+  run_buildah --log-level=error run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   expect_output "$firstlabel" "running container context"
 }

--- a/tests/squash.bats
+++ b/tests/squash.bats
@@ -10,7 +10,7 @@ function check_lengths() {
   # matrix test: check given .Docker.* and .OCIv1.* fields in image
   for which in Docker OCIv1; do
     for field in RootFS.DiffIDs History; do
-      run_buildah --debug=false inspect -t image -f "{{len .$which.$field}}" $image
+      run_buildah --log-level=error inspect -t image -f "{{len .$which.$field}}" $image
       expect_output "$expect"
     done
   done
@@ -80,16 +80,16 @@ function check_lengths() {
 	done
 
 	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --layers -t squashed ${TESTDIR}/squashed
-	run_buildah --debug=false inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	run_buildah --log-level=error inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 
 	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
 	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
-	run_buildah --debug=false inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	run_buildah --log-level=error inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 
 	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
 	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --layers -t squashed ${TESTDIR}/squashed
-	run_buildah --debug=false inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	run_buildah --log-level=error inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 }

--- a/tests/test_buildah_authentication.sh
+++ b/tests/test_buildah_authentication.sh
@@ -136,7 +136,7 @@ buildah images
 # Clean up Buildah
 ########
 buildah rm $ctrid
-buildah rmi -f $(buildah --debug=false images -q)
+buildah rmi -f $(buildah images -q)
 
 ########
 # Pull alpine
@@ -202,7 +202,7 @@ chmod +x $FILE
 # Clean up Buildah
 ########
 buildah rm --all
-buildah rmi -f $(buildah --debug=false images -q)
+buildah rmi -f $(buildah images -q)
 
 ########
 # Try Buildah bud with creds but no auth, this should FAIL 
@@ -235,4 +235,4 @@ rm -rf ${TESTDIR}/auth
 docker rm -f $(docker ps --all -q)
 docker rmi -f $(docker images -q)
 buildah rm $(buildah containers -q)
-buildah rmi -f $(buildah --debug=false images -q)
+buildah rmi -f $(buildah images -q)

--- a/tests/test_buildah_rpm.sh
+++ b/tests/test_buildah_rpm.sh
@@ -15,8 +15,8 @@ load helpers
 
         # Build a container to use for building the binaries.
         image=registry.centos.org/centos/centos:centos7
-        cid=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
-        root=$(buildah --debug=false mount $cid)
+        cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+        root=$(buildah mount $cid)
         commit=$(git log --format=%H -n 1)
         shortcommit=$(echo ${commit} | cut -c-7)
         mkdir -p ${root}/rpmbuild/{SOURCES,SPECS}
@@ -28,13 +28,13 @@ load helpers
         sed s:REPLACEWITHCOMMITID:${commit}:g ${TESTSDIR}/../contrib/rpm/buildah.spec > ${root}/rpmbuild/SPECS/buildah.spec
 
         # Install build dependencies and build binary packages.
-        buildah --debug=false run $cid -- yum -y install rpm-build yum-utils
-        buildah --debug=false run $cid -- yum-builddep -y rpmbuild/SPECS/buildah.spec
-        buildah --debug=false run $cid -- rpmbuild --define "_topdir /rpmbuild" -ba /rpmbuild/SPECS/buildah.spec
+        buildah run $cid -- yum -y install rpm-build yum-utils
+        buildah run $cid -- yum-builddep -y rpmbuild/SPECS/buildah.spec
+        buildah run $cid -- rpmbuild --define "_topdir /rpmbuild" -ba /rpmbuild/SPECS/buildah.spec
 
         # Build a second new container.
-        cid2=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
-        root2=$(buildah --debug=false mount $cid2)
+        cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+        root2=$(buildah mount $cid2)
 
         # Copy the binary packages from the first container to the second one, and build a list of
         # their filenames relative to the root of the second container.
@@ -46,12 +46,12 @@ load helpers
         done
 
         # Install the binary packages into the second container.
-        buildah --debug=false run $cid2 -- yum -y install $rpms
+        buildah run $cid2 -- yum -y install $rpms
 
         # Run the binary package and compare its self-identified version to the one we tried to build.
-        id=$(buildah --debug=false run $cid2 -- buildah version | awk '/^Git Commit:/ { print $NF }')
-        bv=$(buildah --debug=false run $cid2 -- buildah version | awk '/^Version:/ { print $NF }')
-        rv=$(buildah --debug=false run $cid2 -- rpm -q --queryformat '%{version}' buildah)
+        id=$(buildah run $cid2 -- buildah version | awk '/^Git Commit:/ { print $NF }')
+        bv=$(buildah run $cid2 -- buildah version | awk '/^Version:/ { print $NF }')
+        rv=$(buildah run $cid2 -- rpm -q --queryformat '%{version}' buildah)
         echo "short commit: $shortcommit"
         echo "id: $id"
         echo "buildah version: $bv"
@@ -60,7 +60,7 @@ load helpers
         test $bv = ${rv} -o $bv = ${rv}-dev
 
         # Clean up.
-        buildah --debug=false rm $cid $cid2
+        buildah rm $cid $cid2
 }
 
 @test "rpm-build Fedora latest" {
@@ -70,8 +70,8 @@ load helpers
 
         # Build a container to use for building the binaries.
         image=registry.fedoraproject.org/fedora:latest
-        cid=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
-        root=$(buildah --debug=false mount $cid)
+        cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+        root=$(buildah mount $cid)
         commit=$(git log --format=%H -n 1)
         shortcommit=$(echo ${commit} | cut -c-7)
         mkdir -p ${root}/rpmbuild/{SOURCES,SPECS}
@@ -83,13 +83,13 @@ load helpers
         sed s:REPLACEWITHCOMMITID:${commit}:g ${TESTSDIR}/../contrib/rpm/buildah.spec > ${root}/rpmbuild/SPECS/buildah.spec
 
         # Install build dependencies and build binary packages.
-        buildah --debug=false run $cid -- dnf -y install 'dnf-command(builddep)' rpm-build
-        buildah --debug=false run $cid -- dnf -y builddep --spec rpmbuild/SPECS/buildah.spec
-        buildah --debug=false run $cid -- rpmbuild --define "_topdir /rpmbuild" -ba /rpmbuild/SPECS/buildah.spec
+        buildah run $cid -- dnf -y install 'dnf-command(builddep)' rpm-build
+        buildah run $cid -- dnf -y builddep --spec rpmbuild/SPECS/buildah.spec
+        buildah run $cid -- rpmbuild --define "_topdir /rpmbuild" -ba /rpmbuild/SPECS/buildah.spec
 
         # Build a second new container.
-        cid2=$(buildah --debug=false from --pull --signature-policy ${TESTSDIR}/policy.json $image)
-        root2=$(buildah --debug=false mount $cid2)
+        cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+        root2=$(buildah mount $cid2)
 
         # Copy the binary packages from the first container to the second one, and build a list of
         # their filenames relative to the root of the second container.
@@ -101,12 +101,12 @@ load helpers
         done
 
         # Install the binary packages into the second container.
-        buildah --debug=false run $cid2 -- dnf -y install $rpms
+        buildah run $cid2 -- dnf -y install $rpms
 
         # Run the binary package and compare its self-identified version to the one we tried to build.
-        id=$(buildah --debug=false run $cid2 -- buildah version | awk '/^Git Commit:/ { print $NF }')
-        bv=$(buildah --debug=false run $cid2 -- buildah version | awk '/^Version:/ { print $NF }')
-        rv=$(buildah --debug=false run $cid2 -- rpm -q --queryformat '%{version}' buildah)
+        id=$(buildah run $cid2 -- buildah version | awk '/^Git Commit:/ { print $NF }')
+        bv=$(buildah run $cid2 -- buildah version | awk '/^Version:/ { print $NF }')
+        rv=$(buildah run $cid2 -- rpm -q --queryformat '%{version}' buildah)
         echo "short commit: $shortcommit"
         echo "id: $id"
         echo "buildah version: $bv"
@@ -115,5 +115,5 @@ load helpers
 	test $bv = ${rv} -o $bv = ${rv}-dev
 
         # Clean up.
-        buildah --debug=false rm $cid $cid2
+        buildah rm $cid $cid2
 }


### PR DESCRIPTION
The previous log-level implementation does not seem to work, which is
now fixed and aligns to other projects like podman and CRI-O.

Added documentation and integration testing as well.