### PR TITLE
imgtype: reset storage opts if driver overridden

### DIFF
--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -68,6 +68,7 @@ func main() {
 	}
 	if driver != nil {
 		storeOptions.GraphDriverName = *driver
+		storeOptions.GraphDriverOptions = nil
 	}
 	if opts != nil && *opts != "" {
 		storeOptions.GraphDriverOptions = strings.Split(*opts, ",")


### PR DESCRIPTION
If invoked with --storage-driver=foo on command line,
reset GraphDriverOptions. Otherwise, on a default
Fedora install with default /etc/containers/storage.conf:

    # buildah-imgtype --storage-driver vfs -expected-manifest-type '*' sdf
    ERRO[0000] error opening storage: vfs driver does not support overlay.mountopt options

This is because /etc/containers/storage.conf specifies:

    [storage.options.overlay]
    ...
    mountopt = "nodev,metacopy=on"

...and that gets read & set early, before the command-line
overriding of storage-driver.

This fixes two gating-test failures on Fedora.

Signed-off-by: Ed Santiago <santiago@redhat.com>