### PR TITLE
bud COPY does not download URL

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -424,37 +424,37 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 		for _, src := range copy.Src {
 			if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
 				// Source is a URL.
-				sources = append(sources, src)
-			} else {
-				// Treat the source, which is not a URL, as a
-				// location relative to the
-				// all-content-comes-from-below-this-directory
-				// directory.
-				srcSecure, err := securejoin.SecureJoin(contextDir, src)
-				if err != nil {
-					return errors.Wrapf(err, "forbidden path for %q, it is outside of the build context %q", src, contextDir)
-				}
-				if hadFinalPathSeparator {
-					// If destination is a folder, we need to take extra care to
-					// ensure that files are copied with correct names (since
-					// resolving a symlink may result in a different name).
-					_, srcName := filepath.Split(src)
-					_, srcNameSecure := filepath.Split(srcSecure)
-					if srcName != srcNameSecure {
-						options := buildah.AddAndCopyOptions{
-							Chown:            copy.Chown,
-							ContextDir:       contextDir,
-							Excludes:         copyExcludes,
-							IDMappingOptions: idMappingOptions,
-						}
-						if err := s.builder.Add(filepath.Join(copy.Dest, srcName), copy.Download, options, srcSecure); err != nil {
-							return err
-						}
-						continue
-					}
-				}
-				sources = append(sources, srcSecure)
+				// returns an error to be compatible with docker
+				return errors.Errorf("source can't be a URL for COPY")
 			}
+			// Treat the source, which is not a URL, as a
+			// location relative to the
+			// all-content-comes-from-below-this-directory
+			// directory.
+			srcSecure, err := securejoin.SecureJoin(contextDir, src)
+			if err != nil {
+				return errors.Wrapf(err, "forbidden path for %q, it is outside of the build context %q", src, contextDir)
+			}
+			if hadFinalPathSeparator {
+				// If destination is a folder, we need to take extra care to
+				// ensure that files are copied with correct names (since
+				// resolving a symlink may result in a different name).
+				_, srcName := filepath.Split(src)
+				_, srcNameSecure := filepath.Split(srcSecure)
+				if srcName != srcNameSecure {
+					options := buildah.AddAndCopyOptions{
+						Chown:            copy.Chown,
+						ContextDir:       contextDir,
+						Excludes:         copyExcludes,
+						IDMappingOptions: idMappingOptions,
+					}
+					if err := s.builder.Add(filepath.Join(copy.Dest, srcName), copy.Download, options, srcSecure); err != nil {
+						return err
+					}
+					continue
+				}
+			}
+			sources = append(sources, srcSecure)
 		}
 		options := buildah.AddAndCopyOptions{
 			Chown:            copy.Chown,

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -65,7 +65,7 @@ load helpers
   expect_line_count 8
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 ${TESTDIR}/use-layers
   run_buildah --log-level=error images -a
-  expect_line_count 10
+  expect_line_count 9
   run_buildah --log-level=error inspect --format "{{index .Docker.ContainerConfig.Env 1}}" test1
   expect_output "foo=bar"
   run_buildah --log-level=error inspect --format "{{index .Docker.ContainerConfig.Env 1}}" test2
@@ -77,25 +77,25 @@ load helpers
 
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTDIR}/use-layers
   run_buildah --log-level=error images -a
-  expect_line_count 12
+  expect_line_count 11
 
   mkdir -p ${TESTDIR}/use-layers/mount/subdir
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test4 -f Dockerfile.3 ${TESTDIR}/use-layers
   run_buildah --log-level=error images -a
-  expect_line_count 14
+  expect_line_count 13
 
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test5 -f Dockerfile.3 ${TESTDIR}/use-layers
   run_buildah --log-level=error images -a
-  expect_line_count 15
+  expect_line_count 14
 
   touch ${TESTDIR}/use-layers/mount/subdir/file.txt
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test6 -f Dockerfile.3 ${TESTDIR}/use-layers
   run_buildah --log-level=error images -a
-  expect_line_count 17
+  expect_line_count 16
 
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --no-cache -t test7 -f Dockerfile.2 ${TESTDIR}/use-layers
   run_buildah --log-level=error images -a
-  expect_line_count 18
+  expect_line_count 17
 
   buildah rmi -a -f
 }
@@ -1849,4 +1849,16 @@ load helpers
 @test "bud with Containerfile should fail with nonexist authfile" {
   target=alpine-image
   run_buildah 1 bud --authfile /tmp/nonexist --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
+}
+
+@test "bud COPY with URL should fail" {
+  mkdir ${TESTSDIR}/bud/copy
+  FILE=${TESTSDIR}/bud/copy/Dockerfile.url
+  /bin/cat <<EOM >$FILE
+FROM alpine:latest
+COPY https://getfedora.org/index.html .
+EOM
+
+  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy/Dockerfile.url ${TESTSDIR}/bud/copy
+  rm -r ${TESTSDIR}/bud/copy
 }

--- a/tests/bud/use-layers/Dockerfile
+++ b/tests/bud/use-layers/Dockerfile
@@ -3,5 +3,5 @@ RUN mkdir /hello
 VOLUME /var/lib/testdata
 RUN touch file.txt
 EXPOSE 8080
-ADD https://github.com/containers/buildah/blob/master/README.md /tmp/
+ADD Dockerfile.2 /tmp/
 ENV foo=bar


### PR DESCRIPTION
close #1846
buildah bud COPY can download the URL to the container working directory. This is not compatible with Docker.
So after this path, buildah bud COPY URL will return an error.

Signed-off-by: Qi Wang <qiwan@redhat.com>