### PR TITLE
DO NOT MERGE Flake handling: cache and prefetch images

### DIFF
--- a/tests/add.bats
+++ b/tests/add.bats
@@ -111,6 +111,7 @@ load helpers
 }
 
 @test "add single file creates absolute path with correct permissions" {
+  _prefetch ubuntu
   imgName=ubuntu-image
   createrandom ${TESTDIR}/distutils.cfg
   permission=$(stat -c "%a" ${TESTDIR}/distutils.cfg)
@@ -130,6 +131,7 @@ load helpers
 }
 
 @test "add single file creates relative path with correct permissions" {
+  _prefetch ubuntu
   imgName=ubuntu-image
   createrandom ${TESTDIR}/distutils.cfg
   permission=$(stat -c "%a" ${TESTDIR}/distutils.cfg)
@@ -149,6 +151,7 @@ load helpers
 }
 
 @test "add with chown" {
+  _prefetch busybox
   createrandom ${TESTDIR}/randomfile
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
   cid=$output
@@ -159,6 +162,7 @@ load helpers
 }
 
 @test "add url" {
+  _prefetch busybox
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
   cid=$output
   run_buildah add $cid https://github.com/containers/buildah/raw/master/README.md

--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -18,6 +18,7 @@ load helpers
 
 @test "from-authenticate-cert-and-creds" {
 
+  _prefetch alpine
   run_buildah from --pull --name "alpine" --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword alpine localhost:5000/my-alpine
 

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -3,6 +3,7 @@
 load helpers
 
 @test "from" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah rm $cid
@@ -15,6 +16,7 @@ load helpers
 }
 
 @test "from-defaultpull" {
+  _prefetch alpine
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah rm $cid

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1170,7 +1170,7 @@ load helpers
 }
 
 @test "bud with FROM AS construct" {
-  _prefetch centos:7
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
   run_buildah images -a
   expect_output --substring "test1"
@@ -1185,7 +1185,7 @@ load helpers
 }
 
 @test "bud with FROM AS construct with layers" {
-  _prefetch centos:7
+  _prefetch alpine
   run_buildah bud --layers --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
   run_buildah images -a
   expect_output --substring "test1"
@@ -1200,6 +1200,7 @@ load helpers
 }
 
 @test "bud with FROM AS skip FROM construct" {
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t test1 -f ${TESTSDIR}/bud/from-as/Dockerfile.skip ${TESTSDIR}/bud/from-as
   expect_output --substring "LOCAL=/1"
   expect_output --substring "LOCAL2=/2"
@@ -1750,7 +1751,7 @@ load helpers
 }
 
 @test "bud containerfile with args" {
-  _prefetch centos
+  _prefetch alpine
   target=use-args
   touch ${TESTSDIR}/bud/use-args/abc.txt
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg=abc.txt ${TESTSDIR}/bud/use-args
@@ -1918,6 +1919,7 @@ EOM
   run_buildah rm -a
   run_buildah rmi -a -f
 
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/symlink/Containerfile.add-tar-gz-with-link -t testctr ${TESTSDIR}/bud/symlink
   run_buildah from testctr
   run_buildah run testctr-working-container ls /tmp/testdir/testfile.txt

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3,6 +3,7 @@
 load helpers
 
 @test "bud with --dns* flags" {
+  _prefetch alpine
   run_buildah bud --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc  --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/dns/Dockerfile  ${TESTSDIR}/bud/dns
   expect_output --substring "search example.com"
   expect_output --substring "nameserver 223.5.5.5"
@@ -10,6 +11,7 @@ load helpers
 }
 
 @test "bud with .dockerignore" {
+  _prefetch alpine busybox
   run_buildah bud -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/dockerignore/Dockerfile ${TESTSDIR}/bud/dockerignore
 
   run_buildah from --name myctr testbud
@@ -49,6 +51,7 @@ load helpers
 }
 
 @test "bud with --layers and --no-cache flags" {
+  _prefetch alpine
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
 
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTDIR}/use-layers
@@ -90,6 +93,7 @@ load helpers
 }
 
 @test "bud with --layers and single and two line Dockerfiles" {
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test -f Dockerfile.5 ${TESTSDIR}/bud/use-layers
   run_buildah images -a
   expect_line_count 3
@@ -100,6 +104,7 @@ load helpers
 }
 
 @test "bud with --layers, multistage, and COPY with --from" {
+  _prefetch alpine
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
 
   mkdir -p ${TESTDIR}/use-layers/uuid
@@ -144,6 +149,7 @@ load helpers
 }
 
 @test "bud-multistage-partial-cache" {
+  _prefetch alpine
   target=foo
   # build the first stage
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -f ${TESTSDIR}/bud/cache-stages/Dockerfile.1 ${TESTSDIR}/bud/cache-stages
@@ -158,6 +164,7 @@ load helpers
 }
 
 @test "bud-multistage-copy-final-slash" {
+  _prefetch busybox
   target=foo
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-final-slash
   run_buildah from --signature-policy ${TESTSDIR}/policy.json ${target}
@@ -166,6 +173,7 @@ load helpers
 }
 
 @test "bud-multistage-reused" {
+  _prefetch alpine busybox
   target=foo
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
   run_buildah from --signature-policy ${TESTSDIR}/policy.json ${target}
@@ -175,6 +183,7 @@ load helpers
 }
 
 @test "bud-multistage-cache" {
+  _prefetch alpine busybox
   target=foo
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.extended ${TESTSDIR}/bud/multi-stage-builds
   run_buildah from --signature-policy ${TESTSDIR}/policy.json ${target}
@@ -188,6 +197,7 @@ load helpers
 }
 
 @test "bud with --layers and symlink file" {
+  _prefetch alpine
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
   echo 'echo "Hello World!"' > ${TESTDIR}/use-layers/hello.sh
   ln -s hello.sh ${TESTDIR}/use-layers/hello_world.sh
@@ -206,6 +216,7 @@ load helpers
 }
 
 @test "bud with --layers and dangling symlink" {
+  _prefetch alpine
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
   mkdir ${TESTDIR}/use-layers/blah
   ln -s ${TESTSDIR}/policy.json ${TESTDIR}/use-layers/blah/policy.json
@@ -225,6 +236,7 @@ load helpers
 }
 
 @test "bud with --layers and --build-args" {
+  _prefetch alpine
   # base plus 3, plus the header line
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --build-arg=user=0 --layers -t test -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
   run_buildah images -a
@@ -247,6 +259,7 @@ load helpers
 }
 
 @test "bud with --rm flag" {
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
   run_buildah containers
   expect_line_count 1
@@ -257,6 +270,7 @@ load helpers
 }
 
 @test "bud with --force-rm flag" {
+  _prefetch alpine
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --force-rm --layers -t test1 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
   run_buildah containers
   expect_line_count 1
@@ -267,11 +281,13 @@ load helpers
 }
 
 @test "bud --layers with non-existent/down registry" {
+  _prefetch alpine
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --force-rm --layers -t test1 -f Dockerfile.non-existent-registry ${TESTSDIR}/bud/use-layers
   expect_output --substring "no such host"
 }
 
 @test "bud from base image should have base image ENV also" {
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t test -f Dockerfile.check-env ${TESTSDIR}/bud/env
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test
   cid=$output
@@ -337,6 +353,7 @@ load helpers
   run_buildah rm ${cid}
   run_buildah rmi -a
 
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1.alpine -f Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files
   run_buildah from --quiet ${target}
@@ -349,6 +366,7 @@ load helpers
 }
 
 @test "bud-from-multiple-files-two-froms" {
+  _prefetch alpine
   target=scratch-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1.scratch -f Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files
   run_buildah from --quiet ${target}
@@ -361,6 +379,7 @@ load helpers
   run_buildah rm ${cid}
   run_buildah rmi -a
 
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1.alpine -f Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files
   run_buildah from --quiet ${target}
@@ -373,6 +392,7 @@ load helpers
 }
 
 @test "bud-multi-stage-builds" {
+  _prefetch alpine
   target=multi-stage-index
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds
   run_buildah from --quiet ${target}
@@ -384,6 +404,7 @@ load helpers
   run_buildah rm ${cid}
   run_buildah rmi -a
 
+  _prefetch alpine
   target=multi-stage-name
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds
   run_buildah from --quiet ${target}
@@ -407,6 +428,7 @@ load helpers
 }
 
 @test "bud-multi-stage-builds-small-as" {
+  _prefetch alpine
   target=multi-stage-index
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as
   run_buildah from --quiet ${target}
@@ -418,6 +440,7 @@ load helpers
   run_buildah rm ${cid}
   run_buildah rmi -a
 
+  _prefetch alpine
   target=multi-stage-name
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as
   run_buildah from --quiet ${target}
@@ -444,6 +467,7 @@ load helpers
   # This Dockerfile needs us to be able to handle a working RUN instruction.
   skip_if_no_runtime
 
+  _prefetch alpine
   target=volume-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/preserve-volumes
   run_buildah from --quiet ${target}
@@ -483,6 +507,7 @@ load helpers
 }
 
 @test "bud-http-context-dir-with-Dockerfile-post" {
+  # FIXME FIXME FIXME: this is 100% identical to the -pre test above.
   starthttpd ${TESTSDIR}/bud/http-context-subdir
   target=scratch-image
   run_buildah bud  --signature-policy ${TESTSDIR}/policy.json -t ${target} -f context/Dockerfile http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
@@ -526,9 +551,18 @@ load helpers
   cid=$output
   run_buildah rm ${cid}
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target3}:latest
+  run_buildah rm $output
+
+  run_buildah rmi $target3 $target2 $target
+  expect_line_count 4
+  for i in 0 1 2;do
+      expect_output --substring --from="${lines[$i]}" "untagged: "
+  done
+  expect_output --substring --from="${lines[3]}" '^[0-9a-f]{64}$'
 }
 
 @test "bud-additional-tags-cached" {
+  _prefetch busybox
   target=tagged-image
   target2=another-tagged-image
   target3=yet-another-tagged-image
@@ -552,6 +586,7 @@ load helpers
   # This Dockerfile needs us to be able to handle a working RUN instruction.
   skip_if_no_runtime
 
+  _prefetch alpine
   target=volume-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/volume-perms
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
@@ -565,6 +600,7 @@ load helpers
 }
 
 @test "bud-from-glob" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile2.glob ${TESTSDIR}/bud/from-multiple-files
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
@@ -576,6 +612,7 @@ load helpers
 }
 
 @test "bud-maintainer" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/maintainer
   run_buildah inspect --type=image --format '{{.Docker.Author}}' ${target}
