### PR TITLE
Handle missing equal sign in --from and --chown flags for COPY/ADD

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -248,7 +248,7 @@ func (s *StageExecutor) volumeCacheRestore() error {
 	return nil
 }
 
-// digestContent digests any content that this next instruction would add to
+// digestSpecifiedContent digests any content that this next instruction would add to
 // the image, returning the digester if there is any, or nil otherwise.  We
 // don't care about the details of where in the filesystem the content actually
 // goes, because we're not actually going to add it here, so this is less
@@ -816,14 +816,22 @@ func (s *StageExecutor) Execute(ctx context.Context, stage imagebuilder.Stage, b
 		// Check if there's a --from if the step command is COPY or
 		// ADD.  Set copyFrom to point to either the context directory
 		// or the root of the container from the specified stage.
+		// Also check the chown flag for validity.
 		s.copyFrom = s.executor.contextDir
-		for _, n := range step.Flags {
+		for _, flag := range step.Flags {
 			command := strings.ToUpper(step.Command)
-			if strings.Contains(n, "--from") && (command == "COPY" || command == "ADD") {
+			// chown and from flags should have an '=' sign, '--chown=' or '--from='
+			if command == "COPY" && (flag == "--chown" || flag == "--from") {
+				return "", nil, errors.Errorf("COPY only supports the --chown=<uid:gid> and the --from=<image|stage> flags")
+			}
+			if command == "ADD" && flag == "--chown" {
+				return "", nil, errors.Errorf("ADD only supports the --chown=<uid:gid> flag")
+			}
+			if strings.Contains(flag, "--from") && command == "COPY" {
 				var mountPoint string
-				arr := strings.Split(n, "=")
+				arr := strings.Split(flag, "=")
 				if len(arr) != 2 {
-					return "", nil, errors.Errorf("%s: invalid --from flag, should be --from=<name|index>", command)
+					return "", nil, errors.Errorf("%s: invalid --from flag, should be --from=<name|stage>", command)
 				}
 				otherStage, ok := s.executor.stages[arr[1]]
 				if !ok {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1099,6 +1099,13 @@ load helpers
   expect_output --substring "3267"
 }
 
+@test "bud with chown copy with bad chown flag in Dockerfile with --layers" {
+  imgName=alpine-image
+  ctrName=alpine-chown
+  run_buildah 1 --log-level=error bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${imgName} -f ${TESTSDIR}/bud/copy-chown/Dockerfile.bad ${TESTSDIR}/bud/copy-chown
+  expect_output --substring "COPY only supports the --chown=<uid:gid> and the --from=<image|stage> flags"
+}
+
 @test "bud with chown add" {
   imgName=alpine-image
   ctrName=alpine-chown
@@ -1112,6 +1119,13 @@ load helpers
   run_buildah --log-level=error run alpine-chown -- stat -c '%g' /tmp/addchown.txt
   # Validate that output starts with "3267"
   expect_output --substring "3267"
+}
+
+@test "bud with chown add with bad chown flag in Dockerfile with --layers" {
+  imgName=alpine-image
+  ctrName=alpine-chown
+  run_buildah 1 --log-level=error bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${imgName} -f ${TESTSDIR}/bud/add-chown/Dockerfile.bad ${TESTSDIR}/bud/add-chown
+  expect_output --substring "ADD only supports the --chown=<uid:gid> flag"
 }
 
 @test "bud with ADD file construct" {
@@ -1197,7 +1211,7 @@ load helpers
   imgName=ubuntu-image
   ctrName=ubuntu-copy
   run_buildah --log-level=error bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.invalid_from -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths || true
-  expect_output --substring "COPY: invalid --from flag, should be --from=<name|index>"
+  expect_output --substring "COPY only supports the --chown=<uid:gid> and the --from=<image|stage> flags"
 }
 
 @test "bud COPY to root succeeds" {
@@ -1319,6 +1333,12 @@ load helpers
   mnt=$(buildah --log-level=error mount ${ctr})
 
   test -e $mnt/usr/local/bin/composer
+}
+
+@test "bud with copy-from with bad from flag in Dockerfile with --layers" {
+  target=php-image
+  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile.bad ${TESTSDIR}/bud/copy-from
+  expect_output --substring "COPY only supports the --chown=<uid:gid> and the --from=<image|stage> flags"
 }
 
 @test "bud-target" {

--- a/tests/bud/add-chown/Dockerfile.bad
+++ b/tests/bud/add-chown/Dockerfile.bad
@@ -1,0 +1,6 @@
+FROM alpine
+
+ADD --chown 2367:3267 addchown.txt /tmp 
+RUN stat -c "user:%u group:%g" /tmp/addchown.txt 
+CMD /bin/sh
+

--- a/tests/bud/copy-chown/Dockerfile.bad
+++ b/tests/bud/copy-chown/Dockerfile.bad
@@ -1,0 +1,6 @@
+FROM alpine
+
+COPY --chown 2367:3267 copychown.txt /tmp 
+RUN stat -c "user:%u group:%g" /tmp/copychown.txt 
+CMD /bin/sh
+

--- a/tests/bud/copy-from/Dockerfile.bad
+++ b/tests/bud/copy-from/Dockerfile.bad
@@ -1,0 +1,2 @@
+FROM php:7.2
+COPY --from composer:latest /usr/bin/composer /usr/local/bin/composer


### PR DESCRIPTION
When buildah bud runs without layers (default), it hands off the parsing
of the Dockerfile steps to imagebuilder.  However if the the --layers
option is in use, then we start parsing the steps before we hand stuff
off to imagebuilder.

The COPY --chown, ADD --chown, and COPY --from commands in a Dockerfile
were failing if there was not an '=' sign after them like "COPY --chown=2374:3256".
This moves the parsing into the code that handles the layer processing.

Fixes: #1984

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>