### PR TITLE
commit(docker): always set ContainerID and ContainerConfig

### DIFF
--- a/image.go
+++ b/image.go
@@ -190,6 +190,10 @@ func (i *containerImageRef) createConfigsAndManifests() (v1.Image, v1.Manifest, 
 		return v1.Image{}, v1.Manifest{}, docker.V2Image{}, docker.V2S2Manifest{}, err
 	}
 	dimage.Parent = docker.ID(i.parent)
+	dimage.Container = i.containerID
+	if dimage.Config != nil {
+		dimage.ContainerConfig = *dimage.Config
+	}
 	// Always replace this value, since we're newer than our base image.
 	dimage.Created = created
 	// Clear the list of diffIDs, since we always repopulate it.
@@ -455,7 +459,6 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, sc *types.System
 	}
 	dimage.History = append(dimage.History, dnews)
 	appendHistory(i.postEmptyLayers)
-	dimage.Parent = docker.ID(i.parent)
 
 	// Sanity check that we didn't just create a mismatch between non-empty layers in the
 	// history and the number of diffIDs.


### PR DESCRIPTION
For the sake of the Docker output format, always set the ContainerID field when committing, and if we have a non-nil Config, set ContainerConfig to the same values.  /cc @baude 