@@ -585,12 +622,14 @@ load helpers
 }
 
 @test "bud-unrecognized-instruction" {
+  _prefetch alpine
   target=alpine-image
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/unrecognized
   expect_output --substring "BOGUS"
 }
 
 @test "bud-shell" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/shell
   run_buildah inspect --type=image --format '{{printf "%q" .Docker.Config.Shell}}' ${target}
@@ -603,30 +642,35 @@ load helpers
 }
 
 @test "bud-shell during build in Docker format" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/sh"
 }
 
 @test "bud-shell during build in OCI format" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/sh"
 }
 
 @test "bud-shell changed during build in Docker format" {
+  _prefetch ubuntu
   target=ubuntu-image
   run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/bash"
 }
 
 @test "bud-shell changed during build in OCI format" {
+  _prefetch ubuntu
   target=ubuntu-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/sh"
 }
 
 @test "bud with symlinks" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/symlink
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
@@ -645,6 +689,7 @@ load helpers
 }
 
 @test "bud with symlinks to relative path" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.relative-symlink ${TESTSDIR}/bud/symlink
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
@@ -662,6 +707,7 @@ load helpers
 }
 
 @test "bud with multiple symlinks in a path" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.multiple-symlinks ${TESTSDIR}/bud/symlink
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
@@ -687,11 +733,13 @@ load helpers
 }
 
 @test "bud with multiple symlink pointing to itself" {
+  _prefetch alpine
   target=alpine-image
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.symlink-points-to-itself ${TESTSDIR}/bud/symlink
 }
 
 @test "bud multi-stage with symlink to absolute path" {
+  _prefetch ubuntu
   target=ubuntu-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.absolute-symlink ${TESTSDIR}/bud/symlink
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
@@ -708,6 +756,7 @@ load helpers
 }
 
 @test "bud multi-stage with dir symlink to absolute path" {
+  _prefetch ubuntu
   target=ubuntu-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.absolute-dir-symlink ${TESTSDIR}/bud/symlink
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
@@ -720,6 +769,7 @@ load helpers
 }
 
 @test "bud with ENTRYPOINT and RUN" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.entrypoint-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "unique.test.string"
@@ -727,12 +777,14 @@ load helpers
 }
 
 @test "bud with ENTRYPOINT and empty RUN" {
+  _prefetch alpine
   target=alpine-image
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.entrypoint-empty-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "error building at STEP"
 }
 
 @test "bud with CMD and RUN" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.cmd-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "unique.test.string"
@@ -740,12 +792,14 @@ load helpers
 }
 
 @test "bud with CMD and empty RUN" {
+  _prefetch alpine
   target=alpine-image
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.cmd-empty-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "error building at STEP"
 }
 
 @test "bud with ENTRYPOINT, CMD and RUN" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "unique.test.string"
