### PR TITLE
Allow mounts.conf entries for equal source and destination paths

### DIFF
--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -131,11 +131,11 @@ The storage configuration file specifies all of the available container storage 
 
 **mounts.conf** (`/usr/share/containers/mounts.conf` and optionally `/etc/containers/mounts.conf`)
 
-The mounts.conf files specify volume mount directories that are automatically mounted inside containers when executing the `buildah run` or `buildah build-using-dockerfile` commands.  Container process can then use this content.  The volume mount content does not get committed to the final image.
+The mounts.conf files specify volume mount files or directories that are automatically mounted inside containers when executing the `buildah run` or `buildah build-using-dockerfile` commands.  Container processes can then use this content.  The volume mount content does not get committed to the final image.
 
 Usually these directories are used for passing secrets or credentials required by the package software to access remote package repositories.
 
-For example, a mounts.conf with the line "`/usr/share/rhel/secrets:/run/secrets`", the content of `/usr/share/rhel/secrets` directory is mounted on `/run/secrets` inside the container.  This mountpoint allows Red Hat Enterprise Linux subscriptions from the host to be used within the container.
+For example, a mounts.conf with the line "`/usr/share/rhel/secrets:/run/secrets`", the content of `/usr/share/rhel/secrets` directory is mounted on `/run/secrets` inside the container.  This mountpoint allows Red Hat Enterprise Linux subscriptions from the host to be used within the container.  It is also possible to omit the destination if it's equal to the source path.  For example, specifying `/var/lib/secrets` will mount the directory into the same container destination path `/var/lib/secrets`.
 
 Note this is not a volume mount. The content of the volumes is copied into container storage, not bind mounted directly from the host.
 

--- a/install.md
+++ b/install.md
@@ -324,11 +324,11 @@ registries = []
 
 `/usr/share/containers/mounts.conf` and optionally `/etc/containers/mounts.conf`
 
-The mounts.conf files specify volume mount directories that are automatically mounted inside containers when executing the `buildah run` or `buildah build-using-dockerfile` commands.  Container process can then use this content.  The volume mount content does not get committed to the final image.  This file is usually provided by the containers-common package.
+The mounts.conf files specify volume mount files or directories that are automatically mounted inside containers when executing the `buildah run` or `buildah build-using-dockerfile` commands.  Container processes can then use this content.  The volume mount content does not get committed to the final image.  This file is usually provided by the containers-common package.
 
 Usually these directories are used for passing secrets or credentials required by the package software to access remote package repositories.
 
