### PR TITLE
Fix travis-ci on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
     - 1.11.x
     - 1.12.x
     - tip
+go_import_path: github.com/containers/buildah
 
 env:
     global:


### PR DESCRIPTION
When attempting to run travis-ci on a fork of this repo, due to the
organisation name changing the CI job will fail with a rather
bewildering error about "no go files"

Looking closely it becomes apparent that the path being used is not
GOROOT/src/github.com/containers/buildah but
GOROOT/src/github.com/FORKNAME/buildah, which results in the inability
to run the tests.

To solve this issue the travis-ci go_import_path can be set to ensure
the checkout path is correct, resulting in the ability to ensure CI will
succeed before making a PR.  As this sets the path to be the same as
the primary repository it has no effect on the primary repository.

https://docs.travis-ci.com/user/languages/go/#go-import-path

Signed-off-by: Sachi King <nakato@nakato.io>