### PR TITLE
Fix --pull=true||false and add --pull-never to bud and from (retry)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,21 +68,25 @@ script:
     # Fail fast
     - set -e
     # Let's do some docker stuff just for verification purposes
-    - docker ps --all
-    - docker images
-    - ls -alF /home/travis/auth
-    - docker pull docker.io/alpine
-    - echo testpassword | docker login localhost:5000 --username testuser --password-stdin
-    - docker tag alpine localhost:5000/my-alpine
-    - docker push localhost:5000/my-alpine
-    - docker ps --all
-    - docker images
-    - docker rmi docker.io/alpine
-    - docker rmi localhost:5000/my-alpine
-    - docker pull localhost:5000/my-alpine
-    - docker ps --all
-    - docker images
-    - docker rmi localhost:5000/my-alpine
+# Commented out the following in order to get travis runs
+# under the 50 minute requirement.  Do not remove as we may
+# want to use this in cirrius testing when we move there.
+#    - docker ps --all
+#    - docker images
+#    - ls -alF /home/travis/auth
+#    - docker pull docker.io/alpine
+#    - echo testpassword | docker login localhost:5000 --username testuser --password-stdin
+#    - docker tag alpine localhost:5000/my-alpine
+#    - docker push localhost:5000/my-alpine
+#    - docker ps --all
+#    - docker images
+#    - docker rmi docker.io/alpine
+#    - docker rmi localhost:5000/my-alpine
+#    - docker pull localhost:5000/my-alpine
+#    - docker ps --all
+#    - docker images
+#    - docker rmi localhost:5000/my-alpine
+# End Speed up comment
     # Setting up  Docker Registry is complete, let's do Buildah testing!
     - make install.tools -j4
     - make install.libseccomp.sudo all runc validate lint SECURITYTAGS="apparmor seccomp"

--- a/buildah.go
+++ b/buildah.go
@@ -40,7 +40,7 @@ const (
 	stateFile = Package + ".json"
 )
 
