### PR TITLE
Fix --pull=true||false and add --pull-never to bud and from

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -40,7 +40,7 @@ const (
 	stateFile = Package + ".json"
 )
 
-// PullPolicy takes the value PullIfMissing, PullAlways, or PullNever.
+// PullPolicy takes the value PullIfMissing, PullAlways, PullIfNewer, or PullNever.
 type PullPolicy int
 
 const (
@@ -52,6 +52,11 @@ const (
 	// take, signalling that a fresh, possibly updated, copy of the image
 	// should be pulled from a registry before the build proceeds.
 	PullAlways
+	// PullIfNewer is one of the values that BuilderOptions.PullPolicy
+	// can take, signalling that the source image should only be pulled
+	// from a registry if a local copy is not already present or if a
+	// newer version the image is present on the repository.
+	PullIfNewer
 	// PullNever is one of the values that BuilderOptions.PullPolicy can
 	// take, signalling that the source image should not be pulled from a
 	// registry if a local copy of it is not already present.
@@ -65,6 +70,8 @@ func (p PullPolicy) String() string {
 		return "PullIfMissing"
 	case PullAlways:
 		return "PullAlways"
+	case PullIfNewer:
+		return "PullIfNewer"
 	case PullNever:
 		return "PullNever"
 	}

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -366,6 +366,7 @@ return 1
      --no-cache
      --pull
      --pull-always
+     --pull-never
      --quiet
      -q
      --squash
@@ -833,6 +834,7 @@ _buildah_containers() {
      -h
      --pull
      --pull-always
+     --pull-never
      --quiet
      -q
      --tls-verify

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -350,8 +350,8 @@ than the one in storage. Raise an error if the image is not in any listed
 registry and is not present locally.
 
 If the flag is disabled (with *--pull=false*), do not pull the image from the
-registry, use only the local version. Raise an error if the image is not
-present locally.
+registry unless there is no local image. Raise an error if the image is not
+in any registry and is not present locally.
 
 Defaults to *true*.
 
@@ -359,6 +359,11 @@ Defaults to *true*.
 
 Pull the image from the first registry it is found in as listed in registries.conf.
 Raise an error if not found in the registries, even if the image is present locally.
+
+**--pull-never**
+
+Do not pull the image from the registry, use only the local version. Raise an error
+if the image is not present locally.
 
 **--quiet, -q**
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -279,8 +279,8 @@ than the one in storage. Raise an error if the image is not in any listed
 registry and is not present locally.
 
 If the flag is disabled (with *--pull=false*), do not pull the image from the
-registry, use only the local version. Raise an error if the image is not
-present locally.
+registry unless there is no local image. Raise an error if the image is not
+in any registry and is not present locally.
 
 Defaults to *true*.
 
@@ -288,6 +288,11 @@ Defaults to *true*.
 
 Pull the image from the first registry it is found in as listed in registries.conf.
 Raise an error if not found in the registries, even if the image is present locally.
+
+**--pull-never**
+
+Do not pull the image from the registry, use only the local version. Raise an error
+if the image is not present locally.
 
 **--quiet, -q**
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -27,6 +27,7 @@ import (
 const (
 	PullIfMissing = buildah.PullIfMissing
 	PullAlways    = buildah.PullAlways
+	PullIfNewer   = buildah.PullIfNewer
 	PullNever     = buildah.PullNever
 
 	Gzip         = archive.Gzip
@@ -45,7 +46,7 @@ type BuildOptions struct {
 	// commands.
 	ContextDirectory string
 	// PullPolicy controls whether or not we pull images.  It should be one
-	// of PullIfMissing, PullAlways, or PullNever.
+	// of PullIfMissing, PullAlways, PullIfNewer, or PullNever.
 	PullPolicy buildah.PullPolicy
 	// Registry is a value which is prepended to the image's name, if it
 	// needs to be pulled and the image name alone can not be resolved to a

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -63,6 +63,7 @@ type BudResults struct {
 	Platform            string
 	Pull                bool
 	PullAlways          bool
+	PullNever           bool
 	Quiet               bool
 	Rm                  bool
 	Runtime             string
@@ -159,8 +160,9 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.Logfile, "logfile", "", "log to `file` instead of stdout/stderr")
 	fs.IntVar(&flags.Loglevel, "loglevel", 0, "adjust logging level (range from -2 to 3)")
 	fs.StringVar(&flags.Platform, "platform", "", "CLI compatibility: no action or effect")
-	fs.BoolVar(&flags.Pull, "pull", true, "pull the image if not present")
-	fs.BoolVar(&flags.PullAlways, "pull-always", false, "pull the image, even if a version is present")
+	fs.BoolVar(&flags.Pull, "pull", true, "pull the image from the registry if newer or not present in store, if false, only pull the image if not present")
+	fs.BoolVar(&flags.PullAlways, "pull-always", false, "pull the image even if the named image is present in store")
+	fs.BoolVar(&flags.PullNever, "pull-never", false, "do not pull the image, use the image present in store if available")
 	fs.BoolVarP(&flags.Quiet, "quiet", "q", false, "refrain from announcing build instructions and image read/write progress")
 	fs.BoolVar(&flags.Rm, "rm", true, "Remove intermediate containers after a successful build")
 	// "runtime" definition moved to avoid name collision in podman build.  Defined in cmd/buildah/bud.go.

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -24,7 +24,7 @@ load helpers
 }
 
 @test "from-nopull" {
-  run_buildah 1 from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah 1 from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
 }
 
 @test "mount" {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1030,7 +1030,6 @@ load helpers
 @test "bud-logfile" {
   rm -f ${TESTDIR}/logfile
   run_buildah bud --logfile ${TESTDIR}/logfile --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/preserve-volumes
-  expect_output ""
   test -s ${TESTDIR}/logfile
 }
 
@@ -1788,6 +1787,31 @@ load helpers
 
   rm ${TESTSDIR}/bud/use-args/abc.txt
   buildah rm --all
+}
+
+@test "bud pull never" {
+  target=pull
+  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull-never ${TESTSDIR}/bud/pull
+  echo "$output"
+  expect_output --substring "no such image"
+
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull ${TESTSDIR}/bud/pull
+  echo "$output"
+  expect_output --substring "COMMIT pull"
+
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull-never ${TESTSDIR}/bud/pull
+  echo "$output"
+  expect_output --substring "COMMIT pull"
+
+  buildah rmi --all --force
+}
+
+@test "bud pull false no local image" {
+  target=pull
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull=false ${TESTSDIR}/bud/pull
+  echo "$output"
+  expect_output --substring "COMMIT pull"
+
   buildah rmi --all --force
 }
 

--- a/tests/bud/pull/Containerfile
+++ b/tests/bud/pull/Containerfile
@@ -1,0 +1,1 @@
+FROM alpine

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -345,3 +345,28 @@ load helpers
   run_buildah --log-level=error containers -f id=${cid}
   buildah rm ${cid}
 }
+
+@test "from pull never" {
+  run_buildah 1 from --signature-policy ${TESTSDIR}/policy.json --pull-never alpine
+  echo "$output"
+  expect_output --substring "no such image"
+
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json --pull alpine
+  echo "$output"
+  expect_output --substring "alpine-working-container"
+
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json --pull-never alpine
+  echo "$output"
+  expect_output --substring "alpine-working-container"
+
+  buildah rmi --all --force
+}
+
+@test "from pull false no local image" {
+  target=my-alpine
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json --pull=false alpine
+  echo "$output"
+  expect_output --substring "alpine-working-container"
+
+  buildah rmi --all --force
+}


### PR DESCRIPTION
Prior to this fix, if someone did `buildah bud --pull=false .` and the image in
the Containerfile's FROM statement was not local, the build would fail. The same
build on Docker will succeed. In Docker, when `--pull` is set to false, it only
pulls the image from the registry if there was not one locally. Buildah would never
pull the image and if the image was not locally available, it would throw an error.
In certain Kubernetes environments, this was especially troublesome.

To retain the old `--pull=false` functionality, I've created a new `--pull-never`
option that fails if an image is not locally available just like the old
`--pull=false` option used to do.

In addition, if there was a newer version of the image on the repository than 
the one locally, the `--pull=true` option would not pull the image as it should 
have, this corrects that.

Changes both the from and bud commands.


Addresses: #1675

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>