### PR TITLE
Silence "using cache" to ensure -q is fully quiet

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -759,6 +759,12 @@ func (s *StageExecutor) Execute(ctx context.Context, stage imagebuilder.Stage, b
 			s.executor.log(commitMessage)
 		}
 	}
+	logCacheHit := func(cacheID string) {
+		if !s.executor.quiet {
+			cacheHitMessage := "--> Using cache"
+			fmt.Fprintf(s.executor.out, "%s %s\n", cacheHitMessage, cacheID)
+		}
+	}
 	logImageID := func(imgID string) {
 		if s.executor.iidfile == "" {
 			fmt.Fprintf(s.executor.out, "%s\n", imgID)
@@ -909,7 +915,7 @@ func (s *StageExecutor) Execute(ctx context.Context, stage imagebuilder.Stage, b
 			}
 			if cacheID != "" {
 				// Note the cache hit.
-				fmt.Fprintf(s.executor.out, "--> Using cache %s\n", cacheID)
+				logCacheHit(cacheID)
 			} else {
 				// We're not going to find any more cache hits.
 				checkForLayers = false


### PR DESCRIPTION
  + Add a helper function inside of `(s *StageExecutor) Execute()` to
handle "using cache" messages

Signed-off-by: Tyler Ramer <tyaramer@gmail.com>

---
Addresses https://github.com/containers/buildah/issues/1897