### PR TITLE
Rework overlay pkg for use with libpod

### DIFF
--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -9,46 +9,48 @@ import (
 	"strings"
 
 	"github.com/containers/common/pkg/unshare"
-	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/system"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
-// MountTemp creates a subdir of the contentDir based on the source directory
-// from the source system.  It then mounts up the source directory on to the
-// generated mount point and returns the mount point to the caller.
-func MountTemp(store storage.Store, containerID, source, dest string, rootUID, rootGID int) (mount specs.Mount, contentDir string, Err error) {
+// TempDir generates an overlay Temp directory in the container content
+func TempDir(containerDir string, rootUID, rootGID int) (string, error) {
 
-	containerDir, err := store.ContainerDirectory(containerID)
-	if err != nil {
-		return mount, "", err
-	}
-	contentDir = filepath.Join(containerDir, "overlay")
+	contentDir := filepath.Join(containerDir, "overlay")
 	if err := idtools.MkdirAllAs(contentDir, 0700, rootUID, rootGID); err != nil {
-		return mount, "", errors.Wrapf(err, "failed to create the overlay %s directory", contentDir)
+		return "", errors.Wrapf(err, "failed to create the overlay %s directory", contentDir)
 	}
 
-	contentDir, err = ioutil.TempDir(contentDir, "")
+	contentDir, err := ioutil.TempDir(contentDir, "")
 	if err != nil {
-		return mount, "", errors.Wrapf(err, "failed to create TempDir in the overlay %s directory", contentDir)
+		return "", errors.Wrapf(err, "failed to create the overlay tmpdir in %s directory", contentDir)
 	}
-	defer func() {
-		if Err != nil {
-			os.RemoveAll(contentDir)
-		}
-	}()
-
 	upperDir := filepath.Join(contentDir, "upper")
 	workDir := filepath.Join(contentDir, "work")
 	if err := idtools.MkdirAllAs(upperDir, 0700, rootUID, rootGID); err != nil {
-		return mount, "", errors.Wrapf(err, "failed to create the overlay %s directory", upperDir)
+		return "", errors.Wrapf(err, "failed to create the overlay %s directory", upperDir)
 	}
 	if err := idtools.MkdirAllAs(workDir, 0700, rootUID, rootGID); err != nil {
-		return mount, "", errors.Wrapf(err, "failed to create the overlay %s directory", workDir)
+		return "", errors.Wrapf(err, "failed to create the overlay %s directory", workDir)
+	}
+	mergeDir := filepath.Join(contentDir, "merge")
+	if err := idtools.MkdirAllAs(mergeDir, 0700, rootUID, rootGID); err != nil {
+		return "", errors.Wrapf(err, "failed to create the overlay %s directory", mergeDir)
 	}
 
+	return contentDir, nil
+}
+
+// Mount creates a subdir of the contentDir based on the source directory
+// from the source system.  It then mounts up the source directory on to the
+// generated mount point and returns the mount point to the caller.
+func Mount(contentDir, source, dest string, rootUID, rootGID int, graphOptions []string) (mount specs.Mount, Err error) {
+	upperDir := filepath.Join(contentDir, "upper")
+	workDir := filepath.Join(contentDir, "work")
+	mergeDir := filepath.Join(contentDir, "merge")
 	overlayOptions := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,private", source, upperDir, workDir)
 
 	if unshare.IsRootless() {
@@ -60,36 +62,30 @@ func MountTemp(store storage.Store, containerID, source, dest string, rootUID, r
 			"overlay2.mount_program": true,
 		}
 
-		for _, i := range store.GraphOptions() {
+		for _, i := range graphOptions {
 			s := strings.SplitN(i, "=", 2)
 			if len(s) != 2 {
 				continue
 			}
-			k := s[0]
-			v := s[1]
-			if mountMap[k] {
-				mountProgram = v
+			key := s[0]
+			val := s[1]
+			if mountMap[key] {
+				mountProgram = val
 				break
 			}
 		}
 		if mountProgram != "" {
-			mergeDir := filepath.Join(contentDir, "merge")
-
-			if err := idtools.MkdirAllAs(mergeDir, 0700, rootUID, rootGID); err != nil {
-				return mount, "", errors.Wrapf(err, "failed to create the overlay %s directory", mergeDir)
-			}
-
 			cmd := exec.Command(mountProgram, "-o", overlayOptions, mergeDir)
 
 			if err := cmd.Run(); err != nil {
-				return mount, "", errors.Wrapf(err, "exec %s", mountProgram)
+				return mount, errors.Wrapf(err, "exec %s", mountProgram)
 			}
 
 			mount.Source = mergeDir
 			mount.Destination = dest
 			mount.Type = "bind"
 			mount.Options = []string{"bind", "slave"}
-			return mount, contentDir, nil
+			return mount, nil
 		}
 		/* If a mount_program is not specified, fallback to try mount native overlay.  */
 	}
@@ -99,21 +95,57 @@ func MountTemp(store storage.Store, containerID, source, dest string, rootUID, r
 	mount.Type = "overlay"
 	mount.Options = strings.Split(overlayOptions, ",")
 
-	return mount, contentDir, nil
+	return mount, nil
 }
 
 // RemoveTemp removes temporary mountpoint and all content from its parent
 // directory
 func RemoveTemp(contentDir string) error {
 	if unshare.IsRootless() {
-		mergeDir := filepath.Join(contentDir, "merge")
-		if err := unix.Unmount(mergeDir, 0); err != nil {
-			if !os.IsNotExist(err) {
-				return errors.Wrapf(err, "unmount overlay %s", mergeDir)
-			}
+		if err := Unmount(contentDir); err != nil {
+			return err
 		}
 	}
 	return os.RemoveAll(contentDir)
+}
+
+// Unmount the overlay mountpoint
+func Unmount(contentDir string) (Err error) {
+	mergeDir := filepath.Join(contentDir, "merge")
+	if err := unix.Unmount(mergeDir, 0); err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(err, "unmount overlay %s", mergeDir)
+	}
+	return nil
+}
+
+func recreate(contentDir string) error {
+	st, err := system.Stat(contentDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to stat overlay upper %s directory", contentDir)
+	}
+
+	if err := os.RemoveAll(contentDir); err != nil {
+		return errors.Wrapf(err, "failed to cleanup overlay %s directory", contentDir)
+	}
+
+	if err := idtools.MkdirAllAs(contentDir, os.FileMode(st.Mode()), int(st.UID()), int(st.GID())); err != nil {
+		return errors.Wrapf(err, "failed to create the overlay %s directory", contentDir)
+	}
+	return nil
+}
+
+// CleanupMount removes all temporary mountpoint conten
+func CleanupMount(contentDir string) (Err error) {
+	if err := recreate(filepath.Join(contentDir, "upper")); err != nil {
+		return err
+	}
+	if err := recreate(filepath.Join(contentDir, "work")); err != nil {
+		return err
+	}
+	return nil
 }
 
 // CleanupContent removes all temporary mountpoint and all content from


### PR DESCRIPTION
Podman uses the overlay mounts differently then in buildah.  Specifically the
overlay mount points can be used over and over again when starting and stopping
the container.  Since the paths are backed into the contianer config, we have
to be able to cleanout just the Upper and Merged directory rather then destroying
and recreating the overlay directories on each container start.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>