-For example, a mounts.conf with the line "`/usr/share/rhel/secrets:/run/secrets`", the content of `/usr/share/rhel/secrets` directory is mounted on `/run/secrets` inside the container.  This mountpoint allows Red Hat Enterprise Linux subscriptions from the host to be used within the container.
+For example, a mounts.conf with the line "`/usr/share/rhel/secrets:/run/secrets`", the content of `/usr/share/rhel/secrets` directory is mounted on `/run/secrets` inside the container.  This mountpoint allows Red Hat Enterprise Linux subscriptions from the host to be used within the container.  It is also possible to omit the destination if it's equal to the source path.  For example, specifying `/var/lib/secrets` will mount the directory into the same container destination path `/var/lib/secrets`.
 
 Note this is not a volume mount. The content of the volumes is copied into container storage, not bind mounted directly from the host.
 

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -130,10 +130,13 @@ func getMounts(filePath string) []string {
 // getHostAndCtrDir separates the host:container paths
 func getMountsMap(path string) (string, string, error) {
 	arr := strings.SplitN(path, ":", 2)
-	if len(arr) == 2 {
+	switch len(arr) {
+	case 1:
+		return arr[0], arr[0], nil
+	case 2:
 		return arr[0], arr[1], nil
 	}
-	return "", "", errors.Errorf("unable to get host and container dir")
+	return "", "", errors.Errorf("unable to get host and container dir from path: %s", path)
 }
 
 // SecretMounts copies, adds, and mounts the secrets to the container root filesystem
@@ -162,7 +165,7 @@ func SecretMountsWithUIDGID(mountLabel, containerWorkingDir, mountFile, mountPre
 		if _, err := os.Stat(file); err == nil {
 			mounts, err := addSecretsFromMountsFile(file, mountLabel, containerWorkingDir, mountPrefix, uid, gid)
 			if err != nil {
-				logrus.Warnf("error mounting secrets, skipping: %v", err)
+				logrus.Warnf("error mounting secrets, skipping entry in %s: %v", file, err)
 			}
 			secretMounts = mounts
 			break

--- a/tests/secrets.bats
+++ b/tests/secrets.bats
@@ -3,20 +3,34 @@
 load helpers
 
 function setup() {
+    # prepare the test mounts file
     mkdir $TESTSDIR/containers
     touch $TESTSDIR/containers/mounts.conf
     MOUNTS_PATH=$TESTSDIR/containers/mounts.conf
-    echo "$TESTSDIR/rhel/secrets:/run/secrets" > $MOUNTS_PATH
 
+    # add the mounts entries
+    echo "$TESTSDIR/rhel/secrets:/run/secrets" > $MOUNTS_PATH
+    echo "$TESTSDIR/rhel/secrets" >> $MOUNTS_PATH
+    echo "$TESTSDIR/rhel/secrets/test.txt:/test.txt" >> $MOUNTS_PATH
+
+    # create the files to be tested
     mkdir -p $TESTSDIR/rhel/secrets
-    touch $TESTSDIR/rhel/secrets/test.txt
-    echo "Testing secrets mounts. I am mounted!" > $TESTSDIR/rhel/secrets/test.txt
+    TESTFILE=$TESTSDIR/rhel/secrets/test.txt
+    touch $TESTFILE
+
+    TESTFILE_CONTENT="Testing secrets mounts. I am mounted!"
+    echo $TESTFILE_CONTENT > $TESTSDIR/rhel/secrets/test.txt
+
     mkdir -p $TESTSDIR/symlink/target
     touch $TESTSDIR/symlink/target/key.pem
     ln -s $TESTSDIR/symlink/target $TESTSDIR/rhel/secrets/mysymlink
 }
 
 function teardown() {
+    buildah rm $cid
+    rm -rf $TESTSDIR/containers
+    rm -rf $TESTSDIR/rhel
+    rm -rf $TESTSDIR/symlink
     for d in containers rhel symlink;do
         rm -rf $TESTSDIR/$d
     done
@@ -24,16 +38,28 @@ function teardown() {
 
 @test "bind secrets mounts to container" {
     if ! which runc ; then
-		skip "no runc in PATH"
+        skip "no runc in PATH"
     fi
     runc --version
-    cid=$(buildah --default-mounts-file "$MOUNTS_PATH" --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+
+
+    # setup the test container
+    cid=$(buildah --default-mounts-file "$MOUNTS_PATH" --log-level=error \
+        from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+
+    # test a standard mount to /run/secrets
     run_buildah --log-level=error run $cid ls /run/secrets
     expect_output --substring "test.txt"
+
+    # test a mount without destination
+    run_buildah --log-level=error run $cid ls "$TESTSDIR"/rhel/secrets
+    expect_output --substring "test.txt"
+
+    # test a file-based mount
+    run_buildah --log-level=error run $cid cat /test.txt
+    expect_output --substring $TESTFILE_CONTENT
+
+    # test a symlink
     run_buildah run $cid ls /run/secrets/mysymlink
     expect_output --substring "key.pem"
-    buildah rm $cid
-    rm -rf $TESTSDIR/containers
-    rm -rf $TESTSDIR/rhel
-    rm -rf $TESTSDIR/symlink
 }


### PR DESCRIPTION
It is now possible to simplify entries in `mounts.conf` files if the
source and destination paths are equal, like this:

```
/my/very/long/path:/my/very/long/path
```

can be now written as:

```
/my/very/long/path
```

The documentation has been adapted as well as the testing.