-// PullPolicy takes the value PullIfMissing, PullAlways, or PullNever.
+// PullPolicy takes the value PullIfMissing, PullAlways, PullIfNewer, or PullNever.
 type PullPolicy int
 
 const (
@@ -52,6 +52,11 @@ const (
 	// take, signalling that a fresh, possibly updated, copy of the image
 	// should be pulled from a registry before the build proceeds.
 	PullAlways
+	// PullIfNewer is one of the values that BuilderOptions.PullPolicy
+	// can take, signalling that the source image should only be pulled
+	// from a registry if a local copy is not already present or if a
+	// newer version the image is present on the repository.
+	PullIfNewer
 	// PullNever is one of the values that BuilderOptions.PullPolicy can
 	// take, signalling that the source image should not be pulled from a
 	// registry if a local copy of it is not already present.
@@ -65,6 +70,8 @@ func (p PullPolicy) String() string {
 		return "PullIfMissing"
 	case PullAlways:
 		return "PullAlways"
+	case PullIfNewer:
+		return "PullIfNewer"
 	case PullNever:
 		return "PullNever"
 	}

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -366,6 +366,7 @@ return 1
      --no-cache
      --pull
      --pull-always
+     --pull-never
      --quiet
      -q
      --squash
@@ -990,6 +991,7 @@ _buildah_containers() {
      -h
      --pull
      --pull-always
+     --pull-never
      --quiet
      -q
      --tls-verify

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -350,8 +350,8 @@ than the one in storage. Raise an error if the image is not in any listed
 registry and is not present locally.
 
 If the flag is disabled (with *--pull=false*), do not pull the image from the
-registry, use only the local version. Raise an error if the image is not
-present locally.
+registry, unless there is no local image. Raise an error if the image is not
+in any registry and is not present locally.
 
 Defaults to *true*.
 
@@ -359,6 +359,11 @@ Defaults to *true*.
 
 Pull the image from the first registry it is found in as listed in registries.conf.
 Raise an error if not found in the registries, even if the image is present locally.
+
+**--pull-never**
+
+Do not pull the image from the registry, use only the local version. Raise an error
+if the image is not present locally.
 
 **--quiet, -q**
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -286,6 +286,11 @@ Defaults to *true*.
 Pull the image from the first registry it is found in as listed in registries.conf.
 Raise an error if not found in the registries, even if the image is present locally.
 
+**--pull-never**
+
+Do not pull the image from the registry, use only the local version. Raise an error
+if the image is not present locally.
+
 **--quiet, -q**
 
 If an image needs to be pulled from the registry, suppress progress output.

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -27,6 +27,7 @@ import (
 const (
 	PullIfMissing = buildah.PullIfMissing
 	PullAlways    = buildah.PullAlways
+	PullIfNewer   = buildah.PullIfNewer
 	PullNever     = buildah.PullNever
 
 	Gzip         = archive.Gzip
@@ -45,7 +46,7 @@ type BuildOptions struct {
 	// commands.
 	ContextDirectory string
 	// PullPolicy controls whether or not we pull images.  It should be one
-	// of PullIfMissing, PullAlways, or PullNever.
+	// of PullIfMissing, PullAlways, PullIfNewer, or PullNever.
 	PullPolicy buildah.PullPolicy
 	// Registry is a value which is prepended to the image's name, if it
 	// needs to be pulled and the image name alone can not be resolved to a

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -63,6 +63,7 @@ type BudResults struct {
 	Platform            string
 	Pull                bool
 	PullAlways          bool
+	PullNever           bool
 	Quiet               bool
 	Rm                  bool
 	Runtime             string
@@ -159,8 +160,9 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.Logfile, "logfile", "", "log to `file` instead of stdout/stderr")
 	fs.IntVar(&flags.Loglevel, "loglevel", 0, "adjust logging level (range from -2 to 3)")
 	fs.StringVar(&flags.Platform, "platform", "", "CLI compatibility: no action or effect")
-	fs.BoolVar(&flags.Pull, "pull", true, "pull the image if not present")
-	fs.BoolVar(&flags.PullAlways, "pull-always", false, "pull the image, even if a version is present")
+	fs.BoolVar(&flags.Pull, "pull", true, "pull the image from the registry if newer or not present in store, if false, only pull the image if not present")
+	fs.BoolVar(&flags.PullAlways, "pull-always", false, "pull the image even if the named image is present in store")
+	fs.BoolVar(&flags.PullNever, "pull-never", false, "do not pull the image, use the image present in store if available")
 	fs.BoolVarP(&flags.Quiet, "quiet", "q", false, "refrain from announcing build instructions and image read/write progress")
 	fs.BoolVar(&flags.Rm, "rm", true, "Remove intermediate containers after a successful build")
 	// "runtime" definition moved to avoid name collision in podman build.  Defined in cmd/buildah/bud.go.

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -3,11 +3,11 @@
 load helpers
 
 @test "from" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah rm $cid
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   run_buildah rm $cid
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --name i-love-naming-things alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json --name i-love-naming-things alpine)
   run_buildah rm i-love-naming-things
 }
 
@@ -24,11 +24,11 @@ load helpers
 }
 
 @test "from-nopull" {
-  run_buildah 1 from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah 1 from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
 }
 
 @test "mount" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   root=$(buildah mount $cid)
   run_buildah unmount $cid
   root=$(buildah mount $cid)
@@ -38,7 +38,7 @@ load helpers
 }
 
 @test "by-name" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json --name scratch-working-image-for-test scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json --name scratch-working-image-for-test scratch)
   root=$(buildah mount scratch-working-image-for-test)
   run_buildah unmount scratch-working-image-for-test
   run_buildah rm scratch-working-image-for-test
@@ -48,7 +48,7 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   root=$(buildah mount $cid)
   cp ${TESTDIR}/randomfile $root/randomfile
   run_buildah unmount $cid

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1028,7 +1028,6 @@ load helpers
 @test "bud-logfile" {
   rm -f ${TESTDIR}/logfile
   run_buildah bud --logfile ${TESTDIR}/logfile --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/preserve-volumes
-  expect_output ""
   test -s ${TESTDIR}/logfile
 }
 
@@ -1818,4 +1817,31 @@ load helpers
   expect_output --substring "COMMIT copy-archive"
 
   rm -f ${TESTSDIR}/bud/${target}/test*
+}
+
+@test "bud pull never" {
+  target=pull
+  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull-never ${TESTSDIR}/bud/pull
+  echo "$output"
+  expect_output --substring "no such image"
+
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull ${TESTSDIR}/bud/pull
+  echo "$output"
+  expect_output --substring "COMMIT pull"
+
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull-never ${TESTSDIR}/bud/pull
+  echo "$output"
+  expect_output --substring "COMMIT pull"
+
+  buildah rmi --all --force
+}
+
+@test "bud pull false no local image" {
+  target=pull
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull=false ${TESTSDIR}/bud/pull
+  echo "$output"
+  expect_output --substring "COMMIT pull"
+
+  buildah rmi --all --force
+  buildah rmi --all --force
 }

