### PR TITLE
Print build 'STEP' line to stdout, not stderr

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -164,7 +164,7 @@ func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Nod
 			stepCounter++
 			prefix := fmt.Sprintf("STEP %d: ", stepCounter)
 			suffix := "\n"
-			fmt.Fprintf(exec.err, prefix+format+suffix, args...)
+			fmt.Fprintf(exec.out, prefix+format+suffix, args...)
 		}
 	}
 	for arg := range options.Args {


### PR DESCRIPTION
The 'STEP' line that's printed as part of the build processing was
going to Stderr and causing some issues for OpenShift who was looking
for it.  Instead print it to Stdout.

Addresses: #1772

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>