### PR TITLE
Enable interfacer linter and fix lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - interfacer
     - misspell
     - nakedret
     - staticcheck
@@ -37,7 +38,6 @@ linters:
     # - gocritic
     # - gocyclo
     # - gosec
-    # - interfacer
     # - lll
     # - maligned
     # - prealloc

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -264,7 +264,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options BuildOpt
 // dockerfile content and will use ctxDir as the base include path.
 //
 // Note: we cannot use cmd.StdoutPipe() as cmd.Wait() closes it.
-func preprocessDockerfileContents(r io.ReadCloser, ctxDir string) (rdrCloser *io.ReadCloser, err error) {
+func preprocessDockerfileContents(r io.Reader, ctxDir string) (rdrCloser *io.ReadCloser, err error) {
 	cppPath := "/usr/bin/cpp"
 	if _, err = os.Stat(cppPath); err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
This fixes a single issue where the interface could be an `io.Reader`
instead of an `io.ReadCloser`.