--- a/tests/bud/pull/Containerfile
+++ b/tests/bud/pull/Containerfile
@@ -1,0 +1,1 @@
+FROM busybox

--- a/tests/byid.bats
+++ b/tests/byid.bats
@@ -6,7 +6,7 @@ load helpers
   image=busybox
 
   # Pull down the image, if we have to.
-  cid=$(buildah --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+  cid=$(buildah --log-level=error from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
   buildah rm $cid
@@ -17,13 +17,13 @@ load helpers
   iid="$output"
 
   # Use the image's ID to create a container.
-  run_buildah --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json ${iid}
+  run_buildah --log-level=error from --pull=false --signature-policy ${TESTSDIR}/policy.json ${iid}
   expect_line_count 1
   cid="$output"
   buildah rm $cid
 
   # Use a truncated form of the image's ID to create a container.
-  run_buildah --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json ${iid:0:6}
+  run_buildah --log-level=error from --pull=false --signature-policy ${TESTSDIR}/policy.json ${iid:0:6}
   expect_line_count 1
   cid="$output"
   buildah rm $cid
@@ -35,7 +35,7 @@ load helpers
   image=busybox
 
   # Pull down the image, if we have to.
-  cid=$(buildah --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+  cid=$(buildah --log-level=error from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
   buildah rm $cid
@@ -62,7 +62,7 @@ load helpers
     mkdir -p $TARGET $TARGET-truncated
 
     # Pull down the image, if we have to.
-    cid=$(buildah --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+    cid=$(buildah --log-level=error from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
     [ $? -eq 0 ]
     [ $(wc -l <<< "$cid") -eq 1 ]
     buildah rm $cid
@@ -87,7 +87,7 @@ load helpers
   image=busybox
 
   # Pull down the image, if we have to.
-  cid=$(buildah --log-level=error from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+  cid=$(buildah --log-level=error from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
   buildah rm $cid

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -17,7 +17,7 @@ load helpers
 }
 
 @test "commit" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
   run_buildah images alpine-image
   buildah rm $cid
@@ -25,7 +25,7 @@ load helpers
 }
 
 @test "commit format test" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-oci
   buildah commit --format docker --disable-compression=false --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-docker
 
@@ -36,7 +36,7 @@ load helpers
 }
 
 @test "commit quiet test" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah --log-level=error commit --iidfile /dev/null --signature-policy ${TESTSDIR}/policy.json -q $cid alpine-image
   expect_output ""
   buildah rm $cid
@@ -44,7 +44,7 @@ load helpers
 }
 
 @test "commit rm test" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah commit --signature-policy ${TESTSDIR}/policy.json --rm $cid alpine-image
   run_buildah 1 --log-level=error rm $cid
   expect_output --substring "error removing container \"alpine-working-container\": error reading build container: container not known"
@@ -53,7 +53,7 @@ load helpers
 
 @test "commit-alternate-storage" {
   echo FROM
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json openshift/hello-openshift)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json openshift/hello-openshift)
   echo COMMIT
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid "containers-storage:[vfs@${TESTDIR}/root2+${TESTDIR}/runroot2]newimage"
   echo FROM
@@ -61,7 +61,7 @@ load helpers
 }
 
 @test "commit-rejected-name" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah 1 --log-level=error commit --signature-policy ${TESTSDIR}/policy.json $cid ThisNameShouldBeRejected
   expect_output --substring "must be lower"
 }
@@ -71,7 +71,7 @@ load helpers
     skip "python interpreter with json module not found"
   fi
   target=new-image
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 
   run_buildah --log-level=error config --created-by "untracked actions" $cid
   run_buildah --log-level=error commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
@@ -93,6 +93,6 @@ load helpers
 }
 
 @test "commit-no-name" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid
 }

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -30,7 +30,7 @@ function check_matrix() {
 }
 
 @test "config entrypoint using single element in JSON array (exec form)" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
