### PR TITLE
Builder.untarPath(): always evaluate b.ContentDigester.Hash()

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1796,3 +1796,29 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} git://github.com/containers/BuildSourceImage#master
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} git://github.com/containers/BuildSourceImage
 }
+
+@test "bud containerfile with tar archive in copy" {
+  # First check to verify cache is uses if the tar file does not change
+  target=copy-archive
+  date>bud/${target}/test; tar cJf - bud/${target}/test > bud/${target}/test.tar.xz
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} ${TESTSDIR}/bud/${target}
+  expect_output --substring "COMMIT copy-archive"
+
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} ${TESTSDIR}/bud/${target}
+  expect_output --substring " Using cache"
+  expect_output --substring "COMMIT copy-archive"
+
+  # Now test that we do NOT use cache if the tar file changes
+  date>bud/${target}/test; tar cJf - bud/${target}/test > bud/${target}/test.tar.xz
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} ${TESTSDIR}/bud/${target}
+  expect_output --substring "COMMIT copy-archive"
+
+  date>bud/${target}/test; tar cJf - bud/${target}/test > bud/${target}/test.tar.xz
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} ${TESTSDIR}/bud/${target}
+  if [[ "$output" =~ " Using cache" ]]; then
+      is "$output" "[no instance of 'Using cache']" "no cache used"
+  fi
+  expect_output --substring "COMMIT copy-archive"
+
+  rm bud/${target}/test*
+}

--- a/tests/bud/copy-archive/Containerfile
+++ b/tests/bud/copy-archive/Containerfile
@@ -1,0 +1,2 @@
+FROM docker.io/busybox
+ADD test.tar.xz /


### PR DESCRIPTION
Make sure we evaluate `b.ContentDigester.Hash()` every time the callback returned by `Builder.untarPath()` is called, since it may be for a different digest object than the previous time it was called, or different even from when the callback was first retrieved.

Adds the test from #1929, and aims to fix #1906.