@@ -753,6 +807,7 @@ load helpers
 }
 
 @test "bud with ENTRYPOINT, CMD and empty RUN" {
+  _prefetch alpine
   target=alpine-image
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-empty-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "error building at STEP"
@@ -760,6 +815,7 @@ load helpers
 
 # Determines if a variable set with ENV is available to following commands in the Dockerfile
 @test "bud access ENV variable defined in same source file" {
+  _prefetch alpine
   target=env-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/env/Dockerfile.env-same-file ${TESTSDIR}/bud/env
   expect_output --substring ":unique.test.string:"
@@ -768,6 +824,7 @@ load helpers
 
 # Determines if a variable set with ENV in an image is available to commands in downstream Dockerfile
 @test "bud access ENV variable defined in FROM image" {
+  _prefetch alpine
   from_target=env-from-image
   target=env-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${from_target} -f ${TESTSDIR}/bud/env/Dockerfile.env-same-file ${TESTSDIR}/bud/env
@@ -779,6 +836,7 @@ load helpers
 }
 
 @test "bud ENV preserves special characters after commit" {
+  _prefetch ubuntu
   from_target=special-chars
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${from_target} -f ${TESTSDIR}/bud/env/Dockerfile.special-chars ${TESTSDIR}/bud/env
   run_buildah from --quiet ${from_target}
@@ -855,6 +913,7 @@ load helpers
 }
 
 @test "bud-onbuild" {
+  _prefetch alpine
   target=onbuild
   run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
@@ -893,6 +952,7 @@ load helpers
 }
 
 @test "bud-onbuild-layers" {
+  _prefetch alpine
   target=onbuild
   run_buildah bud --format docker --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile2 ${TESTSDIR}/bud/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
@@ -900,18 +960,21 @@ load helpers
 }
 
 @test "bud-logfile" {
+  _prefetch alpine
   rm -f ${TESTDIR}/logfile
   run_buildah bud --logfile ${TESTDIR}/logfile --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/preserve-volumes
   test -s ${TESTDIR}/logfile
 }
 
 @test "bud with ARGS" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.args ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "arg_value"
 }
 
 @test "bud with unused ARGS" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "USED_VALUE"
@@ -922,6 +985,7 @@ load helpers
 }
 
 @test "bud with multi-value ARGS" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=plugin1,plugin2,plugin3 ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "plugin1,plugin2,plugin3"
@@ -941,6 +1005,7 @@ load helpers
 }
 
 @test "bud with preprocessor" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Decomposed.in ${TESTSDIR}/bud/preprocess
 }
@@ -957,6 +1022,7 @@ load helpers
 }
 
 @test "bud with chown copy" {
+  _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-chown
@@ -972,6 +1038,7 @@ load helpers
 }
 
 @test "bud with chown copy with bad chown flag in Dockerfile with --layers" {
+  _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${imgName} -f ${TESTSDIR}/bud/copy-chown/Dockerfile.bad ${TESTSDIR}/bud/copy-chown
@@ -979,6 +1046,7 @@ load helpers
 }
 
 @test "bud with chown add" {
+  _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-chown
@@ -994,6 +1062,7 @@ load helpers
 }
 
 @test "bud with chown add with bad chown flag in Dockerfile with --layers" {
+  _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${imgName} -f ${TESTSDIR}/bud/add-chown/Dockerfile.bad ${TESTSDIR}/bud/add-chown
@@ -1001,6 +1070,7 @@ load helpers
 }
 
 @test "bud with ADD file construct" {
+  _prefetch busybox
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/add-file
   run_buildah images -a
   expect_output --substring "test1"
@@ -1015,6 +1085,7 @@ load helpers
 }
 
 @test "bud with COPY of single file creates absolute path with correct permissions" {
+  _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-create-absolute-path
@@ -1026,6 +1097,7 @@ load helpers
 }
 
 @test "bud with COPY of single file creates relative path with correct permissions" {
+  _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-create-relative-path
@@ -1037,6 +1109,7 @@ load helpers
 }
 
 @test "bud with ADD of single file creates absolute path with correct permissions" {
+  _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-create-absolute-path
@@ -1048,6 +1121,7 @@ load helpers
 }
 
 @test "bud with ADD of single file creates relative path with correct permissions" {
+  _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-create-relative-path
@@ -1059,6 +1133,7 @@ load helpers
 }
 
 @test "bud multi-stage COPY creates absolute path with correct permissions" {
+  _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.absolute -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
@@ -1070,6 +1145,7 @@ load helpers
 }
 
 @test "bud multi-stage COPY creates relative path with correct permissions" {
+  _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.relative -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
@@ -1081,6 +1157,7 @@ load helpers
 }
 
 @test "bud multi-stage COPY with invalid from statement" {
+  _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.invalid_from -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths || true
@@ -1088,10 +1165,12 @@ load helpers
 }
 
 @test "bud COPY to root succeeds" {
+  _prefetch ubuntu
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/copy-root
 }
 
 @test "bud with FROM AS construct" {
+  _prefetch centos:7
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
   run_buildah images -a
   expect_output --substring "test1"
@@ -1106,6 +1185,7 @@ load helpers
 }
 
 @test "bud with FROM AS construct with layers" {
+  _prefetch centos:7
   run_buildah bud --layers --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
   run_buildah images -a
   expect_output --substring "test1"
@@ -1142,6 +1222,7 @@ load helpers
 }
 
 @test "bud with symlink Dockerfile not specified in file" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/symlink ${TESTSDIR}/bud/symlink
   expect_output --substring "FROM alpine"
@@ -1160,16 +1241,19 @@ load helpers
 }
 
 @test "bud with ARG before FROM default value" {
+  _prefetch busybox
   target=leading-args-default
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/leading-args/Dockerfile ${TESTSDIR}/bud/leading-args
 }
 
 @test "bud with ARG before FROM" {
+  _prefetch busybox:musl
   target=leading-args
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg=VERSION=musl -f ${TESTSDIR}/bud/leading-args/Dockerfile ${TESTSDIR}/bud/leading-args
 }
 
 @test "bud-with-healthcheck" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --format docker ${TESTSDIR}/bud/healthcheck
   run_buildah inspect -f '{{printf "%q" .Docker.Config.Healthcheck.Test}} {{printf "%d" .Docker.Config.Healthcheck.StartPeriod}} {{printf "%d" .Docker.Config.Healthcheck.Interval}} {{printf "%d" .Docker.Config.Healthcheck.Timeout}} {{printf "%d" .Docker.Config.Healthcheck.Retries}}' ${target}