@@ -42,7 +42,7 @@ function check_matrix() {
 }
 
 @test "config entrypoint using multiple elements in JSON array (exec form)" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah config --entrypoint '[ "/ENTRYPOINT", "ELEMENT2" ]' $cid
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
@@ -54,7 +54,7 @@ function check_matrix() {
 }
 
 @test "config entrypoint using string (shell form)" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah config --entrypoint /ENTRYPOINT $cid
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
@@ -66,7 +66,7 @@ function check_matrix() {
 }
 
 @test "config set empty entrypoint doesn't wipe cmd" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah config --cmd "command" $cid
   buildah config --entrypoint "" $cid
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
@@ -79,7 +79,7 @@ function check_matrix() {
 }
 
 @test "config entrypoint with cmd" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah config \
    --entrypoint /ENTRYPOINT \
    --cmd COMMAND-OR-ARGS \
@@ -107,7 +107,7 @@ function check_matrix() {
 }
 
 @test "config" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah config \
    --author TESTAUTHOR \
    --created-by COINCIDENCE \
@@ -177,7 +177,7 @@ function check_matrix() {
 }
 
 @test "config env using --env expansion" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah config --env 'foo=bar' --env 'foo1=bar1' $cid
   buildah config --env 'combined=$foo/${foo1}' $cid
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid env-image-docker
@@ -210,7 +210,7 @@ function check_matrix() {
 }
 
 @test "remove configs using '-' syntax" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah config \
    --created-by COINCIDENCE \
    --volume /VOLUME \

--- a/tests/containers.bats
+++ b/tests/containers.bats
@@ -3,8 +3,8 @@
 load helpers
 
 @test "containers" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error containers
   expect_line_count 3
 
@@ -13,8 +13,8 @@ load helpers
 }
 
 @test "containers filter test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error containers --filter name=$cid1
   expect_line_count 2
 
@@ -23,8 +23,8 @@ load helpers
 }
 
 @test "containers format test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error containers --format "{{.ContainerName}}"
   expect_line_count 2
 
@@ -33,7 +33,7 @@ load helpers
 }
 
 @test "containers json test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   out=$(buildah --log-level=error containers --json | grep "{" | wc -l)
   [ "$out" -ne "0" ]
   buildah rm -a
@@ -41,8 +41,8 @@ load helpers
 }
 
 @test "containers noheading test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error containers --noheading
   expect_line_count 2
 
@@ -51,8 +51,8 @@ load helpers
 }
 
 @test "containers quiet test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error containers --quiet
   expect_line_count 2
 

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -18,21 +18,21 @@ load helpers
   createrandom ${TESTDIR}/other-randomfile
   createrandom ${TESTDIR}/third-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   root=$(buildah mount $cid)
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile
   run_buildah 1 copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile
   buildah rm $cid
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   root=$(buildah mount $cid)
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile
   buildah copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile /etc
   buildah rm $cid
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   root=$(buildah mount $cid)
   buildah config --workingdir / $cid
   buildah copy $cid "${TESTDIR}/*randomfile" /etc
