### PR TITLE
Bats major cleanup

### DIFF
--- a/tests/add.bats
+++ b/tests/add.bats
@@ -39,7 +39,7 @@ load helpers
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   run_buildah rm $cid
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json new-image
   newcid=$output
   run_buildah mount $newcid
   newroot=$output
@@ -63,8 +63,7 @@ load helpers
 
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  run_buildah mount $cid
-  root=$output
+
   dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/random1
   dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/random2
   tar -c -C ${TESTDIR}    -f ${TESTDIR}/tarball1.tar random1 random2
@@ -86,11 +85,10 @@ load helpers
   run_buildah add $cid ${TESTDIR}/tarball2.tar.gz
   run_buildah add $cid ${TESTDIR}/tarball3.tar.bz2
   run_buildah add $cid ${TESTDIR}/tarball4.tar.bz2
-  run_buildah unmount $cid
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   run_buildah rm $cid
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json new-image
   newcid=$output
   run_buildah mount $newcid
   newroot=$output
@@ -110,7 +108,6 @@ load helpers
   cmp ${TESTDIR}/tarball4/tarball4.random1 $newroot/tarball4/tarball4.random1
   test -s $newroot/tarball4/tarball4.random2
   cmp ${TESTDIR}/tarball4/tarball4.random2 $newroot/tarball4/tarball4.random2
-  run_buildah rm $newcid
 }
 
 @test "add single file creates absolute path with correct permissions" {
@@ -122,8 +119,6 @@ load helpers
   cid=$output
   run_buildah add $cid ${TESTDIR}/distutils.cfg /usr/lib/python3.7/distutils
   run_buildah run $cid stat -c "%a" /usr/lib/python3.7/distutils
-  run_buildah mount $cid
-  root=$output
   expect_output $permission
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:${imgName}
   run_buildah rm $cid
@@ -132,7 +127,6 @@ load helpers
   newcid=$output
   run_buildah run $newcid stat -c "%a" /usr/lib/python3.7/distutils
   expect_output $permission
-  run_buildah rm $newcid
 }
 
 @test "add single file creates relative path with correct permissions" {
@@ -144,8 +138,6 @@ load helpers
   cid=$output
   run_buildah add $cid ${TESTDIR}/distutils.cfg lib/custom
   run_buildah run $cid stat -c "%a" lib/custom
-  run_buildah mount $cid
-  root=$output
   expect_output $permission
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:${imgName}
   run_buildah rm $cid
@@ -154,7 +146,6 @@ load helpers
   newcid=$output
   run_buildah run $newcid stat -c "%a" lib/custom
   expect_output $permission
-  run_buildah rm $newcid
 }
 
 @test "add with chown" {
@@ -165,7 +156,6 @@ load helpers
   run_buildah run $cid ls -l /tmp/random
 
   expect_output --substring bin.*bin
-  run_buildah rm $cid
 }
 
 @test "add url" {
@@ -176,6 +166,4 @@ load helpers
 
   run_buildah add $cid https://github.com/containers/buildah/raw/master/README.md /home
   run_buildah run $cid ls /home/README.md
-
-  run_buildah rm $cid
 }

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -165,7 +165,7 @@ load helpers
   run_buildah run $cid ls -l /tmp/random
 
   expect_output --substring bin.*bin
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "add url" {
@@ -177,5 +177,5 @@ load helpers
   run_buildah add $cid https://github.com/containers/buildah/raw/master/README.md /home
   run_buildah run $cid ls /home/README.md
 
-  buildah rm $cid
+  run_buildah rm $cid
 }

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -17,8 +17,10 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
-  root=$(buildah mount $cid)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
+  run_buildah mount $cid
+  root=$output
   mkdir $root/subdir $root/other-subdir
   # Copy a file to the working directory
   run_buildah config --workingdir=/ $cid
@@ -37,8 +39,10 @@ load helpers
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   run_buildah rm $cid
 
-  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json new-image)
-  newroot=$(buildah mount $newcid)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  newcid=$output
+  run_buildah mount $newcid
+  newroot=$output
   test -s $newroot/randomfile
   cmp ${TESTDIR}/randomfile $newroot/randomfile
   test -s $newroot/subdir/randomfile
@@ -57,8 +61,10 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
-  root=$(buildah mount $cid)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
+  run_buildah mount $cid
+  root=$output
   dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/random1
   dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/random2
   tar -c -C ${TESTDIR}    -f ${TESTDIR}/tarball1.tar random1 random2
@@ -84,8 +90,10 @@ load helpers
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   run_buildah rm $cid
 
-  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json new-image)
-  newroot=$(buildah mount $newcid)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  newcid=$output
+  run_buildah mount $newcid
+  newroot=$output
   test -s $newroot/random1
   cmp ${TESTDIR}/random1 $newroot/random1
   test -s $newroot/random2
@@ -110,15 +118,18 @@ load helpers
   createrandom ${TESTDIR}/distutils.cfg
   permission=$(stat -c "%a" ${TESTDIR}/distutils.cfg)
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ubuntu)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ubuntu
+  cid=$output
   run_buildah add $cid ${TESTDIR}/distutils.cfg /usr/lib/python3.7/distutils
   run_buildah run $cid stat -c "%a" /usr/lib/python3.7/distutils
-  root=$(buildah mount $cid)
+  run_buildah mount $cid
+  root=$output
   expect_output $permission
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:${imgName}
   run_buildah rm $cid
 
-  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${imgName})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${imgName}
+  newcid=$output
   run_buildah run $newcid stat -c "%a" /usr/lib/python3.7/distutils
   expect_output $permission
   run_buildah rm $newcid
@@ -129,15 +140,18 @@ load helpers
   createrandom ${TESTDIR}/distutils.cfg
   permission=$(stat -c "%a" ${TESTDIR}/distutils.cfg)
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ubuntu)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ubuntu
+  cid=$output
   run_buildah add $cid ${TESTDIR}/distutils.cfg lib/custom
   run_buildah run $cid stat -c "%a" lib/custom
-  root=$(buildah mount $cid)
+  run_buildah mount $cid
+  root=$output
   expect_output $permission
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:${imgName}
   run_buildah rm $cid
 
-  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${imgName})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${imgName}
+  newcid=$output
   run_buildah run $newcid stat -c "%a" lib/custom
   expect_output $permission
   run_buildah rm $newcid
@@ -145,7 +159,8 @@ load helpers
 
 @test "add with chown" {
   createrandom ${TESTDIR}/randomfile
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  cid=$output
   run_buildah add --chown bin:bin $cid ${TESTDIR}/randomfile /tmp/random
   run_buildah run $cid ls -l /tmp/random
 
@@ -154,7 +169,8 @@ load helpers
 }
 
 @test "add url" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  cid=$output
   run_buildah add $cid https://github.com/containers/buildah/raw/master/README.md
   run_buildah run $cid ls /README.md
 

--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -31,24 +31,19 @@ load helpers
   run_buildah from --name "my-alpine" --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword localhost:5000/my-alpine
 
   # Create Dockerfile for bud tests
-  FILE=./Dockerfile
-  /bin/cat <<EOM >$FILE
+  mkdir -p ${TESTDIR}/dockerdir
+  DOCKERFILE=${TESTDIR}/dockerdir/Dockerfile
+  /bin/cat <<EOM >$DOCKERFILE
 FROM localhost:5000/my-alpine
 EOM
-  chmod +x $FILE
 
   # Remove containers and images before bud tests
   run_buildah rm --all
   run_buildah rmi -f --all
 
   # bud test bad password should fail
-  run_buildah 1 bud -f ./Dockerfile --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds=testuser:badpassword
+  run_buildah 1 bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds=testuser:badpassword
 
   # bud test this should work
-  run_buildah bud -f ./Dockerfile --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds=testuser:testpassword .
-
-  # Clean up
-  rm -f ./Dockerfile
-  run_buildah rm -a
-  run_buildah rmi -f --all
+  run_buildah bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds=testuser:testpassword .
 }

--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -38,8 +38,8 @@ EOM
   chmod +x $FILE
 
   # Remove containers and images before bud tests
-  buildah rm --all
-  buildah rmi -f --all
+  run_buildah rm --all
+  run_buildah rmi -f --all
 
   # bud test bad password should fail
   run_buildah 1 bud -f ./Dockerfile --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds=testuser:badpassword
@@ -49,6 +49,6 @@ EOM
 
   # Clean up
   rm -f ./Dockerfile
-  buildah rm -a
-  buildah rmi -f --all
+  run_buildah rm -a
+  run_buildah rmi -f --all
 }

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -118,7 +118,7 @@ load helpers
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
   newcid=$output
-  buildah commit --rm --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:remove-container-image
+  run_buildah commit --rm --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:remove-container-image
   run_buildah 1 mount $newcid
 
   run_buildah rmi remove-container-image

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -102,9 +102,9 @@ load helpers
   run_buildah rmi remove-container-image
   run_buildah rmi containers-storage:other-new-image
   run_buildah rmi another-new-image
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   [ "$output" != "" ]
   run_buildah rmi -a
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   expect_output ""
 }

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -3,23 +3,29 @@
 load helpers
 
 @test "from" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah rm $cid
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   run_buildah rm $cid
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json --name i-love-naming-things alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json --name i-love-naming-things alpine
+  cid=$output
   run_buildah rm i-love-naming-things
 }
 
 @test "from-defaultpull" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah rm $cid
 }
 
 @test "from-scratch" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   run_buildah rm $cid
-  cid=$(buildah from --pull=true  --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --pull=true  --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   run_buildah rm $cid
 }
 
@@ -28,18 +34,23 @@ load helpers
 }
 
 @test "mount" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
-  root=$(buildah mount $cid)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
+  run_buildah mount $cid
+  root=$output
   run_buildah unmount $cid
-  root=$(buildah mount $cid)
+  run_buildah mount $cid
+  root=$output
   touch $root/foobar
   run_buildah unmount $cid
   run_buildah rm $cid
 }
 
 @test "by-name" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json --name scratch-working-image-for-test scratch)
-  root=$(buildah mount scratch-working-image-for-test)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name scratch-working-image-for-test scratch
+  cid=$output
+  run_buildah mount scratch-working-image-for-test
+  root=$output
   run_buildah unmount scratch-working-image-for-test
   run_buildah rm scratch-working-image-for-test
 }
@@ -48,8 +59,10 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
-  root=$(buildah mount $cid)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
+  run_buildah mount $cid
+  root=$output
   cp ${TESTDIR}/randomfile $root/randomfile
   run_buildah unmount $cid
   run_buildah commit --iidfile output.iid --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
@@ -57,8 +70,10 @@ load helpers
   run_buildah rmi $iid
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   run_buildah rm $cid
-  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json new-image)
-  newroot=$(buildah mount $newcid)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  newcid=$output
+  run_buildah mount $newcid
+  newroot=$output
   test -s $newroot/randomfile
   cmp ${TESTDIR}/randomfile $newroot/randomfile
   cp ${TESTDIR}/other-randomfile $newroot/other-randomfile
@@ -71,31 +86,38 @@ load helpers
   run_buildah unmount $newcid
   run_buildah rm $newcid
 
-  othernewcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json other-new-image)
-  othernewroot=$(buildah mount $othernewcid)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json other-new-image
+  othernewcid=$output
+  run_buildah mount $othernewcid
+  othernewroot=$output
   test -s $othernewroot/randomfile
   cmp ${TESTDIR}/randomfile $othernewroot/randomfile
   test -s $othernewroot/other-randomfile
   cmp ${TESTDIR}/other-randomfile $othernewroot/other-randomfile
   run_buildah rm $othernewcid
 
-  anothernewcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json another-new-image)
-  anothernewroot=$(buildah mount $anothernewcid)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json another-new-image
+  anothernewcid=$output
+  run_buildah mount $anothernewcid
+  anothernewroot=$output
   test -s $anothernewroot/randomfile
   cmp ${TESTDIR}/randomfile $anothernewroot/randomfile
   test -s $anothernewroot/other-randomfile
   cmp ${TESTDIR}/other-randomfile $anothernewroot/other-randomfile
   run_buildah rm $anothernewcid
 
-  yetanothernewcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json yet-another-new-image)
-  yetanothernewroot=$(buildah mount $yetanothernewcid)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json yet-another-new-image
+  yetanothernewcid=$output
+  run_buildah mount $yetanothernewcid
+  yetanothernewroot=$output
   test -s $yetanothernewroot/randomfile
   cmp ${TESTDIR}/randomfile $yetanothernewroot/randomfile
   test -s $yetanothernewroot/other-randomfile
   cmp ${TESTDIR}/other-randomfile $yetanothernewroot/other-randomfile
   run_buildah delete $yetanothernewcid
 
-  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json new-image)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  newcid=$output
   buildah commit --rm --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:remove-container-image
   run_buildah 1 mount $newcid
 

--- a/tests/blobcache.bats
+++ b/tests/blobcache.bats
@@ -30,7 +30,7 @@ load helpers
 	blobcachedir=${TESTDIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah --log-level=error from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
+	run_buildah from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
 	ctr="$output"
 	run_buildah add ${ctr} ${TESTSDIR}/bud/add-file/file /
 	# Commit the image without using the blob cache, using compression so that uncompressed blobs
@@ -97,7 +97,7 @@ load helpers
 	blobcachedir=${TESTDIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah --log-level=error from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
+	run_buildah from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
 	ctr="$output"
 	run_buildah add ${ctr} ${TESTSDIR}/bud/add-file/file /
 	# Commit the image using the blob cache.

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -8,14 +8,14 @@ load helpers
   expect_output --substring "nameserver 223.5.5.5"
   expect_output --substring "options use-vc"
 
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "bud with .dockerignore" {
   # Remove containers and images before bud tests
-  buildah rm --all
-  buildah rmi -f --all
+  run_buildah rm --all
+  run_buildah rmi -f --all
 
   run_buildah bud -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/dockerignore/Dockerfile ${TESTSDIR}/bud/dockerignore
 
@@ -40,7 +40,7 @@ load helpers
   run sed '/CUT HERE/d' <<< "$output"
   expect_output "$(cat ${TESTSDIR}/bud/dockerignore3/manifest)"
 
-  buildah rmi -a -f
+  run_buildah rmi -a -f
 }
 
 @test "bud-flags-order-verification" {
@@ -97,7 +97,7 @@ load helpers
   run_buildah images -a
   expect_line_count 18
 
-  buildah rmi -a -f
+  run_buildah rmi -a -f
 }
 
 @test "bud with --layers and single and two line Dockerfiles" {
@@ -109,7 +109,7 @@ load helpers
   run_buildah images -a
   expect_line_count 4
 
-  buildah rmi -a -f
+  run_buildah rmi -a -f
 }
 
 @test "bud with --layers, multistage, and COPY with --from" {
@@ -157,7 +157,7 @@ load helpers
   run_buildah images -a
   expect_line_count 12
 
-  buildah rmi -a -f
+  run_buildah rmi -a -f
 }
 
 @test "bud-multistage-partial-cache" {
@@ -221,7 +221,7 @@ load helpers
   run_buildah images -a
   expect_line_count 7
 
-  buildah rmi -a -f
+  run_buildah rmi -a -f
 }
 
 @test "bud with --layers and dangling symlink" {
@@ -242,8 +242,8 @@ load helpers
   run_buildah run $cid ls /tmp
   expect_output "policy.json"
 
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
   rm -rf ${TESTDIR}/use-layers/blah
 }
 
@@ -268,7 +268,7 @@ load helpers
   run_buildah images -a
   expect_line_count 10
 
-  buildah rmi -a -f
+  run_buildah rmi -a -f
 }
 
 @test "bud with --rm flag" {
@@ -280,8 +280,8 @@ load helpers
   run_buildah containers
   expect_line_count 7
 
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "bud with --force-rm flag" {
@@ -293,8 +293,8 @@ load helpers
   run_buildah containers
   expect_line_count 2
 
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "bud --layers with non-existent/down registry" {
@@ -312,8 +312,8 @@ load helpers
   expect_output "foo=bar"
   run_buildah inspect --format '{{index .Docker.ContainerConfig.Env 2}}' test1
   expect_output "random=hello,goodbye"
-  buildah rm ${cid}
-  buildah rmi -a -f
+  run_buildah rm ${cid}
+  run_buildah rmi -a -f
 }
 
 @test "bud-from-scratch" {
@@ -321,8 +321,8 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -333,8 +333,8 @@ load helpers
   iid=$(cat ${TESTDIR}/output.iid)
   run_buildah from --quiet ${iid}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -345,7 +345,7 @@ load helpers
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output 'map["test":"label"]'
 
-  buildah rmi ${target}
+  run_buildah rmi ${target}
 }
 
 @test "bud-from-scratch-annotation" {
@@ -353,7 +353,7 @@ load helpers
   run_buildah bud --annotation "test=annotation1,annotation2=z" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah inspect --format '{{printf "%q" .ImageAnnotations}}' ${target}
   expect_output 'map["test":"annotation1,annotation2=z"]'
-  buildah rmi ${target}
+  run_buildah rmi ${target}
 }
 
 @test "bud-from-scratch-layers" {
@@ -378,8 +378,8 @@ load helpers
   cmp $root/Dockerfile1 ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch
   cmp $root/Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom
   test ! -s $root/etc/passwd
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 
@@ -392,8 +392,8 @@ load helpers
   cmp $root/Dockerfile1 ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.alpine
   cmp $root/Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom
   test -s $root/etc/passwd
-  buildah rm ${cid}
-  buildah rmi -a
+  run_buildah rm ${cid}
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 }
@@ -408,8 +408,8 @@ load helpers
   test ! -s $root/Dockerfile1
   cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
   test -s $root/etc/passwd
-  buildah rm ${cid}
-  buildah rmi -a
+  run_buildah rm ${cid}
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 
@@ -422,8 +422,8 @@ load helpers
   test ! -s $root/Dockerfile1
   cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
   test -s $root/etc/passwd
-  buildah rm ${cid}
-  buildah rmi -a
+  run_buildah rm ${cid}
+  run_buildah rmi -a
   run_buildah images -q
   echo "$output"
   expect_output ""
@@ -431,33 +431,33 @@ load helpers
 
 @test "bud-multi-stage-builds" {
   target=multi-stage-index
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
   cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index
   test -s $root/etc/passwd
-  buildah rm ${cid}
-  buildah rmi -a
+  run_buildah rm ${cid}
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 
   target=multi-stage-name
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
   cmp $root/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.name
   test ! -s $root/etc/passwd
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 
   target=multi-stage-mixed
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -465,41 +465,41 @@ load helpers
   cmp $root/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.name
   cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index
   cmp $root/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.mixed
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
 
 @test "bud-multi-stage-builds-small-as" {
   target=multi-stage-index
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
   cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index
   test -s $root/etc/passwd
-  buildah rm ${cid}
-  buildah rmi -a
+  run_buildah rm ${cid}
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 
   target=multi-stage-name
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
   cmp $root/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.name
   test ! -s $root/etc/passwd
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 
   target=multi-stage-mixed
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds-small-as
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds-small-as
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -507,8 +507,8 @@ load helpers
   cmp $root/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.name
   cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index
   cmp $root/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.mixed
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -518,7 +518,7 @@ load helpers
   skip_if_no_runtime
 
   target=volume-image
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/preserve-volumes
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/preserve-volumes
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -529,8 +529,8 @@ load helpers
   test -s $root/vol/Dockerfile
   test -s $root/vol/Dockerfile2
   test ! -s $root/vol/anothervolfile
-  buildah rm ${cid}
-  buildah rmi -a
+  run_buildah rm ${cid}
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 }
@@ -538,12 +538,12 @@ load helpers
 @test "bud-http-Dockerfile" {
   starthttpd ${TESTSDIR}/bud/from-scratch
   target=scratch-image
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} http://0.0.0.0:${HTTP_SERVER_PORT}/Dockerfile
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} http://0.0.0.0:${HTTP_SERVER_PORT}/Dockerfile
   stophttpd
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -551,12 +551,12 @@ load helpers
 @test "bud-http-context-with-Dockerfile" {
   starthttpd ${TESTSDIR}/bud/http-context
   target=scratch-image
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
   stophttpd
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -564,12 +564,12 @@ load helpers
 @test "bud-http-context-dir-with-Dockerfile-pre" {
   starthttpd ${TESTSDIR}/bud/http-context-subdir
   target=scratch-image
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f context/Dockerfile http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f context/Dockerfile http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
   stophttpd
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -577,12 +577,12 @@ load helpers
 @test "bud-http-context-dir-with-Dockerfile-post" {
   starthttpd ${TESTSDIR}/bud/http-context-subdir
   target=scratch-image
-  buildah bud  --signature-policy ${TESTSDIR}/policy.json -t ${target} -f context/Dockerfile http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
+  run_buildah bud  --signature-policy ${TESTSDIR}/policy.json -t ${target} -f context/Dockerfile http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
   stophttpd
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -598,11 +598,11 @@ load helpers
   target=giturl-image
   # Any repo should do, but this one is small and is FROM: scratch.
   gitrepo=git://github.com/projectatomic/nulecule-library
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} "${gitrepo}"
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} "${gitrepo}"
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -611,12 +611,12 @@ load helpers
   target=github-image
   # Any repo should do, but this one is small and is FROM: scratch.
   gitrepo=github.com/projectatomic/nulecule-library
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} "${gitrepo}"
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} "${gitrepo}"
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah images -q
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah images -q
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -625,18 +625,18 @@ load helpers
   target=scratch-image
   target2=another-scratch-image
   target3=so-many-scratch-images
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -t docker.io/${target2} -t ${target3} ${TESTSDIR}/bud/from-scratch
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -t docker.io/${target2} -t ${target3} ${TESTSDIR}/bud/from-scratch
   run_buildah images
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
+  run_buildah rm ${cid}
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json library/${target2}
   cid=$output
-  buildah rm ${cid}
+  run_buildah rm ${cid}
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target3}:latest
   cid=$output
-  buildah rm ${cid}
-  buildah rmi -f $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi -f $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -669,7 +669,7 @@ load helpers
   skip_if_no_runtime
 
   target=volume-image
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/volume-perms
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/volume-perms
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -679,35 +679,35 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   [ "$output" = 41ed ]
-  buildah rm ${cid}
-  buildah rmi -a
+  run_buildah rm ${cid}
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 }
 
 @test "bud-from-glob" {
   target=alpine-image
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile2.glob ${TESTSDIR}/bud/from-multiple-files
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile2.glob ${TESTSDIR}/bud/from-multiple-files
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
   cmp $root/Dockerfile1.alpine ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.alpine
   cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
-  buildah rm ${cid}
-  buildah rmi -a
+  run_buildah rm ${cid}
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 }
 
 @test "bud-maintainer" {
   target=alpine-image
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/maintainer
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/maintainer
   run_buildah inspect --type=image --format '{{.Docker.Author}}' ${target}
   expect_output "kilroy"
   run_buildah inspect --type=image --format '{{.OCIv1.Author}}' ${target}
   expect_output "kilroy"
-  buildah rmi -a
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 }
@@ -716,14 +716,14 @@ load helpers
   target=alpine-image
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/unrecognized
   expect_output --substring "BOGUS"
-  buildah rmi $(buildah images -q)
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
 
 @test "bud-shell" {
   target=alpine-image
-  buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/shell
+  run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/shell
   run_buildah inspect --type=image --format '{{printf "%q" .Docker.Config.Shell}}' ${target}
   expect_output '["/bin/sh" "-c"]' ".Docker.Config.Shell (original)"
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
@@ -731,8 +731,8 @@ load helpers
   run_buildah config --shell "/bin/bash -c" ${ctr}
   run_buildah inspect --type=container --format '{{printf "%q" .Docker.Config.Shell}}' ${ctr}
   expect_output '["/bin/bash" "-c"]' ".Docker.Config.Shell (changed)"
-  buildah rm ${ctr}
-  buildah rmi -a
+  run_buildah rm ${ctr}
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 }
@@ -741,7 +741,7 @@ load helpers
   target=alpine-image
   run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/sh"
-  buildah rmi -a
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 }
@@ -750,7 +750,7 @@ load helpers
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/sh"
-  buildah rmi -a
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 }
@@ -759,7 +759,7 @@ load helpers
   target=ubuntu-image
   run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/bash"
-  buildah rmi -a
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 }
@@ -768,7 +768,7 @@ load helpers
   target=ubuntu-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/sh"
-  buildah rmi -a
+  run_buildah rmi -a
   run_buildah images -q
   expect_output ""
 }
@@ -790,8 +790,8 @@ load helpers
   [ "$status" -eq 0 ]
   [[ "$output" =~ "test-log -> /data/log" ]]
   [[ "$output" =~ "blah -> /test-log" ]]
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud with symlinks to relative path" {
@@ -810,8 +810,8 @@ load helpers
   [ "$status" -eq 0 ]
   [[ "$output" =~ "test-log -> ../log" ]]
   test -r $root/var/data/empty
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud with multiple symlinks in a path" {
@@ -838,8 +838,8 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ "foo -> /data/log" ]]
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud with multiple symlink pointing to itself" {
@@ -861,8 +861,8 @@ load helpers
   run cat $root/bin/myexe
   [ "$status" -eq 0 ]
   [[ "$output" == "symlink-test" ]]
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud multi-stage with dir symlink to absolute path" {
@@ -876,8 +876,8 @@ load helpers
   echo "$output"
   [ "$status" -eq 0 ]
   [[ "$output" =~ myexe ]]
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud with ENTRYPOINT and RUN" {
@@ -886,8 +886,8 @@ load helpers
   expect_output --substring "unique.test.string"
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud with ENTRYPOINT and empty RUN" {
@@ -902,8 +902,8 @@ load helpers
   expect_output --substring "unique.test.string"
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud with CMD and empty RUN" {
@@ -918,8 +918,8 @@ load helpers
   expect_output --substring "unique.test.string"
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud with ENTRYPOINT, CMD and empty RUN" {
@@ -935,8 +935,8 @@ load helpers
   expect_output --substring ":unique.test.string:"
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 # Determines if a variable set with ENV in an image is available to commands in downstream Dockerfile
@@ -950,8 +950,8 @@ load helpers
   from_cid=$output
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${from_cid} ${cid}
-  buildah rmi -a -f
+  run_buildah rm ${from_cid} ${cid}
+  run_buildah rmi -a -f
 }
 
 @test "bud ENV preserves special characters after commit" {
@@ -961,8 +961,8 @@ load helpers
   cid=$output
   run_buildah run ${cid} env
   expect_output --substring "LIB=\\$\(PREFIX\)/lib"
-  buildah rm ${cid}
-  buildah rmi -a -f
+  run_buildah rm ${cid}
+  run_buildah rmi -a -f
 }
 
 @test "bud with Dockerfile from valid URL" {
@@ -971,8 +971,8 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${url}
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud with Dockerfile from invalid URL" {
@@ -987,8 +987,8 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 # Following flags are configured to result in noop but should not affect buildiah bud behavior
@@ -997,8 +997,8 @@ load helpers
   run_buildah bud --cache-from=invalidimage --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud with --compress noop flag" {
@@ -1006,8 +1006,8 @@ load helpers
   run_buildah bud --compress --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud with --cpu-shares flag, no argument" {
@@ -1026,8 +1026,8 @@ load helpers
   run_buildah bud --cpu-shares 2 --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile ${TESTSDIR}/bud/from-scratch
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud with --cpu-shares short flag (-c), no argument" {
@@ -1046,13 +1046,13 @@ load helpers
   run_buildah bud -c 2 --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi ${target}
+  run_buildah rm ${cid}
+  run_buildah rmi ${target}
 }
 
 @test "bud-onbuild" {
   target=onbuild
-  buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/onbuild
+  run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild1" "RUN touch /onbuild2"]'
   run_buildah from --quiet ${target}
@@ -1062,11 +1062,11 @@ load helpers
   run ls ${root}/onbuild1 ${root}/onbuild2
   echo "$output"
   [ "$status" -eq 0 ]
-  buildah umount ${cid}
-  buildah rm ${cid}
+  run_buildah umount ${cid}
+  run_buildah rm ${cid}
 
   target=onbuild-image2
-  buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1 ${TESTSDIR}/bud/onbuild
+  run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1 ${TESTSDIR}/bud/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild3"]'
   run_buildah from --quiet ${target}
@@ -1076,21 +1076,21 @@ load helpers
   run ls ${root}/onbuild1 ${root}/onbuild2 ${root}/onbuild3
   echo "$output"
   [ "$status" -eq 0 ]
-  buildah umount ${cid}
+  run_buildah umount ${cid}
 
   run_buildah config --onbuild "RUN touch /onbuild4" ${cid}
 
   target=onbuild-image3
-  buildah commit --signature-policy ${TESTSDIR}/policy.json --format docker ${cid} ${target}
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --format docker ${cid} ${target}
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild4"]'
-  buildah rm ${cid}
-  buildah rmi --all
+  run_buildah rm ${cid}
+  run_buildah rmi --all
 }
 
 @test "bud-onbuild-layers" {
   target=onbuild
-  buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile2 ${TESTSDIR}/bud/onbuild
+  run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile2 ${TESTSDIR}/bud/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild1" "RUN touch /onbuild2"]'
 }
