### PR TITLE
Fix git build with branch specified

### DIFF
--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -23,8 +23,15 @@ func cloneToDirectory(url, dir string) error {
 	if !strings.HasPrefix(url, "git://") && !strings.HasSuffix(url, ".git") {
 		url = "git://" + url
 	}
-	logrus.Debugf("cloning %q to %q", url, dir)
-	cmd := exec.Command("git", "clone", url, dir)
+	gitBranch := strings.Split(url, "#")
+	var cmd *exec.Cmd
+	if len(gitBranch) < 2 {
+		logrus.Debugf("cloning %q to %q", url, dir)
+		cmd = exec.Command("git", "clone", url, dir)
+	} else {
+		logrus.Debugf("cloning repo %q and branch %q to %q", gitBranch[0], gitBranch[1], dir)
+		cmd = exec.Command("git", "clone", "-b", gitBranch[1], gitBranch[0], dir)
+	}
 	return cmd.Run()
 }
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1797,3 +1797,9 @@ load helpers
   buildah rm --all
   buildah rmi --all --force
 }
+
+@test "bud using gitrepo and branch" {
+  target=gittarget
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} git://github.com/containers/BuildSourceImage#master
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} git://github.com/containers/BuildSourceImage
+}


### PR DESCRIPTION
If the context directory was specified as a git repo with a
branch reference ala

```
buildah bud --layers -t test git://github.com/containers/skopeo#master
```

The internal `git clone` command executed by buildah would fail as the
`#master` branch specification needed to be removed and specified with
the `-b` option like:

```
git clone -b master git://github.com/containers/skopeo /var/tmp/buildah12332
```
rather than:
```
git clone git://github.com/containers/skopeo#master /var/tmp/buildah12332
```

Addresses #1934

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>