### PR TITLE
imgtype: check earlier for expected manifest type

### DIFF
--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -137,6 +137,12 @@ func main() {
 			continue
 		}
 
+		if expectedManifestType != "" && manifestType != expectedManifestType {
+			logrus.Errorf("expected manifest type %q in %q, got %q", expectedManifestType, image, manifestType)
+			errors = true
+			continue
+		}
+
 		switch expectedManifestType {
 		case buildah.OCIv1ImageManifest:
 			err = json.Unmarshal(manifest, &oManifest)
@@ -169,11 +175,7 @@ func main() {
 			manifestType = dManifest.MediaType
 			configType = dManifest.Config.MediaType
 		}
-		if expectedManifestType != "" && manifestType != expectedManifestType {
-			logrus.Errorf("expected manifest type %q in %q, got %q", expectedManifestType, image, manifestType)
-			errors = true
-			continue
-		}
+
 		switch manifestType {
 		case buildah.OCIv1ImageManifest:
 			if rebuildm != nil && *rebuildm {


### PR DESCRIPTION
imgtype has a --expected-manifest-type option; the intention
seems to be to fail if the given image is not of the expected
type. This was not actually working as intended: the user-
specified expected-type was being trusted prematurely and
used to set state inappropriately.

Solution: check earlier, and bail if actual != expected.

There's quite a bit of duplicate code which I think can be
refactored here but it's probably ok to defer that for
the proverbial rainy day.

Fixes: #1951

Signed-off-by: Ed Santiago <santiago@redhat.com>