### PR TITLE
Enhance error on unsafe symbolic link targets

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -318,7 +318,7 @@ func (s *StageExecutor) digestSpecifiedContent(node *parser.Node, argValues []st
 			// directory.
 			contextSrc, err := securejoin.SecureJoin(contextDir, src)
 			if err != nil {
-				return "", errors.Wrapf(err, "error joining %q and %q", contextDir, src)
+				return "", errors.Wrapf(err, "forbidden path for %q, it is outside of the build context %q", src, contextDir)
 			}
 			sources = append(sources, contextSrc)
 		}
@@ -432,7 +432,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 				// directory.
 				srcSecure, err := securejoin.SecureJoin(contextDir, src)
 				if err != nil {
-					return err
+					return errors.Wrapf(err, "forbidden path for %q, it is outside of the build context %q", src, contextDir)
 				}
 				if hadFinalPathSeparator {
 					// If destination is a folder, we need to take extra care to


### PR DESCRIPTION
If a COPY target was a symbolic link that resolved at a directory
above the context directory, securejoin gave an error that wasn't clear
to the end user (or this developer):

```
STEP 4: COPY README.md /
error building at STEP "COPY README.md /": secure join: too many levels of symbolic links
ERRO exit status 1
```

This change updates that error message to hopefully clear the issue up
for the user.  At the very least it will be easier to find in the code:

```
STEP 4: COPY README.md /
error building at STEP "COPY README.md /": forbidden path for "README.md", it is outside of the build context "/root/tsweeney/workspaces/containers/toolbox/images/fedora/f31": secure join: too many levels of symbolic links
```
Addressed #1952

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>