### PR TITLE
Bump 1.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 # Changelog
 
+## v1.11.6 (2019-12-03)
+    Handle missing equal sign in --from and --chown flags for COPY/ADD
+    bud COPY does not download URL
+    Bump github.com/onsi/gomega from 1.7.0 to 1.7.1
+    Fix .dockerignore exclude regression
+    Ran buildah through codespell
+    commit(docker): always set ContainerID and ContainerConfig
+    Touch up commit man page image parameter
+    Add builder identity annotations.
+    info: use util.Runtime()
+    Bump github.com/onsi/ginkgo from 1.10.2 to 1.10.3
+    Bump back to v1.12.0-dev
+
 ## v1.11.5 (2019-11-11)
     Enhance error on unsafe symbolic link targets
     Add OCIRuntime to info

--- a/buildah.go
+++ b/buildah.go
@@ -27,7 +27,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.11.6"
+	Version = "1.12.0-dev"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/buildah.go
+++ b/buildah.go
@@ -27,7 +27,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.12.0-dev"
+	Version = "1.11.6"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,16 @@
+- Changelog for v1.11.6 (2019-12-03)
+  * Handle missing equal sign in --from and --chown flags for COPY/ADD
+  * bud COPY does not download URL
+  * Bump github.com/onsi/gomega from 1.7.0 to 1.7.1
+  * Fix .dockerignore exclude regression
+  * Ran buildah through codespell
+  * commit(docker): always set ContainerID and ContainerConfig
+  * Touch up commit man page image parameter
+  * Add builder identity annotations.
+  * info: use util.Runtime()
+  * Bump github.com/onsi/ginkgo from 1.10.2 to 1.10.3
+  * Bump back to v1.12.0-dev
+
 - Changelog for v1.11.5 (2019-11-11)
   * Enhance error on unsafe symbolic link targets
   * Add OCIRuntime to info

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in buildah.go too
-Version:        1.12.0-dev
+Version:        1.11.6
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -99,7 +99,18 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
-* Mon Nov 11, 2019 Tom Sweeney <tsweeney@redhat.com> 1.12.0-dev-1
+* Tue Dec 3, 2019 Tom Sweeney <tsweeney@redhat.com> 1.11.6-1
+- Handle missing equal sign in --from and --chown flags for COPY/ADD
+- bud COPY does not download URL
+- Bump github.com/onsi/gomega from 1.7.0 to 1.7.1
+- Fix .dockerignore exclude regression
+- Ran buildah through codespell
+- commit(docker): always set ContainerID and ContainerConfig
+- Touch up commit man page image parameter
+- Add builder identity annotations.
+- info: use util.Runtime()
+- Bump github.com/onsi/ginkgo from 1.10.2 to 1.10.3
+- Bump back to v1.12.0-dev
 
 * Mon Nov 11, 2019 Tom Sweeney <tsweeney@redhat.com> 1.11.5-1
 - Enhance error on unsafe symbolic link targets

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in buildah.go too
-Version:        1.11.6
+Version:        1.12.0-dev
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -99,6 +99,8 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Tue Dec 3, 2019 Tom Sweeney <tsweeney@redhat.com> 1.12.0-dev-1
+
 * Tue Dec 3, 2019 Tom Sweeney <tsweeney@redhat.com> 1.11.6-1
 - Handle missing equal sign in --from and --chown flags for COPY/ADD
 - bud COPY does not download URL


### PR DESCRIPTION
Bump to 1.11.6.  Needed for this commit 'commit(docker): always set ContainerID and ContainerConfig' to prepare for the upcoming Podman release.