### PR TITLE
imgtype: exit with error if storage fails

### DIFF
--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -83,7 +83,7 @@ func main() {
 	store, err := storage.GetStore(storeOptions)
 	if err != nil {
 		logrus.Errorf("error opening storage: %v", err)
-		return
+		os.Exit(1)
 	}
 	is.Transport.SetStore(store)
 


### PR DESCRIPTION
'imgtype' on my system has been exiting zero regardless of
the command being run; looking at logs shows:

   error opening storage: vfs driver does not support overlay.mountopt options

(but exiting zero). Tests which rely on exit status zero have
been passing, but without actually testing anything.

Signed-off-by: Ed Santiago <santiago@redhat.com>