@@ -1181,6 +1265,7 @@ load helpers
 }
 
 @test "bud with unused build arg" {
+  _prefetch alpine busybox
   target=busybox-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg foo=bar --build-arg foo2=bar2 -f ${TESTSDIR}/bud/build-arg ${TESTSDIR}/bud/build-arg
   expect_output --substring "one or more build args were not consumed: \[foo2\]"
@@ -1190,6 +1275,7 @@ load helpers
 }
 
 @test "bud with copy-from and cache" {
+  _prefetch busybox
   target=busybox-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers --iidfile ${TESTDIR}/iid1 -f ${TESTSDIR}/bud/copy-from/Dockerfile2 ${TESTSDIR}/bud/copy-from
   cat ${TESTDIR}/iid1
@@ -1201,6 +1287,7 @@ load helpers
 }
 
 @test "bud with copy-from in Dockerfile no prior FROM" {
+  _prefetch php:7.2
   target=php-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy-from ${TESTSDIR}/bud/copy-from
 
@@ -1213,12 +1300,14 @@ load helpers
 }
 
 @test "bud with copy-from with bad from flag in Dockerfile with --layers" {
+  _prefetch php:7.2
   target=php-image
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile.bad ${TESTSDIR}/bud/copy-from
   expect_output --substring "COPY only supports the --chown=<uid:gid> and the --from=<image|stage> flags"
 }
 
 @test "bud-target" {
+  _prefetch alpine ubuntu
   target=target
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --target mytarget ${TESTSDIR}/bud/target
   expect_output --substring "STEP 1: FROM ubuntu:latest"
@@ -1232,10 +1321,12 @@ load helpers
 }
 
 @test "bud-no-target-name" {
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/maintainer
 }
 
 @test "bud-multi-stage-nocache-nocommit" {
+  _prefetch alpine
   # pull the base image directly, so that we don't record it being written to local storage in the next step
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json alpine
   # okay, build an image with two stages
@@ -1246,6 +1337,7 @@ load helpers
 }
 
 @test "bud-multi-stage-cache-nocontainer" {
+  _prefetch alpine
   # first time through, quite normal
   run_buildah bud --layers -t base --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.rebase ${TESTSDIR}/bud/multi-stage-builds
   # second time through, everything should be cached, and we shouldn't create a container based on the final image
@@ -1259,6 +1351,7 @@ load helpers
 }
 
 @test "bud copy to symlink" {
+  _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-symlink
@@ -1275,6 +1368,7 @@ load helpers
 }
 
 @test "bud copy to dangling symlink" {
+  _prefetch ubuntu
   target=ubuntu-image
   ctr=ubuntu-ctr
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-symlink-dangling
@@ -1291,6 +1385,7 @@ load helpers
 }
 
 @test "bud WORKDIR isa symlink" {
+  _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/workdir-symlink
@@ -1307,6 +1402,7 @@ load helpers
 }
 
 @test "bud WORKDIR isa symlink no target dir" {
+  _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile-2 ${TESTSDIR}/bud/workdir-symlink
@@ -1326,6 +1422,7 @@ load helpers
 }
 
 @test "bud WORKDIR isa symlink no target dir and follow on dir" {
+  _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile-3 ${TESTSDIR}/bud/workdir-symlink
@@ -1351,6 +1448,7 @@ load helpers
   voldir=${TESTDIR}/bud-volume
   mkdir -p ${voldir}
 
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -v ${voldir}:/testdir ${TESTSDIR}/bud/mount
   expect_output --substring "/testdir"
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -v ${voldir}:/testdir:rw ${TESTSDIR}/bud/mount
@@ -1360,6 +1458,7 @@ load helpers
 }
 
 @test "bud-copy-dot with --layers picks up changed file" {
+  _prefetch alpine
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
 
   mkdir -p ${TESTDIR}/use-layers/subdir
@@ -1379,17 +1478,15 @@ load helpers
   target=foo
 
   # A deny-all policy should prevent us from pulling the base image.
-  run_buildah '?' bud --signature-policy ${TESTSDIR}/deny.json -t ${target} -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
-  [ "$status" -ne 0 ]
+  run_buildah 1 bud --signature-policy ${TESTSDIR}/deny.json -t ${target} -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
   expect_output --substring 'Source image rejected: Running image .* rejected by policy.'
-  run_buildah rmi -a -f
 
   # A docker-only policy should allow us to pull the base image and commit.
   run_buildah bud --signature-policy ${TESTSDIR}/docker.json -t ${target} -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
   # A deny-all policy shouldn't break pushing, since policy is only evaluated
   # on the source image, and we force it to allow local storage.
   run_buildah push --signature-policy ${TESTSDIR}/deny.json ${target} dir:${TESTDIR}/mount
-  run_buildah rmi -a -f
+  run_buildah rmi ${target}
 
   # A docker-only policy should allow us to pull the base image first...
   run_buildah pull --signature-policy ${TESTSDIR}/docker.json alpine
@@ -1430,6 +1527,7 @@ load helpers
 }
 
 @test "bud-build-arg-cache" {
+  _prefetch busybox
   target=derived-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 ${TESTSDIR}/bud/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
@@ -1460,9 +1558,9 @@ load helpers
 }
 
 @test "bud test RUN with a priv'd command" {
+  _prefetch alpine
   target=alpinepriv
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-privd/Dockerfile ${TESTSDIR}/bud/run-privd
-  [ "${status}" -eq 0 ]
   expect_output --substring "STEP 3: COMMIT"
   run_buildah images -q
   expect_line_count 2
@@ -1530,6 +1628,7 @@ load helpers
 }
 
 @test "bud-no-change" {
+  _prefetch alpine
   parent=alpine
   target=no-change-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
@@ -1540,6 +1639,7 @@ load helpers
 }
 
 @test "bud-no-change-label" {
+  _prefetch alpine
   parent=alpine
   target=no-change-image
   run_buildah bud --label "test=label" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
@@ -1548,6 +1648,7 @@ load helpers
 }
 
 @test "bud-no-change-annotation" {
+  _prefetch alpine
   target=no-change-image
   run_buildah bud --annotation "test=annotation" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
   run_buildah inspect --format '{{printf "%q" .ImageAnnotations}}' ${target}
@@ -1555,6 +1656,7 @@ load helpers
 }
 
 @test "bud-squash-layers" {
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --squash ${TESTSDIR}/bud/layers-squash
 }
 
@@ -1562,6 +1664,7 @@ load helpers
   skip_if_chroot
   skip_if_rootless
 
+  _prefetch alpine
   target=alpine-image
   rm -rf ${TESTSDIR}/foo
   mkdir -p ${TESTSDIR}/foo
@@ -1571,6 +1674,7 @@ load helpers
 }
 
 @test "bud with additional device" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --device /dev/fuse -t ${target} -f ${TESTSDIR}/bud/device/Dockerfile ${TESTSDIR}/bud/device
   [ "${status}" -eq 0 ]
@@ -1578,6 +1682,7 @@ load helpers
 }
 
 @test "bud with Containerfile" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
   [ "${status}" -eq 0 ]
@@ -1585,6 +1690,7 @@ load helpers
 }
 
 @test "bud with Dockerfile" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dockerfile
   [ "${status}" -eq 0 ]
