### PR TITLE
Fix copy/add behaviour with .dockerignore

### DIFF
--- a/add.go
+++ b/add.go
@@ -299,7 +299,7 @@ func (b *Builder) addHelper(excludes *fileutils.PatternMatcher, extract bool, de
 					}
 				}
 				logrus.Debugf("copying[%d] %q to %q", n, esrc+string(os.PathSeparator)+"*", dest+string(os.PathSeparator)+"*")
-				if excludes == nil || !excludes.Exclusions() {
+				if excludes == nil || len(excludes.Patterns()) == 0 {
 					if err = copyWithTar(esrc, dest); err != nil {
 						return errors.Wrapf(err, "error copying %q to %q", esrc, dest)
 					}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -34,6 +34,10 @@ load helpers
 
   run_buildah bud -t testbud2 --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/dockerignore2
 
+  run_buildah from --name myctr2 testbud2
+  run_buildah 1 run myctr2 ls -l unmatched
+  run_buildah run myctr2 ls -l matched
+
   run_buildah bud -t testbud3 --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/dockerignore3
 
   run sed -e '/^CUT HERE/,/^CUT HERE/p' -e 'd' <<< "$output"

--- a/tests/bud/dockerignore2/.dockerignore
+++ b/tests/bud/dockerignore2/.dockerignore
@@ -1,1 +1,2 @@
 unmatched
+matched

--- a/tests/bud/dockerignore2/Dockerfile
+++ b/tests/bud/dockerignore2/Dockerfile
@@ -1,2 +1,3 @@
-FROM scratch
+FROM alpine
+
 COPY . .


### PR DESCRIPTION
When a directory is being copied/added, the whole directory was being copied in unless there was an exclusion (e.g., `!include-this-file`) in the `.dockerignore`.

So for this `Dockerfile`:
```Dockerfile
FROM alpine
COPY . /tmp/foo
RUN ls /tmp/foo
```

With this `.dockerignore`:
```bash
# !foo
quux
```

A file named `quux` in the build context would be copied in, unless the first line was uncommented. This is fixed by checking if there are any patterns at all, instead of for an exclusion.

Note: the `run_buildah run myctr2 ls -l matched` test fails on my machine with: `printf: write error: Resource temporarily unavailable`. I'm not sure why this happens, as far as I can tell it's correct.