### PR TITLE
Correctly detect ExitError values from Run()

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -158,7 +158,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 	if runerr != nil {
 		logrus.Debugf("error running %v in container %q: %v", args, builder.Container, runerr)
 	}
-	if ee, ok := runerr.(*exec.ExitError); ok {
+	if ee, ok := (errors.Cause(runerr)).(*exec.ExitError); ok {
 		if w, ok := ee.Sys().(syscall.WaitStatus); ok {
 			os.Exit(w.ExitStatus())
 		}

--- a/run_linux.go
+++ b/run_linux.go
@@ -1384,8 +1384,7 @@ func runUsingRuntimeMain() {
 		os.Exit(1)
 	}
 	// Set ourselves up to read the container's exit status.  We're doing this in a child process
-	// so that we won't mess with the setting in a caller of the library. This stubs to OS specific
-	// calls
+	// so that we won't mess with the setting in a caller of the library.
 	if err := setChildProcess(); err != nil {
 		os.Exit(1)
 	}

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -362,3 +362,11 @@ function configure_and_check_user() {
 	# Double-check that the mountpoint is there.
 	test -d "$mnt"/var/lib/registry
 }
+
+@test "run-exit-status" {
+	if ! which runc ; then
+		skip "no runc in PATH"
+	fi
+	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	run_buildah 42 run ${cid} sh -c 'exit 42'
+}


### PR DESCRIPTION
Correctly detect `ExitError` error values returned by buildah.Run().  This should fix #1813.