@@ -45,7 +45,7 @@ load helpers
   createrandom ${TESTDIR}/other-randomfile
   createrandom ${TESTDIR}/third-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   root=$(buildah mount $cid)
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile
@@ -140,7 +140,7 @@ load helpers
   createrandom ${TESTDIR}/other-subdir/randomfile
   createrandom ${TESTDIR}/other-subdir/other-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah config --workingdir / $cid
   buildah copy --chown 1:1 $cid ${TESTDIR}/randomfile
   buildah copy --chown root:1 $cid ${TESTDIR}/randomfile /randomfile2
@@ -163,7 +163,7 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   ln -s ${TESTDIR}/randomfile ${TESTDIR}/link-randomfile
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   root=$(buildah mount $cid)
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/link-randomfile

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -16,8 +16,8 @@ load helpers
 }
 
 @test "images" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error images
   expect_line_count 3
   buildah rm -a
@@ -41,8 +41,8 @@ load helpers
 }
 
 @test "images filter test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error images --noheading --filter since=k8s.gcr.io/pause
   expect_line_count 1
   buildah rm -a
@@ -50,8 +50,8 @@ load helpers
 }
 
 @test "images format test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error images --format "{{.Name}}"
   expect_line_count 2
   buildah rm -a
@@ -59,8 +59,8 @@ load helpers
 }
 
 @test "images noheading test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error images --noheading
   expect_line_count 2
   buildah rm -a
@@ -68,8 +68,8 @@ load helpers
 }
 
 @test "images quiet test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error images --quiet
   expect_line_count 2
   buildah rm -a
@@ -77,8 +77,8 @@ load helpers
 }
 
 @test "images no-trunc test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error images -q --no-trunc
   expect_line_count 2
   expect_output --substring --from="${lines[0]}" "sha256"
@@ -87,8 +87,8 @@ load helpers
 }
 
 @test "images json test" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error images --json
   expect_line_count 24
 
@@ -125,8 +125,8 @@ load helpers
 }
 
 @test "specify an existing image" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error images alpine
   expect_line_count 2
   buildah rm -a
@@ -140,7 +140,7 @@ load helpers
 }
 
 @test "Test dangling images" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
   run_buildah --log-level=error images

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -14,7 +14,7 @@ load helpers
 }
 
 @test "inspect" {
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	run_buildah commit --signature-policy ${TESTSDIR}/policy.json "$cid" alpine-image
 
 	out1=$(buildah inspect --format '{{.OCIv1.Config}}' alpine)
@@ -24,7 +24,7 @@ load helpers
 }
 
 @test "inspect-config-is-json" {
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	out=$(buildah inspect alpine | grep "Config" | grep "{" | wc -l)
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
@@ -33,7 +33,7 @@ load helpers
 }
 
 @test "inspect-manifest-is-json" {
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	out=$(buildah inspect alpine | grep "Manifest" | grep "{" | wc -l)
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
@@ -42,7 +42,7 @@ load helpers
 }
 
 @test "inspect-ociv1-is-json" {
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	out=$(buildah inspect alpine | grep "OCIv1" | grep "{" | wc -l)
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
@@ -51,7 +51,7 @@ load helpers
 }
 
 @test "inspect-docker-is-json" {
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	out=$(buildah inspect alpine | grep "Docker" | grep "{" | wc -l)
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
@@ -60,7 +60,7 @@ load helpers
 }
 
 @test "inspect-format-config-is-json" {
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	out=$(buildah inspect --format "{{.Config}}" alpine | grep "{" | wc -l)
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
@@ -69,7 +69,7 @@ load helpers
 }
 
 @test "inspect-format-manifest-is-json" {
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	out=$(buildah inspect --format "{{.Manifest}}" alpine |  grep "{" | wc -l)
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
@@ -78,7 +78,7 @@ load helpers
 }
 
 @test "inspect-format-ociv1-is-json" {
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	out=$(buildah inspect --format "{{.OCIv1}}" alpine |  grep "{" | wc -l)
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
@@ -87,7 +87,7 @@ load helpers
 }
 
 @test "inspect-format-docker-is-json" {
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	out=$(buildah inspect --format "{{.Docker}}" alpine |  grep "{" | wc -l)
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -14,7 +14,7 @@ load helpers
 }
 
 @test "mount one container" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah --log-level=error mount "$cid"
   buildah rm $cid
   buildah rmi -f alpine