@@ -1592,6 +1698,7 @@ load helpers
 }
 
 @test "bud with Containerfile and Dockerfile" {
+  _prefetch alpine
   target=alpine-image
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containeranddockerfile
   [ "${status}" -eq 0 ]
@@ -1607,6 +1714,7 @@ load helpers
 }
 
 @test "bud with Dockerfile from stdin" {
+  _prefetch alpine
   target=df-stdin
   cat ${TESTSDIR}/bud/context-from-stdin/Dockerfile | buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -
   [ "$?" -eq 0 ]
@@ -1624,6 +1732,7 @@ load helpers
 }
 
 @test "bud with Dockerfile from stdin tar" {
+  _prefetch alpine
   target=df-stdin
   tar -c -C ${TESTSDIR}/bud/context-from-stdin . | buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -
   [ "$?" -eq 0 ]
@@ -1641,6 +1750,7 @@ load helpers
 }
 
 @test "bud containerfile with args" {
+  _prefetch centos
   target=use-args
   touch ${TESTSDIR}/bud/use-args/abc.txt
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg=abc.txt ${TESTSDIR}/bud/use-args
@@ -1669,12 +1779,14 @@ load helpers
 
 @test "bud using gitrepo and branch" {
   target=gittarget
+  # FIXME: this test takes a really long time. Is it necessary to do twice?
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} git://github.com/containers/BuildSourceImage#master
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} git://github.com/containers/BuildSourceImage
 }
 
 # Fixes #1906: buildah was not detecting changed tarfile
 @test "bud containerfile with tar archive in copy" {
+  _prefetch busybox
   # First check to verify cache is used if the tar file does not change
   target=copy-archive
   date > ${TESTSDIR}/bud/${target}/test
@@ -1734,12 +1846,14 @@ EOM
 }
 
 @test "bud quiet" {
+  _prefetch alpine
   run_buildah bud --format docker -t quiet-test --signature-policy ${TESTSDIR}/policy.json -q ${TESTSDIR}/bud/shell
   expect_line_count 1
   expect_output --substring '^[0-9a-f]{64}$'
 }
 
 @test "bud COPY with Env Var in Containerfile" {
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t testctr ${TESTSDIR}/bud/copy-envvar
   run_buildah from testctr
   run_buildah run testctr-working-container ls /file-0.0.1.txt
@@ -1797,6 +1911,7 @@ EOM
 }
 
 @test "bud Add with linked tarball" {
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/symlink/Containerfile.add-tar-with-link -t testctr ${TESTSDIR}/bud/symlink
   run_buildah from testctr
   run_buildah run testctr-working-container ls /tmp/testdir/testfile.txt

--- a/tests/bud/from-as/Dockerfile
+++ b/tests/bud/from-as/Dockerfile
@@ -1,7 +1,7 @@
-FROM centos:7 AS base
+FROM alpine AS base
 RUN touch /1
 ENV LOCAL=/1
 RUN find $LOCAL
-    	
+
 FROM base
 RUN find $LOCAL

--- a/tests/bud/from-as/Dockerfile.skip
+++ b/tests/bud/from-as/Dockerfile.skip
@@ -1,8 +1,8 @@
-FROM registry.centos.org/centos/centos:centos7 AS base
+FROM alpine AS base
 RUN touch /1
 ENV LOCAL=/1
 RUN find $LOCAL
-    	
+
 FROM base
 RUN find $LOCAL
 RUN touch /2
@@ -11,4 +11,4 @@ RUN find $LOCAL2
 
 FROM base
 RUN find $LOCAL
-RUN ls / 
+RUN ls /

--- a/tests/bud/use-args/Containerfile
+++ b/tests/bud/use-args/Containerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM alpine
 ARG testArg
 RUN echo ${testArg}
 COPY ${testArg} .

--- a/tests/bud/use-args/Containerfile.dest_nobrace
+++ b/tests/bud/use-args/Containerfile.dest_nobrace
@@ -1,4 +1,4 @@
-FROM centos
+FROM alpine
 ARG testArg
 ARG destination
 RUN echo $testArg

--- a/tests/bud/use-args/Containerfile.destination
+++ b/tests/bud/use-args/Containerfile.destination
@@ -1,4 +1,4 @@
-FROM centos
+FROM alpine
 ARG testArg
 ARG destination
 RUN echo ${testArg}

--- a/tests/byid.bats
+++ b/tests/byid.bats
@@ -4,6 +4,7 @@ load helpers
 
 @test "from-by-id" {
   image=busybox
+  _prefetch $image
 
   # Pull down the image, if we have to.
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
@@ -33,6 +34,7 @@ load helpers
 
 @test "inspect-by-id" {
   image=busybox
+  _prefetch $image
 
   # Pull down the image, if we have to.
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
@@ -57,6 +59,7 @@ load helpers
 @test "push-by-id" {
   for image in busybox k8s.gcr.io/pause ; do
     echo pulling/pushing image $image
+    _prefetch $image
 
     TARGET=${TESTDIR}/subdir-$(basename $image)
     mkdir -p $TARGET $TARGET-truncated
@@ -84,6 +87,7 @@ load helpers
 
 @test "rmi-by-id" {
   image=busybox
+  _prefetch $image
 
   # Pull down the image, if we have to.
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -17,6 +17,7 @@ load helpers
 }
 
 @test "commit" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
@@ -24,6 +25,7 @@ load helpers
 }
 
 @test "commit format test" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-oci
@@ -34,6 +36,7 @@ load helpers
 }
 
 @test "commit quiet test" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah commit --iidfile /dev/null --signature-policy ${TESTSDIR}/policy.json -q $cid alpine-image
@@ -41,6 +44,7 @@ load helpers
 }
 
 @test "commit rm test" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json --rm $cid alpine-image
@@ -59,6 +63,7 @@ load helpers
 }
 
 @test "commit-rejected-name" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah 1 commit --signature-policy ${TESTSDIR}/policy.json $cid ThisNameShouldBeRejected
@@ -70,6 +75,7 @@ load helpers
     skip "python interpreter with json module not found"
   fi
   target=new-image
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
 
@@ -93,18 +99,21 @@ load helpers
 }
 
 @test "commit-no-name" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid
 }
 
 @test "commit should fail with nonexist authfile" {
+  _prefetch alpine
   run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah 1 commit --authfile /tmp/nonexist --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
 }
 
 @test "commit-builder-identity" {
+	_prefetch alpine
 	run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
@@ -118,6 +127,7 @@ load helpers
 }
 
 @test "commit-parent-id" {
+  _prefetch alpine
   run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah inspect --format '{{.FromImageID}}' $cid
@@ -129,6 +139,7 @@ load helpers
 }
 
 @test "commit-container-id" {
+  _prefetch alpine
   run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
 
   # There is exactly one container. Get its ID.
@@ -141,6 +152,7 @@ load helpers
 }
 
 @test "commit with name" {
+  _prefetch busybox
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json --name busyboxc busybox
   expect_output "busyboxc"
 
@@ -157,6 +169,7 @@ load helpers
 }
 
 @test "commit to docker-distribution" {
+  _prefetch busybox
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc busybox
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword busyboxc docker://localhost:5000/commit/busybox
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --name fromdocker --tls-verify=false --creds testuser:testpassword docker://localhost:5000/commit/busybox

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -186,6 +186,7 @@ function check_matrix() {
 }
 
 @test "user" {
+  _prefetch alpine
   run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah run $cid grep CapBnd /proc/self/status

--- a/tests/containers.bats
+++ b/tests/containers.bats
@@ -3,6 +3,7 @@
 load helpers
 
 @test "containers" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
   run_buildah containers
@@ -10,6 +11,7 @@ load helpers
 }
 
 @test "containers filter test" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
@@ -19,6 +21,7 @@ load helpers
 }
 
 @test "containers format test" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
   run_buildah containers --format "{{.ContainerName}}"
@@ -28,12 +31,14 @@ load helpers
 }
 
 @test "containers json test" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah containers --json
   expect_output --substring '\{'
 }
 
 @test "containers noheading test" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
   run_buildah containers --noheading
