### PR TITLE
Disable empty logrus timestamps to reduce logger noise

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -47,6 +47,7 @@ var (
 )
 
 func init() {
+	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
 
 	var (
 		defaultStoreDriverOptions []string


### PR DESCRIPTION
The logrus timestmaps are always empty where we can disable them to have
cleaner log outputs:

Before:
```
DEBU[0000] [graphdriver] trying provided driver "overlay"
```

After:
```
DEBU [graphdriver] trying provided driver "overlay"
```