@@ -25,29 +25,29 @@ load helpers
 }
 
 @test "mount multi images" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid3=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah mount "$cid1" "$cid2" "$cid3"
   buildah rm --all
   buildah rmi -f alpine
 }
 
 @test "mount multi images one bad" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid3=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah 1 mount "$cid1" badcontainer "$cid2" "$cid3"
   buildah rm --all
   buildah rmi -f alpine
 }
 
 @test "list currently mounted containers" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid1"
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid2"
-  cid3=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid3"
   run_buildah --log-level=error mount
   expect_output --from="${lines[0]}" --substring "/tmp" "mount line 1 of 3"

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -38,7 +38,7 @@ load helpers
 }
 
 @test "push with manifest type conversion" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah push --signature-policy ${TESTSDIR}/policy.json --format oci alpine dir:my-dir
   manifest=$(cat my-dir/manifest.json)
   run grep "application/vnd.oci.image.config.v1+json" <<< "$manifest"
@@ -54,7 +54,7 @@ load helpers
 }
 
 @test "push with imageid" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   imageid=$(buildah images -q)
   run_buildah push --signature-policy ${TESTSDIR}/policy.json $imageid dir:my-dir
   buildah rm "$cid"
@@ -63,7 +63,7 @@ load helpers
 }
 
 @test "push with imageid and digest file" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   imageid=$(buildah images -q)
   run_buildah push --digestfile=${TESTDIR}/digest.txt --signature-policy ${TESTSDIR}/policy.json $imageid dir:my-dir
   cat ${TESTDIR}/digest.txt

--- a/tests/registries.bats
+++ b/tests/registries.bats
@@ -16,10 +16,10 @@ load helpers
     done
 
     # Create a container by specifying the image with one name.
-    buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image
+    buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $image
 
     # Create a container by specifying the image with another name.
-    buildah from --pull --signature-policy ${TESTSDIR}/policy.json $imagename
+    buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $imagename
 
     # Get their image IDs.  They should be the same one.
     lastid=

--- a/tests/rename.bats
+++ b/tests/rename.bats
@@ -4,7 +4,7 @@ load helpers
 
 @test "rename" {
   new_name=test-container
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   old_name=$(buildah containers --format "{{.ContainerName}}")
   buildah rename ${cid} ${new_name}
 
@@ -19,7 +19,7 @@ load helpers
 }
 
 @test "rename same name as current name" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah 1 --log-level=error rename ${cid} ${cid}
   expect_output 'renaming a container with the same name as its current name'
 
@@ -28,8 +28,8 @@ load helpers
 }
 
 @test "rename same name as other container name" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json busybox)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah 1 --log-level=error rename ${cid1} ${cid2}
   expect_output --substring " already in use by "
 

--- a/tests/rm.bats
+++ b/tests/rm.bats
@@ -19,7 +19,7 @@ load helpers
 }
 
 @test "remove one container" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah --log-level=error rm "$cid"
   run_buildah rmi alpine
 }
@@ -40,7 +40,7 @@ load helpers
 }
 
 @test "use conflicting commands to remove containers" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   run_buildah 1 --log-level=error rm -a "$cid"
   expect_output --substring "when using the --all switch, you may not pass any containers names or IDs"
   run_buildah rm "$cid"

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -14,7 +14,7 @@ load helpers
 }
 
 @test "remove one image" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
   buildah rmi alpine
   run_buildah --log-level=error images -q
