### PR TITLE
BATS tests - lots of mostly minor cleanup

### DIFF
--- a/tests/add.bats
+++ b/tests/add.bats
@@ -113,13 +113,13 @@ load helpers
   run_buildah add $cid ${TESTDIR}/distutils.cfg /usr/lib/python3.7/distutils
   run_buildah run $cid stat -c "%a" /usr/lib/python3.7/distutils
   root=$(buildah mount $cid)
-  expect_output --substring "755"
+  expect_output "644"
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:${imgName}
   run_buildah rm $cid
 
   newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${imgName})
   run_buildah run $newcid stat -c "%a" /usr/lib/python3.7/distutils
-  expect_output --substring "755"
+  expect_output "644"
   run_buildah rm $newcid
 }
 
@@ -131,12 +131,12 @@ load helpers
   run_buildah add $cid ${TESTDIR}/distutils.cfg lib/custom
   run_buildah run $cid stat -c "%a" lib/custom
   root=$(buildah mount $cid)
-  expect_output --substring "755"
+  expect_output "644"
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:${imgName}
   run_buildah rm $cid
 
   newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${imgName})
   run_buildah run $newcid stat -c "%a" lib/custom
-  expect_output --substring "755"
+  expect_output "644"
   run_buildah rm $newcid
 }

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -115,10 +115,8 @@ load helpers
   root=$(buildah mount $cid)
   test -s $root/urlfile
   cmp ${TESTDIR}/randomfile $root/urlfile
-  run test -nt ${TESTDIR}/randomfile $root/urlfile
-  [ "$status" -ne 0 ]
-  run test -ot ${TESTDIR}/randomfile $root/urlfile
-  [ "$status" -ne 0 ]
+  test ! -nt ${TESTDIR}/randomfile $root/urlfile
+  test ! -ot ${TESTDIR}/randomfile $root/urlfile
   buildah rm $cid
 }
 

--- a/tests/formats.bats
+++ b/tests/formats.bats
@@ -2,33 +2,66 @@
 
 load helpers
 
