### PR TITLE
remove XDG_RUNTIME_DIR from default authfile path

### DIFF
--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -7,7 +7,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -269,10 +268,6 @@ func GetDefaultAuthFile() string {
 	authfile := os.Getenv("REGISTRY_AUTH_FILE")
 	if authfile != "" {
 		return authfile
-	}
-	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
-	if runtimeDir != "" {
-		return filepath.Join(runtimeDir, "containers/auth.json")
 	}
 	return ""
 }


### PR DESCRIPTION
Remove XDG_RUNTIME_DIR from default authfile path.
This patch will let authfile path default to the containers/image location for the authentication file. Which for now will be xdg_runtime_dir, but eventually will switch to kernel keyring.

Signed-off-by: Qi Wang qiwan@redhat.com