@@ -44,6 +49,7 @@ load helpers
 }
 
 @test "containers quiet test" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
   run_buildah containers --quiet

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -27,6 +27,7 @@ load helpers
   run_buildah 1 copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile
   run_buildah rm $cid
 
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah mount $cid
@@ -150,6 +151,7 @@ load helpers
   createrandom ${TESTDIR}/other-subdir/randomfile
   createrandom ${TESTDIR}/other-subdir/other-randomfile
 
+  _prefetch alpine
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah config --workingdir / $cid
@@ -205,6 +207,8 @@ load helpers
 }
 
 @test "copy-detect-missing-data" {
+  _prefetch busybox
+
   : > ${TESTDIR}/Dockerfile
   echo FROM busybox AS builder                                >> ${TESTDIR}/Dockerfile
   echo FROM scratch                                           >> ${TESTDIR}/Dockerfile

--- a/tests/digest.bats
+++ b/tests/digest.bats
@@ -3,6 +3,7 @@
 load helpers
 
 fromreftest() {
+  _prefetch $1
   run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json $1
   cid=$output
   pushdir=${TESTDIR}/fromreftest

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -164,6 +164,7 @@ load helpers
 }
 
 @test "from the following transports: docker-archive, oci-archive, and dir" {
+  _prefetch alpine
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah rm $output
 
@@ -187,6 +188,7 @@ load helpers
 }
 
 @test "from the following transports: docker-archive and oci-archive with no image reference" {
+  _prefetch alpine
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah rm $output
 
@@ -211,6 +213,7 @@ load helpers
   skip_if_no_runtime
   skip_if_cgroupsv2
 
+  _prefetch alpine
   run_buildah from --quiet --cpu-period=5000 --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
@@ -223,6 +226,7 @@ load helpers
   skip_if_no_runtime
   skip_if_cgroupsv2
 
+  _prefetch alpine
   run_buildah from --quiet --cpu-quota=5000 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
@@ -235,6 +239,7 @@ load helpers
   skip_if_no_runtime
   skip_if_cgroupsv2
 
+  _prefetch alpine
   run_buildah from --quiet --cpu-shares=2 --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.shares
@@ -247,6 +252,7 @@ load helpers
   skip_if_no_runtime
   skip_if_cgroupsv2 "cgroupsv2: fails with EPERM on writing cpuset.cpus"
 
+  _prefetch alpine
   run_buildah from --quiet --cpuset-cpus=0 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpuset/cpuset.cpus
@@ -259,6 +265,7 @@ load helpers
   skip_if_no_runtime
   skip_if_cgroupsv2 "cgroupsv2: fails with EPERM on writing cpuset.mems"
 
+  _prefetch alpine
   run_buildah from --quiet --cpuset-mems=0 --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah run $cid cat /sys/fs/cgroup/cpuset/cpuset.mems
@@ -269,6 +276,7 @@ load helpers
   skip_if_chroot
   skip_if_rootless
 
+  _prefetch alpine
   run_buildah from --quiet --memory=40m --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
 
@@ -284,6 +292,7 @@ load helpers
 @test "from volume test" {
   skip_if_no_runtime
 
+  _prefetch alpine
   run_buildah from --quiet --volume=${TESTDIR}:/myvol --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah run $cid -- cat /proc/mounts
@@ -294,6 +303,7 @@ load helpers
   skip_if_chroot
   skip_if_no_runtime
 
+  _prefetch alpine
   run_buildah from --quiet --volume=${TESTDIR}:/myvol:ro --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah run $cid -- cat /proc/mounts
@@ -304,6 +314,7 @@ load helpers
   skip_if_chroot
   skip_if_no_runtime
 
+  _prefetch alpine
   run_buildah from --quiet --shm-size=80m --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah run $cid -- df -h /dev/shm
@@ -313,6 +324,7 @@ load helpers
 @test "from add-host test" {
   skip_if_no_runtime
 
+  _prefetch alpine
   run_buildah from --quiet --add-host=localhost:127.0.0.1 --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah run $cid -- cat /etc/hosts
@@ -320,6 +332,7 @@ load helpers
 }
 
 @test "from name test" {
+  _prefetch alpine
   container_name=mycontainer
   run_buildah from --quiet --name=${container_name} --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
@@ -327,6 +340,7 @@ load helpers
 }
 
 @test "from cidfile test" {
+  _prefetch alpine
   run_buildah from --cidfile output.cid --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$(cat output.cid)
   run_buildah containers -f id=${cid}
@@ -347,6 +361,7 @@ load helpers
 }
 
 @test "from pull false no local image" {
+  _prefetch busybox
   target=my-busybox
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --pull=false busybox
   echo "$output"
@@ -359,6 +374,7 @@ load helpers
 }
 
 @test "from --pull-always: emits 'Getting' even if image is cached" {
+  _prefetch docker.io/busybox
   run buildah pull --signature-policy ${TESTSDIR}/policy.json docker.io/busybox
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc --pull-always docker.io/busybox
   expect_output --substring "Getting"

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -69,8 +69,8 @@ function _prefetch() {
                     )
                 )
                 rm -f $_BUILDAH_IMAGE_CACHEDIR/$fname.tar
-                echo "# [podman save $img >$_BUILDAH_IMAGE_CACHEDIR/$fname.tar ]" >&2
-                podman $_podman_opts save --output=${_BUILDAH_IMAGE_CACHEDIR}/$fname.tar $img
+                echo "# [podman save --format oci-archive $img >$_BUILDAH_IMAGE_CACHEDIR/$fname.tar ]" >&2
+                podman $_podman_opts save --format oci-archive --output=${_BUILDAH_IMAGE_CACHEDIR}/$fname.tar $img
             fi
         done
 }

--- a/tests/history.bats
+++ b/tests/history.bats
@@ -98,6 +98,7 @@ function testconfighistory() {
 }
 
 @test "history-run" {
+  _prefetch busybox
   run_buildah from --name runctr --format docker --signature-policy ${TESTSDIR}/policy.json busybox
   run_buildah run --add-history runctr -- uname -a
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json runctr runimg

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -16,6 +16,7 @@ load helpers
 }
 
 @test "images" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
@@ -25,6 +26,7 @@ load helpers
 }
 
 @test "images all test" {
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test ${TESTSDIR}/bud/use-layers
   run_buildah images
   expect_line_count 3
@@ -39,6 +41,7 @@ load helpers
 }
 
 @test "images filter test" {
+  _prefetch k8s.gcr.io/pause busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
   cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
@@ -48,6 +51,7 @@ load helpers
 }
 
 @test "images format test" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
@@ -57,6 +61,7 @@ load helpers
 }
 
 @test "images noheading test" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
@@ -66,6 +71,7 @@ load helpers
 }
 
 @test "images quiet test" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
@@ -75,6 +81,7 @@ load helpers
 }
 
 @test "images no-trunc test" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
@@ -85,6 +92,7 @@ load helpers
 }
 
 @test "images json test" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
