### PR TITLE
add support for cgroupsV2

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -368,16 +368,15 @@ Remove intermediate containers after a successful build (default true).
 **--runtime** *path*
 
 The *path* to an alternate OCI-compatible runtime, which will be used to run
-commands specified by the **RUN** instruction. Default is runc.
+commands specified by the **RUN** instruction. Default is `runc`, or `crun` when machine is configured to use cgroups V2.
 
 Note: You can also override the default runtime by setting the BUILDAH\_RUNTIME
-environment variable.  `export BUILDAH_RUNTIME=/usr/local/bin/runc`
+environment variable.  `export BUILDAH_RUNTIME=/usr/bin/crun`
 
 **--runtime-flag** *flag*
 
 Adds global flags for the container rutime. To list the supported flags, please
-consult the manpages of the selected container runtime (`runc` is the default
-runtime, the manpage to consult is `runc(8)`).
+consult the manpages of the selected container runtime.
 
 Note: Do not pass the leading `--` to the flag. To pass the runc flag `--log-format json`
 to buildah bud, the option given would be `--runtime-flag log-format=json`.
@@ -682,4 +681,4 @@ registries.conf is the configuration file which specifies which container regist
 Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
-buildah(1), CPP(1), buildah-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)
+buildah(1), CPP(1), buildah-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7), crun(1), runc(8)

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -137,16 +137,15 @@ process.
 
 **--runtime** *path*
 
-The *path* to an alternate OCI-compatible runtime. Default is runc.
+The *path* to an alternate OCI-compatible runtime. Default is `runc`, or `crun` when machine is configured to use cgroups V2.
 
 Note: You can also override the default runtime by setting the BUILDAH\_RUNTIME
-environment variable.  `export BUILDAH_RUNTIME=/usr/local/bin/runc`
+environment variable.  `export BUILDAH_RUNTIME=/usr/bin/crun`
 
 **--runtime-flag** *flag*
 
 Adds global flags for the container runtime. To list the supported flags, please
-consult the manpages of the selected container runtime (`runc` is the default
-runtime, the manpage to consult is `runc(8)`).
+consult the manpages of the selected container runtime.
 Note: Do not pass the leading `--` to the flag. To pass the runc flag `--log-format json`
 to buildah run, the option given would be `--runtime-flag log-format=json`.
 
@@ -275,4 +274,4 @@ buildah run --volume /path/on/host:/path/in/container:ro,z containerID sh
 buildah run --mount type=bind,src=/tmp/on:host,dst=/in:container,ro containerID sh
 
 ## SEE ALSO
-buildah(1), namespaces(7), pid\_namespaces(7)
+buildah(1), buildah-from(1), buildah-config(1), namespaces(7), pid\_namespaces(7), crun(1), runc(8)

--- a/pkg/cgroups/cgroups_supported.go
+++ b/pkg/cgroups/cgroups_supported.go
@@ -1,0 +1,31 @@
+// +build linux
+
+package cgroups
+
+import (
+	"sync"
+	"syscall"
+)
+
+const (
+	_cgroup2SuperMagic = 0x63677270
+)
+
+var (
+	isUnifiedOnce sync.Once
+	isUnified     bool
+	isUnifiedErr  error
+)
+
+// IsCgroup2UnifiedMode returns whether we are running in cgroup 2 cgroup2 mode.
+func IsCgroup2UnifiedMode() (bool, error) {
+	isUnifiedOnce.Do(func() {
+		var st syscall.Statfs_t
+		if err := syscall.Statfs("/sys/fs/cgroup", &st); err != nil {
+			isUnified, isUnifiedErr = false, err
+		} else {
+			isUnified, isUnifiedErr = st.Type == _cgroup2SuperMagic, nil
+		}
+	})
+	return isUnified, isUnifiedErr
+}

--- a/pkg/cgroups/cgroups_unsupported.go
+++ b/pkg/cgroups/cgroups_unsupported.go
@@ -1,0 +1,8 @@
+// +build !linux
+
+package cgroups
+
+// IsCgroup2UnifiedMode returns whether we are running in cgroup 2 cgroup2 mode.
+func IsCgroup2UnifiedMode() (bool, error) {
+	return false, nil
+}

--- a/util/util.go
+++ b/util/util.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containers/buildah/pkg/cgroups"
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/pkg/sysregistriesv2"
 	"github.com/containers/image/signature"
@@ -249,6 +250,12 @@ func Runtime() string {
 	if runtime != "" {
 		return runtime
 	}
+
+	// Need to switch default until runc supports cgroups v2
+	if unified, _ := cgroups.IsCgroup2UnifiedMode(); unified {
+		return "crun"
+	}
+
 	return DefaultRuntime
 }
 


### PR DESCRIPTION
We need to run with crun rather then runc on cgroupsV2 platforms.

runc does not currently support cgroups V2, so if the machine is
in cgroups V2 mode we have to use crun by default.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>