### PR TITLE
Bump GoLang for CVE-2019-17596

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 dist: xenial
 sudo: required
 go:
-    - 1.11.x
-    - 1.12.x
+    - 1.12.12
+    - 1.13.x
     - tip
 go_import_path: github.com/containers/buildah
 


### PR DESCRIPTION
Bump golang to 1.12.12 and 1.13.X to avoid security issues
noted in CVE-2019-17596. See: https://groups.google.com/forum/#!msg/golang-announce/lVEm7llp0w0/VbafyRkgCgAJ and https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17596

I've dropped 1.11 compiles and added 1.13.X while we're at it.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>