@@ -97,17 +97,17 @@ load helpers
 }
 
 @test "use conflicting commands to remove images" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
   run_buildah 1 --log-level=error rmi -a alpine
   expect_output --substring "when using the --all switch, you may not pass any images names or IDs"
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
   run_buildah 1 --log-level=error rmi -p alpine
   expect_output --substring "when using the --prune switch, you may not pass any images names or IDs"
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
   run_buildah 1 --log-level=error rmi -a -p
   expect_output --substring "when using the --all switch, you may not use --prune switch"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -7,7 +7,7 @@ load helpers
 
 	runc --version
 	createrandom ${TESTDIR}/randomfile
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	root=$(buildah mount $cid)
 	buildah config --workingdir /tmp $cid
 	run_buildah --log-level=error run $cid pwd
@@ -29,7 +29,7 @@ load helpers
 @test "run--args" {
 	skip_if_no_runtime
 
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 
 	# This should fail, because buildah run doesn't have a -n flag.
 	run_buildah 1 --log-level=error run -n $cid echo test
@@ -56,7 +56,7 @@ load helpers
 @test "run-cmd" {
 	skip_if_no_runtime
 
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	buildah config --workingdir /tmp $cid
 
 
@@ -174,7 +174,7 @@ function configure_and_check_user() {
 	if test "$CGO_ENABLED" -ne 1; then
 		skip "CGO_ENABLED = '$CGO_ENABLED'"
 	fi
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	root=$(buildah mount $cid)
 
 	testuser=jimbo
@@ -218,7 +218,7 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	runc --version
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	run_buildah --log-level=error run $cid hostname
 	[ "$output" != "foobar" ]
 	run_buildah --log-level=error run --hostname foobar $cid hostname
@@ -236,7 +236,7 @@ function configure_and_check_user() {
 		fi
 	fi
 	runc --version
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	mkdir -p ${TESTDIR}/was-empty
 	# As a baseline, this should succeed.
 	run_buildah --log-level=error run -v ${TESTDIR}/was-empty:/var/not-empty${zflag:+:${zflag}}     $cid touch /var/not-empty/testfile
@@ -260,7 +260,7 @@ function configure_and_check_user() {
 		fi
 	fi
 	runc --version
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	mkdir -p ${TESTDIR}/was:empty
 	# As a baseline, this should succeed.
 	run_buildah --log-level=error run --mount type=tmpfs,dst=/var/tmpfs-not-empty                                           $cid touch /var/tmpfs-not-empty/testfile
@@ -277,7 +277,7 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	runc --version
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	mkdir -p ${TESTDIR}/tmp
 	ln -s tmp ${TESTDIR}/tmp2
 	export TMPDIR=${TESTDIR}/tmp2
@@ -288,7 +288,7 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	runc --version
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	# Try with default caps.
 	run_buildah --log-level=error run $cid grep ^CapEff /proc/self/status
 	defaultcaps="$output"
@@ -312,21 +312,21 @@ function configure_and_check_user() {
 @test "Check if containers run with correct open files/processes limits" {
 	skip_if_no_runtime
 
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output "1048576" "limits: open files (unlimited)"
 	run_buildah --log-level=error run $cid awk '/processes/{print $3}' /proc/self/limits
 	expect_output "1048576" "limits: processes (unlimited)"
 	buildah rm $cid
 
-	cid=$(buildah from --ulimit nofile=300:400 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --ulimit nofile=300:400 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output "300" "limits: open files (w/file limit)"
 	run_buildah --log-level=error run $cid awk '/processes/{print $3}' /proc/self/limits
 	expect_output "1048576" "limits: processes (w/file limit)"
 	buildah rm $cid
 
-	cid=$(buildah from --ulimit nproc=100:200 --ulimit nofile=300:400 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --ulimit nproc=100:200 --ulimit nofile=300:400 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output "300" "limits: open files (w/file & proc limits)"
 	run_buildah --log-level=error run $cid awk '/processes/{print $3}' /proc/self/limits
@@ -337,7 +337,7 @@ function configure_and_check_user() {
 @test "run-builtin-volume-omitted" {
 	# This image is known to include a volume, but not include the mountpoint
 	# in the image.
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/library/registry@sha256:a25e4660ed5226bdb59a5e555083e08ded157b1218282840e55d25add0223390)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json docker.io/library/registry@sha256:a25e4660ed5226bdb59a5e555083e08ded157b1218282840e55d25add0223390)
 	mnt=$(buildah mount $cid)
 	# By default, the mountpoint should not be there.
 	run test -d "$mnt"/var/lib/registry
@@ -354,14 +354,14 @@ function configure_and_check_user() {
 @test "run-exit-status" {
 	skip_if_no_runtime
 
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	run_buildah 42 run ${cid} sh -c 'exit 42'
 }
 
 @test "Verify /run/.containerenv exist" {
 	skip_if_no_runtime
 
-	cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	# test a standard mount to /run/.containerenv
 	run_buildah --log-level=error run $cid ls -1 /run/.containerenv
 	expect_output --substring "/run/.containerenv"
@@ -370,13 +370,13 @@ function configure_and_check_user() {
 @test "run-device" {
 	skip_if_no_runtime
 
-	cid=$(buildah from --pull --device /dev/fuse --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --device /dev/fuse --signature-policy ${TESTSDIR}/policy.json alpine)
 	run_buildah 0 run ${cid} ls /dev/fuse
 
-	cid=$(buildah from --pull --device /dev/fuse:/dev/fuse:rm --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --device /dev/fuse:/dev/fuse:rm --signature-policy ${TESTSDIR}/policy.json alpine)
 	run_buildah 0 run ${cid} ls /dev/fuse
 
-	cid=$(buildah from --pull --device /dev/fuse:/dev/fuse:rwm --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --device /dev/fuse:/dev/fuse:rwm --signature-policy ${TESTSDIR}/policy.json alpine)
 	run_buildah 0 run ${cid} ls /dev/fuse
 
 }
@@ -386,6 +386,6 @@ function configure_and_check_user() {
 	skip_if_chroot
 	skip_if_rootless
 
-	cid=$(buildah from --pull --device /dev/fuse:/dev/fuse1 --signature-policy ${TESTSDIR}/policy.json alpine)
+	cid=$(buildah from --pull=false --device /dev/fuse:/dev/fuse1 --signature-policy ${TESTSDIR}/policy.json alpine)
 	run_buildah 0 run ${cid} ls /dev/fuse1
 }

--- a/tests/umount.bats
+++ b/tests/umount.bats
@@ -14,7 +14,7 @@ load helpers
 }
 
 @test "umount one image" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid"
   run_buildah umount "$cid"
   buildah rm --all
@@ -26,33 +26,33 @@ load helpers
 }
 
 @test "umount multi images" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid1"
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid2"
-  cid3=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid3"
   run_buildah umount "$cid1" "$cid2" "$cid3"
   buildah rm --all
 }
 
 @test "umount all images" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid1"
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid2"
-  cid3=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid3"
   run_buildah umount --all
   buildah rm --all
 }
 
 @test "umount multi images one bad" {
-  cid1=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid1"
-  cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid2=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid2"
-  cid3=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid3"
   run_buildah 1 umount "$cid1" badcontainer "$cid2" "$cid3"
   buildah rm --all


### PR DESCRIPTION
(Replaces #1873 as it had lint issues that were timing out tests that I couldn't
track down easily)

Prior to this fix, if someone did `buildah bud --pull=false .` and the image in
the Containerfile's FROM statement was not local, the build would fail. The same
build on Docker will succeed. In Docker, when `--pull` is set to false, it only
pulls the image from the registry if there was not one locally. Buildah would never
pull the image and if the image was not locally available, it would throw an error.
In certain Kubernetes environments, this was especially troublesome.

To retain the old `--pull=false` functionality, I've created a new `--pull-never`
option that fails if an image is not locally available just like the old
`--pull=false` option used to do.

In addition, if there was a newer version of the image on the repository than
the one locally, the `--pull=true` option would not pull the image as it should
have, this corrects that.

Changes both the from and bud commands.

Addresses: #1675

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>