### PR TITLE
Touch up commit man page image parameter

### DIFF
--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -4,12 +4,14 @@
 buildah\-commit - Create an image from a working container.
 
 ## SYNOPSIS
-**buildah commit** [*options*] *container* *image*
+**buildah commit** [*options*] *container* [*image*]
 
 ## DESCRIPTION
 Writes a new image using the specified container's read-write layer and if it
 is based on an image, the layers of that image.  If *image* does not begin
-with a registry name component, `localhost` will be added to the name.
+with a registry name component, `localhost` will be added to the name.  If
+*image* is not provided, the values for the `REPOSITORY` and `TAG` values of
+the created image will each be set to `<none>`.
 
 ## RETURN VALUE
 The image ID of the image that was created.  On error, 1 is returned and errno is returned.


### PR DESCRIPTION
The commit command does not require that a value for the
image be provided.  Change the man page to reflect that
and explain the behavior in that instance.  This is the
same behavior as Docker.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>