### PR TITLE
Downgrade .papr to highest atomic version

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -4,7 +4,8 @@ branches:
   - try
 
 host:
-  distro: fedora/30/atomic
+  # 29 is the highest level of atomic
+  distro: fedora/29/atomic
 
 required: true
 


### PR DESCRIPTION
Per @jlebon, the highest level of fedora atomic is 29, not 30.
Bumping the version down one in hopes of fixing our test
issues.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>