### PR TITLE
Handle configuration blobs for manifest lists

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ func unmarshalConvertedConfig(ctx context.Context, dest interface{}, img types.I
 		return errors.Wrapf(err, "error getting manifest MIME type for %q", transports.ImageName(img.Reference()))
 	}
 	if wantedManifestMIMEType != actualManifestMIMEType {
-		img, err = img.UpdatedImage(ctx, types.ManifestUpdateOptions{
+		updatedImg, err := img.UpdatedImage(ctx, types.ManifestUpdateOptions{
 			ManifestMIMEType: wantedManifestMIMEType,
 			InformationOnly: types.ManifestUpdateInformation{ // Strictly speaking, every value in here is invalid. But…
 				Destination:  nil, // Destination is technically required, but actually necessary only for conversion _to_ v2s1.  Leave it nil, we will crash if that ever changes.
@@ -35,8 +35,9 @@ func unmarshalConvertedConfig(ctx context.Context, dest interface{}, img types.I
 			},
 		})
 		if err != nil {
-			return errors.Wrapf(err, "error converting image %q to %s", transports.ImageName(img.Reference()), wantedManifestMIMEType)
+			return errors.Wrapf(err, "error converting image %q from %q to %q", transports.ImageName(img.Reference()), actualManifestMIMEType, wantedManifestMIMEType)
 		}
+		img = updatedImg
 	}
 	config, err := img.ConfigBlob(ctx)
 	if err != nil {

--- a/import.go
+++ b/import.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/containers/buildah/docker"
 	"github.com/containers/buildah/util"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
 	is "github.com/containers/image/v5/storage"
+	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	digest "github.com/opencontainers/go-digest"
@@ -28,11 +30,38 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 	if err != nil {
 		return nil, errors.Wrapf(err, "no such image %q", imageID)
 	}
-	src, err2 := ref.NewImage(ctx, systemContext)
-	if err2 != nil {
-		return nil, errors.Wrapf(err2, "error instantiating image")
+	src, err := ref.NewImageSource(ctx, systemContext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error instantiating image source")
 	}
 	defer src.Close()
+
+	imageDigest := ""
+	manifestBytes, manifestType, err := src.GetManifest(ctx, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error loading image manifest for %q", transports.ImageName(ref))
+	}
+	if manifestDigest, err := manifest.Digest(manifestBytes); err == nil {
+		imageDigest = manifestDigest.String()
+	}
+
+	var instanceDigest *digest.Digest
+	if manifest.MIMETypeIsMultiImage(manifestType) {
+		list, err := manifest.ListFromBlob(manifestBytes, manifestType)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error parsing image manifest for %q as list", transports.ImageName(ref))
+		}
+		instance, err := list.ChooseInstance(systemContext)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error finding an appropriate image in manifest list %q", transports.ImageName(ref))
+		}
+		instanceDigest = &instance
+	}
+
+	image, err := image.FromUnparsedImage(ctx, systemContext, image.UnparsedInstance(src, instanceDigest))
+	if err != nil {
+		return nil, errors.Wrapf(err, "error instantiating image for %q instance %q", transports.ImageName(ref), instanceDigest)
+	}
 
 	imageName := ""
 	if img, err3 := store.Image(imageID); err3 == nil {
@@ -45,13 +74,6 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 				return nil, errors.Wrapf(err4, "error reading information about image's top layer")
 			}
 			uidmap, gidmap = convertStorageIDMaps(layer.UIDMap, layer.GIDMap)
-		}
-	}
-
-	imageDigest := ""
-	if manifestBytes, _, err := src.Manifest(ctx); err == nil {
-		if manifestDigest, err := manifest.Digest(manifestBytes); err == nil {
-			imageDigest = manifestDigest.String()
 		}
 	}
 
@@ -79,7 +101,7 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 		},
 	}
 
-	if err := builder.initConfig(ctx, src); err != nil {
+	if err := builder.initConfig(ctx, image); err != nil {
 		return nil, errors.Wrapf(err, "error preparing image configuration")
 	}
 

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -3,6 +3,7 @@
 load helpers
 
 IMAGE_LIST=docker://k8s.gcr.io/pause:3.1
+IMAGE_LIST_DIGEST=docker://k8s.gcr.io/pause@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea
 IMAGE_LIST_INSTANCE=docker://k8s.gcr.io/pause@sha256:f365626a556e58189fc21d099fc64603db0f440bff07f77c740989515c544a39
 IMAGE_LIST_AMD64_INSTANCE_DIGEST=sha256:59eec8837a4d942cc19a52b8c09ea75121acc38114a2c68b98983ce9356b8610
 IMAGE_LIST_ARM_INSTANCE_DIGEST=sha256:c84b0a3a07b628bc4d62e5047d0f8dff80f7c00979e1e28a821a033ecda8fe53
@@ -94,4 +95,28 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest inspect foo
     run_buildah manifest push --signature-policy ${TESTSDIR}/policy.json --purge foo dir:${TESTDIR}/pushed
     run_buildah 1 manifest inspect foo
+}
+
+@test "manifest-from-tag" {
+    run_buildah from --signature-policy ${TESTSDIR}/policy.json --name test-container ${IMAGE_LIST}
+    run_buildah inspect --format ''{{.OCIv1.Architecture}}' ${IMAGE_LIST}
+    expect_output --substring $(go env GOARCH)
+    run_buildah inspect --format ''{{.OCIv1.Architecture}}' test-container
+    expect_output --substring $(go env GOARCH)
+}
+
+@test "manifest-from-digest" {
+    run_buildah from --signature-policy ${TESTSDIR}/policy.json --name test-container ${IMAGE_LIST_DIGEST}
+    run_buildah inspect --format ''{{.OCIv1.Architecture}}' ${IMAGE_LIST_DIGEST}
+    expect_output --substring $(go env GOARCH)
+    run_buildah inspect --format ''{{.OCIv1.Architecture}}' test-container
+    expect_output --substring $(go env GOARCH)
+}
+
+@test "manifest-from-instance" {
+    run_buildah from --signature-policy ${TESTSDIR}/policy.json --name test-container ${IMAGE_LIST_INSTANCE}
+    run_buildah inspect --format ''{{.OCIv1.Architecture}}' ${IMAGE_LIST_INSTANCE}
+    expect_output --substring arm64
+    run_buildah inspect --format ''{{.OCIv1.Architecture}}' test-container
+    expect_output --substring arm64
 }


### PR DESCRIPTION
When the base image or an image that we're inspecting is a reference to a manifest list, resolve it to a runnable image instance, then try to read the configuration blob from the runnable image.