@@ -120,6 +128,7 @@ load helpers
 }
 
 @test "specify an existing image" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
@@ -152,6 +161,7 @@ load helpers
 }
 
 @test "image digest test" {
+  _prefetch busybox
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
   run_buildah images --digests
   expect_output --substring "sha256:"

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -14,6 +14,7 @@ load helpers
 }
 
 @test "inspect" {
+  _prefetch alpine
   run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json "$cid" alpine-image
@@ -50,6 +51,7 @@ load helpers
 }
 
 @test "inspect-config-is-json" {
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah inspect alpine
@@ -57,6 +59,7 @@ load helpers
 }
 
 @test "inspect-manifest-is-json" {
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah inspect alpine
@@ -64,6 +67,7 @@ load helpers
 }
 
 @test "inspect-ociv1-is-json" {
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah inspect alpine
@@ -71,6 +75,7 @@ load helpers
 }
 
 @test "inspect-docker-is-json" {
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah inspect alpine
@@ -78,6 +83,7 @@ load helpers
 }
 
 @test "inspect-format-config-is-json" {
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah inspect --format "{{.Config}}" alpine
@@ -85,6 +91,7 @@ load helpers
 }
 
 @test "inspect-format-manifest-is-json" {
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah inspect --format "{{.Manifest}}" alpine
@@ -92,6 +99,7 @@ load helpers
 }
 
 @test "inspect-format-ociv1-is-json" {
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah inspect --format "{{.OCIv1}}" alpine
@@ -99,6 +107,7 @@ load helpers
 }
 
 @test "inspect-format-docker-is-json" {
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah inspect --format "{{.Docker}}" alpine

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -14,6 +14,7 @@ load helpers
 }
 
 @test "mount one container" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah mount "$cid"
@@ -24,6 +25,7 @@ load helpers
 }
 
 @test "mount multi images" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
@@ -34,6 +36,7 @@ load helpers
 }
 
 @test "mount multi images one bad" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
@@ -44,6 +47,7 @@ load helpers
 }
 
 @test "list currently mounted containers" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah mount "$cid1"

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -7,6 +7,7 @@ load helpers
     skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION"
   fi
 
+  _prefetch alpine
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet alpine
   expect_output "alpine-working-container"
   ctr="$output"
@@ -37,6 +38,7 @@ load helpers
   gidsize=$((${RANDOM}+1024))
 
   # Create a container that uses that mapping.
+  _prefetch alpine
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet --userns-uid-map 0:$uidbase:$uidsize --userns-gid-map 0:$gidbase:$gidsize alpine
   ctr="$output"
 
@@ -158,6 +160,7 @@ load helpers
   for i in $(seq 0 "$((${#maps[*]}-1))") ; do
     # Create a container using these mappings.
     echo "Building container with --signature-policy ${TESTSDIR}/policy.json --quiet ${uidmapargs[$i]} ${gidmapargs[$i]} alpine"
+    _prefetch alpine
     run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet ${uidmapargs[$i]} ${gidmapargs[$i]} alpine
     ctr="$output"
 
@@ -227,6 +230,7 @@ general_namespace() {
   types[2]=host
   types[3]=/proc/$$/ns/$nstype
 
+  _prefetch alpine
   for namespace in "${types[@]}" ; do
     # Specify the setting for this namespace for this container.
     run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet --"$nsflag"=$namespace alpine
@@ -314,6 +318,7 @@ general_namespace() {
   skip_if_chroot
   skip_if_rootless
 
+  _prefetch alpine
   # mnt is always per-container, cgroup isn't a thing runc lets us configure
   for ipc in host container ; do
     for net in host container ; do

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -41,6 +41,7 @@ load helpers
   mytmpdir=${TESTDIR}/my-dir
   mkdir -p $mytmpdir
 
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah push --signature-policy ${TESTSDIR}/policy.json --format oci alpine dir:$mytmpdir
@@ -56,6 +57,7 @@ load helpers
   mytmpdir=${TESTDIR}/my-dir
   mkdir -p $mytmpdir
 
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah images -q
@@ -67,6 +69,7 @@ load helpers
   mytmpdir=${TESTDIR}/my-dir
   mkdir -p $mytmpdir
 
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah images -q
@@ -77,12 +80,14 @@ load helpers
 }
 
 @test "push without destination" {
+  _prefetch busybox
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
   run_buildah 1 push --signature-policy ${TESTSDIR}/policy.json busybox
   expect_output --substring "docker://busybox"
 }
 
 @test "push should fail with nonexist authfile" {
+  _prefetch alpine
   run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah images -q
@@ -91,6 +96,8 @@ load helpers
 }
 
 @test "push-denied-by-registry-sources" {
+  _prefetch busybox
+
   export BUILD_REGISTRY_SOURCES='{"blockedRegistries": ["registry.example.com"]}'
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json --quiet busybox
@@ -116,14 +123,14 @@ load helpers
 
 
 @test "buildah push image to containers-storage" {
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
+  _prefetch busybox
   run_buildah push --signature-policy ${TESTSDIR}/policy.json busybox containers-storage:newimage:latest
   run_buildah images
   expect_output --substring "newimage"
 }
 
 @test "buildah push image to docker-archive and oci-archive" {
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
+  _prefetch busybox
   for dest in docker-archive oci-archive; do
     mkdir ${TESTDIR}/tmp
     run_buildah push --signature-policy ${TESTSDIR}/policy.json busybox $dest:${TESTDIR}/tmp/busybox.tar:latest
@@ -138,7 +145,7 @@ load helpers
     skip "docker is not installed"
   fi
 
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
+  _prefetch busybox
   run_buildah push --signature-policy ${TESTSDIR}/policy.json busybox docker-daemon:buildah/busybox:latest
   run docker images
   expect_output --substring "buildah/busybox"

--- a/tests/rename.bats
+++ b/tests/rename.bats
@@ -3,6 +3,7 @@
 load helpers
 
 @test "rename" {
+  _prefetch alpine
   new_name=test-container
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
@@ -18,6 +19,7 @@ load helpers
 }
 
 @test "rename same name as current name" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah 1 rename ${cid} ${cid}
@@ -25,6 +27,7 @@ load helpers
 }
 
 @test "rename same name as other container name" {
+  _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox

--- a/tests/rm.bats
+++ b/tests/rm.bats
@@ -19,12 +19,14 @@ load helpers
 }
 
 @test "remove one container" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah rm "$cid"
 }
 
 @test "remove multiple containers" {
+  _prefetch alpine busybox
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
   cid2=$output
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
@@ -33,6 +35,7 @@ load helpers
 }
 
 @test "remove all containers" {
+  _prefetch alpine busybox
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid1=$output
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
@@ -43,6 +46,7 @@ load helpers
 }
 
 @test "use conflicting commands to remove containers" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah 1 rm -a "$cid"

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -14,6 +14,7 @@ load helpers
 }
 
 @test "remove one image" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah rm "$cid"
