### PR TITLE
Ypu bats tests

### DIFF
--- a/tests/add.bats
+++ b/tests/add.bats
@@ -140,3 +140,24 @@ load helpers
   expect_output "644"
   run_buildah rm $newcid
 }
+
+@test "add with chown" {
+  createrandom ${TESTDIR}/randomfile
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah add --chown bin:bin $cid ${TESTDIR}/randomfile /tmp/random
+  run_buildah run $cid ls -l /tmp/random
+
+  expect_output --substring bin.*bin
+  buildah rm $cid
+}
+
+@test "add url" {
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah add $cid https://github.com/containers/buildah/raw/master/README.md
+  run_buildah run $cid ls /README.md
+
+  run_buildah add $cid https://github.com/containers/buildah/raw/master/README.md /home
+  run_buildah run $cid ls /home/README.md
+
+  buildah rm $cid
+}

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -108,36 +108,38 @@ load helpers
 @test "add single file creates absolute path with correct permissions" {
   imgName=ubuntu-image
   createrandom ${TESTDIR}/distutils.cfg
+  permission=$(stat -c "%a" ${TESTDIR}/distutils.cfg)
 
   cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ubuntu)
   run_buildah add $cid ${TESTDIR}/distutils.cfg /usr/lib/python3.7/distutils
   run_buildah run $cid stat -c "%a" /usr/lib/python3.7/distutils
   root=$(buildah mount $cid)
-  expect_output "644"
+  expect_output $permission
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:${imgName}
   run_buildah rm $cid
 
   newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${imgName})
   run_buildah run $newcid stat -c "%a" /usr/lib/python3.7/distutils
-  expect_output "644"
+  expect_output $permission
   run_buildah rm $newcid
 }
 
 @test "add single file creates relative path with correct permissions" {
   imgName=ubuntu-image
   createrandom ${TESTDIR}/distutils.cfg
+  permission=$(stat -c "%a" ${TESTDIR}/distutils.cfg)
 
   cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ubuntu)
   run_buildah add $cid ${TESTDIR}/distutils.cfg lib/custom
   run_buildah run $cid stat -c "%a" lib/custom
   root=$(buildah mount $cid)
-  expect_output "644"
+  expect_output $permission
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:${imgName}
   run_buildah rm $cid
 
   newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${imgName})
   run_buildah run $newcid stat -c "%a" lib/custom
-  expect_output "644"
+  expect_output $permission
   run_buildah rm $newcid
 }
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1886,7 +1886,7 @@ EOM
 @test "bud quiet" {
   run_buildah bud --format docker -t quiet-test --signature-policy ${TESTSDIR}/policy.json -q ${TESTSDIR}/bud/shell
   expect_line_count 1
-  expect_output --substring "^[0-9a-z]{64}$"
+  expect_output --substring '^[0-9a-f]{64}$'
 
   buildah rmi quiet-test
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1882,3 +1882,11 @@ EOM
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy/Dockerfile.url ${TESTSDIR}/bud/copy
   rm -r ${TESTSDIR}/bud/copy
 }
+
+@test "bud quiet" {
+  run_buildah bud --format docker -t quiet-test --signature-policy ${TESTSDIR}/policy.json -q ${TESTSDIR}/bud/shell
+  expect_line_count 1
+  expect_output --substring "^[0-9a-z]{64}$"
+
+  buildah rmi quiet-test
+}

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -134,6 +134,7 @@ load helpers
   containerid=$(buildah inspect --format '{{.Docker.Container}}' alpine-image)
   echo recorded container ID: "$containerid"
   [ "$containerid" = "$cid" ]
+}
 
 @test "commit with name" {
   buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc busybox

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -134,4 +134,20 @@ load helpers
   containerid=$(buildah inspect --format '{{.Docker.Container}}' alpine-image)
   echo recorded container ID: "$containerid"
   [ "$containerid" = "$cid" ]
+
+@test "commit with name" {
+  buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc busybox
+  run_buildah --log-level=error commit --signature-policy ${TESTSDIR}/policy.json busyboxc commitbyname/busyboxbyname
+  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json localhost/commitbyname/busyboxbyname)
+  run_buildah inspect --format '{{.Container}}' $cid
+  expect_output $cid
+  buildah rm busyboxc $cid
+  buildah rmi commitbyname/busyboxbyname
+}
+
+@test "commit to docker-distribution" {
+  buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc busybox
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword busyboxc docker://localhost:5000/commit/busybox
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name fromdocker --tls-verify=false --creds testuser:testpassword docker://localhost:5000/commit/busybox
+  buildah rm busyboxc fromdocker
 }

--- a/tests/containers.bats
+++ b/tests/containers.bats
@@ -47,7 +47,9 @@ load helpers
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error containers --noheading
   expect_line_count 2
-  [[ "$output" != "NAME"* ]]
+  if [[ $output =~ "NAME" ]]; then
+      expect_output "[no instance of 'NAME']" "'NAME' header should be absent"
+  fi
 
   buildah rm -a
   buildah rmi -a -f
@@ -59,8 +61,9 @@ load helpers
   run_buildah --log-level=error containers --quiet
   expect_line_count 2
 
