### PR TITLE
Set the TMPDIR for pulling/pushing image to $TMPDIR

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/containers/buildah"
+	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/pkg/unshare"
 	"github.com/containers/storage"
 	ispecs "github.com/opencontainers/image-spec/specs-go"
@@ -134,10 +135,10 @@ func main() {
 	if buildah.InitReexec() {
 		return
 	}
-	// Hard code TMPDIR functions to use /var/tmp, if user did not override
-	if _, ok := os.LookupEnv("TMPDIR"); !ok {
-		os.Setenv("TMPDIR", "/var/tmp")
-	}
+
+	// Hard code TMPDIR functions to use $TMPDIR or /var/tmp
+	os.Setenv("TMPDIR", parse.GetTempDir())
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -680,6 +680,23 @@ buildah bud --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc .
 
   Note: supported compression formats are 'xz', 'bzip2', 'gzip' and 'identity' (no compression).
 
+## ENVIRONMENT
+
+**BUILD\_REGISTRY\_SOURCES**
+
+BUILD\_REGISTRY\_SOURCES, if set, is treated as a JSON object which contains
+lists of registry names under the keys `insecureRegistries`,
+`blockedRegistries`, and `allowedRegistries`.
+
+When pulling an image from a registry, if the name of the registry matches any
+of the items in the `blockedRegistries` list, the image pull attempt is denied.
+If there are registries in the `allowedRegistries` list, and the registry's
+name is not in the list, the pull attempt is denied.
+
+**TMPDIR**
+The TMPDIR environment variable allows the user to specify where temporary files
+are stored while pulling and pushing images.  Defaults to '/var/tmp'.
+
 ## Files
 
 **registries.conf** (`/etc/containers/registries.conf`)

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -118,6 +118,10 @@ denied.  If there are registries in the `allowedRegistries` list, and the
 portion of the name that corresponds to the registry is not in the list, the
 commit attempt is denied.
 
+**TMPDIR**
+The TMPDIR environment variable allows the user to specify where temporary files
+are stored while pulling and pushing images.  Defaults to '/var/tmp'.
+
 ## FILES
 
 **registries.conf** (`/etc/containers/registries.conf`)

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -556,6 +556,10 @@ of the items in the `blockedRegistries` list, the image pull attempt is denied.
 If there are registries in the `allowedRegistries` list, and the registry's
 name is not in the list, the pull attempt is denied.
 
+**TMPDIR**
+The TMPDIR environment variable allows the user to specify where temporary files
+are stored while pulling and pushing images.  Defaults to '/var/tmp'.
+
 ## FILES
 
 **registries.conf** (`/etc/containers/registries.conf`)

--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -110,6 +110,10 @@ of the items in the `blockedRegistries` list, the image pull attempt is denied.
 If there are registries in the `allowedRegistries` list, and the registry's
 name is not in the list, the pull attempt is denied.
 
+**TMPDIR**
+The TMPDIR environment variable allows the user to specify where temporary files
+are stored while pulling and pushing images.  Defaults to '/var/tmp'.
+
 ## FILES
 
 **registries.conf** (`/etc/containers/registries.conf`)

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -133,6 +133,10 @@ denied.  If there are registries in the `allowedRegistries` list, and the
 portion of the name that corresponds to the registry is not in the list, the
 push attempt is denied.
 
+**TMPDIR**
+The TMPDIR environment variable allows the user to specify where temporary files
+are stored while pulling and pushing images.  Defaults to '/var/tmp'.
+
 ## FILES
 
 **registries.conf** (`/etc/containers/registries.conf`)

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -589,6 +589,7 @@ func SystemContextFromOptions(c *cobra.Command) (*types.SystemContext, error) {
 	if arch, err := c.Flags().GetString("override-arch"); err == nil {
 		ctx.ArchitectureChoice = arch
 	}
+	ctx.BigFilesTemporaryDir = GetTempDir()
 	return ctx, nil
 }
 
@@ -955,4 +956,11 @@ func isValidDeviceMode(mode string) bool {
 		legalDeviceMode[c] = false
 	}
 	return true
+}
+
+func GetTempDir() string {
+	if tmpdir, ok := os.LookupEnv("TMPDIR"); ok {
+		return tmpdir
+	}
+	return "/var/tmp"
 }


### PR DESCRIPTION
Or set it to /var/tmp if the user did not specify.

Currently certain large workloads can not be handled because users are running
out of space on pulls/ and pushes.  Containers/image stores data temporarily in
the file system.  This allows the user to overide the location of the temporary
storage.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>