### PR TITLE
Fix crash when invalid COPY --from flag is specified.

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -816,6 +816,9 @@ func (s *StageExecutor) Execute(ctx context.Context, stage imagebuilder.Stage, b
 			if strings.Contains(n, "--from") && (command == "COPY" || command == "ADD") {
 				var mountPoint string
 				arr := strings.Split(n, "=")
+				if len(arr) != 2 {
+					return "", nil, errors.Errorf("%s: invalid --from flag, should be --from=<name|index>", command)
+				}
 				otherStage, ok := s.executor.stages[arr[1]]
 				if !ok {
 					if mountPoint, err = s.getImageRootfs(ctx, stage, arr[1]); err != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1215,6 +1215,13 @@ load helpers
   expect_output --substring "755"
 }
 
+@test "bud multi-stage COPY with invalid from statement" {
+  imgName=ubuntu-image
+  ctrName=ubuntu-copy
+  run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.invalid_from -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths || true
+  expect_output --substring "COPY: invalid --from flag, should be --from=<name|index>"
+}
+
 @test "bud COPY to root succeeds" {
   run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/copy-root
 }

--- a/tests/bud/copy-multistage-paths/Dockerfile.invalid_from
+++ b/tests/bud/copy-multistage-paths/Dockerfile.invalid_from
@@ -1,0 +1,4 @@
+FROM ubuntu as builder
+FROM ubuntu
+COPY --from builder /bin/bash /my/bin/bash
+RUN stat -c "permissions=%a" /my/bin


### PR DESCRIPTION
Closes #1894. This fixes a pretty simple issue where an invalid `COPY --from` flag is incorrectly specified. Being a new contributor I'm unsure if I should add a test case under `tests` but would be happy to supply one. This bug in particular is triggered by an invalid statement in a Dockerfile.

Signed-off-by: caiges <caigesn@gmail.com>