### PR TITLE
DO-NOT-MERGE: Add squash-all for podman build

### DIFF
--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -42,6 +42,12 @@ type NameSpaceResults struct {
 	UTS           string
 }
 
+// PodmanBuildResults represents the results for Podman Build flags
+// that are unique to Podman
+type PodmanBuildResults struct {
+	SquashAll bool
+}
+
 // BudResults represents the results for Bud flags
 type BudResults struct {
 	Annotation          []string
@@ -134,6 +140,14 @@ func GetLayerFlags(flags *LayerResults) pflag.FlagSet {
 	fs := pflag.FlagSet{}
 	fs.BoolVar(&flags.ForceRm, "force-rm", false, "Always remove intermediate containers after a build, even if the build is unsuccessful.")
 	fs.BoolVar(&flags.Layers, "layers", UseLayers(), fmt.Sprintf("cache intermediate layers during build. Use BUILDAH_LAYERS environment variable to override."))
+	return fs
+}
+
+// GetPodmanBuildFlags flags used only by `podman build` and not by
+// `buildah bud`.
+func GetPodmanBuildFlags(flags *PodmanBuildResults) pflag.FlagSet {
+	fs := pflag.FlagSet{}
+	fs.BoolVar(&flags.SquashAll, "squash-all", false, "Squash all layers into a single layer.")
 	return fs
 }
 


### PR DESCRIPTION
Add a `--squash-all` flag that will be unique to `podman build` and will not
be used by Buildah.  `buildah bud --layers=false` is equivalent to `docker build --squash` (experimental).  When a podman build command includes the `--squash` option, podman will translate that to `--layers=false` for the buildah bud api code.  A `docker build` call is equivalent to `podman build` or `podman build --layers=true` and that's not changing.

When podman build uses the `--squash-all` command, it will turn on the --squash option for the buildah bud api to have only one layer returned by the buildah bud code.  There's not a Docker equivalent for this at the moment.

I'll hopefully be spinning up a Podman PR in the next day or two that will use this new option.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>