@@ -23,6 +24,7 @@ load helpers
 }
 
 @test "remove multiple images" {
+  _prefetch alpine busybox
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
   cid2=$output
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
@@ -45,6 +47,7 @@ load helpers
 }
 
 @test "remove all images" {
+  _prefetch alpine busybox
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid1=$output
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
@@ -55,6 +58,7 @@ load helpers
   run_buildah images -q
   expect_output ""
 
+  _prefetch alpine busybox
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid1=$output
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
@@ -71,6 +75,8 @@ load helpers
 }
 
 @test "use prune to remove dangling images" {
+  _prefetch busybox
+
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
@@ -109,6 +115,7 @@ load helpers
 }
 
 @test "use conflicting commands to remove images" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah rm "$cid"
@@ -130,7 +137,7 @@ load helpers
 }
 
 @test "remove image that is a parent of another image" {
-  run_buildah rmi -a -f
+  _prefetch alpine
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid
@@ -150,7 +157,7 @@ load helpers
 }
 
 @test "rmi with cached images" {
-  run_buildah rmi -a -f
+  _prefetch alpine
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
   run_buildah images -a -q
   expect_line_count 7
@@ -172,7 +179,7 @@ load helpers
 }
 
 @test "rmi image that is created from another named image" {
-  run_buildah rmi -a -f
+  _prefetch alpine
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -5,6 +5,7 @@ load helpers
 @test "run" {
 	skip_if_no_runtime
 
+	_prefetch alpine
 	runc --version
 	createrandom ${TESTDIR}/randomfile
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
@@ -28,6 +29,7 @@ load helpers
 @test "run--args" {
 	skip_if_no_runtime
 
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 
@@ -54,6 +56,7 @@ load helpers
 @test "run-cmd" {
 	skip_if_no_runtime
 
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah config --workingdir /tmp $cid
@@ -171,6 +174,7 @@ function configure_and_check_user() {
 	if test "$CGO_ENABLED" -ne 1; then
 		skip "CGO_ENABLED = '$CGO_ENABLED'"
 	fi
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah mount $cid
@@ -213,6 +217,7 @@ function configure_and_check_user() {
 	skip_if_rootless
 	skip_if_no_runtime
 
+	_prefetch alpine
 	runc --version
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
@@ -232,6 +237,7 @@ function configure_and_check_user() {
 		fi
 	fi
 	runc --version
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	mkdir -p ${TESTDIR}/was-empty
@@ -257,6 +263,7 @@ function configure_and_check_user() {
 		fi
 	fi
 	runc --version
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	mkdir -p ${TESTDIR}/was:empty
@@ -275,6 +282,7 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	runc --version
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	mkdir -p ${TESTDIR}/tmp
@@ -287,6 +295,7 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	runc --version
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	# Try with default caps.
@@ -312,6 +321,7 @@ function configure_and_check_user() {
 @test "Check if containers run with correct open files/processes limits" {
 	skip_if_no_runtime
 
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah run $cid awk '/open files/{print $4}' /proc/self/limits
@@ -358,6 +368,7 @@ function configure_and_check_user() {
 @test "run-exit-status" {
 	skip_if_no_runtime
 
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah 42 run ${cid} sh -c 'exit 42'
@@ -366,6 +377,7 @@ function configure_and_check_user() {
 @test "Verify /run/.containerenv exist" {
 	skip_if_no_runtime
 
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	# test a standard mount to /run/.containerenv
@@ -376,6 +388,7 @@ function configure_and_check_user() {
 @test "run-device" {
 	skip_if_no_runtime
 
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --device /dev/fuse --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah 0 run ${cid} ls /dev/fuse
@@ -395,6 +408,7 @@ function configure_and_check_user() {
 	skip_if_chroot
 	skip_if_rootless
 
+	_prefetch alpine
 	run_buildah from --quiet --pull=false --device /dev/fuse:/dev/fuse1 --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah 0 run ${cid} ls /dev/fuse1

--- a/tests/secrets.bats
+++ b/tests/secrets.bats
@@ -39,6 +39,7 @@ load helpers
 
 
     # setup the test container
+    _prefetch alpine
     run_buildah --default-mounts-file "$MOUNTS_PATH" \
                 from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
     cid=$output

--- a/tests/selinux.bats
+++ b/tests/selinux.bats
@@ -10,6 +10,7 @@ load helpers
   fi
 
   image=alpine
+  _prefetch $image
 
   # Create a container and read its context as a baseline.
   run_buildah from --quiet --quiet --signature-policy ${TESTSDIR}/policy.json $image
@@ -39,6 +40,7 @@ load helpers
   fi
 
   image=alpine
+  _prefetch $image
 
   # Create a container and read its context as a baseline.
   run_buildah from --quiet --security-opt label=disable --quiet --signature-policy ${TESTSDIR}/policy.json $image
@@ -67,6 +69,7 @@ load helpers
   fi
 
   image=alpine
+  _prefetch $image
 
   firstlabel="system_u:system_r:container_t:s0:c1,c2"
   # Create a container and read its context as a baseline.

--- a/tests/sign.bats
+++ b/tests/sign.bats
@@ -34,6 +34,7 @@ function _gpg_setup() {
 
 @test "commit-pull-push-signatures" {
   _gpg_setup
+  _prefetch alpine
 
   mkdir -p ${TESTDIR}/signed-image ${TESTDIR}/unsigned-image
 

--- a/tests/tag.bats
+++ b/tests/tag.bats
@@ -14,6 +14,7 @@ load helpers
 }
 
 @test "tag by id" {
+  _prefetch busybox
   run_buildah pull --quiet --signature-policy ${TESTSDIR}/policy.json busybox
   id=$output
 

--- a/tests/umount.bats
+++ b/tests/umount.bats
@@ -14,6 +14,7 @@ load helpers
 }
 
 @test "umount one image" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah mount "$cid"
@@ -25,6 +26,7 @@ load helpers
 }
 
 @test "umount multi images" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah mount "$cid1"
@@ -38,6 +40,7 @@ load helpers
 }
 
 @test "umount all images" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah mount "$cid1"
@@ -51,6 +54,7 @@ load helpers
 }
 
 @test "umount multi images one bad" {
+  _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
   run_buildah mount "$cid1"


### PR DESCRIPTION
Show of hands: who here loves submitting a PR, then coming back
hours later to find one job failed, then spending time poring
over logs and finding a network error? Anyone? Anyone?

This is a lame attempt to minimize such flakes by caching
commonly-used images and restoring them on demand. We
introduce a new helper, _prefetch(), which podman-pulls
an image the first time, podman-saves it, then on
subsequent calls (for the same image) podman-loads it:

    @test foo {
        _prefetch alpine busybox
        ...tests that run buildah-from either
    }

This is an imperfect solution: it is incomplete and will
grow more so over time as new tests are added. It is
difficult to verify its coverage. I'm really unhappy
with it but if it works, the Total Sum Of Unhappiness
might decrease overall thanks to fewer flakes. If it
doesn't work, it's trivial to remove _prefetch calls
using a sed script. Shall we give it a chance?

Signed-off-by: Ed Santiago <santiago@redhat.com>