@@ -1134,8 +1134,8 @@ load helpers
   run test -s $root/Dockerfile1
   echo "$output"
   [ "$status" -eq 0 ]
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -1201,7 +1201,7 @@ load helpers
 }
 
 @test "bud with ADD file construct" {
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/add-file
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/add-file
   run_buildah images -a
   expect_output --substring "test1"
 
@@ -1292,7 +1292,7 @@ load helpers
 }
 
 @test "bud with FROM AS construct" {
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
   run_buildah images -a
   expect_output --substring "test1"
 
@@ -1306,7 +1306,7 @@ load helpers
 }
 
 @test "bud with FROM AS construct with layers" {
-  buildah bud --layers --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
+  run_buildah bud --layers --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
   run_buildah images -a
   expect_output --substring "test1"
 
@@ -1373,7 +1373,7 @@ load helpers
 
 @test "bud-with-healthcheck" {
   target=alpine-image
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --format docker ${TESTSDIR}/bud/healthcheck
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --format docker ${TESTSDIR}/bud/healthcheck
   run_buildah inspect -f '{{printf "%q" .Docker.Config.Healthcheck.Test}} {{printf "%d" .Docker.Config.Healthcheck.StartPeriod}} {{printf "%d" .Docker.Config.Healthcheck.Interval}} {{printf "%d" .Docker.Config.Healthcheck.Timeout}} {{printf "%d" .Docker.Config.Healthcheck.Retries}}' ${target}
   second=1000000000
   threeseconds=$(( 3 * $second ))
@@ -1434,8 +1434,8 @@ load helpers
   [ "$status" -eq 0 ]
   run ls ${root}/3
   [ "$status" -ne 0 ]
-  buildah umount ${cid}
-  buildah rm ${cid}
+  run_buildah umount ${cid}
+  run_buildah rm ${cid}
 }
 
 @test "bud-no-target-name" {
@@ -1575,7 +1575,7 @@ load helpers
     false
   fi
 
-  buildah rmi -a -f
+  run_buildah rmi -a -f
 }
 
 @test "buildah-bud-policy" {
@@ -1734,32 +1734,32 @@ load helpers
 @test "bud-no-change" {
   parent=alpine
   target=no-change-image
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
   run_buildah inspect --format '{{printf "%q" .FromImageDigest}}' ${parent}
   parentid="$output"
   run_buildah inspect --format '{{printf "%q" .FromImageDigest}}' ${target}
   [[ "$output" == "$parentid" ]]
 
-  buildah rmi ${target}
+  run_buildah rmi ${target}
 }
 
 @test "bud-no-change-label" {
   parent=alpine
   target=no-change-image
-  buildah bud --label "test=label" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
+  run_buildah bud --label "test=label" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output 'map["test":"label"]'
 
-  buildah rmi ${target}
+  run_buildah rmi ${target}
 }
 
 @test "bud-no-change-annotation" {
   target=no-change-image
-  buildah bud --annotation "test=annotation" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
+  run_buildah bud --annotation "test=annotation" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
   run_buildah inspect --format '{{printf "%q" .ImageAnnotations}}' ${target}
   expect_output 'map["test":"annotation"]'
 
-  buildah rmi ${target}
+  run_buildah rmi ${target}
 }
 
 @test "bud-squash-layers" {
@@ -1777,7 +1777,7 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --device ${TESTSDIR}/foo:/dev/fuse  -t ${target} -f ${TESTSDIR}/bud/device/Dockerfile ${TESTSDIR}/bud/device
   expect_output --substring "null"
 
-  buildah rmi ${target}
+  run_buildah rmi ${target}
   rm -rf ${TESTSDIR}/foo
 }
 
@@ -1787,7 +1787,7 @@ load helpers
   [ "${status}" -eq 0 ]
   expect_output --substring "/dev/fuse"
 
-  buildah rmi ${target}
+  run_buildah rmi ${target}
 }
 
 @test "bud with Containerfile" {
@@ -1796,7 +1796,7 @@ load helpers
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 
-  buildah rmi ${target}
+  run_buildah rmi ${target}
 }
 
 @test "bud with Dockerfile" {
@@ -1805,7 +1805,7 @@ load helpers
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 
-  buildah rmi ${target}
+  run_buildah rmi ${target}
 }
 
 @test "bud with Containerfile and Dockerfile" {
@@ -1814,18 +1814,18 @@ load helpers
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 
-  buildah rmi ${target}
+  run_buildah rmi ${target}
 }
 
 @test "bud-http-context-with-Containerfile" {
   starthttpd ${TESTSDIR}/bud/http-context-containerfile
   target=scratch-image
-  buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
   stophttpd
   run_buildah from --quiet ${target}
   cid=$output
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -1840,8 +1840,8 @@ load helpers
   root=$output
   run test -s $root/etc/alpine-release
   echo "$output"
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -1856,8 +1856,8 @@ load helpers
   root=$output
   run test -s $root/etc/alpine-release
   echo "$output"
-  buildah rm ${cid}
-  buildah rmi $(buildah images -q)
+  run_buildah rm ${cid}
+  run_buildah rmi $(buildah images -q)
   run_buildah images -q
   expect_output ""
 }
@@ -1893,8 +1893,8 @@ load helpers
   expect_output --substring "abc.txt"
 
   rm ${TESTSDIR}/bud/use-args/abc.txt
-  buildah rm --all
-  buildah rmi --all --force
+  run_buildah rm --all
+  run_buildah rmi --all --force
 }
 
 @test "bud using gitrepo and branch" {
@@ -1942,7 +1942,7 @@ load helpers
   echo "$output"
   expect_output --substring "COMMIT pull"
 
-  buildah rmi --all --force
+  run_buildah rmi --all --force
 }
 
 @test "bud pull false no local image" {
@@ -1951,8 +1951,8 @@ load helpers
   echo "$output"
   expect_output --substring "COMMIT pull"
 
-  buildah rmi --all --force
-  buildah rmi --all --force
+  run_buildah rmi --all --force
+  run_buildah rmi --all --force
 }
 
 @test "bud with Containerfile should fail with nonexist authfile" {
@@ -1977,5 +1977,5 @@ EOM
   expect_line_count 1
   expect_output --substring '^[0-9a-f]{64}$'
 
-  buildah rmi quiet-test
+  run_buildah rmi quiet-test
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -143,8 +143,10 @@ load helpers
   run_buildah containers
   expect_line_count 1
 
-  ctr=$(buildah from --signature-policy ${TESTSDIR}/policy.json test3)
-  mnt=$(buildah mount ${ctr})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test3
+  ctr=$output
+  run_buildah mount ${ctr}
+  mnt=$output
   run test -e $mnt/uuid
   [ "${status}" -eq 0 ]
   run test -e $mnt/date
@@ -235,7 +237,8 @@ load helpers
   run_buildah images -a
   expect_line_count 4
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json test)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test
+  cid=$output
   run_buildah run $cid ls /tmp
   expect_output "policy.json"
 
@@ -301,7 +304,8 @@ load helpers
 
 @test "bud from base image should have base image ENV also" {
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t test -f Dockerfile.check-env ${TESTSDIR}/bud/env
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json test)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test
+  cid=$output
   run_buildah config --env random=hello,goodbye ${cid}
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json ${cid} test1
   run_buildah inspect --format '{{index .Docker.ContainerConfig.Env 1}}' test1
@@ -315,7 +319,8 @@ load helpers
 @test "bud-from-scratch" {
   target=scratch-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi $(buildah images -q)
   run_buildah images -q
@@ -326,7 +331,8 @@ load helpers
   target=scratch-image
   run_buildah bud --iidfile ${TESTDIR}/output.iid --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
   iid=$(cat ${TESTDIR}/output.iid)
-  cid=$(buildah from ${iid})
+  run_buildah from --quiet ${iid}
+  cid=$output
   buildah rm ${cid}
   buildah rmi $(buildah images -q)
   run_buildah images -q
@@ -354,7 +360,8 @@ load helpers
   target=scratch-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -f  ${TESTSDIR}/bud/from-scratch/Dockerfile2 -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -f  ${TESTSDIR}/bud/from-scratch/Dockerfile2 -t ${target} ${TESTSDIR}/bud/from-scratch
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   run_buildah images
   expect_line_count 3
   run_buildah rm ${cid}
@@ -364,8 +371,10 @@ load helpers
 @test "bud-from-multiple-files-one-from" {
   target=scratch-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   cmp $root/Dockerfile1 ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch
   cmp $root/Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom
   test ! -s $root/etc/passwd
@@ -376,8 +385,10 @@ load helpers
 
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1.alpine -f Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   cmp $root/Dockerfile1 ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.alpine
   cmp $root/Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom
   test -s $root/etc/passwd
@@ -390,8 +401,10 @@ load helpers
 @test "bud-from-multiple-files-two-froms" {
   target=scratch-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1.scratch -f Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   test ! -s $root/Dockerfile1
   cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
   test -s $root/etc/passwd
@@ -402,8 +415,10 @@ load helpers
 
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1.alpine -f Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   test ! -s $root/Dockerfile1
   cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
   test -s $root/etc/passwd
@@ -417,8 +432,10 @@ load helpers
 @test "bud-multi-stage-builds" {
   target=multi-stage-index
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index
   test -s $root/etc/passwd
   buildah rm ${cid}
@@ -428,8 +445,10 @@ load helpers
 
   target=multi-stage-name
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   cmp $root/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.name
   test ! -s $root/etc/passwd
   buildah rm ${cid}
@@ -439,8 +458,10 @@ load helpers
 
   target=multi-stage-mixed
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   cmp $root/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.name
   cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index
   cmp $root/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.mixed
@@ -453,8 +474,10 @@ load helpers
 @test "bud-multi-stage-builds-small-as" {
   target=multi-stage-index
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index
   test -s $root/etc/passwd
   buildah rm ${cid}
@@ -464,8 +487,10 @@ load helpers
 
   target=multi-stage-name
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   cmp $root/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.name
   test ! -s $root/etc/passwd
   buildah rm ${cid}
@@ -475,8 +500,10 @@ load helpers
 
   target=multi-stage-mixed
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds-small-as
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   cmp $root/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.name
   cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index
   cmp $root/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.mixed
@@ -492,8 +519,10 @@ load helpers
 
   target=volume-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/preserve-volumes
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   test -s $root/vol/subvol/subsubvol/subsubvolfile
   test ! -s $root/vol/subvol/subvolfile
   test -s $root/vol/volfile
@@ -511,7 +540,8 @@ load helpers
   target=scratch-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} http://0.0.0.0:${HTTP_SERVER_PORT}/Dockerfile
   stophttpd
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi $(buildah images -q)
   run_buildah images -q
@@ -523,7 +553,8 @@ load helpers
   target=scratch-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
   stophttpd
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi $(buildah images -q)
   run_buildah images -q
@@ -535,7 +566,8 @@ load helpers
   target=scratch-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f context/Dockerfile http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
   stophttpd
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi $(buildah images -q)
   run_buildah images -q
@@ -547,7 +579,8 @@ load helpers
   target=scratch-image
   buildah bud  --signature-policy ${TESTSDIR}/policy.json -t ${target} -f context/Dockerfile http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
   stophttpd
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi $(buildah images -q)
   run_buildah images -q
@@ -566,7 +599,8 @@ load helpers
   # Any repo should do, but this one is small and is FROM: scratch.
   gitrepo=git://github.com/projectatomic/nulecule-library
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} "${gitrepo}"
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi $(buildah images -q)
   run_buildah images -q
@@ -578,7 +612,8 @@ load helpers
   # Any repo should do, but this one is small and is FROM: scratch.
   gitrepo=github.com/projectatomic/nulecule-library
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} "${gitrepo}"
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah images -q
   buildah rmi $(buildah images -q)
@@ -592,11 +627,14 @@ load helpers
   target3=so-many-scratch-images
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -t docker.io/${target2} -t ${target3} ${TESTSDIR}/bud/from-scratch
   run_buildah images
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json library/${target2})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json library/${target2}
+  cid=$output
   buildah rm ${cid}
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target3}:latest)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target3}:latest
+  cid=$output
   buildah rm ${cid}
   buildah rmi -f $(buildah images -q)
   run_buildah images -q
@@ -632,8 +670,10 @@ load helpers
 
   target=volume-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/volume-perms
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   test ! -s $root/vol/subvol/subvolfile
   run stat -c %f $root/vol/subvol
   echo "$output"
