### PR TITLE
images: adjust output of tags and digests

### DIFF
--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -92,7 +92,7 @@ func TestGetSize(t *testing.T) {
 		t.Fatalf("Error reading images: %v", err)
 	}
 
-	_, _, _, err = getDateAndDigestAndSize(getContext(), &testSystemContext, store, images[0])
+	_, _, err = getDateAndSize(getContext(), &testSystemContext, store, images[0])
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -72,6 +72,7 @@ type imageResults struct {
 var imagesHeader = map[string]string{
 	"Name":      "REPOSITORY",
 	"Tag":       "TAG",
+	"Digest":    "DIGEST",
 	"ID":        "IMAGE ID",
 	"CreatedAt": "CREATED",
 	"Size":      "SIZE",

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -329,8 +329,8 @@ func TestParseFilterInvalidFilter(t *testing.T) {
 }
 
 func TestMatchesDangingTrue(t *testing.T) {
-	if !matchesDangling("<none>", "true") {
-		t.Error("matchesDangling() should return true with dangling=true and name=<none>")
+	if !matchesDangling("", "true") {
+		t.Error("matchesDangling() should return true with dangling=true and empty name")
 	}
 
 	if !matchesDangling("hello", "false") {
@@ -343,8 +343,8 @@ func TestMatchesDangingFalse(t *testing.T) {
 		t.Error("matchesDangling() should return false with dangling=true and name=hello")
 	}
 
-	if matchesDangling("<none>", "false") {
-		t.Error("matchesDangling() should return false with dangling=false and name=<none>")
+	if matchesDangling("", "false") {
+		t.Error("matchesDangling() should return false with dangling=false and empty name")
 	}
 }
 

--- a/docs/buildah-images.md
+++ b/docs/buildah-images.md
@@ -31,13 +31,16 @@ keywords are 'before', 'dangling', 'label', 'readonly' and 'since' .
     Filter on images created before the given time.Time.
 
   **dangling=true|false**
-    Show dangling images. Dangling images are a file system layer that was used in a previous build of an image and is no longer referenced by any active images. They are denoted with the <none> tag, consume disk space and serve no active purpose.
+    Show dangling images.  Dangling images are file system layers that were used in a previous build of an image and are no longer referenced by any active images.  They are denoted with the <none> name and tag, consume disk space and serve no active purpose.
 
   **label**
     Filter by images labels key and/or value.
 
   **readonly=true|false**
-     Show only read only images or Read/Write images. The default is to show both.  Read/Only images can be configured by modifying the  "additionalimagestores" in the /etc/containers/storage.conf file.
+    Show only read only images or Read/Write images. The default is to show both.  Read/Only images can be configured by modifying the  "additionalimagestores" in the /etc/containers/storage.conf file.
+
+  **reference=repo[:tag]**
+    Show only images whose names, or suffixes of names, match the specified repository name.  If the specified value includes a tag, the image must match it as well.
 
   **since==TIMESTRING**
     Filter on images created since the given time.Time.

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -90,10 +90,10 @@ load helpers
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error images --json
-  expect_line_count 24
+  expect_line_count 32
 
   run_buildah --log-level=error images --json alpine
-  expect_line_count 13
+  expect_line_count 17
   buildah rm -a
   buildah rmi -a -f
 }


### PR DESCRIPTION
Output (possibly multiple) tags and digests in the JSON images list, and provide all of an image's digests when listing then in non-JSON format.   Don't mistake image names which end in "@sha256:hex..." for images whose tagged names include a repository name that ends with "@sha256".