### PR TITLE
Set TMPDIR to /var/tmp by default

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -134,6 +134,10 @@ func main() {
 	if buildah.InitReexec() {
 		return
 	}
+	// Hard code TMPDIR functions to use /var/tmp, if user did not override
+	if _, ok := os.LookupEnv("TMPDIR"); !ok {
+		os.Setenv("TMPDIR", "/var/tmp")
+	}
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
We have had some issues with users squashing large images or pulling large
content from github, that could trigger crashes based on the size of /tmp.

Docker had an issue with this back in 2016. https://github.com/golang/go/issues/14021

The discussion there was to change the default to /var/tmp.

This change will only effect systems that do not set the TMPDIR environment variable.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>