### PR TITLE
Add support for retrieving context from stdin "-"

### DIFF
--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -76,7 +76,7 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 	if strings.HasPrefix(url, "git://") || strings.HasSuffix(url, ".git") {
 		err = cloneToDirectory(url, name)
 		if err != nil {
-			if err2 := os.Remove(name); err2 != nil {
+			if err2 := os.RemoveAll(name); err2 != nil {
 				logrus.Debugf("error removing temporary directory %q: %v", name, err2)
 			}
 			return "", "", err
@@ -92,7 +92,7 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
 		err = downloadToDirectory(url, name)
 		if err != nil {
-			if err2 := os.Remove(name); err2 != nil {
+			if err2 := os.RemoveAll(name); err2 != nil {
 				logrus.Debugf("error removing temporary directory %q: %v", name, err2)
 			}
 			return "", subdir, err

--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -1,6 +1,8 @@
 package imagebuildah
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -55,7 +57,25 @@ func downloadToDirectory(url, dir string) error {
 	return nil
 }
 
-// TempDirForURL checks if the passed-in string looks like a URL.  If it is,
+func stdinToDirectory(dir string) error {
+	logrus.Debugf("extracting stdin to %q", dir)
+	r := bufio.NewReader(os.Stdin)
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to read from stdin")
+	}
+	reader := bytes.NewReader(b)
+	if err := chrootarchive.Untar(reader, dir, nil); err != nil {
+		dockerfile := filepath.Join(dir, "Dockerfile")
+		// Assume this is a Dockerfile
+		if err := ioutil.WriteFile(dockerfile, b, 0600); err != nil {
+			return errors.Wrapf(err, "Failed to write bytes to %q", dockerfile)
+		}
+	}
+	return nil
+}
+
+// TempDirForURL checks if the passed-in string looks like a URL or -.  If it is,
 // TempDirForURL creates a temporary directory, arranges for its contents to be
 // the contents of that URL, and returns the temporary directory's path, along
 // with the name of a subdirectory which should be used as the build context
@@ -66,7 +86,8 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 	if !strings.HasPrefix(url, "http://") &&
 		!strings.HasPrefix(url, "https://") &&
 		!strings.HasPrefix(url, "git://") &&
-		!strings.HasPrefix(url, "github.com/") {
+		!strings.HasPrefix(url, "github.com/") &&
+		url != "-" {
 		return "", "", nil
 	}
 	name, err = ioutil.TempDir(dir, prefix)
@@ -97,6 +118,17 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 			}
 			return "", subdir, err
 		}
+		return name, subdir, nil
+	}
+	if url == "-" {
+		err = stdinToDirectory(name)
+		if err != nil {
+			if err2 := os.RemoveAll(name); err2 != nil {
+				logrus.Debugf("error removing temporary directory %q: %v", name, err2)
+			}
+			return "", subdir, err
+		}
+		logrus.Debugf("Build context is at %q", name)
 		return name, subdir, nil
 	}
 	logrus.Debugf("don't know how to retrieve %q", url)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1730,3 +1730,31 @@ load helpers
   run_buildah --log-level=error images -q
   expect_output ""
 }
+
+@test "bud with Dockerfile from stdin" {
+  target=df-stdin
+  cat ${TESTSDIR}/bud/context-from-stdin/Dockerfile | buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -
+  [ "$?" -eq 0 ]
+  cid=$(buildah from ${target})
+  root=$(buildah mount ${cid})
+  run test -s $root/etc/alpine-release
+  echo "$output"
+  buildah rm ${cid}
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
+  expect_output ""
+}
+
+@test "bud with Dockerfile from stdin tar" {
+  target=df-stdin
+  tar -c -C ${TESTSDIR}/bud/context-from-stdin . | buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -
+  [ "$?" -eq 0 ]
+  cid=$(buildah from ${target})
+  root=$(buildah mount ${cid})
+  run test -s $root/etc/alpine-release
+  echo "$output"
+  buildah rm ${cid}
+  buildah rmi $(buildah --log-level=error images -q)
+  run_buildah --log-level=error images -q
+  expect_output ""
+}

--- a/tests/bud/context-from-stdin/Dockerfile
+++ b/tests/bud/context-from-stdin/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine as base
+RUN echo "stdin-context" > /scratchfile
+
+FROM scratch
+COPY --from=base /scratchfile /


### PR DESCRIPTION
Some consumers of the docker command line API expect to be able to pass
a tar or a Dockerfile into the build command via stdin, which causes a
build failure when it hits 'buildah bud' or 'podman build', which calls
buildah.  A good example of this is the `linuxkit pkg build $dir`
command, which will append a `-` to the build command.

To improve compatibility with `docker build` support for `-` is added to
mean "read from stdin".
While a user could pass /dev/stdin or /proc/self/fd/0, or a path to some
other character device, as such tricks are common when attempting to get
programs to read from stdin, `docker build` does not support this, thus
this leaves out a bit of complexity while improving 'docker build' cli
compatibility.

---

I recognize that we'll probably need to perform some iteration on this.

The first issue to consider in my opinion is whether TempDirForURL the correct place for this, and if it is added to TempDirForURL, does it constitute an API change due to now potentially opening stdin if passed '-'.

This was however in my opinion the most logical location to add this.