### PR TITLE
fix label and annotation for 1-line Dockerfiles

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -757,9 +757,17 @@ func (s *StageExecutor) Execute(ctx context.Context, stage imagebuilder.Stage, b
 			if imgID, ref, err = s.commit(ctx, ib, s.executor.getCreatedBy(nil, ""), false, s.output); err != nil {
 				return "", nil, errors.Wrapf(err, "error committing base container")
 			}
+		} else if len(s.executor.labels) > 0 || len(s.executor.annotations) > 0 {
+			// The image would be modified by the labels passed
+			// via the command line, so we need to commit.
+			logCommit(s.output, -1)
+			if imgID, ref, err = s.commit(ctx, ib, s.executor.getCreatedBy(stage.Node, ""), true, s.output); err != nil {
+				return "", nil, err
+			}
 		} else {
-			// We don't need to squash the base image, so just
-			// reuse the base image.
+			// We don't need to squash the base image, and the
+			// image wouldn't be modified by the command line
+			// options, so just reuse the base image.
 			logCommit(s.output, -1)
 			if imgID, ref, err = s.tagExistingImage(ctx, s.builder.FromImageID, s.output); err != nil {
 				return "", nil, err

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1641,3 +1641,34 @@ load helpers
   touch "$DIR"/Dockerfile
   run_buildah 0 bud "$DIR"/Dockerfile
 }
+
+@test "bud-no-change" {
+  parent=alpine
+  target=no-change-image
+  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
+  run_buildah --debug=false inspect --format '{{printf "%q" .FromImageDigest}}' ${parent}
+  parentid="$output"
+  run_buildah --debug=false inspect --format '{{printf "%q" .FromImageDigest}}' ${target}
+  [[ "$output" == "$parentid" ]]
+
+  buildah rmi ${target}
+}
+
+@test "bud-no-change-label" {
+  parent=alpine
+  target=no-change-image
+  buildah bud --label "test=label" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
+  run_buildah --debug=false inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
+  expect_output 'map["test":"label"]'
+
+  buildah rmi ${target}
+}
+
+@test "bud-no-change-annotation" {
+  target=no-change-image
+  buildah bud --annotation "test=annotation" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
+  run_buildah --debug=false inspect --format '{{printf "%q" .ImageAnnotations}}' ${target}
+  expect_output 'map["test":"annotation"]'
+
+  buildah rmi ${target}
+}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1646,9 +1646,9 @@ load helpers
   parent=alpine
   target=no-change-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
-  run_buildah --debug=false inspect --format '{{printf "%q" .FromImageDigest}}' ${parent}
+  run_buildah --log-level=error inspect --format '{{printf "%q" .FromImageDigest}}' ${parent}
   parentid="$output"
-  run_buildah --debug=false inspect --format '{{printf "%q" .FromImageDigest}}' ${target}
+  run_buildah --log-level=error inspect --format '{{printf "%q" .FromImageDigest}}' ${target}
   [[ "$output" == "$parentid" ]]
 
   buildah rmi ${target}
@@ -1658,7 +1658,7 @@ load helpers
   parent=alpine
   target=no-change-image
   buildah bud --label "test=label" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
-  run_buildah --debug=false inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
+  run_buildah --log-level=error inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output 'map["test":"label"]'
 
   buildah rmi ${target}
@@ -1667,7 +1667,7 @@ load helpers
 @test "bud-no-change-annotation" {
   target=no-change-image
   buildah bud --annotation "test=annotation" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
-  run_buildah --debug=false inspect --format '{{printf "%q" .ImageAnnotations}}' ${target}
+  run_buildah --log-level=error inspect --format '{{printf "%q" .ImageAnnotations}}' ${target}
   expect_output 'map["test":"annotation"]'
 
   buildah rmi ${target}

--- a/tests/bud/no-change/Dockerfile
+++ b/tests/bud/no-change/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine


### PR DESCRIPTION
I encountered a bug while trying to use buildah bud on 1-line Dockerfiles (i.e. just a FROM line).  There is an optimization to simply re-tag the image in this case.  However, it doesn't take into account modifications to the image that might occur from arguments passed to buildah.  In particular, --label and --annotation arguments.

I added a check for labels and annotations before opting to re-tag the existing image.  I also added tests that perform the reproduction steps below.

**Steps to reproduce the issue:**

1. Create a one-line Dockerfile with the following contents:
```
$ cat Dockerfile.from_alpine
FROM alpine
```
2. Build the image. Notice that it is simply alpine re-tagged (expected)
```
$ buildah bud -f Dockerfile.from_alpine -t from_alpine .
STEP 1: FROM alpine
Getting image source signatures
Copying blob 9d48c3bd43c5 done
Copying config 9617696764 done
Writing manifest to image destination
Storing signatures
STEP 2: COMMIT from_alpine
--> 961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4

$ buildah images | grep alpine
localhost/from_alpine        latest    961769676411   2 weeks ago      5.85 MB
docker.io/library/alpine     latest    961769676411   2 weeks ago      5.85 MB
```
3. Build the image, adding a label. Notice that it is simply alpine re-tagged (**unexpected**)
```
$ buildah bud -f Dockerfile.from_alpine -t from_alpine_with_label --label test-label=true .
STEP 1: FROM alpine
STEP 2: COMMIT from_alpine_with_label
--> 961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4

$ buildah images | grep alpine
localhost/from_alpine                  latest    961769676411   2 weeks ago      5.85 MB
localhost/from_alpine_with_label       latest    961769676411   2 weeks ago      5.85 MB
docker.io/library/alpine               latest    961769676411   2 weeks ago      5.85 MB
```
4. Further notice that the label was not applied to the newly built image (**unexpected**)
```
$ buildah inspect localhost/from_alpine_with_label | grep Labels\"
            "Labels": null
            "Labels": null
```
5. Note: the same occurs with --annotation as with --label.