@@ -648,8 +688,10 @@ load helpers
 @test "bud-from-glob" {
   target=alpine-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile2.glob ${TESTSDIR}/bud/from-multiple-files
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   cmp $root/Dockerfile1.alpine ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.alpine
   cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
   buildah rm ${cid}
@@ -684,7 +726,8 @@ load helpers
   buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/shell
   run_buildah inspect --type=image --format '{{printf "%q" .Docker.Config.Shell}}' ${target}
   expect_output '["/bin/sh" "-c"]' ".Docker.Config.Shell (original)"
-  ctr=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  ctr=$output
   run_buildah config --shell "/bin/bash -c" ${ctr}
   run_buildah inspect --type=container --format '{{printf "%q" .Docker.Config.Shell}}' ${ctr}
   expect_output '["/bin/bash" "-c"]' ".Docker.Config.Shell (changed)"
@@ -733,8 +776,10 @@ load helpers
 @test "bud with symlinks" {
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/symlink
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   run ls $root/data/log
   echo "$output"
   [ "$status" -eq 0 ]
@@ -752,8 +797,10 @@ load helpers
 @test "bud with symlinks to relative path" {
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.relative-symlink ${TESTSDIR}/bud/symlink
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   run ls $root/log
   echo "$output"
   [ "$status" -eq 0 ]
@@ -770,8 +817,10 @@ load helpers
 @test "bud with multiple symlinks in a path" {
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.multiple-symlinks ${TESTSDIR}/bud/symlink
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   run ls $root/data/log
   echo "$output"
   [ "$status" -eq 0 ]
@@ -801,8 +850,10 @@ load helpers
 @test "bud multi-stage with symlink to absolute path" {
   target=ubuntu-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.absolute-symlink ${TESTSDIR}/bud/symlink
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   run ls $root/bin
   echo "$output"
   [ "$status" -eq 0 ]
@@ -817,8 +868,10 @@ load helpers
 @test "bud multi-stage with dir symlink to absolute path" {
   target=ubuntu-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.absolute-dir-symlink ${TESTSDIR}/bud/symlink
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   run ls $root/data
   echo "$output"
   [ "$status" -eq 0 ]
@@ -831,7 +884,8 @@ load helpers
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.entrypoint-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "unique.test.string"
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -846,7 +900,8 @@ load helpers
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.cmd-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "unique.test.string"
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -861,7 +916,8 @@ load helpers
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "unique.test.string"
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -877,7 +933,8 @@ load helpers
   target=env-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/env/Dockerfile.env-same-file ${TESTSDIR}/bud/env
   expect_output --substring ":unique.test.string:"
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -889,8 +946,10 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${from_target} -f ${TESTSDIR}/bud/env/Dockerfile.env-same-file ${TESTSDIR}/bud/env
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/env/Dockerfile.env-from-image ${TESTSDIR}/bud/env
   expect_output --substring "@unique.test.string@"
-  from_cid=$(buildah from ${from_target})
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${from_target}
+  from_cid=$output
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${from_cid} ${cid}
   buildah rmi -a -f
 }
@@ -898,7 +957,8 @@ load helpers
 @test "bud ENV preserves special characters after commit" {
   from_target=special-chars
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${from_target} -f ${TESTSDIR}/bud/env/Dockerfile.special-chars ${TESTSDIR}/bud/env
-  cid=$(buildah from ${from_target})
+  run_buildah from --quiet ${from_target}
+  cid=$output
   run_buildah run ${cid} env
   expect_output --substring "LIB=\\$\(PREFIX\)/lib"
   buildah rm ${cid}
@@ -909,7 +969,8 @@ load helpers
   target=url-image
   url=https://raw.githubusercontent.com/containers/buildah/master/tests/bud/from-scratch/Dockerfile
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${url}
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -924,7 +985,8 @@ load helpers
 @test "bud with -f flag, alternate Dockerfile name" {
   target=fileflag-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -933,7 +995,8 @@ load helpers
 @test "bud with --cache-from noop flag" {
   target=noop-image
   run_buildah bud --cache-from=invalidimage --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -941,7 +1004,8 @@ load helpers
 @test "bud with --compress noop flag" {
   target=noop-image
   run_buildah bud --compress --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -960,7 +1024,8 @@ load helpers
 @test "bud with --cpu-shares flag, valid argument" {
   target=bud-flag
   run_buildah bud --cpu-shares 2 --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile ${TESTSDIR}/bud/from-scratch
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -979,7 +1044,8 @@ load helpers
 @test "bud with --cpu-shares short flag (-c), valid argument" {
   target=bud-flag
   run_buildah bud -c 2 --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi ${target}
 }
@@ -989,8 +1055,10 @@ load helpers
   buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild1" "RUN touch /onbuild2"]'
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   run ls ${root}/onbuild1 ${root}/onbuild2
   echo "$output"
   [ "$status" -eq 0 ]
@@ -1001,8 +1069,10 @@ load helpers
   buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1 ${TESTSDIR}/bud/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild3"]'
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   run ls ${root}/onbuild1 ${root}/onbuild2 ${root}/onbuild3
   echo "$output"
   [ "$status" -eq 0 ]
@@ -1057,8 +1127,10 @@ load helpers
 @test "bud-from-stdin" {
   target=scratch-image
   cat ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch | buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f - ${TESTSDIR}/bud/from-multiple-files
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   run test -s $root/Dockerfile1
   echo "$output"
   [ "$status" -eq 0 ]
@@ -1133,7 +1205,8 @@ load helpers
   run_buildah images -a
   expect_output --substring "test1"
 
-  ctr=$(buildah from --signature-policy ${TESTSDIR}/policy.json test1)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test1
+  ctr=$output
   run_buildah containers -a
   expect_output --substring "test1"
 
@@ -1223,7 +1296,8 @@ load helpers
   run_buildah images -a
   expect_output --substring "test1"
 
-  ctr=$(buildah from --signature-policy ${TESTSDIR}/policy.json test1)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test1
+  ctr=$output
   run_buildah containers -a
   expect_output --substring "test1"
 
@@ -1236,7 +1310,8 @@ load helpers
   run_buildah images -a
   expect_output --substring "test1"
 
-  ctr=$(buildah from --signature-policy ${TESTSDIR}/policy.json test1)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test1
+  ctr=$output
   run_buildah containers -a
   expect_output --substring "test1"
 
@@ -1252,11 +1327,13 @@ load helpers
   run_buildah images -a
   expect_output --substring "test1"
 
-  ctr=$(buildah from --signature-policy ${TESTSDIR}/policy.json test1)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test1
+  ctr=$output
   run_buildah containers -a
   expect_output --substring "test1"
 
-  mnt=$(buildah mount $ctr)
+  run_buildah mount $ctr
+  mnt=$output
   run test -e $mnt/1
   [ "${status}" -eq 0 ]
   run test -e $mnt/2
@@ -1329,8 +1406,10 @@ load helpers
   target=php-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy-from ${TESTSDIR}/bud/copy-from
 
-  ctr=$(buildah from --signature-policy ${TESTSDIR}/policy.json ${target})
-  mnt=$(buildah mount ${ctr})
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  ctr=$output
+  run_buildah mount ${ctr}
+  mnt=$output
 
   test -e $mnt/usr/local/bin/composer
 }
@@ -1346,8 +1425,10 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --target mytarget ${TESTSDIR}/bud/target
   expect_output --substring "STEP 1: FROM ubuntu:latest"
   expect_output --substring "STEP 3: FROM alpine:latest AS mytarget"
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   run ls ${root}/2
   echo "$output"
   [ "$status" -eq 0 ]
@@ -1741,7 +1822,8 @@ load helpers
   target=scratch-image
   buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
   stophttpd
-  cid=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  cid=$output
   buildah rm ${cid}
   buildah rmi $(buildah images -q)
   run_buildah images -q
@@ -1752,8 +1834,10 @@ load helpers
   target=df-stdin
   cat ${TESTSDIR}/bud/context-from-stdin/Dockerfile | buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -
   [ "$?" -eq 0 ]
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   run test -s $root/etc/alpine-release
   echo "$output"
   buildah rm ${cid}
@@ -1766,8 +1850,10 @@ load helpers
   target=df-stdin
   tar -c -C ${TESTSDIR}/bud/context-from-stdin . | buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -
   [ "$?" -eq 0 ]
-  cid=$(buildah from ${target})
-  root=$(buildah mount ${cid})
+  run_buildah from --quiet ${target}
+  cid=$output
+  run_buildah mount ${cid}
+  root=$output
   run test -s $root/etc/alpine-release
   echo "$output"
   buildah rm ${cid}
@@ -1782,7 +1868,8 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg=abc.txt ${TESTSDIR}/bud/use-args
   echo "$output"
   expect_output --substring "COMMIT use-args"
-  ctrID=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  ctrID=$output
   run_buildah run $ctrID ls abc.txt
   echo "$output"
   expect_output --substring "abc.txt"
@@ -1790,7 +1877,8 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Containerfile.destination --build-arg=testArg=abc.txt --build-arg=destination=/tmp ${TESTSDIR}/bud/use-args
   echo "$output"
   expect_output --substring "COMMIT use-args"
-  ctrID=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  ctrID=$output
   run_buildah run $ctrID ls /tmp/abc.txt
   echo "$output"
   expect_output --substring "abc.txt"
@@ -1798,7 +1886,8 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Containerfile.dest_nobrace --build-arg=testArg=abc.txt --build-arg=destination=/tmp ${TESTSDIR}/bud/use-args
   echo "$output"
   expect_output --substring "COMMIT use-args"
-  ctrID=$(buildah from ${target})
+  run_buildah from --quiet ${target}
+  ctrID=$output
   run_buildah run $ctrID ls /tmp/abc.txt
   echo "$output"
   expect_output --substring "abc.txt"

--- a/tests/byid.bats
+++ b/tests/byid.bats
@@ -7,9 +7,8 @@ load helpers
 
   # Pull down the image, if we have to.
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
+  expect_output "$image-working-container"
   cid=$output
-  [ $? -eq 0 ]
-  [ $(wc -l <<< "$cid") -eq 1 ]
   run_buildah rm $cid
 
   # Get the image's ID.
@@ -37,9 +36,8 @@ load helpers
 
   # Pull down the image, if we have to.
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
+  expect_output "$image-working-container"
   cid=$output
-  [ $? -eq 0 ]
-  [ $(wc -l <<< "$cid") -eq 1 ]
   run_buildah rm $cid
 
   # Get the image's ID.
@@ -65,14 +63,12 @@ load helpers
 
     # Pull down the image, if we have to.
     run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
-    cid=$output
-    [ $? -eq 0 ]
-    [ $(wc -l <<< "$cid") -eq 1 ]
-    run_buildah rm $cid
+    expect_output "${image##*/}-working-container"  # image, w/o registry prefix
+    run_buildah rm $output
 
     # Get the image's ID.
-    run_buildah images -q $IMAGE
-    expect_line_count 1
+    run_buildah images -q $image
+    expect_output --substring '^[0-9a-f]{12,64}$'
     iid="$output"
 
     # Use the image's ID to push it.
@@ -91,14 +87,12 @@ load helpers
 
   # Pull down the image, if we have to.
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
-  cid=$output
-  [ $? -eq 0 ]
-  [ $(wc -l <<< "$cid") -eq 1 ]
-  run_buildah rm $cid
+  expect_output "$image-working-container"
+  run_buildah rm $output
 
   # Get the image's ID.
   run_buildah images -q $image
-  expect_line_count 1
+  expect_output --substring '^[0-9a-f]{12,64}$'
   iid="$output"
 
   # Use a truncated copy of the image's ID to remove it.

--- a/tests/byid.bats
+++ b/tests/byid.bats
@@ -6,7 +6,8 @@ load helpers
   image=busybox
 
   # Pull down the image, if we have to.
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
+  cid=$output
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
   buildah rm $cid
@@ -35,7 +36,8 @@ load helpers
   image=busybox
 
   # Pull down the image, if we have to.
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
+  cid=$output
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
   buildah rm $cid
@@ -62,7 +64,8 @@ load helpers
     mkdir -p $TARGET $TARGET-truncated
 
     # Pull down the image, if we have to.
-    cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
+    run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
+    cid=$output
     [ $? -eq 0 ]
     [ $(wc -l <<< "$cid") -eq 1 ]
     buildah rm $cid
@@ -87,7 +90,8 @@ load helpers
   image=busybox
 
   # Pull down the image, if we have to.
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
+  cid=$output
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
   buildah rm $cid

--- a/tests/byid.bats
+++ b/tests/byid.bats
@@ -10,7 +10,7 @@ load helpers
   cid=$output
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
-  buildah rm $cid
+  run_buildah rm $cid
 
   # Get the image's ID.
   run_buildah images -q $image
@@ -21,15 +21,15 @@ load helpers
   run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json ${iid}
   expect_line_count 1
   cid="$output"
-  buildah rm $cid
+  run_buildah rm $cid
 
   # Use a truncated form of the image's ID to create a container.
   run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json ${iid:0:6}
   expect_line_count 1
   cid="$output"
-  buildah rm $cid
+  run_buildah rm $cid
 
-  buildah rmi $iid
+  run_buildah rmi $iid
 }
 
 @test "inspect-by-id" {
@@ -40,7 +40,7 @@ load helpers
   cid=$output
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
-  buildah rm $cid
+  run_buildah rm $cid
 
   # Get the image's ID.
   run_buildah images -q $image
@@ -53,7 +53,7 @@ load helpers
   # Use a truncated copy of the image's ID to inspect it.
   run_buildah inspect --type=image ${iid:0:6}
 
-  buildah rmi $iid
+  run_buildah rmi $iid
 }
 
 @test "push-by-id" {
@@ -68,7 +68,7 @@ load helpers
     cid=$output
     [ $? -eq 0 ]
     [ $(wc -l <<< "$cid") -eq 1 ]
-    buildah rm $cid
+    run_buildah rm $cid
 
     # Get the image's ID.
     run_buildah images -q $IMAGE
@@ -82,7 +82,7 @@ load helpers
     run_buildah push --signature-policy ${TESTSDIR}/policy.json ${iid:0:6} dir:$TARGET-truncated
 
     # Use the image's complete ID to remove it.
-    buildah rmi $iid
+    run_buildah rmi $iid
   done
 }
 
@@ -94,7 +94,7 @@ load helpers
   cid=$output
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
-  buildah rm $cid
+  run_buildah rm $cid
 
   # Get the image's ID.
   run_buildah images -q $image

--- a/tests/byid.bats
+++ b/tests/byid.bats
@@ -6,24 +6,24 @@ load helpers
   image=busybox
 
   # Pull down the image, if we have to.
-  cid=$(buildah --log-level=error from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
   buildah rm $cid
 
   # Get the image's ID.
-  run_buildah --log-level=error images -q $image
+  run_buildah images -q $image
   expect_line_count 1
   iid="$output"
 
   # Use the image's ID to create a container.
-  run_buildah --log-level=error from --pull=false --signature-policy ${TESTSDIR}/policy.json ${iid}
+  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json ${iid}
   expect_line_count 1
   cid="$output"
   buildah rm $cid
 
   # Use a truncated form of the image's ID to create a container.
-  run_buildah --log-level=error from --pull=false --signature-policy ${TESTSDIR}/policy.json ${iid:0:6}
+  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json ${iid:0:6}
   expect_line_count 1
   cid="$output"
   buildah rm $cid
@@ -35,21 +35,21 @@ load helpers
   image=busybox
 
   # Pull down the image, if we have to.
-  cid=$(buildah --log-level=error from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
   buildah rm $cid
 
   # Get the image's ID.
-  run_buildah --log-level=error images -q $image
+  run_buildah images -q $image
   expect_line_count 1
   iid="$output"
 
   # Use the image's ID to inspect it.
-  run_buildah --log-level=error inspect --type=image ${iid}
+  run_buildah inspect --type=image ${iid}
 
   # Use a truncated copy of the image's ID to inspect it.
-  run_buildah --log-level=error inspect --type=image ${iid:0:6}
+  run_buildah inspect --type=image ${iid:0:6}
 
   buildah rmi $iid
 }
@@ -62,13 +62,13 @@ load helpers
     mkdir -p $TARGET $TARGET-truncated
 
     # Pull down the image, if we have to.
-    cid=$(buildah --log-level=error from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
+    cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
     [ $? -eq 0 ]
     [ $(wc -l <<< "$cid") -eq 1 ]
     buildah rm $cid
 
     # Get the image's ID.
-    run_buildah --log-level=error images -q $IMAGE
+    run_buildah images -q $IMAGE
     expect_line_count 1
     iid="$output"
 
@@ -87,16 +87,16 @@ load helpers
   image=busybox
 
   # Pull down the image, if we have to.
-  cid=$(buildah --log-level=error from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
+  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $image)
   [ $? -eq 0 ]
   [ $(wc -l <<< "$cid") -eq 1 ]
   buildah rm $cid
 
   # Get the image's ID.
-  run_buildah --log-level=error images -q $image
+  run_buildah images -q $image
   expect_line_count 1
   iid="$output"
 
   # Use a truncated copy of the image's ID to remove it.
-  run_buildah --log-level=error rmi ${iid:0:6}
+  run_buildah rmi ${iid:0:6}
 }

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -19,22 +19,22 @@ load helpers
 @test "commit" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
   run_buildah images alpine-image
-  buildah rm $cid
-  buildah rmi -a
+  run_buildah rm $cid
+  run_buildah rmi -a
 }
 
 @test "commit format test" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-oci
-  buildah commit --format docker --disable-compression=false --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-docker
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-oci
+  run_buildah commit --format docker --disable-compression=false --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-docker
 
-  buildah inspect --type=image --format '{{.Manifest}}' alpine-image-oci | grep "application/vnd.oci.image.layer.v1.tar"
-  buildah inspect --type=image --format '{{.Manifest}}' alpine-image-docker | grep "application/vnd.docker.image.rootfs.diff.tar.gzip"
-  buildah rm $cid
-  buildah rmi -a
+  run_buildah inspect --type=image --format '{{.Manifest}}' alpine-image-oci | grep "application/vnd.oci.image.layer.v1.tar"
+  run_buildah inspect --type=image --format '{{.Manifest}}' alpine-image-docker | grep "application/vnd.docker.image.rootfs.diff.tar.gzip"
+  run_buildah rm $cid
+  run_buildah rmi -a
 }
 
 @test "commit quiet test" {
@@ -42,17 +42,17 @@ load helpers
   cid=$output
   run_buildah commit --iidfile /dev/null --signature-policy ${TESTSDIR}/policy.json -q $cid alpine-image
   expect_output ""
-  buildah rm $cid
-  buildah rmi -a
+  run_buildah rm $cid
+  run_buildah rmi -a
 }
 
 @test "commit rm test" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  buildah commit --signature-policy ${TESTSDIR}/policy.json --rm $cid alpine-image
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --rm $cid alpine-image
   run_buildah 1 rm $cid
   expect_output --substring "error removing container \"alpine-working-container\": error reading build container: container not known"
-  buildah rmi -a
+  run_buildah rmi -a
 }
 
 @test "commit-alternate-storage" {
@@ -60,9 +60,9 @@ load helpers
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json openshift/hello-openshift
   cid=$output
   echo COMMIT
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid "containers-storage:[vfs@${TESTDIR}/root2+${TESTDIR}/runroot2]newimage"
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid "containers-storage:[vfs@${TESTDIR}/root2+${TESTDIR}/runroot2]newimage"
   echo FROM
-  buildah --storage-driver vfs --root ${TESTDIR}/root2 --runroot ${TESTDIR}/runroot2 from --signature-policy ${TESTSDIR}/policy.json newimage
+  run_buildah --storage-driver vfs --root ${TESTDIR}/root2 --runroot ${TESTDIR}/runroot2 from --signature-policy ${TESTSDIR}/policy.json newimage
 }
 
 @test "commit-rejected-name" {
@@ -109,14 +109,14 @@ load helpers
   run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah 1 commit --authfile /tmp/nonexist --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
-  buildah rm $cid
-  buildah rmi -a
+  run_buildah rm $cid
+  run_buildah rmi -a
 }
 
 @test "commit-builder-identity" {
 	run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
-	buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
+	run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
 
 	run_buildah --version | awk '{ print $3 }'
 	buildah_version=$output
@@ -124,8 +124,8 @@ load helpers
 	version=$output
 
 	[ "$version" == "$buildah_version" ]
-	buildah rm $cid
-	buildah rmi -f alpine-image
+	run_buildah rm $cid
+	run_buildah rmi -f alpine-image
 }
 
 @test "commit-parent-id" {
@@ -134,7 +134,7 @@ load helpers
   run_buildah inspect --format '{{.FromImageID}}' $cid
   iid=$output
   echo image ID: "$iid"
-  buildah commit --signature-policy ${TESTSDIR}/policy.json --format docker $cid alpine-image
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --format docker $cid alpine-image
   run_buildah inspect --format '{{.Docker.Parent}}' alpine-image
   parentid=$output
   echo parent ID: "$parentid"
@@ -147,7 +147,7 @@ load helpers
   run_buildah containers --format '{{.ContainerID}}:{{.ContainerName}}' | grep :"$cid"'$' | cut -f1 -d:
   cid=$output
   echo container ID: "$cid"
-  buildah commit --signature-policy ${TESTSDIR}/policy.json --format docker $cid alpine-image
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --format docker $cid alpine-image
   run_buildah inspect --format '{{.Docker.Container}}' alpine-image
   containerid=$output
   echo recorded container ID: "$containerid"
@@ -169,13 +169,13 @@ load helpers
   run_buildah inspect --format '{{.FromImage}}' $cname
   expect_output "localhost/$newname:latest"
 
-  buildah rm busyboxc $cname
-  buildah rmi $newname
+  run_buildah rm busyboxc $cname
+  run_buildah rmi $newname
 }
 
 @test "commit to docker-distribution" {
-  buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc busybox
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc busybox
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword busyboxc docker://localhost:5000/commit/busybox
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --name fromdocker --tls-verify=false --creds testuser:testpassword docker://localhost:5000/commit/busybox
-  buildah rm busyboxc fromdocker
+  run_buildah rm busyboxc fromdocker
 }

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -29,15 +29,15 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-oci
   buildah commit --format docker --disable-compression=false --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-docker
 
-  buildah --log-level=error inspect --type=image --format '{{.Manifest}}' alpine-image-oci | grep "application/vnd.oci.image.layer.v1.tar"
-  buildah --log-level=error inspect --type=image --format '{{.Manifest}}' alpine-image-docker | grep "application/vnd.docker.image.rootfs.diff.tar.gzip"
+  buildah inspect --type=image --format '{{.Manifest}}' alpine-image-oci | grep "application/vnd.oci.image.layer.v1.tar"
+  buildah inspect --type=image --format '{{.Manifest}}' alpine-image-docker | grep "application/vnd.docker.image.rootfs.diff.tar.gzip"
   buildah rm $cid
   buildah rmi -a
 }
 
 @test "commit quiet test" {
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --log-level=error commit --iidfile /dev/null --signature-policy ${TESTSDIR}/policy.json -q $cid alpine-image
+  run_buildah commit --iidfile /dev/null --signature-policy ${TESTSDIR}/policy.json -q $cid alpine-image
   expect_output ""
   buildah rm $cid
   buildah rmi -a
@@ -46,7 +46,7 @@ load helpers
 @test "commit rm test" {
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah commit --signature-policy ${TESTSDIR}/policy.json --rm $cid alpine-image
-  run_buildah 1 --log-level=error rm $cid
+  run_buildah 1 rm $cid
   expect_output --substring "error removing container \"alpine-working-container\": error reading build container: container not known"
   buildah rmi -a
 }
@@ -62,7 +62,7 @@ load helpers
 
 @test "commit-rejected-name" {
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah 1 --log-level=error commit --signature-policy ${TESTSDIR}/policy.json $cid ThisNameShouldBeRejected
+  run_buildah 1 commit --signature-policy ${TESTSDIR}/policy.json $cid ThisNameShouldBeRejected
   expect_output --substring "must be lower"
 }
 
@@ -73,18 +73,18 @@ load helpers
   target=new-image
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 
-  run_buildah --log-level=error config --created-by "untracked actions" $cid
-  run_buildah --log-level=error commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
-  run_buildah --log-level=error inspect --format '{{.Config}}' ${target}
+  run_buildah config --created-by "untracked actions" $cid
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
+  run_buildah inspect --format '{{.Config}}' ${target}
   config="$output"
   run python3 -c 'import json, sys; config = json.load(sys.stdin); print(config["history"][len(config["history"])-1]["created_by"])' <<< "$config"
   echo "$output"
   [ "${status}" -eq 0 ]
   [ "$output" == "untracked actions" ]
 
-  run_buildah --log-level=error config --created-by "" $cid
-  run_buildah --log-level=error commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
-  run_buildah --log-level=error inspect --format '{{.Config}}' ${target}
+  run_buildah config --created-by "" $cid
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
+  run_buildah inspect --format '{{.Config}}' ${target}
   config="$output"
   run python3 -c 'import json, sys; config = json.load(sys.stdin); print(config["history"][len(config["history"])-1]["created_by"])' <<< "$config"
   echo "$output"

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -37,9 +37,6 @@ function check_matrix() {
   run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
 
   check_matrix "Config.Entrypoint" '[/ENTRYPOINT]'
-
-  run_buildah rm $cid
-  run_buildah rmi scratch-image-{docker,oci}
 }
 
 @test "config entrypoint using multiple elements in JSON array (exec form)" {
@@ -50,9 +47,6 @@ function check_matrix() {
   run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
 
   check_matrix 'Config.Entrypoint' '[/ENTRYPOINT ELEMENT2]'
-
-  run_buildah rm $cid
-  run_buildah rmi scratch-image-{docker,oci}
 }
 
 @test "config entrypoint using string (shell form)" {
@@ -63,9 +57,6 @@ function check_matrix() {
   run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
 
   check_matrix 'Config.Entrypoint' '[/bin/sh -c /ENTRYPOINT]'
-
-  run_buildah rm $cid
-  run_buildah rmi scratch-image-{docker,oci}
 }
 
 @test "config set empty entrypoint doesn't wipe cmd" {
@@ -77,9 +68,6 @@ function check_matrix() {
   run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
 
   check_matrix 'Config.Cmd' '[command]'
-
-  run_buildah rm $cid
-  run_buildah rmi scratch-image-{docker,oci}
 }
 
 @test "config entrypoint with cmd" {
@@ -195,9 +183,6 @@ function check_matrix() {
 
   run_buildah inspect --type=image --format '{{.OCIv1.Config.Env}}' env-image-docker
   expect_output --substring "combined=bar/bar1"
-
-  run_buildah rm $cid
-  run_buildah rmi env-image-docker env-image-oci
 }
 
 @test "user" {
@@ -214,8 +199,6 @@ function check_matrix() {
 
   run_buildah run $cid grep CapBnd /proc/self/status
   expect_output "$bndoutput"
-
-  run_buildah rm $cid
 }
 
 @test "remove configs using '-' syntax" {
@@ -271,7 +254,4 @@ function check_matrix() {
   run_buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
 
   check_matrix 'Config.Volumes'      "map[/VOLUME-:{}]"
-
-  run_buildah rm $cid
-
 }

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -23,7 +23,7 @@ function check_matrix() {
   # matrix test: all permutations of .Docker.* and .OCIv1.* in all image types
   for image in docker oci; do
       for which in Docker OCIv1; do
-        run_buildah --log-level=error inspect --type=image --format "{{.$which.$setting}}" scratch-image-$image
+        run_buildah inspect --type=image --format "{{.$which.$setting}}" scratch-image-$image
         expect_output "$expect"
     done
   done
@@ -143,7 +143,7 @@ function check_matrix() {
   check_matrix 'Architecture' 'SOMEARCH'
   check_matrix 'OS'           'SOMEOS'
 
-  buildah --log-level=error inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+  buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
 
   check_matrix 'Config.Cmd'          '[COMMAND-OR-ARGS]'
   check_matrix 'Config.Entrypoint'   '[/bin/sh -c /ENTRYPOINT]'
@@ -156,23 +156,23 @@ function check_matrix() {
   check_matrix 'Config.Volumes'      "map[/VOLUME:{}]"
   check_matrix 'Config.WorkingDir'   '/tmp'
 
-  buildah --log-level=error inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-docker | grep PROBABLY-EMPTY
-  buildah --log-level=error inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-docker | grep PROBABLY-EMPTY
-  buildah --log-level=error inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-oci | grep PROBABLY-EMPTY
-  buildah --log-level=error inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-oci | grep PROBABLY-EMPTY
+  buildah inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-docker | grep PROBABLY-EMPTY
+  buildah inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-docker | grep PROBABLY-EMPTY
+  buildah inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-oci | grep PROBABLY-EMPTY
+  buildah inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-oci | grep PROBABLY-EMPTY
 
   # The following aren't part of the Docker v2 spec, so they're discarded when we save to Docker format.
-  buildah --log-level=error inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep ANNOTATION:VALUE1,VALUE2
-  buildah --log-level=error inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep ANNOTATION:VALUE1,VALUE2
-  buildah --log-level=error inspect --type=image --format '{{.Docker.Comment}}'                        scratch-image-docker | grep INFORMATIVE
-  buildah --log-level=error inspect --type=image --format '{{.Docker.Config.Domainname}}'              scratch-image-docker | grep mydomain.local
-  buildah --log-level=error inspect --type=image --format '{{.Docker.Config.Hostname}}'                scratch-image-docker | grep cleverhostname
-  buildah --log-level=error inspect --type=image --format '{{.Docker.Config.Shell}}'                   scratch-image-docker | grep /bin/arbitrarysh
-  buildah --log-level=error inspect               -f      '{{.Docker.Config.Healthcheck.Test}}'        scratch-image-docker | grep true
-  buildah --log-level=error inspect               -f      '{{.Docker.Config.Healthcheck.StartPeriod}}' scratch-image-docker | grep 5
-  buildah --log-level=error inspect               -f      '{{.Docker.Config.Healthcheck.Interval}}'    scratch-image-docker | grep 6
-  buildah --log-level=error inspect               -f      '{{.Docker.Config.Healthcheck.Timeout}}'     scratch-image-docker | grep 7
-  buildah --log-level=error inspect               -f      '{{.Docker.Config.Healthcheck.Retries}}'     scratch-image-docker | grep 8
+  buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep ANNOTATION:VALUE1,VALUE2
+  buildah inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep ANNOTATION:VALUE1,VALUE2
+  buildah inspect --type=image --format '{{.Docker.Comment}}'                        scratch-image-docker | grep INFORMATIVE
+  buildah inspect --type=image --format '{{.Docker.Config.Domainname}}'              scratch-image-docker | grep mydomain.local
+  buildah inspect --type=image --format '{{.Docker.Config.Hostname}}'                scratch-image-docker | grep cleverhostname
+  buildah inspect --type=image --format '{{.Docker.Config.Shell}}'                   scratch-image-docker | grep /bin/arbitrarysh
+  buildah inspect               -f      '{{.Docker.Config.Healthcheck.Test}}'        scratch-image-docker | grep true
+  buildah inspect               -f      '{{.Docker.Config.Healthcheck.StartPeriod}}' scratch-image-docker | grep 5
+  buildah inspect               -f      '{{.Docker.Config.Healthcheck.Interval}}'    scratch-image-docker | grep 6
+  buildah inspect               -f      '{{.Docker.Config.Healthcheck.Timeout}}'     scratch-image-docker | grep 7
+  buildah inspect               -f      '{{.Docker.Config.Healthcheck.Retries}}'     scratch-image-docker | grep 8
   rm -rf /VOLUME
 }
 
@@ -183,10 +183,10 @@ function check_matrix() {
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid env-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid env-image-oci
 
-  run_buildah --log-level=error inspect --type=image --format '{{.Docker.Config.Env}}' env-image-docker
+  run_buildah inspect --type=image --format '{{.Docker.Config.Env}}' env-image-docker
   expect_output --substring "combined=bar/bar1"
 
-  run_buildah --log-level=error inspect --type=image --format '{{.OCIv1.Config.Env}}' env-image-docker
+  run_buildah inspect --type=image --format '{{.OCIv1.Config.Env}}' env-image-docker
   expect_output --substring "combined=bar/bar1"
 
   buildah rm $cid
@@ -195,15 +195,15 @@ function check_matrix() {
 
 @test "user" {
   cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  bndoutput=$(buildah --log-level=error run $cid grep CapBnd /proc/self/status)
+  bndoutput=$(buildah run $cid grep CapBnd /proc/self/status)
   buildah config --user 1000 $cid
-  run_buildah --log-level=error run $cid id -u
+  run_buildah run $cid id -u
   expect_output "1000"
 
-  run_buildah --log-level=error run $cid sh -c "grep CapEff /proc/self/status | cut -f2"
+  run_buildah run $cid sh -c "grep CapEff /proc/self/status | cut -f2"
   expect_output "0000000000000000"
 
-  run_buildah --log-level=error run $cid grep CapBnd /proc/self/status
+  run_buildah run $cid grep CapBnd /proc/self/status
   expect_output "$bndoutput"
 
   buildah rm $cid
@@ -221,13 +221,13 @@ function check_matrix() {
 
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
-  buildah --log-level=error inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+  buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
 
   check_matrix 'Config.Volumes'      "map[/VOLUME:{}]"
   check_matrix 'Config.Env'          '[VARIABLE=VALUE1,VALUE2]'
   check_matrix 'Config.Labels.LABEL' 'VALUE'
-  buildah --log-level=error inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep ANNOTATION:VALUE1,VALUE2
-  buildah --log-level=error inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep ANNOTATION:VALUE1,VALUE2
+  buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep ANNOTATION:VALUE1,VALUE2
+  buildah inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep ANNOTATION:VALUE1,VALUE2
 
   buildah config \
    --created-by COINCIDENCE \
@@ -239,12 +239,12 @@ function check_matrix() {
 
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
-  buildah --log-level=error inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+  buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
   check_matrix 'Config.Volumes'      'map[]'
   check_matrix 'Config.Env'          '[]'
   check_matrix 'Config.Labels.LABEL' '<no value>'
-  buildah --log-level=error inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep "map\[\]"
-  buildah --log-level=error inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep "map\[\]"
+  buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep "map\[\]"
+  buildah inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep "map\[\]"
 
 
 
@@ -258,7 +258,7 @@ function check_matrix() {
 
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
-  buildah --log-level=error inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+  buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
 
   check_matrix 'Config.Volumes'      "map[/VOLUME-:{}]"
 

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -30,7 +30,8 @@ function check_matrix() {
 }
 
 @test "config entrypoint using single element in JSON array (exec form)" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
@@ -42,7 +43,8 @@ function check_matrix() {
 }
 
 @test "config entrypoint using multiple elements in JSON array (exec form)" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah config --entrypoint '[ "/ENTRYPOINT", "ELEMENT2" ]' $cid
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
@@ -54,7 +56,8 @@ function check_matrix() {
 }
 
 @test "config entrypoint using string (shell form)" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah config --entrypoint /ENTRYPOINT $cid
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
@@ -66,7 +69,8 @@ function check_matrix() {
 }
 
 @test "config set empty entrypoint doesn't wipe cmd" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah config --cmd "command" $cid
   buildah config --entrypoint "" $cid
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
@@ -79,7 +83,8 @@ function check_matrix() {
 }
 
 @test "config entrypoint with cmd" {
-  cid=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah config \
    --entrypoint /ENTRYPOINT \
    --cmd COMMAND-OR-ARGS \
@@ -107,7 +112,8 @@ function check_matrix() {
 }
 
 @test "config" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah config \
    --author TESTAUTHOR \
    --created-by COINCIDENCE \
@@ -177,7 +183,8 @@ function check_matrix() {
 }
 
 @test "config env using --env expansion" {
-  cid=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah config --env 'foo=bar' --env 'foo1=bar1' $cid
   buildah config --env 'combined=$foo/${foo1}' $cid
   buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid env-image-docker
@@ -194,8 +201,10 @@ function check_matrix() {
 }
 
 @test "user" {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  bndoutput=$(buildah run $cid grep CapBnd /proc/self/status)
+  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
+  run_buildah run $cid grep CapBnd /proc/self/status
+  bndoutput=$output
   buildah config --user 1000 $cid
   run_buildah run $cid id -u
   expect_output "1000"
@@ -210,7 +219,8 @@ function check_matrix() {
 }
 
 @test "remove configs using '-' syntax" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah config \
    --created-by COINCIDENCE \
    --volume /VOLUME \

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -32,89 +32,89 @@ function check_matrix() {
 @test "config entrypoint using single element in JSON array (exec form)" {
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
 
   check_matrix "Config.Entrypoint" '[/ENTRYPOINT]'
 
-  buildah rm $cid
-  buildah rmi scratch-image-{docker,oci}
+  run_buildah rm $cid
+  run_buildah rmi scratch-image-{docker,oci}
 }
 
 @test "config entrypoint using multiple elements in JSON array (exec form)" {
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah config --entrypoint '[ "/ENTRYPOINT", "ELEMENT2" ]' $cid
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah config --entrypoint '[ "/ENTRYPOINT", "ELEMENT2" ]' $cid
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
 
   check_matrix 'Config.Entrypoint' '[/ENTRYPOINT ELEMENT2]'
 
-  buildah rm $cid
-  buildah rmi scratch-image-{docker,oci}
+  run_buildah rm $cid
+  run_buildah rmi scratch-image-{docker,oci}
 }
 
 @test "config entrypoint using string (shell form)" {
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah config --entrypoint /ENTRYPOINT $cid
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah config --entrypoint /ENTRYPOINT $cid
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
 
   check_matrix 'Config.Entrypoint' '[/bin/sh -c /ENTRYPOINT]'
 
-  buildah rm $cid
-  buildah rmi scratch-image-{docker,oci}
+  run_buildah rm $cid
+  run_buildah rmi scratch-image-{docker,oci}
 }
 
 @test "config set empty entrypoint doesn't wipe cmd" {
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah config --cmd "command" $cid
-  buildah config --entrypoint "" $cid
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah config --cmd "command" $cid
+  run_buildah config --entrypoint "" $cid
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
 
   check_matrix 'Config.Cmd' '[command]'
 
-  buildah rm $cid
-  buildah rmi scratch-image-{docker,oci}
+  run_buildah rm $cid
+  run_buildah rmi scratch-image-{docker,oci}
 }
 
 @test "config entrypoint with cmd" {
   run_buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah config \
+  run_buildah config \
    --entrypoint /ENTRYPOINT \
    --cmd COMMAND-OR-ARGS \
   $cid
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
 
   check_matrix 'Config.Cmd' '[COMMAND-OR-ARGS]'
 
-  buildah config \
+  run_buildah config \
    --entrypoint /ENTRYPOINT \
   $cid
 
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
 
-  buildah config \
+  run_buildah config \
    --entrypoint /ENTRYPOINT \
    --cmd COMMAND-OR-ARGS \
   $cid
 
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
   check_matrix 'Config.Cmd' '[COMMAND-OR-ARGS]'
 }
 
 @test "config" {
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah config \
+  run_buildah config \
    --author TESTAUTHOR \
    --created-by COINCIDENCE \
    --arch SOMEARCH \
@@ -142,14 +142,14 @@ function check_matrix() {
    --healthcheck-retries 8 \
   $cid
 
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
 
   check_matrix 'Author'       'TESTAUTHOR'
   check_matrix 'Architecture' 'SOMEARCH'
   check_matrix 'OS'           'SOMEOS'
 
-  buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+  run_buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
 
   check_matrix 'Config.Cmd'          '[COMMAND-OR-ARGS]'
   check_matrix 'Config.Entrypoint'   '[/bin/sh -c /ENTRYPOINT]'
@@ -162,33 +162,33 @@ function check_matrix() {
   check_matrix 'Config.Volumes'      "map[/VOLUME:{}]"
   check_matrix 'Config.WorkingDir'   '/tmp'
 
-  buildah inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-docker | grep PROBABLY-EMPTY
-  buildah inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-docker | grep PROBABLY-EMPTY
-  buildah inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-oci | grep PROBABLY-EMPTY
-  buildah inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-oci | grep PROBABLY-EMPTY
+  run_buildah inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-docker | grep PROBABLY-EMPTY
+  run_buildah inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-docker | grep PROBABLY-EMPTY
+  run_buildah inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-oci | grep PROBABLY-EMPTY
+  run_buildah inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-oci | grep PROBABLY-EMPTY
 
   # The following aren't part of the Docker v2 spec, so they're discarded when we save to Docker format.
-  buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep ANNOTATION:VALUE1,VALUE2
-  buildah inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep ANNOTATION:VALUE1,VALUE2
-  buildah inspect --type=image --format '{{.Docker.Comment}}'                        scratch-image-docker | grep INFORMATIVE
-  buildah inspect --type=image --format '{{.Docker.Config.Domainname}}'              scratch-image-docker | grep mydomain.local
-  buildah inspect --type=image --format '{{.Docker.Config.Hostname}}'                scratch-image-docker | grep cleverhostname
-  buildah inspect --type=image --format '{{.Docker.Config.Shell}}'                   scratch-image-docker | grep /bin/arbitrarysh
-  buildah inspect               -f      '{{.Docker.Config.Healthcheck.Test}}'        scratch-image-docker | grep true
-  buildah inspect               -f      '{{.Docker.Config.Healthcheck.StartPeriod}}' scratch-image-docker | grep 5
-  buildah inspect               -f      '{{.Docker.Config.Healthcheck.Interval}}'    scratch-image-docker | grep 6
-  buildah inspect               -f      '{{.Docker.Config.Healthcheck.Timeout}}'     scratch-image-docker | grep 7
-  buildah inspect               -f      '{{.Docker.Config.Healthcheck.Retries}}'     scratch-image-docker | grep 8
+  run_buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep ANNOTATION:VALUE1,VALUE2
+  run_buildah inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep ANNOTATION:VALUE1,VALUE2
+  run_buildah inspect --type=image --format '{{.Docker.Comment}}'                        scratch-image-docker | grep INFORMATIVE
+  run_buildah inspect --type=image --format '{{.Docker.Config.Domainname}}'              scratch-image-docker | grep mydomain.local
+  run_buildah inspect --type=image --format '{{.Docker.Config.Hostname}}'                scratch-image-docker | grep cleverhostname
+  run_buildah inspect --type=image --format '{{.Docker.Config.Shell}}'                   scratch-image-docker | grep /bin/arbitrarysh
+  run_buildah inspect               -f      '{{.Docker.Config.Healthcheck.Test}}'        scratch-image-docker | grep true
+  run_buildah inspect               -f      '{{.Docker.Config.Healthcheck.StartPeriod}}' scratch-image-docker | grep 5
+  run_buildah inspect               -f      '{{.Docker.Config.Healthcheck.Interval}}'    scratch-image-docker | grep 6
+  run_buildah inspect               -f      '{{.Docker.Config.Healthcheck.Timeout}}'     scratch-image-docker | grep 7
+  run_buildah inspect               -f      '{{.Docker.Config.Healthcheck.Retries}}'     scratch-image-docker | grep 8
   rm -rf /VOLUME
 }
 
 @test "config env using --env expansion" {
   run_buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah config --env 'foo=bar' --env 'foo1=bar1' $cid
-  buildah config --env 'combined=$foo/${foo1}' $cid
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid env-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid env-image-oci
+  run_buildah config --env 'foo=bar' --env 'foo1=bar1' $cid
+  run_buildah config --env 'combined=$foo/${foo1}' $cid
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid env-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid env-image-oci
 
   run_buildah inspect --type=image --format '{{.Docker.Config.Env}}' env-image-docker
   expect_output --substring "combined=bar/bar1"
@@ -196,8 +196,8 @@ function check_matrix() {
   run_buildah inspect --type=image --format '{{.OCIv1.Config.Env}}' env-image-docker
   expect_output --substring "combined=bar/bar1"
 
-  buildah rm $cid
-  buildah rmi env-image-docker env-image-oci
+  run_buildah rm $cid
+  run_buildah rmi env-image-docker env-image-oci
 }
 
 @test "user" {
@@ -205,7 +205,7 @@ function check_matrix() {
   cid=$output
   run_buildah run $cid grep CapBnd /proc/self/status
   bndoutput=$output
-  buildah config --user 1000 $cid
+  run_buildah config --user 1000 $cid
   run_buildah run $cid id -u
   expect_output "1000"
 
@@ -215,13 +215,13 @@ function check_matrix() {
   run_buildah run $cid grep CapBnd /proc/self/status
   expect_output "$bndoutput"
 
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "remove configs using '-' syntax" {
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah config \
+  run_buildah config \
    --created-by COINCIDENCE \
    --volume /VOLUME \
    --env VARIABLE=VALUE1,VALUE2 \
@@ -229,17 +229,17 @@ function check_matrix() {
    --annotation ANNOTATION=VALUE1,VALUE2 \
   $cid
 
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
-  buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
 
   check_matrix 'Config.Volumes'      "map[/VOLUME:{}]"
   check_matrix 'Config.Env'          '[VARIABLE=VALUE1,VALUE2]'
   check_matrix 'Config.Labels.LABEL' 'VALUE'
-  buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep ANNOTATION:VALUE1,VALUE2
-  buildah inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep ANNOTATION:VALUE1,VALUE2
+  run_buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep ANNOTATION:VALUE1,VALUE2
+  run_buildah inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep ANNOTATION:VALUE1,VALUE2
 
-  buildah config \
+  run_buildah config \
    --created-by COINCIDENCE \
    --volume /VOLUME- \
    --env VARIABLE- \
@@ -247,18 +247,18 @@ function check_matrix() {
    --annotation ANNOTATION- \
   $cid
 
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
-  buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
   check_matrix 'Config.Volumes'      'map[]'
   check_matrix 'Config.Env'          '[]'
   check_matrix 'Config.Labels.LABEL' '<no value>'
-  buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep "map\[\]"
-  buildah inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep "map\[\]"
+  run_buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci    | grep "map\[\]"
+  run_buildah inspect              --format '{{.ImageAnnotations}}'                      $cid                 | grep "map\[\]"
 
 
 
-  buildah config \
+  run_buildah config \
    --created-by COINCIDENCE \
    --volume /VOLUME- \
    --env VARIABLE=VALUE1,VALUE2 \
@@ -266,12 +266,12 @@ function check_matrix() {
    --annotation ANNOTATION=VALUE1,VALUE2 \
   $cid
 
-  buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
-  buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
+  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
+  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah inspect --format '{{.ImageCreatedBy}}' $cid | grep COINCIDENCE
 
   check_matrix 'Config.Volumes'      "map[/VOLUME-:{}]"
 
-  buildah rm $cid
+  run_buildah rm $cid
 
 }

--- a/tests/containers.bats
+++ b/tests/containers.bats
@@ -3,8 +3,10 @@
 load helpers
 
 @test "containers" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah containers
   expect_line_count 3
 
@@ -13,8 +15,10 @@ load helpers
 }
 
 @test "containers filter test" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah containers --filter name=$cid1
   expect_line_count 2
 
@@ -23,8 +27,10 @@ load helpers
 }
 
 @test "containers format test" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah containers --format "{{.ContainerName}}"
   expect_line_count 2
   expect_output --from="${lines[0]}" "alpine-working-container"
@@ -35,16 +41,20 @@ load helpers
 }
 
 @test "containers json test" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  out=$(buildah containers --json | grep "{" | wc -l)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah containers --json | grep "{" | wc -l
+  out=$output
   [ "$out" -ne "0" ]
   buildah rm -a
   buildah rmi -a -f
 }
 
 @test "containers noheading test" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah containers --noheading
   expect_line_count 2
   if [[ $output =~ "NAME" ]]; then
@@ -56,8 +66,10 @@ load helpers
 }
 
 @test "containers quiet test" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah containers --quiet
   expect_line_count 2
 

--- a/tests/containers.bats
+++ b/tests/containers.bats
@@ -5,7 +5,7 @@ load helpers
 @test "containers" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error containers
+  run_buildah containers
   expect_line_count 3
 
   buildah rm -a
@@ -15,7 +15,7 @@ load helpers
 @test "containers filter test" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error containers --filter name=$cid1
+  run_buildah containers --filter name=$cid1
   expect_line_count 2
 
   buildah rm -a
@@ -25,7 +25,7 @@ load helpers
 @test "containers format test" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error containers --format "{{.ContainerName}}"
+  run_buildah containers --format "{{.ContainerName}}"
   expect_line_count 2
   expect_output --from="${lines[0]}" "alpine-working-container"
   expect_output --from="${lines[1]}" "busybox-working-container"
@@ -36,7 +36,7 @@ load helpers
 
 @test "containers json test" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  out=$(buildah --log-level=error containers --json | grep "{" | wc -l)
+  out=$(buildah containers --json | grep "{" | wc -l)
   [ "$out" -ne "0" ]
   buildah rm -a
   buildah rmi -a -f
@@ -45,7 +45,7 @@ load helpers
 @test "containers noheading test" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error containers --noheading
+  run_buildah containers --noheading
   expect_line_count 2
   if [[ $output =~ "NAME" ]]; then
       expect_output "[no instance of 'NAME']" "'NAME' header should be absent"
@@ -58,7 +58,7 @@ load helpers
 @test "containers quiet test" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error containers --quiet
+  run_buildah containers --quiet
   expect_line_count 2
 
   # Both lines should be CIDs and nothing else.

--- a/tests/containers.bats
+++ b/tests/containers.bats
@@ -4,14 +4,9 @@ load helpers
 
 @test "containers" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
-  cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
-  cid2=$output
   run_buildah containers
   expect_line_count 3
-
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "containers filter test" {
@@ -21,62 +16,40 @@ load helpers
   cid2=$output
   run_buildah containers --filter name=$cid1
   expect_line_count 2
-
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "containers format test" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
-  cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
-  cid2=$output
   run_buildah containers --format "{{.ContainerName}}"
   expect_line_count 2
   expect_output --from="${lines[0]}" "alpine-working-container"
   expect_output --from="${lines[1]}" "busybox-working-container"
-
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "containers json test" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
-  cid1=$output
-  run_buildah containers --json | grep "{" | wc -l
-  out=$output
-  [ "$out" -ne "0" ]
-  run_buildah rm -a
-  run_buildah rmi -a -f
+  run_buildah containers --json
+  expect_output --substring '\{'
 }
 
 @test "containers noheading test" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
-  cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
-  cid2=$output
   run_buildah containers --noheading
   expect_line_count 2
   if [[ $output =~ "NAME" ]]; then
       expect_output "[no instance of 'NAME']" "'NAME' header should be absent"
   fi
-
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "containers quiet test" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
-  cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
-  cid2=$output
   run_buildah containers --quiet
   expect_line_count 2
 
   # Both lines should be CIDs and nothing else.
   expect_output --substring --from="${lines[0]}" '^[0-9a-f]{64}$'
   expect_output --substring --from="${lines[1]}" '^[0-9a-f]{64}$'
-
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }

--- a/tests/containers.bats
+++ b/tests/containers.bats
@@ -10,8 +10,8 @@ load helpers
   run_buildah containers
   expect_line_count 3
 
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "containers filter test" {
@@ -22,8 +22,8 @@ load helpers
   run_buildah containers --filter name=$cid1
   expect_line_count 2
 
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "containers format test" {
@@ -36,8 +36,8 @@ load helpers
   expect_output --from="${lines[0]}" "alpine-working-container"
   expect_output --from="${lines[1]}" "busybox-working-container"
 
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "containers json test" {
@@ -46,8 +46,8 @@ load helpers
   run_buildah containers --json | grep "{" | wc -l
   out=$output
   [ "$out" -ne "0" ]
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "containers noheading test" {
@@ -61,8 +61,8 @@ load helpers
       expect_output "[no instance of 'NAME']" "'NAME' header should be absent"
   fi
 
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "containers quiet test" {
@@ -77,6 +77,6 @@ load helpers
   expect_output --substring --from="${lines[0]}" '^[0-9a-f]{64}$'
   expect_output --substring --from="${lines[1]}" '^[0-9a-f]{64}$'
 
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -18,22 +18,28 @@ load helpers
   createrandom ${TESTDIR}/other-randomfile
   createrandom ${TESTDIR}/third-randomfile
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
-  root=$(buildah mount $cid)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
+  run_buildah mount $cid
+  root=$output
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile
   run_buildah 1 copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile
   buildah rm $cid
 
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  root=$(buildah mount $cid)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
+  run_buildah mount $cid
+  root=$output
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile
   buildah copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile /etc
   buildah rm $cid
 
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  root=$(buildah mount $cid)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
+  run_buildah mount $cid
+  root=$output
   buildah config --workingdir / $cid
   buildah copy $cid "${TESTDIR}/*randomfile" /etc
   (cd ${TESTDIR}; for i in *randomfile; do cmp $i ${root}/etc/$i; done)
@@ -45,8 +51,10 @@ load helpers
   createrandom ${TESTDIR}/other-randomfile
   createrandom ${TESTDIR}/third-randomfile
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
-  root=$(buildah mount $cid)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
+  run_buildah mount $cid
+  root=$output
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile
   buildah copy $cid ${TESTDIR}/other-randomfile
@@ -54,8 +62,10 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   buildah rm $cid
 
-  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json new-image)
-  newroot=$(buildah mount $newcid)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  newcid=$output
+  run_buildah mount $newcid
+  newroot=$output
   test -s $newroot/randomfile
   cmp ${TESTDIR}/randomfile $newroot/randomfile
   test -s $newroot/other-randomfile
@@ -68,10 +78,12 @@ load helpers
   createrandom ${TESTDIR}/subdir/randomfile
   createrandom ${TESTDIR}/subdir/other-randomfile
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah config --workingdir /container-subdir $cid
   buildah copy $cid ${TESTDIR}/subdir
-  root=$(buildah mount $cid)
+  run_buildah mount $cid
+  root=$output
   test -s $root/container-subdir/randomfile
   cmp ${TESTDIR}/subdir/randomfile $root/container-subdir/randomfile
   test -s $root/container-subdir/other-randomfile
@@ -87,18 +99,22 @@ load helpers
 @test "copy-local-force-directory" {
   createrandom ${TESTDIR}/randomfile
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile /randomfile
-  root=$(buildah mount $cid)
+  run_buildah mount $cid
+  root=$output
   test -s $root/randomfile
   cmp ${TESTDIR}/randomfile $root/randomfile
   buildah rm $cid
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/randomfile /randomsubdir/
-  root=$(buildah mount $cid)
+  run_buildah mount $cid
+  root=$output
   test -s $root/randomsubdir/randomfile
   cmp ${TESTDIR}/randomfile $root/randomsubdir/randomfile
   buildah rm $cid
@@ -110,12 +126,14 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   touch -t 201910310123.45 ${TESTDIR}/randomfile
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah config --workingdir / $cid
   starthttpd ${TESTDIR}
   buildah copy $cid http://0.0.0.0:${HTTP_SERVER_PORT}/randomfile /urlfile
   stophttpd
-  root=$(buildah mount $cid)
+  run_buildah mount $cid
+  root=$output
   test -s $root/urlfile
   cmp ${TESTDIR}/randomfile $root/urlfile
 
@@ -140,7 +158,8 @@ load helpers
   createrandom ${TESTDIR}/other-subdir/randomfile
   createrandom ${TESTDIR}/other-subdir/other-randomfile
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   buildah config --workingdir / $cid
   buildah copy --chown 1:1 $cid ${TESTDIR}/randomfile
   buildah copy --chown root:1 $cid ${TESTDIR}/randomfile /randomfile2
@@ -163,16 +182,20 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   ln -s ${TESTDIR}/randomfile ${TESTDIR}/link-randomfile
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
-  root=$(buildah mount $cid)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
+  run_buildah mount $cid
+  root=$output
   buildah config --workingdir / $cid
   buildah copy $cid ${TESTDIR}/link-randomfile
   buildah unmount $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   buildah rm $cid
 
-  newcid=$(buildah from --signature-policy ${TESTSDIR}/policy.json new-image)
-  newroot=$(buildah mount $newcid)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  newcid=$output
+  run_buildah mount $newcid
+  newroot=$output
   test -s $newroot/link-randomfile
   test -f $newroot/link-randomfile
   cmp ${TESTDIR}/randomfile $newroot/link-randomfile

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -22,28 +22,28 @@ load helpers
   cid=$output
   run_buildah mount $cid
   root=$output
-  buildah config --workingdir / $cid
-  buildah copy $cid ${TESTDIR}/randomfile
+  run_buildah config --workingdir / $cid
+  run_buildah copy $cid ${TESTDIR}/randomfile
   run_buildah 1 copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile
-  buildah rm $cid
+  run_buildah rm $cid
 
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah mount $cid
   root=$output
-  buildah config --workingdir / $cid
-  buildah copy $cid ${TESTDIR}/randomfile
-  buildah copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile /etc
-  buildah rm $cid
+  run_buildah config --workingdir / $cid
+  run_buildah copy $cid ${TESTDIR}/randomfile
+  run_buildah copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile /etc
+  run_buildah rm $cid
 
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah mount $cid
   root=$output
-  buildah config --workingdir / $cid
-  buildah copy $cid "${TESTDIR}/*randomfile" /etc
+  run_buildah config --workingdir / $cid
+  run_buildah copy $cid "${TESTDIR}/*randomfile" /etc
   (cd ${TESTDIR}; for i in *randomfile; do cmp $i ${root}/etc/$i; done)
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "copy-local-plain" {
@@ -55,12 +55,12 @@ load helpers
   cid=$output
   run_buildah mount $cid
   root=$output
-  buildah config --workingdir / $cid
-  buildah copy $cid ${TESTDIR}/randomfile
-  buildah copy $cid ${TESTDIR}/other-randomfile
-  buildah unmount $cid
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
-  buildah rm $cid
+  run_buildah config --workingdir / $cid
+  run_buildah copy $cid ${TESTDIR}/randomfile
+  run_buildah copy $cid ${TESTDIR}/other-randomfile
+  run_buildah unmount $cid
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  run_buildah rm $cid
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
   newcid=$output
@@ -70,7 +70,7 @@ load helpers
   cmp ${TESTDIR}/randomfile $newroot/randomfile
   test -s $newroot/other-randomfile
   cmp ${TESTDIR}/other-randomfile $newroot/other-randomfile
-  buildah rm $newcid
+  run_buildah rm $newcid
 }
 
 @test "copy-local-subdirectory" {
@@ -80,20 +80,20 @@ load helpers
 
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah config --workingdir /container-subdir $cid
-  buildah copy $cid ${TESTDIR}/subdir
+  run_buildah config --workingdir /container-subdir $cid
+  run_buildah copy $cid ${TESTDIR}/subdir
   run_buildah mount $cid
   root=$output
   test -s $root/container-subdir/randomfile
   cmp ${TESTDIR}/subdir/randomfile $root/container-subdir/randomfile
   test -s $root/container-subdir/other-randomfile
   cmp ${TESTDIR}/subdir/other-randomfile $root/container-subdir/other-randomfile
-  buildah copy $cid ${TESTDIR}/subdir /other-subdir
+  run_buildah copy $cid ${TESTDIR}/subdir /other-subdir
   test -s $root/other-subdir/randomfile
   cmp ${TESTDIR}/subdir/randomfile $root/other-subdir/randomfile
   test -s $root/other-subdir/other-randomfile
   cmp ${TESTDIR}/subdir/other-randomfile $root/other-subdir/other-randomfile
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "copy-local-force-directory" {
@@ -101,23 +101,23 @@ load helpers
 
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah config --workingdir / $cid
-  buildah copy $cid ${TESTDIR}/randomfile /randomfile
+  run_buildah config --workingdir / $cid
+  run_buildah copy $cid ${TESTDIR}/randomfile /randomfile
   run_buildah mount $cid
   root=$output
   test -s $root/randomfile
   cmp ${TESTDIR}/randomfile $root/randomfile
-  buildah rm $cid
+  run_buildah rm $cid
 
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah config --workingdir / $cid
-  buildah copy $cid ${TESTDIR}/randomfile /randomsubdir/
+  run_buildah config --workingdir / $cid
+  run_buildah copy $cid ${TESTDIR}/randomfile /randomsubdir/
   run_buildah mount $cid
   root=$output
   test -s $root/randomsubdir/randomfile
   cmp ${TESTDIR}/randomfile $root/randomsubdir/randomfile
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "copy-url-mtime" {
@@ -128,9 +128,9 @@ load helpers
 
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah config --workingdir / $cid
+  run_buildah config --workingdir / $cid
   starthttpd ${TESTDIR}
-  buildah copy $cid http://0.0.0.0:${HTTP_SERVER_PORT}/randomfile /urlfile
+  run_buildah copy $cid http://0.0.0.0:${HTTP_SERVER_PORT}/randomfile /urlfile
   stophttpd
   run_buildah mount $cid
   root=$output
@@ -146,7 +146,7 @@ load helpers
   echo "mtime[urlfile]    = $mtime_urlfile"
   test "$mtime_randomfile" = "$mtime_urlfile"
 
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "copy --chown" {
@@ -160,21 +160,21 @@ load helpers
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  buildah config --workingdir / $cid
-  buildah copy --chown 1:1 $cid ${TESTDIR}/randomfile
-  buildah copy --chown root:1 $cid ${TESTDIR}/randomfile /randomfile2
-  buildah copy --chown nobody $cid ${TESTDIR}/randomfile /randomfile3
-  buildah copy --chown nobody:root $cid ${TESTDIR}/subdir /subdir
-  buildah run $cid stat -c "%u:%g" /randomfile
+  run_buildah config --workingdir / $cid
+  run_buildah copy --chown 1:1 $cid ${TESTDIR}/randomfile
+  run_buildah copy --chown root:1 $cid ${TESTDIR}/randomfile /randomfile2
+  run_buildah copy --chown nobody $cid ${TESTDIR}/randomfile /randomfile3
+  run_buildah copy --chown nobody:root $cid ${TESTDIR}/subdir /subdir
+  run_buildah run $cid stat -c "%u:%g" /randomfile
   test $(buildah run $cid stat -c "%u:%g" /randomfile) = "1:1"
-  buildah run $cid stat -c "%U:%g" /randomfile2
+  run_buildah run $cid stat -c "%U:%g" /randomfile2
   test $(buildah run $cid stat -c "%U:%g" /randomfile2) = "root:1"
-  buildah run $cid stat -c "%U" /randomfile3
+  run_buildah run $cid stat -c "%U" /randomfile3
   test $(buildah run $cid stat -c "%U" /randomfile3) = "nobody"
   (for i in randomfile other-randomfile ; do test $(buildah run $cid stat -c "%U:%G" /subdir/$i) = "nobody:root"; done)
-  buildah copy --chown root:root $cid ${TESTDIR}/other-subdir /subdir
+  run_buildah copy --chown root:root $cid ${TESTDIR}/other-subdir /subdir
   (for i in randomfile other-randomfile ; do test $(buildah run $cid stat -c "%U:%G" /subdir/$i) = "root:root"; done)
-  buildah run $cid stat -c "%U:%G" /subdir
+  run_buildah run $cid stat -c "%U:%G" /subdir
   test $(buildah run $cid stat -c "%U:%G" /subdir) = "nobody:root"
 }
 
@@ -186,11 +186,11 @@ load helpers
   cid=$output
   run_buildah mount $cid
   root=$output
-  buildah config --workingdir / $cid
-  buildah copy $cid ${TESTDIR}/link-randomfile
-  buildah unmount $cid
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
-  buildah rm $cid
+  run_buildah config --workingdir / $cid
+  run_buildah copy $cid ${TESTDIR}/link-randomfile
+  run_buildah unmount $cid
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  run_buildah rm $cid
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
   newcid=$output
@@ -199,5 +199,5 @@ load helpers
   test -s $newroot/link-randomfile
   test -f $newroot/link-randomfile
   cmp ${TESTDIR}/randomfile $newroot/link-randomfile
-  buildah rm $newcid
+  run_buildah rm $newcid
 }

--- a/tests/digest.bats
+++ b/tests/digest.bats
@@ -7,12 +7,12 @@ fromreftest() {
   cid=$output
   pushdir=${TESTDIR}/fromreftest
   mkdir -p ${pushdir}/{1,2,3}
-  buildah push --signature-policy ${TESTSDIR}/policy.json $1 dir:${pushdir}/1
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid new-image
-  buildah push --signature-policy ${TESTSDIR}/policy.json new-image dir:${pushdir}/2
-  buildah rmi new-image
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${pushdir}/3
-  buildah rm $cid
+  run_buildah push --signature-policy ${TESTSDIR}/policy.json $1 dir:${pushdir}/1
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid new-image
+  run_buildah push --signature-policy ${TESTSDIR}/policy.json new-image dir:${pushdir}/2
+  run_buildah rmi new-image
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${pushdir}/3
+  run_buildah rm $cid
   rm -fr ${pushdir}
 }
 

--- a/tests/digest.bats
+++ b/tests/digest.bats
@@ -3,7 +3,8 @@
 load helpers
 
 fromreftest() {
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $1)
+  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json $1
+  cid=$output
   pushdir=${TESTDIR}/fromreftest
   mkdir -p ${pushdir}/{1,2,3}
   buildah push --signature-policy ${TESTSDIR}/policy.json $1 dir:${pushdir}/1

--- a/tests/formats.bats
+++ b/tests/formats.bats
@@ -46,7 +46,8 @@ function check_imgtype() {
 
 
 @test "write-formats" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-default
   run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -23,27 +23,33 @@ load helpers
   elsewhere=${TESTDIR}/elsewhere-img
   mkdir -p ${elsewhere}
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${elsewhere}
   buildah rm $cid
 
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere})
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere}
+  cid=$output
   buildah rm $cid
   [ "$cid" = elsewhere-img-working-container ]
 
-  cid=$(buildah from --pull-always --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere})
+  run_buildah from --quiet --pull-always --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere}
+  cid=$output
   buildah rm $cid
   [ "$cid" = `basename ${elsewhere}`-working-container ]
 
-  cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${elsewhere}
   buildah rm $cid
 
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere})
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere}
+  cid=$output
   buildah rm $cid
   [ "$cid" = elsewhere-img-working-container ]
 
-  cid=$(buildah from --pull-always --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere})
+  run_buildah from --quiet --pull-always --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere}
+  cid=$output
   buildah rm $cid
   [ "$cid" = `basename ${elsewhere}`-working-container ]
 }
@@ -127,62 +133,74 @@ load helpers
 
 @test "from-tagged-image" {
   # Github #396: Make sure the container name starts with the correct image even when it's tagged.
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah commit --signature-policy ${TESTSDIR}/policy.json "$cid" scratch2
   buildah rm $cid
   buildah tag scratch2 scratch3
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch3)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch3
+  cid=$output
   [ "$cid" == scratch3-working-container ]
   buildah rm ${cid}
   buildah rmi scratch2 scratch3
 
   # Github https://github.com/containers/buildah/issues/396#issuecomment-360949396
-  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   buildah rm $cid
   buildah tag alpine alpine2
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json localhost/alpine2)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json localhost/alpine2
+  cid=$output
   [ "$cid" == alpine2-working-container ]
   buildah rm ${cid}
   buildah rmi alpine alpine2
 
-  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
+  cid=$output
   buildah rm ${cid}
   buildah rmi docker.io/alpine
 
-  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/alpine:latest)
+  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/alpine:latest
+  cid=$output
   buildah rm ${cid}
   buildah rmi docker.io/alpine:latest
 
-  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/centos:7)
+  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/centos:7
+  cid=$output
   buildah rm ${cid}
   buildah rmi docker.io/centos:7
 
-  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/centos:latest)
+  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/centos:latest
+  cid=$output
   buildah rm ${cid}
   buildah rmi docker.io/centos:latest
 }
 
 @test "from the following transports: docker-archive, oci-archive, and dir" {
-  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   buildah rm $cid
   buildah push --signature-policy ${TESTSDIR}/policy.json alpine docker-archive:docker-alp.tar:alpine
   buildah push --signature-policy ${TESTSDIR}/policy.json alpine oci-archive:oci-alp.tar:alpine
   buildah push --signature-policy ${TESTSDIR}/policy.json alpine dir:alp-dir
   buildah rmi alpine
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json docker-archive:docker-alp.tar)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json docker-archive:docker-alp.tar
+  cid=$output
   [ "$cid" == alpine-working-container ]
   buildah rm ${cid}
   buildah rmi alpine
   rm -f docker-alp.tar
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json oci-archive:oci-alp.tar)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json oci-archive:oci-alp.tar
+  cid=$output
   [ "$cid" == alpine-working-container ]
   buildah rm ${cid}
   buildah rmi alpine
   rm -f oci-alp.tar
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json dir:alp-dir)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json dir:alp-dir
+  cid=$output
   [ "$cid" == alp-dir-working-container ]
   buildah rm ${cid}
   buildah rmi alp-dir
@@ -190,19 +208,22 @@ load helpers
 }
 
 @test "from the following transports: docker-archive and oci-archive with no image reference" {
-  cid=$(buildah from --pull=true --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   buildah rm $cid
   buildah push --signature-policy ${TESTSDIR}/policy.json alpine docker-archive:docker-alp.tar
   buildah push --signature-policy ${TESTSDIR}/policy.json alpine oci-archive:oci-alp.tar
   buildah rmi alpine
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json docker-archive:docker-alp.tar)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json docker-archive:docker-alp.tar
+  cid=$output
   [ "$cid" == docker-archive-working-container ]
   buildah rm ${cid}
   buildah rmi -a
   rm -f docker-alp.tar
 
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json oci-archive:oci-alp.tar)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json oci-archive:oci-alp.tar
+  cid=$output
   [ "$cid" == oci-archive-working-container ]
   buildah rm ${cid}
   buildah rmi -a
@@ -215,7 +236,8 @@ load helpers
   skip_if_no_runtime
   skip_if_cgroupsv2
 
-  cid=$(buildah from --cpu-period=5000 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --cpu-period=5000 --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
   expect_output "5000"
   buildah rm $cid
@@ -227,7 +249,8 @@ load helpers
   skip_if_no_runtime
   skip_if_cgroupsv2
 
-  cid=$(buildah from --cpu-quota=5000 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --cpu-quota=5000 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
   expect_output "5000"
   buildah rm $cid
@@ -239,7 +262,8 @@ load helpers
   skip_if_no_runtime
   skip_if_cgroupsv2
 
-  cid=$(buildah from --cpu-shares=2 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --cpu-shares=2 --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.shares
   expect_output "2"
   buildah rm $cid
@@ -251,7 +275,8 @@ load helpers
   skip_if_no_runtime
   skip_if_cgroupsv2 "cgroupsv2: fails with EPERM on writing cpuset.cpus"
 
-  cid=$(buildah from --cpuset-cpus=0 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --cpuset-cpus=0 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpuset/cpuset.cpus
   expect_output "0"
   buildah rm $cid
@@ -263,7 +288,8 @@ load helpers
   skip_if_no_runtime
   skip_if_cgroupsv2 "cgroupsv2: fails with EPERM on writing cpuset.mems"
 
-  cid=$(buildah from --cpuset-mems=0 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --cpuset-mems=0 --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpuset/cpuset.mems
   expect_output "0"
   buildah rm $cid
@@ -273,7 +299,8 @@ load helpers
   skip_if_chroot
   skip_if_rootless
 
-  cid=$(buildah from --memory=40m --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --memory=40m --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
 
   # Life is much more complicated under cgroups v2
   mpath='/sys/fs/cgroup/memory/memory.limit_in_bytes'
@@ -288,7 +315,8 @@ load helpers
 @test "from volume test" {
   skip_if_no_runtime
 
-  cid=$(buildah from --volume=${TESTDIR}:/myvol --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --volume=${TESTDIR}:/myvol --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah run $cid -- cat /proc/mounts
   expect_output --substring " /myvol "
   buildah rm $cid
@@ -298,7 +326,8 @@ load helpers
   skip_if_chroot
   skip_if_no_runtime
 
-  cid=$(buildah from --volume=${TESTDIR}:/myvol:ro --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --volume=${TESTDIR}:/myvol:ro --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah run $cid -- cat /proc/mounts
   expect_output --substring " /myvol "
   buildah rm $cid
@@ -308,7 +337,8 @@ load helpers
   skip_if_chroot
   skip_if_no_runtime
 
-  cid=$(buildah from --shm-size=80m --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --shm-size=80m --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah run $cid -- df -h /dev/shm
   expect_output --substring " 80.0M "
   buildah rm $cid
@@ -317,7 +347,8 @@ load helpers
 @test "from add-host test" {
   skip_if_no_runtime
 
-  cid=$(buildah from --add-host=localhost:127.0.0.1 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --add-host=localhost:127.0.0.1 --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah run $cid -- cat /etc/hosts
   expect_output --substring "127.0.0.1 +localhost"
   buildah rm $cid
@@ -325,7 +356,8 @@ load helpers
 
 @test "from name test" {
   container_name=mycontainer
-  cid=$(buildah from --name=${container_name} --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --name=${container_name} --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   buildah inspect --format '{{.Container}}' ${container_name}
   buildah rm $cid
 }

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -25,32 +25,32 @@ load helpers
 
   run_buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${elsewhere}
-  buildah rm $cid
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${elsewhere}
+  run_buildah rm $cid
 
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere}
   cid=$output
-  buildah rm $cid
+  run_buildah rm $cid
   [ "$cid" = elsewhere-img-working-container ]
 
   run_buildah from --quiet --pull-always --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere}
   cid=$output
-  buildah rm $cid
+  run_buildah rm $cid
   [ "$cid" = `basename ${elsewhere}`-working-container ]
 
   run_buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${elsewhere}
-  buildah rm $cid
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${elsewhere}
+  run_buildah rm $cid
 
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere}
   cid=$output
-  buildah rm $cid
+  run_buildah rm $cid
   [ "$cid" = elsewhere-img-working-container ]
 
   run_buildah from --quiet --pull-always --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere}
   cid=$output
-  buildah rm $cid
+  run_buildah rm $cid
   [ "$cid" = `basename ${elsewhere}`-working-container ]
 }
 
@@ -135,98 +135,98 @@ load helpers
   # Github #396: Make sure the container name starts with the correct image even when it's tagged.
   run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah commit --signature-policy ${TESTSDIR}/policy.json "$cid" scratch2
-  buildah rm $cid
-  buildah tag scratch2 scratch3
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json "$cid" scratch2
+  run_buildah rm $cid
+  run_buildah tag scratch2 scratch3
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch3
   cid=$output
   [ "$cid" == scratch3-working-container ]
-  buildah rm ${cid}
-  buildah rmi scratch2 scratch3
+  run_buildah rm ${cid}
+  run_buildah rmi scratch2 scratch3
 
   # Github https://github.com/containers/buildah/issues/396#issuecomment-360949396
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  buildah rm $cid
-  buildah tag alpine alpine2
+  run_buildah rm $cid
+  run_buildah tag alpine alpine2
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json localhost/alpine2
   cid=$output
   [ "$cid" == alpine2-working-container ]
-  buildah rm ${cid}
-  buildah rmi alpine alpine2
+  run_buildah rm ${cid}
+  run_buildah rmi alpine alpine2
 
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
   cid=$output
-  buildah rm ${cid}
-  buildah rmi docker.io/alpine
+  run_buildah rm ${cid}
+  run_buildah rmi docker.io/alpine
 
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/alpine:latest
   cid=$output
-  buildah rm ${cid}
-  buildah rmi docker.io/alpine:latest
+  run_buildah rm ${cid}
+  run_buildah rmi docker.io/alpine:latest
 
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/centos:7
   cid=$output
-  buildah rm ${cid}
-  buildah rmi docker.io/centos:7
+  run_buildah rm ${cid}
+  run_buildah rmi docker.io/centos:7
 
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/centos:latest
   cid=$output
-  buildah rm ${cid}
-  buildah rmi docker.io/centos:latest
+  run_buildah rm ${cid}
+  run_buildah rmi docker.io/centos:latest
 }
 
 @test "from the following transports: docker-archive, oci-archive, and dir" {
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  buildah rm $cid
-  buildah push --signature-policy ${TESTSDIR}/policy.json alpine docker-archive:docker-alp.tar:alpine
-  buildah push --signature-policy ${TESTSDIR}/policy.json alpine oci-archive:oci-alp.tar:alpine
-  buildah push --signature-policy ${TESTSDIR}/policy.json alpine dir:alp-dir
-  buildah rmi alpine
+  run_buildah rm $cid
+  run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine docker-archive:docker-alp.tar:alpine
+  run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine oci-archive:oci-alp.tar:alpine
+  run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine dir:alp-dir
+  run_buildah rmi alpine
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json docker-archive:docker-alp.tar
   cid=$output
   [ "$cid" == alpine-working-container ]
-  buildah rm ${cid}
-  buildah rmi alpine
+  run_buildah rm ${cid}
+  run_buildah rmi alpine
   rm -f docker-alp.tar
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json oci-archive:oci-alp.tar
   cid=$output
   [ "$cid" == alpine-working-container ]
-  buildah rm ${cid}
-  buildah rmi alpine
+  run_buildah rm ${cid}
+  run_buildah rmi alpine
   rm -f oci-alp.tar
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json dir:alp-dir
   cid=$output
   [ "$cid" == alp-dir-working-container ]
-  buildah rm ${cid}
-  buildah rmi alp-dir
+  run_buildah rm ${cid}
+  run_buildah rmi alp-dir
   rm -rf alp-dir
 }
 
 @test "from the following transports: docker-archive and oci-archive with no image reference" {
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  buildah rm $cid
-  buildah push --signature-policy ${TESTSDIR}/policy.json alpine docker-archive:docker-alp.tar
-  buildah push --signature-policy ${TESTSDIR}/policy.json alpine oci-archive:oci-alp.tar
-  buildah rmi alpine
+  run_buildah rm $cid
+  run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine docker-archive:docker-alp.tar
+  run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine oci-archive:oci-alp.tar
+  run_buildah rmi alpine
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json docker-archive:docker-alp.tar
   cid=$output
   [ "$cid" == docker-archive-working-container ]
-  buildah rm ${cid}
-  buildah rmi -a
+  run_buildah rm ${cid}
+  run_buildah rmi -a
   rm -f docker-alp.tar
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json oci-archive:oci-alp.tar
   cid=$output
   [ "$cid" == oci-archive-working-container ]
-  buildah rm ${cid}
-  buildah rmi -a
+  run_buildah rm ${cid}
+  run_buildah rmi -a
   rm -f oci-alp.tar
 }
 
@@ -240,7 +240,7 @@ load helpers
   cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
   expect_output "5000"
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "from cpu-quota test" {
@@ -253,7 +253,7 @@ load helpers
   cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
   expect_output "5000"
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "from cpu-shares test" {
@@ -266,7 +266,7 @@ load helpers
   cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.shares
   expect_output "2"
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "from cpuset-cpus test" {
@@ -279,7 +279,7 @@ load helpers
   cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpuset/cpuset.cpus
   expect_output "0"
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "from cpuset-mems test" {
@@ -292,7 +292,7 @@ load helpers
   cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpuset/cpuset.mems
   expect_output "0"
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "from memory test" {
@@ -309,7 +309,7 @@ load helpers
   fi
   run_buildah run $cid sh -c "cat $mpath"
   expect_output "41943040" "$mpath"
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "from volume test" {
@@ -319,7 +319,7 @@ load helpers
   cid=$output
   run_buildah run $cid -- cat /proc/mounts
   expect_output --substring " /myvol "
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "from volume ro test" {
@@ -330,7 +330,7 @@ load helpers
   cid=$output
   run_buildah run $cid -- cat /proc/mounts
   expect_output --substring " /myvol "
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "from shm-size test" {
@@ -341,7 +341,7 @@ load helpers
   cid=$output
   run_buildah run $cid -- df -h /dev/shm
   expect_output --substring " 80.0M "
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "from add-host test" {
@@ -351,22 +351,22 @@ load helpers
   cid=$output
   run_buildah run $cid -- cat /etc/hosts
   expect_output --substring "127.0.0.1 +localhost"
-  buildah rm $cid
+  run_buildah rm $cid
 }
 
 @test "from name test" {
   container_name=mycontainer
   run_buildah from --quiet --name=${container_name} --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  buildah inspect --format '{{.Container}}' ${container_name}
-  buildah rm $cid
+  run_buildah inspect --format '{{.Container}}' ${container_name}
+  run_buildah rm $cid
 }
 
 @test "from cidfile test" {
-  buildah from --cidfile output.cid --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --cidfile output.cid --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$(cat output.cid)
   run_buildah containers -f id=${cid}
-  buildah rm ${cid}
+  run_buildah rm ${cid}
 }
 
 @test "from pull never" {
@@ -382,7 +382,7 @@ load helpers
   echo "$output"
   expect_output --substring "busybox-working-container"
 
-  buildah rmi --all --force
+  run_buildah rmi --all --force
 }
 
 @test "from pull false no local image" {
@@ -391,7 +391,7 @@ load helpers
   echo "$output"
   expect_output --substring "busybox-working-container"
 
-  buildah rmi --all --force
+  run_buildah rmi --all --force
 }
 
 @test "from with nonexistent authfile: fails" {
@@ -403,7 +403,7 @@ load helpers
   run buildah pull --signature-policy ${TESTSDIR}/policy.json docker.io/busybox
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc --pull-always docker.io/busybox
   expect_output --substring "Getting"
-  buildah commit --signature-policy ${TESTSDIR}/policy.json busyboxc fakename-img
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json busyboxc fakename-img
   run_buildah 1 from --signature-policy ${TESTSDIR}/policy.json --pull-always fakename-img
   run_buildah rm busyboxc
   run_buildah rmi fakename-img

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -66,7 +66,7 @@ load helpers
 
 #  ctrid=$(buildah from localhost:5000/my-alpine --cert-dir ${TESTDIR}/auth)
 #  buildah rm $ctrid
-#  buildah rmi -f $(buildah --log-level=error images -q)
+#  buildah rmi -f $(buildah images -q)
 
   # This should work
 #  ctrid=$(buildah from localhost:5000/my-alpine --cert-dir ${TESTDIR}/auth  --tls-verify true)
@@ -82,7 +82,7 @@ load helpers
 #  docker rmi -f localhost:5000/my-alpine
 #  docker rmi -f $(docker images -q)
 #  buildah rm $ctrid
-#  buildah rmi -f $(buildah --log-level=error images -q)
+#  buildah rmi -f $(buildah images -q)
 }
 
 @test "from-authenticate-cert-and-creds" {
@@ -105,7 +105,7 @@ load helpers
 
 #  ctrid=$(buildah from localhost:5000/my-alpine --cert-dir ${TESTDIR}/auth)
 #  buildah rm $ctrid
-#  buildah rmi -f $(buildah --log-level=error images -q)
+#  buildah rmi -f $(buildah images -q)
 
 #  docker logout localhost:5000
 
@@ -122,7 +122,7 @@ load helpers
 #  docker rmi -f localhost:5000/my-alpine
 #  docker rmi -f $(docker images -q)
 #  buildah rm $ctrid
-#  buildah rmi -f $(buildah --log-level=error images -q)
+#  buildah rmi -f $(buildah images -q)
 }
 
 @test "from-tagged-image" {
@@ -216,7 +216,7 @@ load helpers
   skip_if_cgroupsv2
 
   cid=$(buildah from --cpu-period=5000 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --log-level=error run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
+  run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
   expect_output "5000"
   buildah rm $cid
 }
@@ -228,7 +228,7 @@ load helpers
   skip_if_cgroupsv2
 
   cid=$(buildah from --cpu-quota=5000 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --log-level=error run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
+  run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
   expect_output "5000"
   buildah rm $cid
 }
@@ -240,7 +240,7 @@ load helpers
   skip_if_cgroupsv2
 
   cid=$(buildah from --cpu-shares=2 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --log-level=error run $cid cat /sys/fs/cgroup/cpu/cpu.shares
+  run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.shares
   expect_output "2"
   buildah rm $cid
 }
@@ -252,7 +252,7 @@ load helpers
   skip_if_cgroupsv2 "cgroupsv2: fails with EPERM on writing cpuset.cpus"
 
   cid=$(buildah from --cpuset-cpus=0 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --log-level=error run $cid cat /sys/fs/cgroup/cpuset/cpuset.cpus
+  run_buildah run $cid cat /sys/fs/cgroup/cpuset/cpuset.cpus
   expect_output "0"
   buildah rm $cid
 }
@@ -264,7 +264,7 @@ load helpers
   skip_if_cgroupsv2 "cgroupsv2: fails with EPERM on writing cpuset.mems"
 
   cid=$(buildah from --cpuset-mems=0 --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --log-level=error run $cid cat /sys/fs/cgroup/cpuset/cpuset.mems
+  run_buildah run $cid cat /sys/fs/cgroup/cpuset/cpuset.mems
   expect_output "0"
   buildah rm $cid
 }
@@ -280,7 +280,7 @@ load helpers
   if is_cgroupsv2; then
       mpath="/sys/fs/cgroup\$(awk -F: '{print \$3}' /proc/self/cgroup)/memory.max"
   fi
-  run_buildah --log-level=error run $cid sh -c "cat $mpath"
+  run_buildah run $cid sh -c "cat $mpath"
   expect_output "41943040" "$mpath"
   buildah rm $cid
 }
@@ -289,7 +289,7 @@ load helpers
   skip_if_no_runtime
 
   cid=$(buildah from --volume=${TESTDIR}:/myvol --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --log-level=error run $cid -- cat /proc/mounts
+  run_buildah run $cid -- cat /proc/mounts
   expect_output --substring " /myvol "
   buildah rm $cid
 }
@@ -299,7 +299,7 @@ load helpers
   skip_if_no_runtime
 
   cid=$(buildah from --volume=${TESTDIR}:/myvol:ro --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --log-level=error run $cid -- cat /proc/mounts
+  run_buildah run $cid -- cat /proc/mounts
   expect_output --substring " /myvol "
   buildah rm $cid
 }
@@ -309,7 +309,7 @@ load helpers
   skip_if_no_runtime
 
   cid=$(buildah from --shm-size=80m --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --log-level=error run $cid -- df -h /dev/shm
+  run_buildah run $cid -- df -h /dev/shm
   expect_output --substring " 80.0M "
   buildah rm $cid
 }
@@ -326,14 +326,14 @@ load helpers
 @test "from name test" {
   container_name=mycontainer
   cid=$(buildah from --name=${container_name} --pull --signature-policy ${TESTSDIR}/policy.json alpine)
-  buildah --log-level=error inspect --format '{{.Container}}' ${container_name}
+  buildah inspect --format '{{.Container}}' ${container_name}
   buildah rm $cid
 }
 
 @test "from cidfile test" {
   buildah from --cidfile output.cid --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$(cat output.cid)
-  run_buildah --log-level=error containers -f id=${cid}
+  run_buildah containers -f id=${cid}
   buildah rm ${cid}
 }
 

--- a/tests/history.bats
+++ b/tests/history.bats
@@ -86,7 +86,7 @@ function testconfighistory() {
 @test "history-copy" {
   createrandom ${TESTDIR}/randomfile
   buildah from --name copyctr --format docker scratch
-  run_buildah --log-level=error copy --add-history copyctr ${TESTDIR}/randomfile
+  run_buildah copy --add-history copyctr ${TESTDIR}/randomfile
   digest="$output"
   buildah commit --signature-policy ${TESTSDIR}/policy.json copyctr copyimg
   buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg

--- a/tests/history.bats
+++ b/tests/history.bats
@@ -34,7 +34,8 @@ function testconfighistory() {
   run_buildah config --healthcheck "CMD /foo" --healthcheck-timeout=10s --healthcheck-interval=20s --healthcheck-retries=7 --healthcheck-start-period=30s --add-history healthcheckctr
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json healthcheckctr healthcheckimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg | grep "HEALTHCHECK --interval=20s --retries=7 --start-period=30s --timeout=10s CMD /foo"
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg
+  expect_output --substring "HEALTHCHECK --interval=20s --retries=7 --start-period=30s --timeout=10s CMD /foo"
 }
 
 @test "history-label" {
@@ -46,7 +47,8 @@ function testconfighistory() {
   run_buildah config --onbuild "CMD /foo" --add-history onbuildctr
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json onbuildctr onbuildimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg | grep "ONBUILD CMD /foo"
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg
+  expect_output --substring "ONBUILD CMD /foo"
 }
 
 @test "history-port" {
@@ -80,7 +82,8 @@ function testconfighistory() {
   digest="$output"
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json addctr addimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg | grep "ADD file:$digest"
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg
+  expect_output --substring "ADD file:$digest"
 }
 
 @test "history-copy" {
@@ -90,7 +93,8 @@ function testconfighistory() {
   digest="$output"
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json copyctr copyimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg | grep "COPY file:$digest"
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg
+  expect_output --substring "COPY file:$digest"
 }
 
 @test "history-run" {
@@ -98,5 +102,6 @@ function testconfighistory() {
   run_buildah run --add-history runctr -- uname -a
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json runctr runimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg | grep "/bin/sh -c uname -a"
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg
+  expect_output --substring "/bin/sh -c uname -a"
 }

--- a/tests/history.bats
+++ b/tests/history.bats
@@ -7,13 +7,13 @@ function testconfighistory() {
   expected="$2"
   container=$(echo "c$config" | sed -E -e 's|[[:blank:]]|_|g' -e "s,[-=/:'],_,g" | tr '[A-Z]' '[a-z]')
   image=$(echo "i$config" | sed -E -e 's|[[:blank:]]|_|g' -e "s,[-=/:'],_,g" | tr '[A-Z]' '[a-z]')
-  buildah from --name "$container" --format docker scratch
-  buildah config $config --add-history "$container"
-  buildah commit --signature-policy ${TESTSDIR}/policy.json "$container" "$image"
-  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image"
-  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image" | grep "$expected"
+  run_buildah from --name "$container" --format docker scratch
+  run_buildah config $config --add-history "$container"
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json "$container" "$image"
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image"
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image" | grep "$expected"
   if test "$3" != "not-oci" ; then
-    buildah inspect --format '{{range .OCIv1.History}}{{println .CreatedBy}}{{end}}' "$image" | grep "$expected"
+    run_buildah inspect --format '{{range .OCIv1.History}}{{println .CreatedBy}}{{end}}' "$image" | grep "$expected"
   fi
 }
 
@@ -30,11 +30,11 @@ function testconfighistory() {
 }
 
 @test "history-healthcheck" {
-  buildah from --name healthcheckctr --format docker scratch
-  buildah config --healthcheck "CMD /foo" --healthcheck-timeout=10s --healthcheck-interval=20s --healthcheck-retries=7 --healthcheck-start-period=30s --add-history healthcheckctr
-  buildah commit --signature-policy ${TESTSDIR}/policy.json healthcheckctr healthcheckimg
-  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg
-  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg | grep "HEALTHCHECK --interval=20s --retries=7 --start-period=30s --timeout=10s CMD /foo"
+  run_buildah from --name healthcheckctr --format docker scratch
+  run_buildah config --healthcheck "CMD /foo" --healthcheck-timeout=10s --healthcheck-interval=20s --healthcheck-retries=7 --healthcheck-start-period=30s --add-history healthcheckctr
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json healthcheckctr healthcheckimg
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg | grep "HEALTHCHECK --interval=20s --retries=7 --start-period=30s --timeout=10s CMD /foo"
 }
 
 @test "history-label" {
@@ -42,11 +42,11 @@ function testconfighistory() {
 }
 
 @test "history-onbuild" {
-  buildah from --name onbuildctr --format docker scratch
-  buildah config --onbuild "CMD /foo" --add-history onbuildctr
-  buildah commit --signature-policy ${TESTSDIR}/policy.json onbuildctr onbuildimg
-  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg
-  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg | grep "ONBUILD CMD /foo"
+  run_buildah from --name onbuildctr --format docker scratch
+  run_buildah config --onbuild "CMD /foo" --add-history onbuildctr
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json onbuildctr onbuildimg
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg | grep "ONBUILD CMD /foo"
 }
 
 @test "history-port" {
@@ -75,28 +75,28 @@ function testconfighistory() {
 
 @test "history-add" {
   createrandom ${TESTDIR}/randomfile
-  buildah from --name addctr --format docker scratch
+  run_buildah from --name addctr --format docker scratch
   run_buildah add --add-history addctr ${TESTDIR}/randomfile
   digest="$output"
-  buildah commit --signature-policy ${TESTSDIR}/policy.json addctr addimg
-  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg
-  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg | grep "ADD file:$digest"
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json addctr addimg
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg | grep "ADD file:$digest"
 }
 
 @test "history-copy" {
   createrandom ${TESTDIR}/randomfile
-  buildah from --name copyctr --format docker scratch
+  run_buildah from --name copyctr --format docker scratch
   run_buildah copy --add-history copyctr ${TESTDIR}/randomfile
   digest="$output"
-  buildah commit --signature-policy ${TESTSDIR}/policy.json copyctr copyimg
-  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg
-  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg | grep "COPY file:$digest"
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json copyctr copyimg
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg | grep "COPY file:$digest"
 }
 
 @test "history-run" {
-  buildah from --name runctr --format docker --signature-policy ${TESTSDIR}/policy.json busybox
-  buildah run --add-history runctr -- uname -a
-  buildah commit --signature-policy ${TESTSDIR}/policy.json runctr runimg
-  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg
-  buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg | grep "/bin/sh -c uname -a"
+  run_buildah from --name runctr --format docker --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah run --add-history runctr -- uname -a
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json runctr runimg
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg | grep "/bin/sh -c uname -a"
 }

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -16,8 +16,10 @@ load helpers
 }
 
 @test "images" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah images
   expect_line_count 3
   buildah rm -a
@@ -41,8 +43,10 @@ load helpers
 }
 
 @test "images filter test" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah images --noheading --filter since=k8s.gcr.io/pause
   expect_line_count 1
   buildah rm -a
@@ -50,8 +54,10 @@ load helpers
 }
 
 @test "images format test" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah images --format "{{.Name}}"
   expect_line_count 2
   buildah rm -a
@@ -59,8 +65,10 @@ load helpers
 }
 
 @test "images noheading test" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah images --noheading
   expect_line_count 2
   buildah rm -a
@@ -68,8 +76,10 @@ load helpers
 }
 
 @test "images quiet test" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah images --quiet
   expect_line_count 2
   buildah rm -a
@@ -77,8 +87,10 @@ load helpers
 }
 
 @test "images no-trunc test" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah images -q --no-trunc
   expect_line_count 2
   expect_output --substring --from="${lines[0]}" "sha256"
@@ -87,8 +99,10 @@ load helpers
 }
 
 @test "images json test" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah images --json
   expect_line_count 30
 
@@ -99,7 +113,8 @@ load helpers
 }
 
 @test "images json dup test" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
   buildah tag test new-name
 
@@ -111,8 +126,10 @@ load helpers
 }
 
 @test "images json valid" {
-  cid1=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
-  cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid1=$output
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid2=$output
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid1 test
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid2 test2
 
@@ -125,8 +142,10 @@ load helpers
 }
 
 @test "specify an existing image" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah images alpine
   expect_line_count 2
   buildah rm -a
@@ -140,7 +159,8 @@ load helpers
 }
 
 @test "Test dangling images" {
-  cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
   run_buildah images

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -18,7 +18,7 @@ load helpers
 @test "images" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error images
+  run_buildah images
   expect_line_count 3
   buildah rm -a
   buildah rmi -a -f
@@ -26,15 +26,15 @@ load helpers
 
 @test "images all test" {
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test ${TESTSDIR}/bud/use-layers
-  run_buildah --log-level=error images
+  run_buildah images
   expect_line_count 3
 
-  run_buildah --log-level=error images -a
+  run_buildah images -a
   expect_line_count 8
 
   # create a no name image which should show up when doing buildah images without the --all flag
   buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/use-layers
-  run_buildah --log-level=error images
+  run_buildah images
   expect_line_count 4
 
   buildah rmi -a -f
@@ -43,7 +43,7 @@ load helpers
 @test "images filter test" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error images --noheading --filter since=k8s.gcr.io/pause
+  run_buildah images --noheading --filter since=k8s.gcr.io/pause
   expect_line_count 1
   buildah rm -a
   buildah rmi -a -f
@@ -52,7 +52,7 @@ load helpers
 @test "images format test" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error images --format "{{.Name}}"
+  run_buildah images --format "{{.Name}}"
   expect_line_count 2
   buildah rm -a
   buildah rmi -a -f
@@ -61,7 +61,7 @@ load helpers
 @test "images noheading test" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error images --noheading
+  run_buildah images --noheading
   expect_line_count 2
   buildah rm -a
   buildah rmi -a -f
@@ -70,7 +70,7 @@ load helpers
 @test "images quiet test" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error images --quiet
+  run_buildah images --quiet
   expect_line_count 2
   buildah rm -a
   buildah rmi -a -f
@@ -79,7 +79,7 @@ load helpers
 @test "images no-trunc test" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error images -q --no-trunc
+  run_buildah images -q --no-trunc
   expect_line_count 2
   expect_output --substring --from="${lines[0]}" "sha256"
   buildah rm -a
@@ -89,10 +89,10 @@ load helpers
 @test "images json test" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error images --json
+  run_buildah images --json
   expect_line_count 30
 
-  run_buildah --log-level=error images --json alpine
+  run_buildah images --json alpine
   expect_line_count 16
   buildah rm -a
   buildah rmi -a -f
@@ -103,7 +103,7 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
   buildah tag test new-name
 
-  run_buildah --log-level=error images --json
+  run_buildah images --json
   [ $(grep '"id": "' <<< "$output" | wc -l) -eq 1 ]
 
   buildah rm -a
@@ -116,7 +116,7 @@ load helpers
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid1 test
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid2 test2
 
-  run_buildah --log-level=error images --json
+  run_buildah images --json
   run python3 -m json.tool <<< "$output"
   [ "${status}" -eq 0 ]
 
@@ -127,14 +127,14 @@ load helpers
 @test "specify an existing image" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error images alpine
+  run_buildah images alpine
   expect_line_count 2
   buildah rm -a
   buildah rmi -a -f
 }
 
 @test "specify a nonexistent image" {
-  run_buildah 1 --log-level=error images alpine
+  run_buildah 1 images alpine
   expect_output --from="${lines[0]}" "No such image alpine"
   expect_line_count 1
 }
@@ -143,14 +143,14 @@ load helpers
   cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
-  run_buildah --log-level=error images
+  run_buildah images
   expect_line_count 3
 
-  run_buildah --log-level=error images --filter dangling=true
+  run_buildah images --filter dangling=true
   expect_output --substring " <none> "
   expect_line_count 2
 
-  run_buildah --log-level=error images --filter dangling=false
+  run_buildah images --filter dangling=false
   expect_output --substring " latest "
   expect_line_count 2
 

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -22,12 +22,12 @@ load helpers
   cid2=$output
   run_buildah images
   expect_line_count 3
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "images all test" {
-  buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test ${TESTSDIR}/bud/use-layers
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test ${TESTSDIR}/bud/use-layers
   run_buildah images
   expect_line_count 3
 
@@ -35,11 +35,11 @@ load helpers
   expect_line_count 8
 
   # create a no name image which should show up when doing buildah images without the --all flag
-  buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/use-layers
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/use-layers
   run_buildah images
   expect_line_count 4
 
-  buildah rmi -a -f
+  run_buildah rmi -a -f
 }
 
 @test "images filter test" {
@@ -49,8 +49,8 @@ load helpers
   cid2=$output
   run_buildah images --noheading --filter since=k8s.gcr.io/pause
   expect_line_count 1
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "images format test" {
@@ -60,8 +60,8 @@ load helpers
   cid2=$output
   run_buildah images --format "{{.Name}}"
   expect_line_count 2
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "images noheading test" {
@@ -71,8 +71,8 @@ load helpers
   cid2=$output
   run_buildah images --noheading
   expect_line_count 2
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "images quiet test" {
@@ -82,8 +82,8 @@ load helpers
   cid2=$output
   run_buildah images --quiet
   expect_line_count 2
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "images no-trunc test" {
@@ -94,8 +94,8 @@ load helpers
   run_buildah images -q --no-trunc
   expect_line_count 2
   expect_output --substring --from="${lines[0]}" "sha256"
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "images json test" {
@@ -108,21 +108,21 @@ load helpers
 
   run_buildah images --json alpine
   expect_line_count 16
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "images json dup test" {
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
-  buildah tag test new-name
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
+  run_buildah tag test new-name
 
   run_buildah images --json
   [ $(grep '"id": "' <<< "$output" | wc -l) -eq 1 ]
 
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "images json valid" {
@@ -130,15 +130,15 @@ load helpers
   cid1=$output
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid2=$output
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid1 test
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid2 test2
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid1 test
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid2 test2
 
   run_buildah images --json
   run python3 -m json.tool <<< "$output"
   [ "${status}" -eq 0 ]
 
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "specify an existing image" {
@@ -148,8 +148,8 @@ load helpers
   cid2=$output
   run_buildah images alpine
   expect_line_count 2
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "specify a nonexistent image" {
@@ -161,8 +161,8 @@ load helpers
 @test "Test dangling images" {
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
-  buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
   run_buildah images
   expect_line_count 3
 
@@ -174,12 +174,12 @@ load helpers
   expect_output --substring " latest "
   expect_line_count 2
 
-  buildah rm -a
-  buildah rmi -a -f
+  run_buildah rm -a
+  run_buildah rmi -a -f
 }
 
 @test "image digest test" {
-  buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
   run_buildah images --digests
   expect_output --substring "sha256:"
 }

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -22,8 +22,6 @@ load helpers
   cid2=$output
   run_buildah images
   expect_line_count 3
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "images all test" {
@@ -38,8 +36,6 @@ load helpers
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/use-layers
   run_buildah images
   expect_line_count 4
-
-  run_buildah rmi -a -f
 }
 
 @test "images filter test" {
@@ -49,8 +45,6 @@ load helpers
   cid2=$output
   run_buildah images --noheading --filter since=k8s.gcr.io/pause
   expect_line_count 1
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "images format test" {
@@ -60,8 +54,6 @@ load helpers
   cid2=$output
   run_buildah images --format "{{.Name}}"
   expect_line_count 2
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "images noheading test" {
@@ -71,8 +63,6 @@ load helpers
   cid2=$output
   run_buildah images --noheading
   expect_line_count 2
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "images quiet test" {
@@ -82,8 +72,6 @@ load helpers
   cid2=$output
   run_buildah images --quiet
   expect_line_count 2
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "images no-trunc test" {
@@ -94,8 +82,6 @@ load helpers
   run_buildah images -q --no-trunc
   expect_line_count 2
   expect_output --substring --from="${lines[0]}" "sha256"
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "images json test" {
@@ -108,8 +94,6 @@ load helpers
 
   run_buildah images --json alpine
   expect_line_count 16
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "images json dup test" {
@@ -119,10 +103,7 @@ load helpers
   run_buildah tag test new-name
 
   run_buildah images --json
-  [ $(grep '"id": "' <<< "$output" | wc -l) -eq 1 ]
-
-  run_buildah rm -a
-  run_buildah rmi -a -f
+  expect_output --substring '"id": '
 }
 
 @test "images json valid" {
@@ -136,9 +117,6 @@ load helpers
   run_buildah images --json
   run python3 -m json.tool <<< "$output"
   [ "${status}" -eq 0 ]
-
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "specify an existing image" {
@@ -148,8 +126,6 @@ load helpers
   cid2=$output
   run_buildah images alpine
   expect_line_count 2
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "specify a nonexistent image" {
@@ -173,9 +149,6 @@ load helpers
   run_buildah images --filter dangling=false
   expect_output --substring " latest "
   expect_line_count 2
-
-  run_buildah rm -a
-  run_buildah rmi -a -f
 }
 
 @test "image digest test" {

--- a/tests/info.bats
+++ b/tests/info.bats
@@ -3,9 +3,11 @@
 load helpers
 
 @test "info" {
-  out1=$(buildah info | grep "host" | wc -l)
+  run_buildah info | grep "host" | wc -l
+  out1=$output
   [ "$out1" -ne "0" ]
 
-  out2=$(buildah info --format='{{.store}}')
+  run_buildah info --format='{{.store}}'
+  out2=$output
   [ "$out2" != "" ]
 }

--- a/tests/info.bats
+++ b/tests/info.bats
@@ -3,11 +3,9 @@
 load helpers
 
 @test "info" {
-  run_buildah info | grep "host" | wc -l
-  out1=$output
-  [ "$out1" -ne "0" ]
+  run_buildah info
+  expect_output --substring "host"
 
   run_buildah info --format='{{.store}}'
-  out2=$output
-  [ "$out2" != "" ]
+  expect_output --substring 'map.*ContainerStore.*GraphDriverName.*GraphRoot:.*RunRoot:'
 }

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -47,8 +47,8 @@ load helpers
   run_buildah inspect --type image --format '{{.OCIv1.Config}}' $imageid
   expect_output "$inspect_after_commit"
 
-  buildah rm $cid
-  buildah rmi alpine-image alpine
+  run_buildah rm $cid
+  run_buildah rmi alpine-image alpine
 }
 
 @test "inspect-config-is-json" {
@@ -58,8 +58,8 @@ load helpers
 	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
-	buildah rm $cid
-	buildah rmi -f alpine
+	run_buildah rm $cid
+	run_buildah rmi -f alpine
 }
 
 @test "inspect-manifest-is-json" {
@@ -69,8 +69,8 @@ load helpers
 	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
-	buildah rm $cid
-	buildah rmi -f alpine
+	run_buildah rm $cid
+	run_buildah rmi -f alpine
 }
 
 @test "inspect-ociv1-is-json" {
@@ -80,8 +80,8 @@ load helpers
 	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
-	buildah rm $cid
-	buildah rmi -f alpine
+	run_buildah rm $cid
+	run_buildah rmi -f alpine
 }
 
 @test "inspect-docker-is-json" {
@@ -91,8 +91,8 @@ load helpers
 	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
-	buildah rm $cid
-	buildah rmi -f alpine
+	run_buildah rm $cid
+	run_buildah rmi -f alpine
 }
 
 @test "inspect-format-config-is-json" {
@@ -102,8 +102,8 @@ load helpers
 	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
-	buildah rm $cid
-	buildah rmi -f alpine
+	run_buildah rm $cid
+	run_buildah rmi -f alpine
 }
 
 @test "inspect-format-manifest-is-json" {
@@ -113,8 +113,8 @@ load helpers
 	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
-	buildah rm $cid
-	buildah rmi -f alpine
+	run_buildah rm $cid
+	run_buildah rmi -f alpine
 }
 
 @test "inspect-format-ociv1-is-json" {
@@ -124,8 +124,8 @@ load helpers
 	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
-	buildah rm $cid
-	buildah rmi -f alpine
+	run_buildah rm $cid
+	run_buildah rmi -f alpine
 }
 
 @test "inspect-format-docker-is-json" {
@@ -135,6 +135,6 @@ load helpers
 	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
-	buildah rm $cid
-	buildah rmi -f alpine
+	run_buildah rm $cid
+	run_buildah rmi -f alpine
 }

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -29,8 +29,9 @@ load helpers
 
   # ...except that at some point in November 2019 buildah-inspect started
   # including version. Strip it out,
-  run_buildah --version | awk '{ print $3 }'
-  buildah_version=$output
+  run_buildah --version
+  local -a output_fields=($output)
+  buildah_version=${output_fields[2]}
   inspect_cleaned=$(echo "$inspect_after_commit" | sed "s/io.buildah.version:${buildah_version}//g")
   expect_output --from="$inspect_cleaned" "$inspect_basic"
 
@@ -46,95 +47,60 @@ load helpers
   # This one should.
   run_buildah inspect --type image --format '{{.OCIv1.Config}}' $imageid
   expect_output "$inspect_after_commit"
-
-  run_buildah rm $cid
-  run_buildah rmi alpine-image alpine
 }
 
 @test "inspect-config-is-json" {
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
-	run_buildah inspect alpine | grep "Config" | grep "{" | wc -l
-	out=$output
-	# if there is "{" it's a JSON string
-	[ "$out" -ne "0" ]
-	run_buildah rm $cid
-	run_buildah rmi -f alpine
+	run_buildah inspect alpine
+        expect_output --substring 'Config.*\{'
 }
 
 @test "inspect-manifest-is-json" {
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
-	run_buildah inspect alpine | grep "Manifest" | grep "{" | wc -l
-	out=$output
-	# if there is "{" it's a JSON string
-	[ "$out" -ne "0" ]
-	run_buildah rm $cid
-	run_buildah rmi -f alpine
+	run_buildah inspect alpine
+        expect_output --substring 'Manifest.*\{'
 }
 
 @test "inspect-ociv1-is-json" {
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
-	run_buildah inspect alpine | grep "OCIv1" | grep "{" | wc -l
-	out=$output
-	# if there is "{" it's a JSON string
-	[ "$out" -ne "0" ]
-	run_buildah rm $cid
-	run_buildah rmi -f alpine
+	run_buildah inspect alpine
+        expect_output --substring 'OCIv1.*\{'
 }
 
 @test "inspect-docker-is-json" {
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
-	run_buildah inspect alpine | grep "Docker" | grep "{" | wc -l
-	out=$output
-	# if there is "{" it's a JSON string
-	[ "$out" -ne "0" ]
-	run_buildah rm $cid
-	run_buildah rmi -f alpine
+	run_buildah inspect alpine
+        expect_output --substring 'Docker.*\{'
 }
 
 @test "inspect-format-config-is-json" {
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
-	run_buildah inspect --format "{{.Config}}" alpine | grep "{" | wc -l
-	out=$output
-	# if there is "{" it's a JSON string
-	[ "$out" -ne "0" ]
-	run_buildah rm $cid
-	run_buildah rmi -f alpine
+	run_buildah inspect --format "{{.Config}}" alpine
+        expect_output --substring '\{'
 }
 
 @test "inspect-format-manifest-is-json" {
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
-	run_buildah inspect --format "{{.Manifest}}" alpine |  grep "{" | wc -l
-	out=$output
-	# if there is "{" it's a JSON string
-	[ "$out" -ne "0" ]
-	run_buildah rm $cid
-	run_buildah rmi -f alpine
+	run_buildah inspect --format "{{.Manifest}}" alpine
+        expect_output --substring '\{'
 }
 
 @test "inspect-format-ociv1-is-json" {
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
-	run_buildah inspect --format "{{.OCIv1}}" alpine |  grep "{" | wc -l
-	out=$output
-	# if there is "{" it's a JSON string
-	[ "$out" -ne "0" ]
-	run_buildah rm $cid
-	run_buildah rmi -f alpine
+	run_buildah inspect --format "{{.OCIv1}}" alpine
+        expect_output --substring '\{'
 }
 
 @test "inspect-format-docker-is-json" {
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
-	run_buildah inspect --format "{{.Docker}}" alpine |  grep "{" | wc -l
-	out=$output
-	# if there is "{" it's a JSON string
-	[ "$out" -ne "0" ]
-	run_buildah rm $cid
-	run_buildah rmi -f alpine
+	run_buildah inspect --format "{{.Docker}}" alpine
+        expect_output --substring '\{'
 }

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -29,12 +29,15 @@ load helpers
 
   # ...except that at some point in November 2019 buildah-inspect started
   # including version. Strip it out,
-  buildah_version=$(buildah --version | awk '{ print $3 }')
+  run_buildah --version | awk '{ print $3 }'
+  buildah_version=$output
   inspect_cleaned=$(echo "$inspect_after_commit" | sed "s/io.buildah.version:${buildah_version}//g")
   expect_output --from="$inspect_cleaned" "$inspect_basic"
 
-  imageid=$(buildah images -q alpine-image)
-  containerid=$(buildah containers -q)
+  run_buildah images -q alpine-image
+  imageid=$output
+  run_buildah containers -q
+  containerid=$output
 
   # This one should not include buildah version
   run_buildah inspect --format '{{.OCIv1.Config}}' $containerid
@@ -49,8 +52,10 @@ load helpers
 }
 
 @test "inspect-config-is-json" {
-	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-	out=$(buildah inspect alpine | grep "Config" | grep "{" | wc -l)
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	cid=$output
+	run_buildah inspect alpine | grep "Config" | grep "{" | wc -l
+	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
 	buildah rm $cid
@@ -58,8 +63,10 @@ load helpers
 }
 
 @test "inspect-manifest-is-json" {
-	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-	out=$(buildah inspect alpine | grep "Manifest" | grep "{" | wc -l)
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	cid=$output
+	run_buildah inspect alpine | grep "Manifest" | grep "{" | wc -l
+	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
 	buildah rm $cid
@@ -67,8 +74,10 @@ load helpers
 }
 
 @test "inspect-ociv1-is-json" {
-	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-	out=$(buildah inspect alpine | grep "OCIv1" | grep "{" | wc -l)
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	cid=$output
+	run_buildah inspect alpine | grep "OCIv1" | grep "{" | wc -l
+	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
 	buildah rm $cid
@@ -76,8 +85,10 @@ load helpers
 }
 
 @test "inspect-docker-is-json" {
-	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-	out=$(buildah inspect alpine | grep "Docker" | grep "{" | wc -l)
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	cid=$output
+	run_buildah inspect alpine | grep "Docker" | grep "{" | wc -l
+	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
 	buildah rm $cid
@@ -85,8 +96,10 @@ load helpers
 }
 
 @test "inspect-format-config-is-json" {
-	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-	out=$(buildah inspect --format "{{.Config}}" alpine | grep "{" | wc -l)
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	cid=$output
+	run_buildah inspect --format "{{.Config}}" alpine | grep "{" | wc -l
+	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
 	buildah rm $cid
@@ -94,8 +107,10 @@ load helpers
 }
 
 @test "inspect-format-manifest-is-json" {
-	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-	out=$(buildah inspect --format "{{.Manifest}}" alpine |  grep "{" | wc -l)
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	cid=$output
+	run_buildah inspect --format "{{.Manifest}}" alpine |  grep "{" | wc -l
+	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
 	buildah rm $cid
@@ -103,8 +118,10 @@ load helpers
 }
 
 @test "inspect-format-ociv1-is-json" {
-	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-	out=$(buildah inspect --format "{{.OCIv1}}" alpine |  grep "{" | wc -l)
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	cid=$output
+	run_buildah inspect --format "{{.OCIv1}}" alpine |  grep "{" | wc -l
+	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
 	buildah rm $cid
@@ -112,8 +129,10 @@ load helpers
 }
 
 @test "inspect-format-docker-is-json" {
-	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-	out=$(buildah inspect --format "{{.Docker}}" alpine |  grep "{" | wc -l)
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	cid=$output
+	run_buildah inspect --format "{{.Docker}}" alpine |  grep "{" | wc -l
+	out=$output
 	# if there is "{" it's a JSON string
 	[ "$out" -ne "0" ]
 	buildah rm $cid

--- a/tests/loglevel.bats
+++ b/tests/loglevel.bats
@@ -3,26 +3,26 @@
 load helpers
 
 @test "log-level set to debug" {
-  run_buildah --log-level=error --log-level=debug images -q
+  run_buildah --log-level=debug images -q
   expect_output --substring "level=debug "
 }
 
 @test "log-level set to info" {
-  run_buildah --log-level=error --log-level=info images -q
+  run_buildah --log-level=info images -q
   expect_output ""
 }
 
 @test "log-level set to warn" {
-  run_buildah --log-level=error --log-level=warn images -q
+  run_buildah --log-level=warn images -q
   expect_output ""
 }
 
 @test "log-level set to error" {
-  run_buildah --log-level=error --log-level=error images -q
+  run_buildah --log-level=error images -q
   expect_output ""
 }
 
 @test "log-level set to invalid" {
-  run_buildah 1 --log-level=error --log-level=invalid images -q
+  run_buildah 1 --log-level=invalid images -q
   expect_output --substring "unable to parse log level"
 }

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -15,13 +15,13 @@ load helpers
 
 @test "mount one container" {
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --log-level=error mount "$cid"
+  run_buildah mount "$cid"
   buildah rm $cid
   buildah rmi -f alpine
 }
 
 @test "mount bad container" {
-  run_buildah 1 --log-level=error mount badcontainer
+  run_buildah 1 mount badcontainer
 }
 
 @test "mount multi images" {
@@ -49,7 +49,7 @@ load helpers
   buildah mount "$cid2"
   cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah mount "$cid3"
-  run_buildah --log-level=error mount
+  run_buildah mount
   expect_output --from="${lines[0]}" --substring "/tmp" "mount line 1 of 3"
   expect_output --from="${lines[1]}" --substring "/tmp" "mount line 2 of 3"
   expect_output --from="${lines[2]}" --substring "/tmp" "mount line 3 of 3"

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -17,8 +17,6 @@ load helpers
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah mount "$cid"
-  run_buildah rm $cid
-  run_buildah rmi -f alpine
 }
 
 @test "mount bad container" {
@@ -33,8 +31,6 @@ load helpers
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid3=$output
   run_buildah mount "$cid1" "$cid2" "$cid3"
-  run_buildah rm --all
-  run_buildah rmi -f alpine
 }
 
 @test "mount multi images one bad" {
@@ -45,8 +41,6 @@ load helpers
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid3=$output
   run_buildah 1 mount "$cid1" badcontainer "$cid2" "$cid3"
-  run_buildah rm --all
-  run_buildah rmi -f alpine
 }
 
 @test "list currently mounted containers" {
@@ -60,11 +54,8 @@ load helpers
   cid3=$output
   run_buildah mount "$cid3"
   run_buildah mount
+  expect_line_count 3
   expect_output --from="${lines[0]}" --substring "/tmp" "mount line 1 of 3"
   expect_output --from="${lines[1]}" --substring "/tmp" "mount line 2 of 3"
   expect_output --from="${lines[2]}" --substring "/tmp" "mount line 3 of 3"
-  expect_line_count 3
-
-  run_buildah rm --all
-  run_buildah rmi -f alpine
 }

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -14,7 +14,8 @@ load helpers
 }
 
 @test "mount one container" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah mount "$cid"
   buildah rm $cid
   buildah rmi -f alpine
@@ -25,29 +26,38 @@ load helpers
 }
 
 @test "mount multi images" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  cid2=$output
+  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  cid3=$output
   run_buildah mount "$cid1" "$cid2" "$cid3"
   buildah rm --all
   buildah rmi -f alpine
 }
 
 @test "mount multi images one bad" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  cid2=$output
+  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  cid3=$output
   run_buildah 1 mount "$cid1" badcontainer "$cid2" "$cid3"
   buildah rm --all
   buildah rmi -f alpine
 }
 
 @test "list currently mounted containers" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
   buildah mount "$cid1"
-  cid2=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  cid2=$output
   buildah mount "$cid2"
-  cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  cid3=$output
   buildah mount "$cid3"
   run_buildah mount
   expect_output --from="${lines[0]}" --substring "/tmp" "mount line 1 of 3"

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -17,8 +17,8 @@ load helpers
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah mount "$cid"
-  buildah rm $cid
-  buildah rmi -f alpine
+  run_buildah rm $cid
+  run_buildah rmi -f alpine
 }
 
 @test "mount bad container" {
@@ -33,8 +33,8 @@ load helpers
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid3=$output
   run_buildah mount "$cid1" "$cid2" "$cid3"
-  buildah rm --all
-  buildah rmi -f alpine
+  run_buildah rm --all
+  run_buildah rmi -f alpine
 }
 
 @test "mount multi images one bad" {
@@ -45,26 +45,26 @@ load helpers
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid3=$output
   run_buildah 1 mount "$cid1" badcontainer "$cid2" "$cid3"
-  buildah rm --all
-  buildah rmi -f alpine
+  run_buildah rm --all
+  run_buildah rmi -f alpine
 }
 
 @test "list currently mounted containers" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
-  buildah mount "$cid1"
+  run_buildah mount "$cid1"
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid2=$output
-  buildah mount "$cid2"
+  run_buildah mount "$cid2"
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid3=$output
-  buildah mount "$cid3"
+  run_buildah mount "$cid3"
   run_buildah mount
   expect_output --from="${lines[0]}" --substring "/tmp" "mount line 1 of 3"
   expect_output --from="${lines[1]}" --substring "/tmp" "mount line 2 of 3"
   expect_output --from="${lines[2]}" --substring "/tmp" "mount line 3 of 3"
   expect_line_count 3
 
-  buildah rm --all
-  buildah rmi -f alpine
+  run_buildah rm --all
+  run_buildah rmi -f alpine
 }

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -43,13 +43,13 @@ load helpers
   ctr="$output"
 
   # Check that with settings that require a user namespace, we also get a new network namespace by default.
-  buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/net
+  run_buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/net
   run_buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/net
   [ "$output" != "" ]
   [ "$output" != "$mynetns" ]
 
   # Check that with settings that require a user namespace, we can still try to use the host's network namespace.
-  buildah run $RUNOPTS --net=host "$ctr" readlink /proc/self/ns/net
+  run_buildah run $RUNOPTS --net=host "$ctr" readlink /proc/self/ns/net
   run_buildah run $RUNOPTS --net=host "$ctr" readlink /proc/self/ns/net
   [ "$output" != "" ]
   [ "$output" == "$mynetns" ]
@@ -60,13 +60,13 @@ load helpers
   ctr="$output"
 
   # Check that with settings that don't require a user namespace, we don't get a new network namespace by default.
-  buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/net
+  run_buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/net
   run_buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/net
   [ "$output" != "" ]
   [ "$output" == "$mynetns" ]
 
   # Check that with settings that don't require a user namespace, we can request to use a per-container network namespace.
-  buildah run $RUNOPTS --net=container "$ctr" readlink /proc/self/ns/net
+  run_buildah run $RUNOPTS --net=container "$ctr" readlink /proc/self/ns/net
   run_buildah run $RUNOPTS --net=container "$ctr" readlink /proc/self/ns/net
   [ "$output" != "" ]
   [ "$output" != "$mynetns" ]
@@ -170,7 +170,7 @@ load helpers
     ctr="$output"
 
     # If we specified mappings, expect to be in a different namespace by default.
-    buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/user
+    run_buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/user
     run_buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/user
     [ "$output" != "" ]
     case x"$map" in
@@ -184,11 +184,11 @@ load helpers
       ;;
     esac
     # Check that we got the mappings that we expected.
-    buildah run $RUNOPTS "$ctr" cat /proc/self/uid_map
+    run_buildah run $RUNOPTS "$ctr" cat /proc/self/uid_map
     run_buildah run $RUNOPTS "$ctr" cat /proc/self/uid_map
     [ "$output" != "" ]
     uidmap=$(sed -E -e 's, +, ,g' -e 's,^ +,,g' <<< "$output")
-    buildah run $RUNOPTS "$ctr" cat /proc/self/gid_map
+    run_buildah run $RUNOPTS "$ctr" cat /proc/self/gid_map
     run_buildah run $RUNOPTS "$ctr" cat /proc/self/gid_map
     [ "$output" != "" ]
     gidmap=$(sed -E -e 's, +, ,g' -e 's,^ +,,g' <<< "$output")
@@ -200,13 +200,13 @@ load helpers
 
     # Check that if we copy a file into the container, it gets the right permissions.
     run_buildah copy --chown 1:1 "$ctr" ${TESTDIR}/somefile /
-    buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somefile
+    run_buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somefile
     run_buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somefile
     expect_output "1:1"
 
     # Check that if we copy a directory into the container, its contents get the right permissions.
     run_buildah copy "$ctr" ${TESTDIR}/somedir /somedir
-    buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somedir
+    run_buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somedir
     run_buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somedir
     expect_output "0:0"
     run_buildah mount "$ctr"
@@ -214,7 +214,7 @@ load helpers
     run stat -c '%u:%g %a' "$mnt"/somedir/someotherfile
     [ $status -eq 0 ]
     expect_output "$rootuid:$rootgid 4700"
-    buildah run $RUNOPTS "$ctr" stat -c '%u:%g %a' /somedir/someotherfile
+    run_buildah run $RUNOPTS "$ctr" stat -c '%u:%g %a' /somedir/someotherfile
     run_buildah run $RUNOPTS "$ctr" stat -c '%u:%g %a' /somedir/someotherfile
     expect_output "0:0 4700"
   done
@@ -344,13 +344,13 @@ general_namespace() {
             run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet --ipc=$ipc --net=$net --pid=$pid --userns=$userns --uts=$uts alpine
             [ "$output" != "" ]
             ctr="$output"
-            buildah run $ctr pwd
+            run_buildah run $ctr pwd
             run_buildah run $ctr pwd
             [ "$output" != "" ]
-            buildah run --tty=true  $ctr pwd
+            run_buildah run --tty=true  $ctr pwd
             run_buildah run --tty=true  $ctr pwd
             [ "$output" != "" ]
-            buildah run --tty=false $ctr pwd
+            run_buildah run --tty=false $ctr pwd
             run_buildah run --tty=false $ctr pwd
             [ "$output" != "" ]
           done
@@ -364,9 +364,9 @@ general_namespace() {
 	createrandom ${TESTDIR}/randomfile
 	run_buildah from --userns-uid-map 0:32:16 --userns-gid-map 0:48:16 scratch
 	cid=$output
-	buildah copy "$cid" ${TESTDIR}/randomfile /
-	buildah copy --chown 1:1 "$cid" ${TESTDIR}/randomfile /randomfile2
-	buildah commit --squash --signature-policy ${TESTSDIR}/policy.json --rm "$cid" squashed
+	run_buildah copy "$cid" ${TESTDIR}/randomfile /
+	run_buildah copy --chown 1:1 "$cid" ${TESTDIR}/randomfile /randomfile2
+	run_buildah commit --squash --signature-policy ${TESTSDIR}/policy.json --rm "$cid" squashed
 	run_buildah from --quiet squashed
 	cid=$output
 	run_buildah mount $cid

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -362,12 +362,15 @@ general_namespace() {
 
 @test "idmapping-and-squash" {
 	createrandom ${TESTDIR}/randomfile
-	cid=$(buildah from --userns-uid-map 0:32:16 --userns-gid-map 0:48:16 scratch)
+	run_buildah from --userns-uid-map 0:32:16 --userns-gid-map 0:48:16 scratch
+	cid=$output
 	buildah copy "$cid" ${TESTDIR}/randomfile /
 	buildah copy --chown 1:1 "$cid" ${TESTDIR}/randomfile /randomfile2
 	buildah commit --squash --signature-policy ${TESTSDIR}/policy.json --rm "$cid" squashed
-	cid=$(buildah from squashed)
-	mountpoint=$(buildah mount $cid)
+	run_buildah from --quiet squashed
+	cid=$output
+	run_buildah mount $cid
+	mountpoint=$output
 	run stat -c %u:%g $mountpoint/randomfile
 	echo "$output"
 	[ "$status" -eq 0 ]

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -7,7 +7,7 @@ load helpers
     skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION"
   fi
 
-  run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json --quiet alpine
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet alpine
   [ "$output" != "" ]
   ctr="$output"
 
@@ -38,36 +38,36 @@ load helpers
   gidsize=$((${RANDOM}+1024))
 
   # Create a container that uses that mapping.
-  run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json --quiet --userns-uid-map 0:$uidbase:$uidsize --userns-gid-map 0:$gidbase:$gidsize alpine
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet --userns-uid-map 0:$uidbase:$uidsize --userns-gid-map 0:$gidbase:$gidsize alpine
   [ "$output" != "" ]
   ctr="$output"
 
   # Check that with settings that require a user namespace, we also get a new network namespace by default.
   buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/net
-  run_buildah --log-level=error run $RUNOPTS "$ctr" readlink /proc/self/ns/net
+  run_buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/net
   [ "$output" != "" ]
   [ "$output" != "$mynetns" ]
 
   # Check that with settings that require a user namespace, we can still try to use the host's network namespace.
   buildah run $RUNOPTS --net=host "$ctr" readlink /proc/self/ns/net
-  run_buildah --log-level=error run $RUNOPTS --net=host "$ctr" readlink /proc/self/ns/net
+  run_buildah run $RUNOPTS --net=host "$ctr" readlink /proc/self/ns/net
   [ "$output" != "" ]
   [ "$output" == "$mynetns" ]
 
   # Create a container that doesn't use that mapping.
-  run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json --quiet alpine
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet alpine
   [ "$output" != "" ]
   ctr="$output"
 
   # Check that with settings that don't require a user namespace, we don't get a new network namespace by default.
   buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/net
-  run_buildah --log-level=error run $RUNOPTS "$ctr" readlink /proc/self/ns/net
+  run_buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/net
   [ "$output" != "" ]
   [ "$output" == "$mynetns" ]
 
   # Check that with settings that don't require a user namespace, we can request to use a per-container network namespace.
   buildah run $RUNOPTS --net=container "$ctr" readlink /proc/self/ns/net
-  run_buildah --log-level=error run $RUNOPTS --net=container "$ctr" readlink /proc/self/ns/net
+  run_buildah run $RUNOPTS --net=container "$ctr" readlink /proc/self/ns/net
   [ "$output" != "" ]
   [ "$output" != "$mynetns" ]
 }
@@ -165,13 +165,13 @@ load helpers
   for i in $(seq 0 "$((${#maps[*]}-1))") ; do
     # Create a container using these mappings.
     echo "Building container with --signature-policy ${TESTSDIR}/policy.json --quiet ${uidmapargs[$i]} ${gidmapargs[$i]} alpine"
-    run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json --quiet ${uidmapargs[$i]} ${gidmapargs[$i]} alpine
+    run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet ${uidmapargs[$i]} ${gidmapargs[$i]} alpine
     [ "$output" != "" ]
     ctr="$output"
 
     # If we specified mappings, expect to be in a different namespace by default.
     buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/user
-    run_buildah --log-level=error run $RUNOPTS "$ctr" readlink /proc/self/ns/user
+    run_buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/user
     [ "$output" != "" ]
     case x"$map" in
     x)
@@ -185,11 +185,11 @@ load helpers
     esac
     # Check that we got the mappings that we expected.
     buildah run $RUNOPTS "$ctr" cat /proc/self/uid_map
-    run_buildah --log-level=error run $RUNOPTS "$ctr" cat /proc/self/uid_map
+    run_buildah run $RUNOPTS "$ctr" cat /proc/self/uid_map
     [ "$output" != "" ]
     uidmap=$(sed -E -e 's, +, ,g' -e 's,^ +,,g' <<< "$output")
     buildah run $RUNOPTS "$ctr" cat /proc/self/gid_map
-    run_buildah --log-level=error run $RUNOPTS "$ctr" cat /proc/self/gid_map
+    run_buildah run $RUNOPTS "$ctr" cat /proc/self/gid_map
     [ "$output" != "" ]
     gidmap=$(sed -E -e 's, +, ,g' -e 's,^ +,,g' <<< "$output")
     echo With settings "$map", expected UID map "${uidmaps[$i]}", got UID map "${uidmap}", expected GID map "${gidmaps[$i]}", got GID map "${gidmap}".
@@ -201,21 +201,21 @@ load helpers
     # Check that if we copy a file into the container, it gets the right permissions.
     run_buildah copy --chown 1:1 "$ctr" ${TESTDIR}/somefile /
     buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somefile
-    run_buildah --log-level=error run $RUNOPTS "$ctr" stat -c '%u:%g' /somefile
+    run_buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somefile
     expect_output "1:1"
 
     # Check that if we copy a directory into the container, its contents get the right permissions.
     run_buildah copy "$ctr" ${TESTDIR}/somedir /somedir
     buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somedir
-    run_buildah --log-level=error run $RUNOPTS "$ctr" stat -c '%u:%g' /somedir
+    run_buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somedir
     expect_output "0:0"
-    run_buildah --log-level=error mount "$ctr"
+    run_buildah mount "$ctr"
     mnt="$output"
     run stat -c '%u:%g %a' "$mnt"/somedir/someotherfile
     [ $status -eq 0 ]
     expect_output "$rootuid:$rootgid 4700"
     buildah run $RUNOPTS "$ctr" stat -c '%u:%g %a' /somedir/someotherfile
-    run_buildah --log-level=error run $RUNOPTS "$ctr" stat -c '%u:%g %a' /somedir/someotherfile
+    run_buildah run $RUNOPTS "$ctr" stat -c '%u:%g %a' /somedir/someotherfile
     expect_output "0:0 4700"
   done
 }
@@ -243,12 +243,12 @@ general_namespace() {
 
   for namespace in "${types[@]}" ; do
     # Specify the setting for this namespace for this container.
-    run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json --quiet --"$nsflag"=$namespace alpine
+    run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet --"$nsflag"=$namespace alpine
     [ "$output" != "" ]
     ctr="$output"
 
     # Check that, unless we override it, we get that setting in "run".
-    run_buildah --log-level=error run $RUNOPTS "$ctr" readlink /proc/self/ns/"$nstype"
+    run_buildah run $RUNOPTS "$ctr" readlink /proc/self/ns/"$nstype"
     [ "$output" != "" ]
     case "$namespace" in
     ""|container)
@@ -264,7 +264,7 @@ general_namespace() {
 
     for different in $types ; do
       # Check that, if we override it, we get what we specify for "run".
-      run_buildah --log-level=error run $RUNOPTS --"$nsflag"=$different "$ctr" readlink /proc/self/ns/"$nstype"
+      run_buildah run $RUNOPTS --"$nsflag"=$different "$ctr" readlink /proc/self/ns/"$nstype"
       [ "$output" != "" ]
       case "$different" in
       ""|container)
@@ -341,17 +341,17 @@ general_namespace() {
             fi
 
             echo "buildah from --signature-policy ${TESTSDIR}/policy.json --ipc=$ipc --net=$net --pid=$pid --userns=$userns --uts=$uts alpine"
-            run_buildah --log-level=error from --signature-policy ${TESTSDIR}/policy.json --quiet --ipc=$ipc --net=$net --pid=$pid --userns=$userns --uts=$uts alpine
+            run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet --ipc=$ipc --net=$net --pid=$pid --userns=$userns --uts=$uts alpine
             [ "$output" != "" ]
             ctr="$output"
             buildah run $ctr pwd
-            run_buildah --log-level=error run $ctr pwd
+            run_buildah run $ctr pwd
             [ "$output" != "" ]
             buildah run --tty=true  $ctr pwd
-            run_buildah --log-level=error run --tty=true  $ctr pwd
+            run_buildah run --tty=true  $ctr pwd
             [ "$output" != "" ]
             buildah run --tty=false $ctr pwd
-            run_buildah --log-level=error run --tty=false $ctr pwd
+            run_buildah run --tty=false $ctr pwd
             [ "$output" != "" ]
           done
         done

--- a/tests/overlay.bats
+++ b/tests/overlay.bats
@@ -10,7 +10,8 @@ load helpers
   mkdir ${TESTDIR}/lower
   touch ${TESTDIR}/lower/foo
 
-  cid=$(buildah from -v ${TESTDIR}/lower:/lower:O --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah from --quiet -v ${TESTDIR}/lower:/lower:O --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  cid=$output
 
   # This should succeed
   run_buildah run $cid ls /lower/foo

--- a/tests/overlay.bats
+++ b/tests/overlay.bats
@@ -10,17 +10,17 @@ load helpers
   mkdir ${TESTDIR}/lower
   touch ${TESTDIR}/lower/foo
 
-  cid=$(buildah --log-level=error from -v ${TESTDIR}/lower:/lower:O --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  cid=$(buildah from -v ${TESTDIR}/lower:/lower:O --quiet --signature-policy ${TESTSDIR}/policy.json $image)
 
   # This should succeed
-  run_buildah --log-level=error run $cid ls /lower/foo
+  run_buildah run $cid ls /lower/foo
 
   # Create and remove content in the overlay directory, should succeed
-  run_buildah --log-level=error run $cid touch /lower/bar
-  run_buildah --log-level=error run $cid rm /lower/foo
+  run_buildah run $cid touch /lower/bar
+  run_buildah run $cid rm /lower/foo
 
   # This should fail, second runs of containers go back to original
-  run_buildah 1 --log-level=error run $cid ls /lower/bar
+  run_buildah 1 run $cid ls /lower/bar
 
   # This should fail
   run ls ${TESTDIR}/lower/bar

--- a/tests/registries.bats
+++ b/tests/registries.bats
@@ -4,50 +4,29 @@ load helpers
 
 @test "registries" {
   registrypair() {
-    image=$1
-    imagename=$2
-
-    # Clean up.
-    for id in $(buildah containers -q) ; do
-      run_buildah rm ${id}
-    done
-    for id in $(buildah images -q) ; do
-      run_buildah rmi ${id}
-    done
+    image1=$1
+    image2=$2
 
     # Create a container by specifying the image with one name.
-    run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $image
+    run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image1
+    cid1=$output
 
     # Create a container by specifying the image with another name.
-    run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $imagename
+    run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image2
+    cid2=$output
 
     # Get their image IDs.  They should be the same one.
-    lastid=
-    for cid in $(buildah containers -q) ; do
-      run_buildah inspect -f "{{.FromImageID}}" $cid
-      expect_line_count 1
-      if [ "$lastid" != "" ] ; then
-        expect_output "$lastid"
-      fi
-      lastid="$output"
-    done
-
-    # A quick bit of troubleshooting help.
-    run_buildah images
+    run_buildah inspect -f "{{.FromImageID}}" $cid1
+    iid1=$output
+    run_buildah inspect -f "{{.FromImageID}}" $cid2
+    expect_output $iid1 "$image2.FromImageID == $image1.FromImageID"
 
     # Clean up.
-    for id in $(buildah containers -q) ; do
-      run_buildah rm ${id}
-    done
-    for id in $(buildah images -q) ; do
-      run_buildah rmi ${id}
-    done
+    run_buildah rm -a
+    run_buildah rmi -a
   }
   # Test with pairs of short and fully-qualified names that should be the same image.
-  registrypair busybox docker.io/busybox
-  registrypair docker.io/busybox busybox
-  registrypair busybox docker.io/library/busybox
-  registrypair docker.io/library/busybox busybox
+  registrypair busybox        docker.io/busybox
+  registrypair busybox        docker.io/library/busybox
   registrypair fedora-minimal registry.fedoraproject.org/fedora-minimal
-  registrypair registry.fedoraproject.org/fedora-minimal fedora-minimal
 }

--- a/tests/registries.bats
+++ b/tests/registries.bats
@@ -8,10 +8,10 @@ load helpers
     imagename=$2
 
     # Clean up.
-    for id in $(buildah --log-level=error containers -q) ; do
+    for id in $(buildah containers -q) ; do
       buildah rm ${id}
     done
-    for id in $(buildah --log-level=error images -q) ; do
+    for id in $(buildah images -q) ; do
       buildah rmi ${id}
     done
 
@@ -23,8 +23,8 @@ load helpers
 
     # Get their image IDs.  They should be the same one.
     lastid=
-    for cid in $(buildah --log-level=error containers -q) ; do
-      run_buildah --log-level=error inspect -f "{{.FromImageID}}" $cid
+    for cid in $(buildah containers -q) ; do
+      run_buildah inspect -f "{{.FromImageID}}" $cid
       expect_line_count 1
       if [ "$lastid" != "" ] ; then
         expect_output "$lastid"
@@ -36,10 +36,10 @@ load helpers
     run_buildah images
 
     # Clean up.
-    for id in $(buildah --log-level=error containers -q) ; do
+    for id in $(buildah containers -q) ; do
       buildah rm ${id}
     done
-    for id in $(buildah --log-level=error images -q) ; do
+    for id in $(buildah images -q) ; do
       buildah rmi ${id}
     done
   }

--- a/tests/registries.bats
+++ b/tests/registries.bats
@@ -9,17 +9,17 @@ load helpers
 
     # Clean up.
     for id in $(buildah containers -q) ; do
-      buildah rm ${id}
+      run_buildah rm ${id}
     done
     for id in $(buildah images -q) ; do
-      buildah rmi ${id}
+      run_buildah rmi ${id}
     done
 
     # Create a container by specifying the image with one name.
-    buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $image
+    run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $image
 
     # Create a container by specifying the image with another name.
-    buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $imagename
+    run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json $imagename
 
     # Get their image IDs.  They should be the same one.
     lastid=
@@ -37,10 +37,10 @@ load helpers
 
     # Clean up.
     for id in $(buildah containers -q) ; do
-      buildah rm ${id}
+      run_buildah rm ${id}
     done
     for id in $(buildah images -q) ; do
-      buildah rmi ${id}
+      run_buildah rmi ${id}
     done
   }
   # Test with pairs of short and fully-qualified names that should be the same image.

--- a/tests/rename.bats
+++ b/tests/rename.bats
@@ -11,7 +11,7 @@ load helpers
   run_buildah containers --format "{{.ContainerName}}"
   expect_output --substring "test-container"
 
-  run_buildah --log-level=error containers --quiet -f name=${old_name}
+  run_buildah containers --quiet -f name=${old_name}
   expect_output ""
 
   buildah rm ${new_name}
@@ -20,7 +20,7 @@ load helpers
 
 @test "rename same name as current name" {
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah 1 --log-level=error rename ${cid} ${cid}
+  run_buildah 1 rename ${cid} ${cid}
   expect_output 'renaming a container with the same name as its current name'
 
   buildah rm $cid
@@ -30,7 +30,7 @@ load helpers
 @test "rename same name as other container name" {
   cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah 1 --log-level=error rename ${cid1} ${cid2}
+  run_buildah 1 rename ${cid1} ${cid2}
   expect_output --substring " already in use by "
 
   buildah rm $cid1 $cid2

--- a/tests/rename.bats
+++ b/tests/rename.bats
@@ -15,9 +15,6 @@ load helpers
 
   run_buildah containers --quiet -f name=${old_name}
   expect_output ""
-
-  run_buildah rm ${new_name}
-  [ "$status" -eq 0 ]
 }
 
 @test "rename same name as current name" {
@@ -25,9 +22,6 @@ load helpers
   cid=$output
   run_buildah 1 rename ${cid} ${cid}
   expect_output 'renaming a container with the same name as its current name'
-
-  run_buildah rm $cid
-  run_buildah rmi -f alpine
 }
 
 @test "rename same name as other container name" {
@@ -37,7 +31,4 @@ load helpers
   cid2=$output
   run_buildah 1 rename ${cid1} ${cid2}
   expect_output --substring " already in use by "
-
-  run_buildah rm $cid1 $cid2
-  run_buildah rmi -f alpine busybox
 }

--- a/tests/rename.bats
+++ b/tests/rename.bats
@@ -4,8 +4,10 @@ load helpers
 
 @test "rename" {
   new_name=test-container
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  old_name=$(buildah containers --format "{{.ContainerName}}")
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
+  run_buildah containers --format "{{.ContainerName}}"
+  old_name=$output
   buildah rename ${cid} ${new_name}
 
   run_buildah containers --format "{{.ContainerName}}"
@@ -19,7 +21,8 @@ load helpers
 }
 
 @test "rename same name as current name" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah 1 rename ${cid} ${cid}
   expect_output 'renaming a container with the same name as its current name'
 
@@ -28,8 +31,10 @@ load helpers
 }
 
 @test "rename same name as other container name" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid2=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid2=$output
   run_buildah 1 rename ${cid1} ${cid2}
   expect_output --substring " already in use by "
 

--- a/tests/rename.bats
+++ b/tests/rename.bats
@@ -8,7 +8,7 @@ load helpers
   cid=$output
   run_buildah containers --format "{{.ContainerName}}"
   old_name=$output
-  buildah rename ${cid} ${new_name}
+  run_buildah rename ${cid} ${new_name}
 
   run_buildah containers --format "{{.ContainerName}}"
   expect_output --substring "test-container"
@@ -16,7 +16,7 @@ load helpers
   run_buildah containers --quiet -f name=${old_name}
   expect_output ""
 
-  buildah rm ${new_name}
+  run_buildah rm ${new_name}
   [ "$status" -eq 0 ]
 }
 
@@ -26,8 +26,8 @@ load helpers
   run_buildah 1 rename ${cid} ${cid}
   expect_output 'renaming a container with the same name as its current name'
 
-  buildah rm $cid
-  buildah rmi -f alpine
+  run_buildah rm $cid
+  run_buildah rmi -f alpine
 }
 
 @test "rename same name as other container name" {
@@ -38,6 +38,6 @@ load helpers
   run_buildah 1 rename ${cid1} ${cid2}
   expect_output --substring " already in use by "
 
-  buildah rm $cid1 $cid2
-  buildah rmi -f alpine busybox
+  run_buildah rm $cid1 $cid2
+  run_buildah rmi -f alpine busybox
 }

--- a/tests/rm.bats
+++ b/tests/rm.bats
@@ -19,28 +19,35 @@ load helpers
 }
 
 @test "remove one container" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah rm "$cid"
   run_buildah rmi alpine
 }
 
 @test "remove multiple containers" {
-  cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  cid2=$output
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  cid3=$output
   run_buildah rm "$cid2" "$cid3"
   run_buildah rmi alpine busybox
 }
 
 @test "remove all containers" {
-  cid1=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
-  cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
-  cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  cid1=$output
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  cid2=$output
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  cid3=$output
   run_buildah rm -a
   run_buildah rmi --all
 }
 
 @test "use conflicting commands to remove containers" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   run_buildah 1 rm -a "$cid"
   expect_output --substring "when using the --all switch, you may not pass any containers names or IDs"
   run_buildah rm "$cid"

--- a/tests/rm.bats
+++ b/tests/rm.bats
@@ -11,7 +11,7 @@ load helpers
 }
 
 @test "remove multiple containers errors" {
-  run_buildah 1 --log-level=error rm mycontainer1 mycontainer2 mycontainer3
+  run_buildah 1 rm mycontainer1 mycontainer2 mycontainer3
   expect_output --from="${lines[0]}" "error removing container \"mycontainer1\": error reading build container: container not known" "output line 1"
   expect_output --from="${lines[1]}" "error removing container \"mycontainer2\": error reading build container: container not known" "output line 2"
   expect_output --from="${lines[2]}" "error removing container \"mycontainer3\": error reading build container: container not known" "output line 3"
@@ -20,14 +20,14 @@ load helpers
 
 @test "remove one container" {
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah --log-level=error rm "$cid"
+  run_buildah rm "$cid"
   run_buildah rmi alpine
 }
 
 @test "remove multiple containers" {
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error rm "$cid2" "$cid3"
+  run_buildah rm "$cid2" "$cid3"
   run_buildah rmi alpine busybox
 }
 
@@ -35,13 +35,13 @@ load helpers
   cid1=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
-  run_buildah --log-level=error rm -a
+  run_buildah rm -a
   run_buildah rmi --all
 }
 
 @test "use conflicting commands to remove containers" {
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-  run_buildah 1 --log-level=error rm -a "$cid"
+  run_buildah 1 rm -a "$cid"
   expect_output --substring "when using the --all switch, you may not pass any containers names or IDs"
   run_buildah rm "$cid"
   run_buildah rmi alpine

--- a/tests/rm.bats
+++ b/tests/rm.bats
@@ -22,7 +22,6 @@ load helpers
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah rm "$cid"
-  run_buildah rmi alpine
 }
 
 @test "remove multiple containers" {
@@ -31,7 +30,6 @@ load helpers
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
   cid3=$output
   run_buildah rm "$cid2" "$cid3"
-  run_buildah rmi alpine busybox
 }
 
 @test "remove all containers" {
@@ -42,7 +40,6 @@ load helpers
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
   cid3=$output
   run_buildah rm -a
-  run_buildah rmi --all
 }
 
 @test "use conflicting commands to remove containers" {
@@ -50,6 +47,4 @@ load helpers
   cid=$output
   run_buildah 1 rm -a "$cid"
   expect_output --substring "when using the --all switch, you may not pass any containers names or IDs"
-  run_buildah rm "$cid"
-  run_buildah rmi alpine
 }

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -17,7 +17,7 @@ load helpers
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
   buildah rmi alpine
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   expect_output ""
 }
 
@@ -25,16 +25,16 @@ load helpers
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah 1 rmi alpine busybox
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   [ "$output" != "" ]
 
   buildah rmi -f alpine busybox
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   expect_output ""
 }
 
 @test "remove multiple non-existent images errors" {
-  run_buildah 1 --log-level=error rmi image1 image2 image3
+  run_buildah 1 rmi image1 image2 image3
   expect_output --from="${lines[0]}" "could not get image \"image1\": identifier is not an image" "output line 1"
   expect_output --from="${lines[1]}" "could not get image \"image2\": identifier is not an image" "output line 2"
   expect_output --from="${lines[2]}" "could not get image \"image3\": identifier is not an image" "output line 3"
@@ -46,18 +46,18 @@ load helpers
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
   buildah rmi -a -f
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   expect_output ""
 
   cid1=$(buildah from --signature-policy ${TESTSDIR}/policy.json scratch)
   cid2=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
   cid3=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
   run_buildah 1 rmi --all
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   [ "$output" != "" ]
 
   buildah rmi --all --force
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   expect_output ""
 }
 
@@ -67,7 +67,7 @@ load helpers
 
   cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json busybox)
 
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   expect_line_count 1
 
   root=$(buildah mount $cid)
@@ -75,7 +75,7 @@ load helpers
   buildah unmount $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
 
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   expect_line_count 2
 
   root=$(buildah mount $cid)
@@ -83,33 +83,33 @@ load helpers
   buildah unmount $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
 
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   expect_line_count 3
 
   buildah rmi --prune
 
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   expect_line_count 2
 
   buildah rmi --all --force
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   expect_output ""
 }
 
 @test "use conflicting commands to remove images" {
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
-  run_buildah 1 --log-level=error rmi -a alpine
+  run_buildah 1 rmi -a alpine
   expect_output --substring "when using the --all switch, you may not pass any images names or IDs"
 
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
-  run_buildah 1 --log-level=error rmi -p alpine
+  run_buildah 1 rmi -p alpine
   expect_output --substring "when using the --prune switch, you may not pass any images names or IDs"
 
   cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
   buildah rm "$cid"
-  run_buildah 1 --log-level=error rmi -a -p
+  run_buildah 1 rmi -a -p
   expect_output --substring "when using the --all switch, you may not use --prune switch"
   buildah rmi --all
 }
@@ -120,36 +120,36 @@ load helpers
   buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid new-image
   buildah rm -a
-  run_buildah 1 --log-level=error rmi alpine
+  run_buildah 1 rmi alpine
   expect_line_count 2
-  run_buildah --log-level=error images -q
+  run_buildah images -q
   expect_line_count 1
-  run_buildah --log-level=error images -q -a
+  run_buildah images -q -a
   expect_line_count 2
-  my_images=( $(buildah --log-level=error images -a -q) )
-  run_buildah 1 --log-level=error rmi ${my_images[2]}
+  my_images=( $(buildah images -a -q) )
+  run_buildah 1 rmi ${my_images[2]}
   buildah rmi new-image
 }
 
 @test "rmi with cached images" {
   buildah rmi -a -f
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
-  run_buildah --log-level=error images -a -q
+  run_buildah images -a -q
   expect_line_count 7
   buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
-  run_buildah --log-level=error images -a -q
+  run_buildah images -a -q
   expect_line_count 9
-  run_buildah --log-level=error rmi test2
-  run_buildah --log-level=error images -a -q
+  run_buildah rmi test2
+  run_buildah images -a -q
   expect_line_count 7
-  run_buildah --log-level=error rmi test1
-  run_buildah --log-level=error images -a -q
+  run_buildah rmi test1
+  run_buildah images -a -q
   expect_line_count 1
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
-  run_buildah 1 --log-level=error rmi alpine
+  run_buildah 1 rmi alpine
   expect_line_count 2
-  run_buildah --log-level=error rmi test3
-  run_buildah --log-level=error images -a -q
+  run_buildah rmi test3
+  run_buildah images -a -q
   expect_output ""
 }
 
@@ -162,7 +162,7 @@ load helpers
   buildah config --env 'foo=bar' $cid
   buildah commit --signature-policy ${TESTSDIR}/policy.json $cid new-image-2
   buildah rm -a
-  run_buildah --log-level=error rmi new-image-2
-  run_buildah --log-level=error images -q
+  run_buildah rmi new-image-2
+  run_buildah images -q
   expect_line_count 2
 }

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -142,8 +142,10 @@ load helpers
   expect_line_count 1
   run_buildah images -q -a
   expect_line_count 2
-  my_images=( $(buildah images -a -q) )
-  run_buildah 1 rmi ${my_images[2]}
+
+  local try_to_delete=${lines[1]}
+  run_buildah 1 rmi $try_to_delete
+  expect_output --substring "unable to delete \"$try_to_delete.*\" \(cannot be forced\) - image has dependent child images"
   run_buildah rmi new-image
 }
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -23,9 +23,6 @@ load helpers
 	cmp ${TESTDIR}/randomfile $root/tmp/other-randomfile
 
 	seq 100000 | buildah run $cid -- sh -c 'while read i; do echo $i; done'
-
-	run_buildah unmount $cid
-	run_buildah rm $cid
 }
 
 @test "run--args" {
@@ -52,8 +49,6 @@ load helpers
 	# This should succeed, because buildah run stops caring at the --.
 	run_buildah run $cid -- echo -n "test"
 	expect_output "test"
-
-	run_buildah rm $cid
 }
 
 @test "run-cmd" {
@@ -153,8 +148,6 @@ load helpers
         run_buildah config --cmd "/invalid/cmd" $cid
         run_buildah run $cid -- pwd
 	expect_output "/tmp" "invalid cmd & entrypoint, pwd"
-
-	run_buildah rm $cid
 }
 
 function configure_and_check_user() {
@@ -214,9 +207,6 @@ function configure_and_check_user() {
 	run_buildah 1 run -- $cid id -u
 	echo "$output"
 	expect_output --substring "unknown user" "run as unknown user"
-
-	run_buildah unmount $cid
-	run_buildah rm $cid
 }
 
 @test "run --hostname" {
@@ -230,7 +220,6 @@ function configure_and_check_user() {
 	[ "$output" != "foobar" ]
 	run_buildah run --hostname foobar $cid hostname
 	expect_output "foobar"
-	run_buildah rm $cid
 }
 
 @test "run --volume" {
@@ -345,7 +334,6 @@ function configure_and_check_user() {
 	expect_output "300" "limits: open files (w/file & proc limits)"
 	run_buildah run $cid awk '/processes/{print $3}' /proc/self/limits
 	expect_output "100" "limits: processes (w/file & proc limits)"
-	run_buildah rm $cid
 }
 
 @test "run-builtin-volume-omitted" {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -10,10 +10,10 @@ load helpers
 	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	root=$(buildah mount $cid)
 	buildah config --workingdir /tmp $cid
-	run_buildah --log-level=error run $cid pwd
+	run_buildah run $cid pwd
 	expect_output "/tmp"
 	buildah config --workingdir /root $cid
-	run_buildah --log-level=error run        $cid pwd
+	run_buildah run        $cid pwd
 	expect_output "/root"
 	cp ${TESTDIR}/randomfile $root/tmp/
 	buildah run        $cid cp /tmp/randomfile /tmp/other-randomfile
@@ -32,22 +32,22 @@ load helpers
 	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 
 	# This should fail, because buildah run doesn't have a -n flag.
-	run_buildah 1 --log-level=error run -n $cid echo test
+	run_buildah 1 run -n $cid echo test
 
 	# This should succeed, because buildah run stops caring at the --, which is preserved as part of the command.
-	run_buildah --log-level=error run $cid echo -- -n test
+	run_buildah run $cid echo -- -n test
 	expect_output -- "-- -n test"
 
 	# This should succeed, because buildah run stops caring at the --, which is not part of the command.
-	run_buildah --log-level=error run $cid -- echo -n -- test
+	run_buildah run $cid -- echo -n -- test
 	expect_output -- "-- test"
 
 	# This should succeed, because buildah run stops caring at the --.
-	run_buildah --log-level=error run $cid -- echo -- -n test --
+	run_buildah run $cid -- echo -- -n test --
 	expect_output -- "-- -n test --"
 
 	# This should succeed, because buildah run stops caring at the --.
-	run_buildah --log-level=error run $cid -- echo -n "test"
+	run_buildah run $cid -- echo -n "test"
 	expect_output "test"
 
 	buildah rm $cid
@@ -65,57 +65,57 @@ load helpers
 	# empty entrypoint, configured cmd, empty run arguments
 	buildah config --entrypoint "" $cid
 	buildah config --cmd pwd $cid
-	run_buildah 1 --log-level=error run $cid
+	run_buildah 1 run $cid
 	expect_output --substring "command must be specified" "empty entrypoint, cmd, no args"
 
 	# empty entrypoint, configured cmd, empty run arguments, end parsing option
 	buildah config --entrypoint "" $cid
 	buildah config --cmd pwd $cid
-	run_buildah 1 --log-level=error run $cid --
+	run_buildah 1 run $cid --
 	expect_output --substring "command must be specified" "empty entrypoint, cmd, no args, --"
 
 	# configured entrypoint, empty cmd, empty run arguments
 	buildah config --entrypoint pwd $cid
 	buildah config --cmd "" $cid
-	run_buildah 1 --log-level=error run $cid
+	run_buildah 1 run $cid
 	expect_output --substring "command must be specified" "entrypoint, empty cmd, no args"
 
 	# configured entrypoint, empty cmd, empty run arguments, end parsing option
 	buildah config --entrypoint pwd $cid
 	buildah config --cmd "" $cid
-	run_buildah 1 --log-level=error run $cid --
+	run_buildah 1 run $cid --
 	expect_output --substring "command must be specified" "entrypoint, empty cmd, no args, --"
 
 	# configured entrypoint only, empty run arguments
 	buildah config --entrypoint pwd $cid
-	run_buildah 1 --log-level=error run $cid
+	run_buildah 1 run $cid
 	expect_output --substring "command must be specified" "entrypoint, no args"
 
 	# configured entrypoint only, empty run arguments, end parsing option
 	buildah config --entrypoint pwd $cid
-	run_buildah 1 --log-level=error run $cid --
+	run_buildah 1 run $cid --
 	expect_output --substring "command must be specified" "entrypoint, no args, --"
 
 	# configured cmd only, empty run arguments
 	buildah config --cmd pwd $cid
-	run_buildah 1 --log-level=error run $cid
+	run_buildah 1 run $cid
 	expect_output --substring "command must be specified" "cmd, no args"
 
 	# configured cmd only, empty run arguments, end parsing option
 	buildah config --cmd pwd $cid
-	run_buildah 1 --log-level=error run $cid --
+	run_buildah 1 run $cid --
 	expect_output --substring "command must be specified" "cmd, no args, --"
 
 	# configured entrypoint, configured cmd, empty run arguments
 	buildah config --entrypoint "pwd" $cid
 	buildah config --cmd "whoami" $cid
-	run_buildah 1 --log-level=error run $cid
+	run_buildah 1 run $cid
 	expect_output --substring "command must be specified" "entrypoint, cmd, no args"
 
 	# configured entrypoint, configured cmd, empty run arguments, end parsing option
 	buildah config --entrypoint "pwd" $cid
 	buildah config --cmd "whoami" $cid
-	run_buildah 1 --log-level=error run $cid --
+	run_buildah 1 run $cid --
 	expect_output --substring "command must be specified"  "entrypoint, cmd, no args"
 
 
@@ -125,29 +125,29 @@ load helpers
 	# empty entrypoint, configured cmd, configured run arguments
 	buildah config --entrypoint "" $cid
 	buildah config --cmd "/invalid/cmd" $cid
-	run_buildah --log-level=error run $cid -- pwd
+	run_buildah run $cid -- pwd
 	expect_output "/tmp" "empty entrypoint, invalid cmd, pwd"
 
         # configured entrypoint, empty cmd, configured run arguments
         buildah config --entrypoint "/invalid/entrypoint" $cid
         buildah config --cmd "" $cid
-        run_buildah --log-level=error run $cid -- pwd
+        run_buildah run $cid -- pwd
 	expect_output "/tmp" "invalid entrypoint, empty cmd, pwd"
 
         # configured entrypoint only, configured run arguments
         buildah config --entrypoint "/invalid/entrypoint" $cid
-        run_buildah --log-level=error run $cid -- pwd
+        run_buildah run $cid -- pwd
 	expect_output "/tmp" "invalid entrypoint, no cmd(??), pwd"
 
         # configured cmd only, configured run arguments
         buildah config --cmd "/invalid/cmd" $cid
-        run_buildah --log-level=error run $cid -- pwd
+        run_buildah run $cid -- pwd
 	expect_output "/tmp" "invalid cmd, no entrypoint(??), pwd"
 
         # configured entrypoint, configured cmd, configured run arguments
         buildah config --entrypoint "/invalid/entrypoint" $cid
         buildah config --cmd "/invalid/cmd" $cid
-        run_buildah --log-level=error run $cid -- pwd
+        run_buildah run $cid -- pwd
 	expect_output "/tmp" "invalid cmd & entrypoint, pwd"
 
 	buildah rm $cid
@@ -159,10 +159,10 @@ function configure_and_check_user() {
     local expect_g=$3
 
     run_buildah config -u "$setting" $cid
-    run_buildah --log-level=error run -- $cid id -u
+    run_buildah run -- $cid id -u
     expect_output "$expect_u" "id -u ($setting)"
 
-    run_buildah --log-level=error run -- $cid id -g
+    run_buildah run -- $cid id -g
     expect_output "$expect_g" "id -g ($setting)"
 }
 
@@ -198,14 +198,14 @@ function configure_and_check_user() {
         configure_and_check_user "${testuid}:${testgroupid}"    $testuid      $testgroupid
 
         buildah config -u ${testbogususer} $cid
-        run_buildah 1 --log-level=error run -- $cid id -u
+        run_buildah 1 run -- $cid id -u
         expect_output --substring "unknown user" "id -u (bogus user)"
-        run_buildah 1 --log-level=error run -- $cid id -g
+        run_buildah 1 run -- $cid id -g
         expect_output --substring "unknown user" "id -g (bogus user)"
 
 	ln -vsf /etc/passwd $root/etc/passwd
 	buildah config -u ${testuser}:${testgroup} $cid
-	run_buildah 1 --log-level=error run -- $cid id -u
+	run_buildah 1 run -- $cid id -u
 	echo "$output"
 	expect_output --substring "unknown user" "run as unknown user"
 
@@ -219,9 +219,9 @@ function configure_and_check_user() {
 
 	runc --version
 	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-	run_buildah --log-level=error run $cid hostname
+	run_buildah run $cid hostname
 	[ "$output" != "foobar" ]
-	run_buildah --log-level=error run --hostname foobar $cid hostname
+	run_buildah run --hostname foobar $cid hostname
 	expect_output "foobar"
 	buildah rm $cid
 }
@@ -239,15 +239,15 @@ function configure_and_check_user() {
 	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	mkdir -p ${TESTDIR}/was-empty
 	# As a baseline, this should succeed.
-	run_buildah --log-level=error run -v ${TESTDIR}/was-empty:/var/not-empty${zflag:+:${zflag}}     $cid touch /var/not-empty/testfile
+	run_buildah run -v ${TESTDIR}/was-empty:/var/not-empty${zflag:+:${zflag}}     $cid touch /var/not-empty/testfile
 	# Parsing options that with comma, this should succeed.
-	run_buildah --log-level=error run -v ${TESTDIR}/was-empty:/var/not-empty:rw,rshared${zflag:+,${zflag}}     $cid touch /var/not-empty/testfile
+	run_buildah run -v ${TESTDIR}/was-empty:/var/not-empty:rw,rshared${zflag:+,${zflag}}     $cid touch /var/not-empty/testfile
 	# If we're parsing the options at all, this should be read-only, so it should fail.
-	run_buildah 1 --log-level=error run -v ${TESTDIR}/was-empty:/var/not-empty:ro${zflag:+,${zflag}} $cid touch /var/not-empty/testfile
+	run_buildah 1 run -v ${TESTDIR}/was-empty:/var/not-empty:ro${zflag:+,${zflag}} $cid touch /var/not-empty/testfile
 	# Even if the parent directory doesn't exist yet, this should succeed.
-	run_buildah --log-level=error run -v ${TESTDIR}/was-empty:/var/multi-level/subdirectory        $cid touch /var/multi-level/subdirectory/testfile
+	run_buildah run -v ${TESTDIR}/was-empty:/var/multi-level/subdirectory        $cid touch /var/multi-level/subdirectory/testfile
 	# And check the same for file volumes.
-	run_buildah --log-level=error run -v ${TESTDIR}/was-empty/testfile:/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
+	run_buildah run -v ${TESTDIR}/was-empty/testfile:/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
 }
 
 @test "run --mount" {
@@ -263,14 +263,14 @@ function configure_and_check_user() {
 	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	mkdir -p ${TESTDIR}/was:empty
 	# As a baseline, this should succeed.
-	run_buildah --log-level=error run --mount type=tmpfs,dst=/var/tmpfs-not-empty                                           $cid touch /var/tmpfs-not-empty/testfile
-	run_buildah --log-level=error run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/not-empty${zflag:+,${zflag}}      $cid touch /var/not-empty/testfile
+	run_buildah run --mount type=tmpfs,dst=/var/tmpfs-not-empty                                           $cid touch /var/tmpfs-not-empty/testfile
+	run_buildah run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/not-empty${zflag:+,${zflag}}      $cid touch /var/not-empty/testfile
 	# If we're parsing the options at all, this should be read-only, so it should fail.
-	run_buildah 1 --log-level=error run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/not-empty,ro${zflag:+,${zflag}} $cid touch /var/not-empty/testfile
+	run_buildah 1 run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/not-empty,ro${zflag:+,${zflag}} $cid touch /var/not-empty/testfile
 	# Even if the parent directory doesn't exist yet, this should succeed.
-	run_buildah --log-level=error run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/multi-level/subdirectory          $cid touch /var/multi-level/subdirectory/testfile
+	run_buildah run --mount type=bind,src=${TESTDIR}/was:empty,dst=/var/multi-level/subdirectory          $cid touch /var/multi-level/subdirectory/testfile
 	# And check the same for file volumes.
-	run_buildah --log-level=error run --mount type=bind,src=${TESTDIR}/was:empty/testfile,dst=/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
+	run_buildah run --mount type=bind,src=${TESTDIR}/was:empty/testfile,dst=/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
 }
 
 @test "run symlinks" {
@@ -281,7 +281,7 @@ function configure_and_check_user() {
 	mkdir -p ${TESTDIR}/tmp
 	ln -s tmp ${TESTDIR}/tmp2
 	export TMPDIR=${TESTDIR}/tmp2
-	run_buildah --log-level=error run $cid id
+	run_buildah run $cid id
 }
 
 @test "run --cap-add/--cap-drop" {
@@ -290,13 +290,13 @@ function configure_and_check_user() {
 	runc --version
 	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	# Try with default caps.
-	run_buildah --log-level=error run $cid grep ^CapEff /proc/self/status
+	run_buildah run $cid grep ^CapEff /proc/self/status
 	defaultcaps="$output"
 	# Try adding DAC_OVERRIDE.
-	run_buildah --log-level=error run --cap-add CAP_DAC_OVERRIDE $cid grep ^CapEff /proc/self/status
+	run_buildah run --cap-add CAP_DAC_OVERRIDE $cid grep ^CapEff /proc/self/status
 	addedcaps="$output"
 	# Try dropping DAC_OVERRIDE.
-	run_buildah --log-level=error run --cap-drop CAP_DAC_OVERRIDE $cid grep ^CapEff /proc/self/status
+	run_buildah run --cap-drop CAP_DAC_OVERRIDE $cid grep ^CapEff /proc/self/status
 	droppedcaps="$output"
 	# Okay, now the "dropped" and "added" should be different.
 	test "$addedcaps" != "$droppedcaps"
@@ -313,23 +313,23 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-	run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
+	run_buildah run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output "1048576" "limits: open files (unlimited)"
-	run_buildah --log-level=error run $cid awk '/processes/{print $3}' /proc/self/limits
+	run_buildah run $cid awk '/processes/{print $3}' /proc/self/limits
 	expect_output "1048576" "limits: processes (unlimited)"
 	buildah rm $cid
 
 	cid=$(buildah from --ulimit nofile=300:400 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-	run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
+	run_buildah run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output "300" "limits: open files (w/file limit)"
-	run_buildah --log-level=error run $cid awk '/processes/{print $3}' /proc/self/limits
+	run_buildah run $cid awk '/processes/{print $3}' /proc/self/limits
 	expect_output "1048576" "limits: processes (w/file limit)"
 	buildah rm $cid
 
 	cid=$(buildah from --ulimit nproc=100:200 --ulimit nofile=300:400 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
-	run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
+	run_buildah run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output "300" "limits: open files (w/file & proc limits)"
-	run_buildah --log-level=error run $cid awk '/processes/{print $3}' /proc/self/limits
+	run_buildah run $cid awk '/processes/{print $3}' /proc/self/limits
 	expect_output "100" "limits: processes (w/file & proc limits)"
 	buildah rm $cid
 }
@@ -344,7 +344,7 @@ function configure_and_check_user() {
 	echo "$output"
 	[ "$status" -ne 0 ]
 	# We'll create the mountpoint for "run".
-	run_buildah --log-level=error run $cid ls -1 /var/lib
+	run_buildah run $cid ls -1 /var/lib
         expect_output --substring "registry"
 
 	# Double-check that the mountpoint is there.
@@ -363,7 +363,7 @@ function configure_and_check_user() {
 
 	cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
 	# test a standard mount to /run/.containerenv
-	run_buildah --log-level=error run $cid ls -1 /run/.containerenv
+	run_buildah run $cid ls -1 /run/.containerenv
 	expect_output --substring "/run/.containerenv"
 }
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -11,21 +11,21 @@ load helpers
 	cid=$output
 	run_buildah mount $cid
 	root=$output
-	buildah config --workingdir /tmp $cid
+	run_buildah config --workingdir /tmp $cid
 	run_buildah run $cid pwd
 	expect_output "/tmp"
-	buildah config --workingdir /root $cid
+	run_buildah config --workingdir /root $cid
 	run_buildah run        $cid pwd
 	expect_output "/root"
 	cp ${TESTDIR}/randomfile $root/tmp/
-	buildah run        $cid cp /tmp/randomfile /tmp/other-randomfile
+	run_buildah run        $cid cp /tmp/randomfile /tmp/other-randomfile
 	test -s $root/tmp/other-randomfile
 	cmp ${TESTDIR}/randomfile $root/tmp/other-randomfile
 
 	seq 100000 | buildah run $cid -- sh -c 'while read i; do echo $i; done'
 
-	buildah unmount $cid
-	buildah rm $cid
+	run_buildah unmount $cid
+	run_buildah rm $cid
 }
 
 @test "run--args" {
@@ -53,7 +53,7 @@ load helpers
 	run_buildah run $cid -- echo -n "test"
 	expect_output "test"
 
-	buildah rm $cid
+	run_buildah rm $cid
 }
 
 @test "run-cmd" {
@@ -61,64 +61,64 @@ load helpers
 
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
-	buildah config --workingdir /tmp $cid
+	run_buildah config --workingdir /tmp $cid
 
 
 	# Configured entrypoint/cmd shouldn't modify behaviour of run with no arguments
 
 	# empty entrypoint, configured cmd, empty run arguments
-	buildah config --entrypoint "" $cid
-	buildah config --cmd pwd $cid
+	run_buildah config --entrypoint "" $cid
+	run_buildah config --cmd pwd $cid
 	run_buildah 1 run $cid
 	expect_output --substring "command must be specified" "empty entrypoint, cmd, no args"
 
 	# empty entrypoint, configured cmd, empty run arguments, end parsing option
-	buildah config --entrypoint "" $cid
-	buildah config --cmd pwd $cid
+	run_buildah config --entrypoint "" $cid
+	run_buildah config --cmd pwd $cid
 	run_buildah 1 run $cid --
 	expect_output --substring "command must be specified" "empty entrypoint, cmd, no args, --"
 
 	# configured entrypoint, empty cmd, empty run arguments
-	buildah config --entrypoint pwd $cid
-	buildah config --cmd "" $cid
+	run_buildah config --entrypoint pwd $cid
+	run_buildah config --cmd "" $cid
 	run_buildah 1 run $cid
 	expect_output --substring "command must be specified" "entrypoint, empty cmd, no args"
 
 	# configured entrypoint, empty cmd, empty run arguments, end parsing option
-	buildah config --entrypoint pwd $cid
-	buildah config --cmd "" $cid
+	run_buildah config --entrypoint pwd $cid
+	run_buildah config --cmd "" $cid
 	run_buildah 1 run $cid --
 	expect_output --substring "command must be specified" "entrypoint, empty cmd, no args, --"
 
 	# configured entrypoint only, empty run arguments
-	buildah config --entrypoint pwd $cid
+	run_buildah config --entrypoint pwd $cid
 	run_buildah 1 run $cid
 	expect_output --substring "command must be specified" "entrypoint, no args"
 
 	# configured entrypoint only, empty run arguments, end parsing option
-	buildah config --entrypoint pwd $cid
+	run_buildah config --entrypoint pwd $cid
 	run_buildah 1 run $cid --
 	expect_output --substring "command must be specified" "entrypoint, no args, --"
 
 	# configured cmd only, empty run arguments
-	buildah config --cmd pwd $cid
+	run_buildah config --cmd pwd $cid
 	run_buildah 1 run $cid
 	expect_output --substring "command must be specified" "cmd, no args"
 
 	# configured cmd only, empty run arguments, end parsing option
-	buildah config --cmd pwd $cid
+	run_buildah config --cmd pwd $cid
 	run_buildah 1 run $cid --
 	expect_output --substring "command must be specified" "cmd, no args, --"
 
 	# configured entrypoint, configured cmd, empty run arguments
-	buildah config --entrypoint "pwd" $cid
-	buildah config --cmd "whoami" $cid
+	run_buildah config --entrypoint "pwd" $cid
+	run_buildah config --cmd "whoami" $cid
 	run_buildah 1 run $cid
 	expect_output --substring "command must be specified" "entrypoint, cmd, no args"
 
 	# configured entrypoint, configured cmd, empty run arguments, end parsing option
-	buildah config --entrypoint "pwd" $cid
-	buildah config --cmd "whoami" $cid
+	run_buildah config --entrypoint "pwd" $cid
+	run_buildah config --cmd "whoami" $cid
 	run_buildah 1 run $cid --
 	expect_output --substring "command must be specified"  "entrypoint, cmd, no args"
 
@@ -127,34 +127,34 @@ load helpers
 	# Note: entrypoint and cmd can be invalid in below tests as they should never execute
 
 	# empty entrypoint, configured cmd, configured run arguments
-	buildah config --entrypoint "" $cid
-	buildah config --cmd "/invalid/cmd" $cid
+	run_buildah config --entrypoint "" $cid
+	run_buildah config --cmd "/invalid/cmd" $cid
 	run_buildah run $cid -- pwd
 	expect_output "/tmp" "empty entrypoint, invalid cmd, pwd"
 
         # configured entrypoint, empty cmd, configured run arguments
-        buildah config --entrypoint "/invalid/entrypoint" $cid
-        buildah config --cmd "" $cid
+        run_buildah config --entrypoint "/invalid/entrypoint" $cid
+        run_buildah config --cmd "" $cid
         run_buildah run $cid -- pwd
 	expect_output "/tmp" "invalid entrypoint, empty cmd, pwd"
 
         # configured entrypoint only, configured run arguments
-        buildah config --entrypoint "/invalid/entrypoint" $cid
+        run_buildah config --entrypoint "/invalid/entrypoint" $cid
         run_buildah run $cid -- pwd
 	expect_output "/tmp" "invalid entrypoint, no cmd(??), pwd"
 
         # configured cmd only, configured run arguments
-        buildah config --cmd "/invalid/cmd" $cid
+        run_buildah config --cmd "/invalid/cmd" $cid
         run_buildah run $cid -- pwd
 	expect_output "/tmp" "invalid cmd, no entrypoint(??), pwd"
 
         # configured entrypoint, configured cmd, configured run arguments
-        buildah config --entrypoint "/invalid/entrypoint" $cid
-        buildah config --cmd "/invalid/cmd" $cid
+        run_buildah config --entrypoint "/invalid/entrypoint" $cid
+        run_buildah config --cmd "/invalid/cmd" $cid
         run_buildah run $cid -- pwd
 	expect_output "/tmp" "invalid cmd & entrypoint, pwd"
 
-	buildah rm $cid
+	run_buildah rm $cid
 }
 
 function configure_and_check_user() {
@@ -203,20 +203,20 @@ function configure_and_check_user() {
         configure_and_check_user "${testuser}:${testgroupid}"   $testuid      $testgroupid
         configure_and_check_user "${testuid}:${testgroupid}"    $testuid      $testgroupid
 
-        buildah config -u ${testbogususer} $cid
+        run_buildah config -u ${testbogususer} $cid
         run_buildah 1 run -- $cid id -u
         expect_output --substring "unknown user" "id -u (bogus user)"
         run_buildah 1 run -- $cid id -g
         expect_output --substring "unknown user" "id -g (bogus user)"
 
 	ln -vsf /etc/passwd $root/etc/passwd
-	buildah config -u ${testuser}:${testgroup} $cid
+	run_buildah config -u ${testuser}:${testgroup} $cid
 	run_buildah 1 run -- $cid id -u
 	echo "$output"
 	expect_output --substring "unknown user" "run as unknown user"
 
-	buildah unmount $cid
-	buildah rm $cid
+	run_buildah unmount $cid
+	run_buildah rm $cid
 }
 
 @test "run --hostname" {
@@ -230,7 +230,7 @@ function configure_and_check_user() {
 	[ "$output" != "foobar" ]
 	run_buildah run --hostname foobar $cid hostname
 	expect_output "foobar"
-	buildah rm $cid
+	run_buildah rm $cid
 }
 
 @test "run --volume" {
@@ -329,7 +329,7 @@ function configure_and_check_user() {
 	expect_output "1048576" "limits: open files (unlimited)"
 	run_buildah run $cid awk '/processes/{print $3}' /proc/self/limits
 	expect_output "1048576" "limits: processes (unlimited)"
-	buildah rm $cid
+	run_buildah rm $cid
 
 	run_buildah from --quiet --ulimit nofile=300:400 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
@@ -337,7 +337,7 @@ function configure_and_check_user() {
 	expect_output "300" "limits: open files (w/file limit)"
 	run_buildah run $cid awk '/processes/{print $3}' /proc/self/limits
 	expect_output "1048576" "limits: processes (w/file limit)"
-	buildah rm $cid
+	run_buildah rm $cid
 
 	run_buildah from --quiet --ulimit nproc=100:200 --ulimit nofile=300:400 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
@@ -345,7 +345,7 @@ function configure_and_check_user() {
 	expect_output "300" "limits: open files (w/file & proc limits)"
 	run_buildah run $cid awk '/processes/{print $3}' /proc/self/limits
 	expect_output "100" "limits: processes (w/file & proc limits)"
-	buildah rm $cid
+	run_buildah rm $cid
 }
 
 @test "run-builtin-volume-omitted" {

--- a/tests/secrets.bats
+++ b/tests/secrets.bats
@@ -39,7 +39,7 @@ function setup() {
 }
 
 function teardown() {
-    buildah rm $cid
+    run_buildah rm $cid
     rm -rf $TESTSDIR/containers
     rm -rf $TESTSDIR/rhel
     rm -rf $TESTSDIR/symlink

--- a/tests/secrets.bats
+++ b/tests/secrets.bats
@@ -55,31 +55,31 @@ function teardown() {
 
 
     # setup the test container
-    cid=$(buildah --default-mounts-file "$MOUNTS_PATH" --log-level=error \
+    cid=$(buildah --default-mounts-file "$MOUNTS_PATH" \
         from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
 
     # test a standard mount to /run/secrets
-    run_buildah --log-level=error run $cid ls /run/secrets
+    run_buildah run $cid ls /run/secrets
     expect_output --substring "test.txt"
 
     # test a mount without destination
-    run_buildah --log-level=error run $cid ls "$TESTSDIR"/rhel/secrets
+    run_buildah run $cid ls "$TESTSDIR"/rhel/secrets
     expect_output --substring "test.txt"
 
     # test a file-based mount
-    run_buildah --log-level=error run $cid cat /test.txt
+    run_buildah run $cid cat /test.txt
     expect_output --substring $TESTFILE_CONTENT
 
     # test permissions for a file-based mount
-    run_buildah --log-level=error run $cid stat -c %a /run/secrets/file.txt
+    run_buildah run $cid stat -c %a /run/secrets/file.txt
     expect_output --substring 604
 
     # test permissions for a directory-based mount
-    run_buildah --log-level=error run $cid stat -c %a /run/secrets/test-dir
+    run_buildah run $cid stat -c %a /run/secrets/test-dir
     expect_output --substring 704
 
     # test permissions for a file-based mount within a sub-directory
-    run_buildah --log-level=error run $cid stat -c %a /run/secrets/test-dir/file.txt
+    run_buildah run $cid stat -c %a /run/secrets/test-dir/file.txt
     expect_output --substring 777
 
     # test a symlink

--- a/tests/secrets.bats
+++ b/tests/secrets.bats
@@ -2,85 +2,70 @@
 
 load helpers
 
-function setup() {
-    # create the files and directories to be tested
-    SECRETS_DIR=$TESTSDIR/rhel/secrets
+@test "bind secrets mounts to container" {
+    skip_if_no_runtime
+
+    # Setup
+    SECRETS_DIR=$TESTDIR/rhel/secrets
     mkdir -p $SECRETS_DIR
 
     TESTFILE1=$SECRETS_DIR/test.txt
-    touch $TESTFILE1
     TESTFILE_CONTENT="Testing secrets mounts. I am mounted!"
     echo $TESTFILE_CONTENT > $TESTFILE1
 
     TESTFILE2=$SECRETS_DIR/file.txt
-    touch $TESTFILE2
+    touch     $TESTFILE2
     chmod 604 $TESTFILE2
 
     TESTDIR1=$SECRETS_DIR/test-dir
     mkdir -m704 $TESTDIR1
 
     TESTFILE3=$TESTDIR1/file.txt
-    touch $TESTFILE3
+    touch     $TESTFILE3
     chmod 777 $TESTFILE3
 
-    mkdir -p $TESTSDIR/symlink/target
-    touch $TESTSDIR/symlink/target/key.pem
-    ln -s $TESTSDIR/symlink/target $SECRETS_DIR/mysymlink
+    mkdir -p $TESTDIR/symlink/target
+    touch    $TESTDIR/symlink/target/key.pem
+    ln -s    $TESTDIR/symlink/target $SECRETS_DIR/mysymlink
 
     # prepare the test mounts file
-    mkdir $TESTSDIR/containers
-    touch $TESTSDIR/containers/mounts.conf
-    MOUNTS_PATH=$TESTSDIR/containers/mounts.conf
+    mkdir $TESTDIR/containers
+    MOUNTS_PATH=$TESTDIR/containers/mounts.conf
 
     # add the mounts entries
-    echo "$SECRETS_DIR:/run/secrets" > $MOUNTS_PATH
-    echo "$SECRETS_DIR" >> $MOUNTS_PATH
-    echo "$TESTFILE1:/test.txt" >> $MOUNTS_PATH
-}
-
-function teardown() {
-    run_buildah rm $cid
-    rm -rf $TESTSDIR/containers
-    rm -rf $TESTSDIR/rhel
-    rm -rf $TESTSDIR/symlink
-    for d in containers rhel symlink;do
-        rm -rf $TESTSDIR/$d
-    done
-}
-
-@test "bind secrets mounts to container" {
-    skip_if_no_runtime
-
-    runc --version
+    echo "$SECRETS_DIR:/run/secrets"  > $MOUNTS_PATH
+    echo "$SECRETS_DIR"              >> $MOUNTS_PATH
+    echo "$TESTFILE1:/test.txt"      >> $MOUNTS_PATH
 
 
     # setup the test container
-    cid=$(buildah --default-mounts-file "$MOUNTS_PATH" \
-        from --pull --signature-policy ${TESTSDIR}/policy.json alpine)
+    run_buildah --default-mounts-file "$MOUNTS_PATH" \
+                from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
+    cid=$output
 
     # test a standard mount to /run/secrets
     run_buildah run $cid ls /run/secrets
     expect_output --substring "test.txt"
 
     # test a mount without destination
-    run_buildah run $cid ls "$TESTSDIR"/rhel/secrets
+    run_buildah run $cid ls "$TESTDIR"/rhel/secrets
     expect_output --substring "test.txt"
 
     # test a file-based mount
     run_buildah run $cid cat /test.txt
-    expect_output --substring $TESTFILE_CONTENT
+    expect_output "$TESTFILE_CONTENT"
 
     # test permissions for a file-based mount
     run_buildah run $cid stat -c %a /run/secrets/file.txt
-    expect_output --substring 604
+    expect_output 604
 
     # test permissions for a directory-based mount
     run_buildah run $cid stat -c %a /run/secrets/test-dir
-    expect_output --substring 704
+    expect_output 704
 
     # test permissions for a file-based mount within a sub-directory
     run_buildah run $cid stat -c %a /run/secrets/test-dir/file.txt
-    expect_output --substring 777
+    expect_output 777
 
     # test a symlink
     run_buildah run $cid ls /run/secrets/mysymlink

--- a/tests/selinux.bats
+++ b/tests/selinux.bats
@@ -12,7 +12,8 @@ load helpers
   image=alpine
 
   # Create a container and read its context as a baseline.
-  cid=$(buildah from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah from --quiet --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  cid=$output
   run_buildah run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   [ "$output" != "" ]
   firstlabel="$output"
@@ -22,7 +23,8 @@ load helpers
   expect_output "$firstlabel" "label of second container == first"
 
   # Ensure that different containers get different labels.
-  cid1=$(buildah from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah from --quiet --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  cid1=$output
   run_buildah run $cid1 sh -c 'tr \\0 \\n < /proc/self/attr/current'
   if [ "$output" = "$firstlabel" ]; then
       die "Second container has the same label as first (both '$output')"
@@ -44,7 +46,8 @@ load helpers
       firstlabel="unconfined_u:system_r:spc_t:s0-s0:c0.c1023"
   fi
   # Create a container and read its context as a baseline.
-  cid=$(buildah from --security-opt label=disable --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah from --quiet --security-opt label=disable --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  cid=$output
   run_buildah run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   expect_output "$firstlabel" "container context matches our own"
 }
@@ -60,7 +63,8 @@ load helpers
 
   firstlabel="system_u:system_r:container_t:s0:c1,c2"
   # Create a container and read its context as a baseline.
-  cid=$(buildah from --security-opt label="level:s0:c1,c2" --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah from --quiet --security-opt label="level:s0:c1,c2" --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  cid=$output
 
   # Inspect image
   run_buildah inspect  --format '{{.ProcessLabel}}' $cid

--- a/tests/selinux.bats
+++ b/tests/selinux.bats
@@ -12,18 +12,18 @@ load helpers
   image=alpine
 
   # Create a container and read its context as a baseline.
-  cid=$(buildah --log-level=error from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
-  run_buildah --log-level=error run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
+  cid=$(buildah from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   [ "$output" != "" ]
   firstlabel="$output"
 
   # Ensure that we label the same container consistently across multiple "run" instructions.
-  run_buildah --log-level=error run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
+  run_buildah run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   expect_output "$firstlabel" "label of second container == first"
 
   # Ensure that different containers get different labels.
-  cid1=$(buildah --log-level=error from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
-  run_buildah --log-level=error run $cid1 sh -c 'tr \\0 \\n < /proc/self/attr/current'
+  cid1=$(buildah from --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah run $cid1 sh -c 'tr \\0 \\n < /proc/self/attr/current'
   if [ "$output" = "$firstlabel" ]; then
       die "Second container has the same label as first (both '$output')"
   fi
@@ -44,8 +44,8 @@ load helpers
       firstlabel="unconfined_u:system_r:spc_t:s0-s0:c0.c1023"
   fi
   # Create a container and read its context as a baseline.
-  cid=$(buildah --log-level=error from --security-opt label=disable --quiet --signature-policy ${TESTSDIR}/policy.json $image)
-  run_buildah --log-level=error run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
+  cid=$(buildah from --security-opt label=disable --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  run_buildah run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   expect_output "$firstlabel" "container context matches our own"
 }
 
@@ -60,13 +60,13 @@ load helpers
 
   firstlabel="system_u:system_r:container_t:s0:c1,c2"
   # Create a container and read its context as a baseline.
-  cid=$(buildah --log-level=error from --security-opt label="level:s0:c1,c2" --quiet --signature-policy ${TESTSDIR}/policy.json $image)
+  cid=$(buildah from --security-opt label="level:s0:c1,c2" --quiet --signature-policy ${TESTSDIR}/policy.json $image)
 
   # Inspect image
-  run_buildah --log-level=error inspect  --format '{{.ProcessLabel}}' $cid
+  run_buildah inspect  --format '{{.ProcessLabel}}' $cid
   expect_output "$firstlabel"
 
   # Check actual running context
-  run_buildah --log-level=error run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
+  run_buildah run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   expect_output "$firstlabel" "running container context"
 }

--- a/tests/squash.bats
+++ b/tests/squash.bats
@@ -10,7 +10,7 @@ function check_lengths() {
   # matrix test: check given .Docker.* and .OCIv1.* fields in image
   for which in Docker OCIv1; do
     for field in RootFS.DiffIDs History; do
-      run_buildah --log-level=error inspect -t image -f "{{len .$which.$field}}" $image
+      run_buildah inspect -t image -f "{{len .$which.$field}}" $image
       expect_output "$expect"
     done
   done
@@ -80,34 +80,34 @@ function check_lengths() {
 	done
 
 	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --layers -t squashed ${TESTDIR}/squashed
-	run_buildah --log-level=error inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 
 	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
 	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
-	run_buildah --log-level=error inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 	echo USER root >> ${TESTDIR}/squashed/Dockerfile
 	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
-	run_buildah --log-level=error inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 	echo COPY file / >> ${TESTDIR}/squashed/Dockerfile
 	echo COPY file / > ${TESTDIR}/squashed/file
 	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
-	run_buildah --log-level=error inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 
 	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
 	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --layers -t squashed ${TESTDIR}/squashed
-	run_buildah --log-level=error inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 	echo USER root >> ${TESTDIR}/squashed/Dockerfile
 	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
-	run_buildah --log-level=error inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 	echo COPY file / >> ${TESTDIR}/squashed/Dockerfile
 	echo COPY file / > ${TESTDIR}/squashed/file
 	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
-	run_buildah --log-level=error inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
+	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 }

--- a/tests/squash.bats
+++ b/tests/squash.bats
@@ -88,33 +88,37 @@ function check_lengths() {
 
 	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --layers -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
-	[ "$output" -eq 1 ]
+        expect_output "1" "len(DiffIDs) - simple image"
 
 	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
 	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
-	[ "$output" -eq 1 ]
+        expect_output "1" "len(DiffIDs) - image with FROM"
+
 	echo USER root >> ${TESTDIR}/squashed/Dockerfile
 	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
-	[ "$output" -eq 1 ]
+        expect_output "1" "len(DiffIDs) - image with FROM and USER"
+
 	echo COPY file / >> ${TESTDIR}/squashed/Dockerfile
 	echo COPY file / > ${TESTDIR}/squashed/file
 	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
-	[ "$output" -eq 1 ]
+        expect_output "1" "len(DiffIDs) - image with FROM, USER, and 2xCOPY"
 
 	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
 	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --layers -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
-	[ "$output" -eq 1 ]
+        expect_output "1" "len(DiffIDs) - image with FROM (--layers)"
+
 	echo USER root >> ${TESTDIR}/squashed/Dockerfile
 	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
-	[ "$output" -eq 1 ]
+        expect_output "1" "len(DiffIDs) - image with FROM and USER (--layers)"
+
 	echo COPY file / >> ${TESTDIR}/squashed/Dockerfile
 	echo COPY file / > ${TESTDIR}/squashed/file
 	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
-	[ "$output" -eq 1 ]
+        expect_output "1" "len(DiffIDs) - image with FROM, USER, and 2xCOPY (--layers)"
 }

--- a/tests/squash.bats
+++ b/tests/squash.bats
@@ -23,19 +23,19 @@ function check_lengths() {
 	image=stage0
 	remove=(8 5)
 	for stage in $(seq 10) ; do
-		buildah copy "$cid" ${TESTDIR}/randomfile /layer${stage}
+		run_buildah copy "$cid" ${TESTDIR}/randomfile /layer${stage}
 		image=stage${stage}
 		if test $stage -eq ${remove[0]} ; then
 			run_buildah mount "$cid"
 			mountpoint=$output
 			rm -f ${mountpoint}/layer${remove[1]}
 		fi
-		buildah commit --signature-policy ${TESTSDIR}/policy.json --rm "$cid" ${image}
+		run_buildah commit --signature-policy ${TESTSDIR}/policy.json --rm "$cid" ${image}
                 check_lengths $image $stage
 		run_buildah from --quiet ${image}
 		cid=$output
 	done
-	buildah commit --signature-policy ${TESTSDIR}/policy.json --rm --squash "$cid" squashed
+	run_buildah commit --signature-policy ${TESTSDIR}/policy.json --rm --squash "$cid" squashed
 
         check_lengths squashed 1
 
@@ -66,7 +66,7 @@ function check_lengths() {
 		echo COPY randomfile /layer${stage} >> ${TESTDIR}/stage${stage}/Dockerfile
 		image=stage${stage}
 		from=${image}
-		buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json -t ${image} ${TESTDIR}/stage${stage}
+		run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json -t ${image} ${TESTDIR}/stage${stage}
                 check_lengths $image $stage
 	done
 
@@ -74,7 +74,7 @@ function check_lengths() {
 	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
 	cp ${TESTDIR}/randomfile ${TESTDIR}/squashed/
 	echo COPY randomfile /layer-squashed >> ${TESTDIR}/stage${stage}/Dockerfile
-	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
+	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
 
         check_lengths squashed 1
 
@@ -86,35 +86,35 @@ function check_lengths() {
 		cmp $mountpoint/layer${stage} ${TESTDIR}/randomfile
 	done
 
-	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --layers -t squashed ${TESTDIR}/squashed
+	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --layers -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 
 	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
-	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
+	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 	echo USER root >> ${TESTDIR}/squashed/Dockerfile
-	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
+	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 	echo COPY file / >> ${TESTDIR}/squashed/Dockerfile
 	echo COPY file / > ${TESTDIR}/squashed/file
-	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
+	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 
 	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
-	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --layers -t squashed ${TESTDIR}/squashed
+	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --layers -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 	echo USER root >> ${TESTDIR}/squashed/Dockerfile
-	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
+	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 	echo COPY file / >> ${TESTDIR}/squashed/Dockerfile
 	echo COPY file / > ${TESTDIR}/squashed/file
-	buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
+	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
 	[ "$output" -eq 1 ]
 }

--- a/tests/tag.bats
+++ b/tests/tag.bats
@@ -26,8 +26,4 @@ load helpers
   expect_output "localhost/busybox1:latest"
   run_buildah inspect --format '{{ .FromImageID }}' busybox1-working-container
   expect_output $id
-
-  # Clean up
-  run_buildah rm busybox1-working-container
-  run_buildah rmi busybox1
 }

--- a/tests/tag.bats
+++ b/tests/tag.bats
@@ -3,7 +3,8 @@
 load helpers
 
 @test "tag by name" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch)
+  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch
+  cid=$output
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json "$cid" scratch-image
   run_buildah 1 inspect --type image tagged-image
   run_buildah tag scratch-image tagged-image tagged-also-image named-image

--- a/tests/umount.bats
+++ b/tests/umount.bats
@@ -18,12 +18,10 @@ load helpers
   cid=$output
   run_buildah mount "$cid"
   run_buildah umount "$cid"
-  run_buildah rm --all
 }
 
 @test "umount bad image" {
   run_buildah 1 umount badcontainer
-  run_buildah rm --all
 }
 
 @test "umount multi images" {
@@ -37,7 +35,6 @@ load helpers
   cid3=$output
   run_buildah mount "$cid3"
   run_buildah umount "$cid1" "$cid2" "$cid3"
-  run_buildah rm --all
 }
 
 @test "umount all images" {
@@ -51,7 +48,6 @@ load helpers
   cid3=$output
   run_buildah mount "$cid3"
   run_buildah umount --all
-  run_buildah rm --all
 }
 
 @test "umount multi images one bad" {
@@ -65,5 +61,4 @@ load helpers
   cid3=$output
   run_buildah mount "$cid3"
   run_buildah 1 umount "$cid1" badcontainer "$cid2" "$cid3"
-  run_buildah rm --all
 }

--- a/tests/umount.bats
+++ b/tests/umount.bats
@@ -16,54 +16,54 @@ load helpers
 @test "umount one image" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  buildah mount "$cid"
+  run_buildah mount "$cid"
   run_buildah umount "$cid"
-  buildah rm --all
+  run_buildah rm --all
 }
 
 @test "umount bad image" {
   run_buildah 1 umount badcontainer
-  buildah rm --all
+  run_buildah rm --all
 }
 
 @test "umount multi images" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
-  buildah mount "$cid1"
+  run_buildah mount "$cid1"
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid2=$output
-  buildah mount "$cid2"
+  run_buildah mount "$cid2"
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid3=$output
-  buildah mount "$cid3"
+  run_buildah mount "$cid3"
   run_buildah umount "$cid1" "$cid2" "$cid3"
-  buildah rm --all
+  run_buildah rm --all
 }
 
 @test "umount all images" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
-  buildah mount "$cid1"
+  run_buildah mount "$cid1"
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid2=$output
-  buildah mount "$cid2"
+  run_buildah mount "$cid2"
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid3=$output
-  buildah mount "$cid3"
+  run_buildah mount "$cid3"
   run_buildah umount --all
-  buildah rm --all
+  run_buildah rm --all
 }
 
 @test "umount multi images one bad" {
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
-  buildah mount "$cid1"
+  run_buildah mount "$cid1"
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid2=$output
-  buildah mount "$cid2"
+  run_buildah mount "$cid2"
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid3=$output
-  buildah mount "$cid3"
+  run_buildah mount "$cid3"
   run_buildah 1 umount "$cid1" badcontainer "$cid2" "$cid3"
-  buildah rm --all
+  run_buildah rm --all
 }

--- a/tests/umount.bats
+++ b/tests/umount.bats
@@ -14,7 +14,8 @@ load helpers
 }
 
 @test "umount one image" {
-  cid=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
   buildah mount "$cid"
   run_buildah umount "$cid"
   buildah rm --all
@@ -26,33 +27,42 @@ load helpers
 }
 
 @test "umount multi images" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
   buildah mount "$cid1"
-  cid2=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  cid2=$output
   buildah mount "$cid2"
-  cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  cid3=$output
   buildah mount "$cid3"
   run_buildah umount "$cid1" "$cid2" "$cid3"
   buildah rm --all
 }
 
 @test "umount all images" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
   buildah mount "$cid1"
-  cid2=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  cid2=$output
   buildah mount "$cid2"
-  cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  cid3=$output
   buildah mount "$cid3"
   run_buildah umount --all
   buildah rm --all
 }
 
 @test "umount multi images one bad" {
-  cid1=$(buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid1=$output
   buildah mount "$cid1"
-  cid2=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  cid2=$output
   buildah mount "$cid2"
-  cid3=$(buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine)
+  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  cid3=$output
   buildah mount "$cid3"
   run_buildah 1 umount "$cid1" badcontainer "$cid2" "$cid3"
   buildah rm --all

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -10,9 +10,11 @@ load helpers
 	if [ ! -d "${TESTSDIR}/../contrib/rpm" ]; then
 		skip "No source dir available"
 	fi
-	run_buildah version | awk '/^Version:/ { print $NF }'
-	bversion=$output
-	rversion=$(cat ${TESTSDIR}/../contrib/rpm/buildah.spec | awk '/^Version:/ { print $NF }')
+	run_buildah version
+	bversion=$(awk '/^Version:/ { print $NF }' <<< "$output")
+	rversion=$(awk '/^Version:/ { print $NF }' < ${TESTSDIR}/../contrib/rpm/buildah.spec)
+	echo "bversion=${bversion}"
+	echo "rversion=${rversion}"
 	test "${bversion}" = "${rversion}" -o "${bversion}" = "${rversion}-dev"
 }
 
@@ -20,7 +22,7 @@ load helpers
 	if [ ! -d "${TESTSDIR}/../contrib/rpm" ]; then
 		skip "No source dir available"
 	fi
-	run_buildah version | awk '/^Version:/ { print $NF }'
-	bversion=$output
+	run_buildah version
+	bversion=$(awk '/^Version:/ { print $NF }' <<< "$output")
 	grep -A1 ^%changelog ${TESTSDIR}/../contrib/rpm/buildah.spec | grep -q " ${bversion}-"
 }

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -10,7 +10,8 @@ load helpers
 	if [ ! -d "${TESTSDIR}/../contrib/rpm" ]; then
 		skip "No source dir available"
 	fi
-	bversion=$(buildah version | awk '/^Version:/ { print $NF }')
+	run_buildah version | awk '/^Version:/ { print $NF }'
+	bversion=$output
 	rversion=$(cat ${TESTSDIR}/../contrib/rpm/buildah.spec | awk '/^Version:/ { print $NF }')
 	test "${bversion}" = "${rversion}" -o "${bversion}" = "${rversion}-dev"
 }
@@ -19,6 +20,7 @@ load helpers
 	if [ ! -d "${TESTSDIR}/../contrib/rpm" ]; then
 		skip "No source dir available"
 	fi
-	bversion=$(buildah version | awk '/^Version:/ { print $NF }')
+	run_buildah version | awk '/^Version:/ { print $NF }'
+	bversion=$output
 	grep -A1 ^%changelog ${TESTSDIR}/../contrib/rpm/buildah.spec | grep -q " ${bversion}-"
 }


### PR DESCRIPTION
Clean up BATS tests:
  -- remove `--log-level=error`, it's no longer necessary
  -- use `run_buildah` (instead of plain `buildah`) wherever possible
  -- use `expect_output` (instead of `test this = that`) wherever possible
  -- remove unnecessary `rm` & `rmi` cleanup steps
  -- use `$TESTDIR` for all tempfiles: do not leave droppings in current dir or in BATS dir
  -- some refactoring, cleanup, fixes (for not-actually-working-as-desired tests) (filed a few issues)

I realize this is huge. I apologize. For ease[1] of review I've split this into five separate commits, see those for details. Only the two topmost commits really need a discerning eye, the earlier three are autogenerated.

 [1] "ease" may not be the right word