-  [[ "${lines[0]}" != "$cid1"* ]]
-  [[ "${lines[1]}" != "$cid2"* ]]
+  # Both lines should be CIDs and nothing else.
+  expect_output --substring --from="${lines[0]}" '^[0-9a-f]{64}$'
+  expect_output --substring --from="${lines[1]}" '^[0-9a-f]{64}$'
 
   buildah rm -a
   buildah rmi -a -f

--- a/tests/containers.bats
+++ b/tests/containers.bats
@@ -27,6 +27,8 @@ load helpers
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error containers --format "{{.ContainerName}}"
   expect_line_count 2
+  expect_output --from="${lines[0]}" "alpine-working-container"
+  expect_output --from="${lines[1]}" "busybox-working-container"
 
   buildah rm -a
   buildah rmi -a -f
@@ -45,6 +47,7 @@ load helpers
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error containers --noheading
   expect_line_count 2
+  [[ "$output" != "NAME"* ]]
 
   buildah rm -a
   buildah rmi -a -f
@@ -55,6 +58,9 @@ load helpers
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah --log-level=error containers --quiet
   expect_line_count 2
+
+  [[ "${lines[0]}" != "$cid1"* ]]
+  [[ "${lines[1]}" != "$cid2"* ]]
 
   buildah rm -a
   buildah rmi -a -f

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -157,3 +157,9 @@ load helpers
   buildah rm -a
   buildah rmi -a -f
 }
+
+@test "image digest test" {
+  buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah images --digests
+  expect_output --substring "sha256:"
+}

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -23,6 +23,17 @@ load helpers
 
 	[ "$out1" != "" ]
 	[ "$out1" = "$out2" ]
+
+	imageid=$(buildah images -q alpine-image)
+	containerid=$(buildah containers -q)
+
+	out3=$(buildah inspect --format '{{.OCIv1.Config}}' $containerid)
+	out4=$(buildah inspect --type image --format '{{.OCIv1.Config}}' $imageid)
+	[ "$out3" = "$out1" ]
+	[ "$out4" = "$out1" ]
+
+	buildah rm $cid
+	buildah rmi alpine-image alpine
 }
 
 @test "inspect-config-is-json" {

--- a/tests/tag.bats
+++ b/tests/tag.bats
@@ -2,7 +2,7 @@
 
 load helpers
 
-@test "tag" {
+@test "tag by name" {
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json "$cid" scratch-image
   run_buildah 1 inspect --type image tagged-image
@@ -10,4 +10,16 @@ load helpers
   run_buildah inspect --type image tagged-image
   run_buildah inspect --type image tagged-also-image
   run_buildah inspect --type image named-image
+}
+
+@test "tag by id" {
+  buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
+  id=$(buildah images -q busybox)
+  run_buildah tag $id busybox1
+  run_buildah from busybox1
+  run_buildah mount busybox1-working-container
+  run_buildah unmount busybox1-working-container
+  run_buildah rm busybox1-working-container
+  run_buildah rmi busybox1
+  run_buildah inspect --type image busybox
 }

--- a/tests/tag.bats
+++ b/tests/tag.bats
@@ -13,13 +13,20 @@ load helpers
 }
 
 @test "tag by id" {
-  buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
-  id=$(buildah images -q busybox)
+  run_buildah pull --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  id=$output
+
+  # Tag by ID, then make a container from that tag
   run_buildah tag $id busybox1
-  run_buildah from busybox1
-  run_buildah mount busybox1-working-container
-  run_buildah unmount busybox1-working-container
+  run_buildah from busybox1            # gives us busybox1-working-container
+
+  # The from-name should be busybox1, but ID should be same as pulled image
+  run_buildah inspect --format '{{ .FromImage }}' busybox1-working-container
+  expect_output "localhost/busybox1:latest"
+  run_buildah inspect --format '{{ .FromImageID }}' busybox1-working-container
+  expect_output $id
+
+  # Clean up
   run_buildah rm busybox1-working-container
   run_buildah rmi busybox1
-  run_buildah inspect --type image busybox
 }


### PR DESCRIPTION
This is a takeover of #1966 

PR 1966 has languished for three weeks without activity from
submitter. In the interests of getting it online, I have
taken it over and:

  - rebased
  - fixed several misunderstandings (bugs) noted in review feedback
  - fixed a few more

I also slightly rewrote two tests (tag by id, commit with name)
that were incomprehensible to me: unnecessary mount/umount and
no actual testing of anything other than checking exit status.
I believe the new code is closer to the intention of testing
but please pay closer attention to those bits.

Also: fixed the basic 'inspect' test. It looks like at some
point in the last month #1917 added a version string to
the buildah-inspect output. The test was fixed on master,
but ypu's PR did not incorporate those fixes and the
test was breaking. I took the liberty of cleaning up
the entire test for readability and maintainability.

Sorry it took so long: I tried (unsuccessfully) to push against ypu's original PR; then it took me a while to refresh my memory from so long ago; then I kept finding new problems.

Review hint: if you reviewed the initial iterations, just go to the `Commits` tab and look at the last one (mine). It's smaller.