+###################
+#  check_imgtype  #  shortcut for running 'imgtype' and verifying image
+###################
+function check_imgtype() {
+  # First argument: image name
+  image="$1"
+
+  # Second argument: expected image type, 'oci' or 'docker'
+  imgtype_oci="application/vnd.oci.image.manifest.v1+json"
+  imgtype_dkr="application/vnd.docker.distribution.manifest.v2+json"
+
+  expect=""
+  case "$2" in
+      oci)    want=$imgtype_oci; reject=$imgtype_dkr;;
+      docker) want=$imgtype_dkr; reject=$imgtype_oci;;
+      *)      die "Internal error: unknown image type '$2'";;
+  esac
+
+  # First test: run imgtype with expected type, confirm exit 0 + no output
+  echo "\$ imgtype -expected-manifest-type $want $image"
+  run imgtype -expected-manifest-type $want $image
+  echo "$output"
+  if [[ $status -ne 0 ]]; then
+    die "exit status is $status (expected 0)"
+  fi
+  expect_output "" "Checking imagetype($image) == $2"
+
+  # Second test: the converse. Run imgtype with the WRONG expected type,
+  # confirm error message and exit status 1
+  echo "\$ imgtype -expected-manifest-type $reject $image [opposite test]"
+  run imgtype -expected-manifest-type $reject $image
+  echo "$output"
+  if [[ $status -ne 1 ]]; then
+    die "exit status is $status (expected 1)"
+  fi
+
+  # Can't embed entire string because the '+' sign is interpreted as regex
+  expect_output --substring \
+                "level=error msg=\"expected .* type \\\\\".*, got " \
+                "Checking imagetype($image) == $2"
+}
+
+
 @test "write-formats" {
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-default
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
-  imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-default
-  imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-oci
-  imgtype -expected-manifest-type application/vnd.docker.distribution.manifest.v2+json scratch-image-docker
-  run imgtype -expected-manifest-type application/vnd.docker.distribution.manifest.v2+json scratch-image-default
-  [ "$status" -ne 0 ]
-  run imgtype -expected-manifest-type application/vnd.docker.distribution.manifest.v2+json scratch-image-oci
-  [ "$status" -ne 0 ]
-  run imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-docker
-  [ "$status" -ne 0 ]
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-default
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+
+  check_imgtype scratch-image-default oci
+  check_imgtype scratch-image-oci     oci
+  check_imgtype scratch-image-docker  docker
 }
 
 @test "bud-formats" {
-  buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json -t scratch-image-default -f Dockerfile bud/from-scratch
-  buildah build-using-dockerfile --format docker --signature-policy ${TESTSDIR}/policy.json -t scratch-image-docker -f Dockerfile bud/from-scratch
-  buildah build-using-dockerfile --format oci --signature-policy ${TESTSDIR}/policy.json -t scratch-image-oci -f Dockerfile bud/from-scratch
-  imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-default
-  imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-oci
-  imgtype -expected-manifest-type application/vnd.docker.distribution.manifest.v2+json scratch-image-docker
-  run imgtype -expected-manifest-type application/vnd.docker.distribution.manifest.v2+json scratch-image-default
-  [ "$status" -ne 0 ]
-  run imgtype -expected-manifest-type application/vnd.docker.distribution.manifest.v2+json scratch-image-oci
-  [ "$status" -ne 0 ]
-  run imgtype -expected-manifest-type application/vnd.oci.image.manifest.v1+json scratch-image-docker
-  [ "$status" -ne 0 ]
+  run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json -t scratch-image-default -f Dockerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah build-using-dockerfile --format docker --signature-policy ${TESTSDIR}/policy.json -t scratch-image-docker -f Dockerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah build-using-dockerfile --format oci --signature-policy ${TESTSDIR}/policy.json -t scratch-image-oci -f Dockerfile ${TESTSDIR}/bud/from-scratch
+
+  check_imgtype scratch-image-default oci
+  check_imgtype scratch-image-oci     oci
+  check_imgtype scratch-image-docker  docker
 }

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -48,7 +48,7 @@ function buildah() {
 }
 
 function imgtype() {
-	${IMGTYPE_BINARY} -debug -root ${TESTDIR}/root -runroot ${TESTDIR}/runroot -storage-driver ${STORAGE_DRIVER} "$@"
+	${IMGTYPE_BINARY} -root ${TESTDIR}/root -runroot ${TESTDIR}/runroot -storage-driver ${STORAGE_DRIVER} "$@"
 }
 
 #################

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -44,7 +44,7 @@ function createrandom() {
 }
 
 function buildah() {
-	${BUILDAH_BINARY} --log-level=debug --registries-conf ${TESTSDIR}/registries.conf --root ${TESTDIR}/root --runroot ${TESTDIR}/runroot --storage-driver ${STORAGE_DRIVER} "$@"
+	${BUILDAH_BINARY} --registries-conf ${TESTSDIR}/registries.conf --root ${TESTDIR}/root --runroot ${TESTDIR}/runroot --storage-driver ${STORAGE_DRIVER} "$@"
 }
 
 function imgtype() {
@@ -85,7 +85,7 @@ function run_buildah() {
 
     # stdout is only emitted upon error; this echo is to help a debugger
     echo "\$ $BUILDAH_BINARY $*"
-    run timeout --foreground --kill=10 $BUILDAH_TIMEOUT ${BUILDAH_BINARY} --log-level=debug --registries-conf ${TESTSDIR}/registries.conf --root ${TESTDIR}/root --runroot ${TESTDIR}/runroot --storage-driver ${STORAGE_DRIVER} "$@"
+    run timeout --foreground --kill=10 $BUILDAH_TIMEOUT ${BUILDAH_BINARY} --registries-conf ${TESTSDIR}/registries.conf --root ${TESTDIR}/root --runroot ${TESTDIR}/runroot --storage-driver ${STORAGE_DRIVER} "$@"
     # without "quotes", multiple lines are glommed together into one
     if [ -n "$output" ]; then
         echo "$output"
@@ -190,7 +190,7 @@ function expect_output() {
     local -a actual_split
     readarray -t actual_split <<<"$actual"
     printf "#/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n" >&2
-    printf "#|     FAIL: $testname\n"                          >&2
+    printf "#|     FAIL: %s\n" "$testname"                     >&2
     printf "#| expected: '%s'\n" "$expect"                     >&2
     printf "#|   actual: '%s'\n" "${actual_split[0]}"          >&2
     local line

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -12,8 +12,7 @@ load helpers
 	fi
 	bversion=$(buildah version | awk '/^Version:/ { print $NF }')
 	rversion=$(cat ${TESTSDIR}/../contrib/rpm/buildah.spec | awk '/^Version:/ { print $NF }')
-	run test "${bversion}" = "${rversion}" -o "${bversion}" = "${rversion}-dev"
-	[ "$status" -eq 0 ]
+	test "${bversion}" = "${rversion}" -o "${bversion}" = "${rversion}-dev"
 }
 
 @test "buildah version current in .spec file changelog" {
@@ -21,6 +20,5 @@ load helpers
 		skip "No source dir available"
 	fi
 	bversion=$(buildah version | awk '/^Version:/ { print $NF }')
-	run bash -c "grep -A1 ^%changelog ${TESTSDIR}/../contrib/rpm/buildah.spec | grep -q \" ${bversion}-.*$\""
-	[ "$status" -eq 0 ]
+	grep -A1 ^%changelog ${TESTSDIR}/../contrib/rpm/buildah.spec | grep -q " ${bversion}-"
 }


### PR DESCRIPTION
First, and possibly most controversial, remove --debug flag.
Output on test failure is painful to read. It is unlikely
(but not inconceivable) that --debug will be of any use.

Second, fix a failure message so it properly uses %s instead
of string interpolation. (If the test name itself includes
a percent sign, we get undefined behavior on output).

Fix a few instances of 'buildah' to be 'run_buildah'.

Remove some unnecessary 'run/echo/check-status' sequences,
sticking with the much cleaner 'test'. When BATS shows
an error of the form 'this failed: [ $status -eq 0 ]'
I weep in despair.

Signed-off-by: Ed Santiago <santiago@redhat.com>