### PR TITLE
Add clarification to the Tutorial for new users

### DIFF
--- a/docs/tutorials/01-intro.md
+++ b/docs/tutorials/01-intro.md
@@ -7,6 +7,10 @@ The purpose of this tutorial is to demonstrate how Buildah can be used to build 
 
 In brief the `containers/image` project provides mechanisms to copy, push, pull, inspect and sign container images. The `containers/storage` project provides mechanisms for storing filesystem layers, container images, and containers. Buildah is a CLI that takes advantage of these underlying projects and therefore allows you to build, move, and manage container images and containers.
 
+Buildah works on a number of Linux distributions, but is not supported on Windows or Mac platforms at this time.  Buildah specializes in building OCI images and [Podman](https://podman.io) specializes in all of the commands and functions that help you to maintain, modify and run OCI images and containers.  For more informaton on the difference between the projects please refer to the [Buildah and Podman relationship](https://github.com/containers/buildah#buildah-and-podman-relationship) section on the main README.md.
+
+## Configure and Install Buildah
+
 Note that installation instructions below assume you are running a Linux distro that uses `dnf` as its package manager, and have all prerequisites fulfilled. See Buildah's [installation instructions][buildah-install] for a full list of prerequisites, and the `buildah` installation section in the [official Red Hat documentation][rh-repo-docs] for RHEL-specific instructions.
 
 [buildah-install]:../../install.md
@@ -19,6 +23,12 @@ First step is to install Buildah. Run as root because you will need to be root f
 Then install buildah by running:
 
     # dnf -y install buildah
+
+## Rootless User Configuration
+
+If you plan to run Buildah as a user without root privileges, i.e. a "rootless user", the administrator of the system might have to do a bit of additional configuration beforehand.  The setup required for this is listed on the Podman GitHub site [here](https://github.com/containers/libpod/blob/master/docs/tutorials/rootless_tutorial.md).  Buildah has the same setup and configuration requirements that Podman does for rootless users.
+
+## Post Installation Verification
 
 After installing Buildah we can see there are no images installed. The `buildah images` command will list all the images:
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -6,8 +6,7 @@
 
 **[Introduction Tutorial](01-intro.md)**
 
-Learn how to build container images compliant with the [Open Container Initiative](https://www.opencontainers.org/) (OCI) [image specification](https://github.com/opencontainers/image-spec) using Buildah.
-
+Learn how to build container images compliant with the [Open Container Initiative](https://www.opencontainers.org/) (OCI) [image specification](https://github.com/opencontainers/image-spec) using Buildah.  This tutorial shows how to [Configure and Setup](01-intro.md#configure-and-install-buildah) Buildah, how to [build containers using a Dockerfile](01-intro.md#using-dockerfiles-with-buildah) and how to [build containers from scratch](01-intro.md#building-a-container-from-scratch).
 
 **[Buildah and Registries Tutorial](02-registries-repositories.md)**
 


### PR DESCRIPTION
This is a partial fix for #1895.  This focuses on (hopefully) helping a
user get into Buildah faster when they first hit the buildah.io site and
click down through the tutorials button.  It also clarifies what's currently
out of scope for Buildah, adds some titles to make links easier and a bit more.

I expect I'll either be adding to this or creating a follow on PR to address more
of the notes in #1895.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>