### PR TITLE
Add OWNERS File to Buildah

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,22 @@
+approvers:
+  - TomSweeneyRedHat
+  - cevich
+  - giuseppe
+  - nalind
+  - rhatdan
+  - vrothberg
+reviewers:
+  - QiWang19
+  - TomSweeneyRedHat
+  - baude
+  - cevich
+  - edsantiago
+  - giuseppe
+  - haircommander
+  - jwhonce
+  - mheon
+  - mrunalp
+  - nalind
+  - rhatdan
+  - umohnani8
+  - vrothberg


### PR DESCRIPTION
Add OWNERS file so that we can move to cirrus/openshift merge bots.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>