### PR TITLE
Move runtime flag to bud from common

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/buildah/imagebuildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/buildah/util"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -65,6 +66,8 @@ func init() {
 
 	// BUD is a all common flags
 	budFlags := buildahcli.GetBudFlags(&budFlagResults)
+	budFlags.StringVar(&budFlagResults.Runtime, "runtime", util.Runtime(), "`path` to an alternate runtime. Use BUILDAH_RUNTIME environment variable to override.")
+
 	layerFlags := buildahcli.GetLayerFlags(&layerFlagsResults)
 	fromAndBudFlags := buildahcli.GetFromAndBudFlags(&fromAndBudResults, &userNSResults, &namespaceResults)
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -161,7 +161,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.BoolVar(&flags.PullAlways, "pull-always", false, "pull the image, even if a version is present")
 	fs.BoolVarP(&flags.Quiet, "quiet", "q", false, "refrain from announcing build instructions and image read/write progress")
 	fs.BoolVar(&flags.Rm, "rm", true, "Remove intermediate containers after a successful build")
-	fs.StringVar(&flags.Runtime, "runtime", util.Runtime(), "`path` to an alternate runtime. Use BUILDAH_RUNTIME environment variable to override.")
+	// "runtime" definition moved to avoid name collision in podman build.  Defined in cmd/buildah/bud.go.
 	fs.StringSliceVar(&flags.RuntimeFlags, "runtime-flag", []string{}, "add global flags for the container runtime")
 	fs.StringVar(&flags.SignaturePolicy, "signature-policy", "", "`pathname` of signature policy file (not usually used)")
 	fs.BoolVar(&flags.Squash, "squash", false, "Squash newly built layers into a single new layer.")


### PR DESCRIPTION
Move the runtime Cobra flag for the build command to the
command itself and out of the common definitions.  Podman
uses the same definition and there was a collision with that
flag and the one here: https://github.com/containers/libpod/blob/master/cmd/podman/main_local.go#L69

This caused wonky results.  The podman global flag would
think it had been set, but no value was captured, or reversely,
the flag didn't think it had been set, but if you peered inside
you'd see the appropriate value from the user input.
This was all based on whether you did
`podman --runtime=/usr/bin/runc build` or
`podman build --runtime=/usr/bin/runc`

As Podman uses their runtime flag in multiple places, it's
easier to remove it from the common definition here in Buildah
and then add the flag into the bud command.

Once merged and vendored into Podman, this will fix: https://bugzilla.redhat.com/show_bug.cgi?id=1758082

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>