### PR TITLE
Truncate output of too long image names

### DIFF
--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/containers/buildah"
+	"github.com/containers/buildah/util"
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -261,7 +262,7 @@ func containerOutputUsingTemplate(format string, params containerOutputParams) e
 
 func containerOutputUsingFormatString(truncate bool, params containerOutputParams) {
 	if truncate {
-		fmt.Printf("%-12.12s  %-8s %-12.12s %-32s %s\n", params.ContainerID, params.Builder, params.ImageID, params.ImageName, params.ContainerName)
+		fmt.Printf("%-12.12s  %-8s %-12.12s %-32s %s\n", params.ContainerID, params.Builder, params.ImageID, util.TruncateString(params.ImageName, 32), params.ContainerName)
 	} else {
 		fmt.Printf("%-64s %-8s %-64s %-32s %s\n", params.ContainerID, params.Builder, params.ImageID, params.ImageName, params.ContainerName)
 	}

--- a/cmd/buildah/containers_test.go
+++ b/cmd/buildah/containers_test.go
@@ -67,14 +67,15 @@ func TestContainerFormatStringOutput(t *testing.T) {
 		ContainerID:   "e477836657bb",
 		Builder:       " ",
 		ImageID:       "f975c5035748",
-		ImageName:     "test/image:latest",
+		ImageName:     "test/with/this/very/long/image:latest",
 		ContainerName: "test-container",
 	}
+	const trimmedImageName = "test/with/this/very/long/imag..."
 
 	output := captureOutput(func() {
 		containerOutputUsingFormatString(true, params)
 	})
-	expectedOutput := fmt.Sprintf("%-12.12s  %-8s %-12.12s %-32s %s\n", params.ContainerID, params.Builder, params.ImageID, params.ImageName, params.ContainerName)
+	expectedOutput := fmt.Sprintf("%-12.12s  %-8s %-12.12s %-32s %s\n", params.ContainerID, params.Builder, params.ImageID, trimmedImageName, params.ContainerName)
 	if output != expectedOutput {
 		t.Errorf("Error outputting using format string:\n\texpected: %s\n\treceived: %s\n", expectedOutput, output)
 	}

--- a/docs/buildah-containers.md
+++ b/docs/buildah-containers.md
@@ -54,7 +54,7 @@ Omit the table headings from the listing of containers.
 
 **--notruncate**
 
-Do not truncate IDs in output.
+Do not truncate IDs and image names in the output.
 
 **--quiet, -q**
 

--- a/util/util.go
+++ b/util/util.go
@@ -381,3 +381,17 @@ func LogIfNotRetryable(err error, what string) (retry bool) {
 func LogIfUnexpectedWhileDraining(err error, what string) {
 	logIfNotErrno(err, what, syscall.EINTR, syscall.EAGAIN, syscall.EIO)
 }
+
+// TruncateString trims the given string to the provided maximum amount of
+// characters and shortens it with `...`.
+func TruncateString(str string, to int) string {
+	newStr := str
+	if len(str) > to {
+		const tr = "..."
+		if to > len(tr) {
+			to -= len(tr)
+		}
+		newStr = str[0:to] + tr
+	}
+	return newStr
+}


### PR DESCRIPTION
Image names longer than 32 characters will now be truncated via `...` in
the default table output. For example this:

```
CONTAINER ID  BUILDER  IMAGE ID     IMAGE NAME                       CONTAINER NAME
579aa959bb4d     *     9b1a5a0c02f5 docker.io/clearlinux/golang:latest golang-working-container
```

Now looks like this:

```
CONTAINER ID  BUILDER  IMAGE ID     IMAGE NAME                       CONTAINER NAME
579aa959bb4d     *     9b1a5a0c02f5 docker.io/clearlinux/golang:l... golang-working-container
```

Signed-off-by: Sascha Grunert <sgrunert@suse.com>