### PR TITLE
Add the --from option to bud

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -338,6 +338,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budResults) error {
 		Target:                  iopts.Target,
 		TransientMounts:         transientMounts,
 		Devices:                 devices,
+		NewFromImage:            iopts.NewFromImage,
 	}
 
 	if iopts.Quiet {

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -360,6 +360,11 @@ return 1
 
  _buildah_bud() {
      local boolean_options="
+     --cache-from
+     --compress
+     --disable-compression
+     --disable-content-trust
+     -D
      --help
      -h
      --layers
@@ -369,6 +374,7 @@ return 1
      --pull-never
      --quiet
      -q
+     --rm
      --squash
      --tls-verify
   "
@@ -378,6 +384,7 @@ return 1
      --annotation
      --authfile
      --build-arg
+     -c
      --cap-add
      --cap-drop
      --cert-dir
@@ -391,17 +398,19 @@ return 1
      --cpuset-mems
      --creds
      --device
-     --dns-search
      --dns
      --dns-option
+     --dns-search
      -f
      --file
+     --force-rm
      --format
      --http-proxy
      --iidfile
-     --isolation
      --ipc
+     --isolation
      --label
+     --logfile
      --loglevel
      -m
      --memory

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -233,6 +233,14 @@ Recognized formats include *oci* (OCI image-spec v1.0, the default) and
 Note: You can also override the default format by setting the BUILDAH\_FORMAT
 environment variable.  `export BUILDAH_FORMAT=docker`
 
+**--from**
+
+When processing the Dockerfile, replace any image name found after a FROM
+statement with the supplied value.  If the value in the FROM statement starts
+with a '$' symbol indicating a variable, it will not be replaced.  Any changes
+occur only during processing and do not change the on file version of the
+Dockerfile.
+
 **--http-proxy**
 
 By default proxy environment variables are passed into the container if set
@@ -274,12 +282,6 @@ BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`
 
 Add an image *label* (e.g. label=*value*) to the image metadata. Can be used multiple times.
 
-**--loglevel** *number*
-
-Adjust the logging level up or down.  Valid option values range from -2 to 3,
-with 3 being roughly equivalent to using the global *--log-level=debug* option, and
-values below 0 omitting even error messages which accompany fatal errors.
-
 **--layers** *bool-value*
 
 Cache intermediate images during the build process (Default is `false`).
@@ -291,6 +293,12 @@ environment variable. `export BUILDAH_LAYERS=true`
 
 Log output which would be sent to standard output and standard error to the
 specified file instead of to standard output and standard error.
+
+**--loglevel** *number*
+
+Adjust the logging level up or down.  Valid option values range from -2 to 3,
+with 3 being roughly equivalent to using the global *--log-level=debug* option, and
+values below 0 omitting even error messages which accompany fatal errors.
 
 **--memory, -m**=""
 
@@ -664,6 +672,8 @@ buildah bud -f Containerfile --layers --force-rm -t imageName .
 buildah bud --no-cache --rm=false -t imageName .
 
 buildah bud --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc .
+
+buildah bud --from busybox .
 
 ### Building an image using a URL
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -160,6 +160,9 @@ type BuildOptions struct {
 	Target string
 	// Devices are the additional devices to add to the containers
 	Devices []configs.Device
+	// NewFromImage is the image specified by the --from option on the command line.
+	// It replaces any image names next to a FROM statement found in the Dockerfile.
+	NewFromImage string
 }
 
 // BuildDockerfiles parses a set of one or more Dockerfiles (which may be

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -60,6 +60,7 @@ type BudResults struct {
 	Logfile             string
 	Loglevel            int
 	NoCache             bool
+	NewFromImage        string
 	Platform            string
 	Pull                bool
 	PullAlways          bool
@@ -159,6 +160,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.BoolVar(&flags.NoCache, "no-cache", false, "Do not use existing cached images for the container build. Build from the start with a new set of cached layers.")
 	fs.StringVar(&flags.Logfile, "logfile", "", "log to `file` instead of stdout/stderr")
 	fs.IntVar(&flags.Loglevel, "loglevel", 0, "adjust logging level (range from -2 to 3)")
+	fs.StringVar(&flags.NewFromImage, "from", "", "Replace the image name in the Dockerfile with this value")
 	fs.StringVar(&flags.Platform, "platform", "", "CLI compatibility: no action or effect")
 	fs.BoolVar(&flags.Pull, "pull", true, "pull the image from the registry if newer or not present in store, if false, only pull the image if not present")
 	fs.BoolVar(&flags.PullAlways, "pull-always", false, "pull the image even if the named image is present in store")

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1731,3 +1731,24 @@ EOM
   expect_line_count 1
   expect_output --substring '^[0-9a-f]{64}$'
 }
+
+@test "bud with --from" {
+  target=from-new-image
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --from "busybox" -t ${target} ${TESTSDIR}/bud/from-new
+  [ "${status}" -eq 0 ]
+  expect_output --substring "FROM busybox"
+
+  buildah rmi ${target}
+}
+
+@test "bud with --from and variable" {
+  target=from-new-multi-image
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --from "alpine" --build-arg ARG=scratch -t ${target} -f ${TESTSDIR}/bud/from-new/Dockerfile.mixed ${TESTSDIR}/bud/from-new
+  [ "${status}" -eq 0 ]
+  expect_output --substring "STEP 1: FROM alpine AS myname"
+  expect_output --substring "STEP 3: FROM alpine AS myname2"
+  expect_output --substring "STEP 5: FROM scratch"
+  expect_output --substring "STEP 7: FROM alpine"
+
+  buildah rmi ${target}
+}

--- a/tests/bud/from-new/Containerfile
+++ b/tests/bud/from-new/Containerfile
@@ -1,0 +1,1 @@
+FROM alpine

--- a/tests/bud/from-new/Dockerfile.mixed
+++ b/tests/bud/from-new/Dockerfile.mixed
@@ -1,0 +1,13 @@
+FROM scratch AS myname
+COPY myname.txt /
+
+FROM scratch AS myname2
+COPY myindex.txt /
+
+FROM $ARG 
+COPY Dockerfile.mixed /
+
+FROM scratch
+COPY --from=myname /myname.txt /myname.txt
+COPY --from=1 /myindex.txt /myindex.txt
+COPY --from=2 /Dockerfile.mixed /Dockerfile.mixed

--- a/tests/bud/from-new/myindex.txt
+++ b/tests/bud/from-new/myindex.txt
@@ -1,0 +1,1 @@
+An index file

--- a/tests/bud/from-new/myname.txt
+++ b/tests/bud/from-new/myname.txt
@@ -1,0 +1,1 @@
+A name file


### PR DESCRIPTION
When processing a Dockerfile supplied to the bud command,
replace any image name after the FROM statement with the
value passed in to the --new-from option.  This will not
change the value in the on-disk version of the Dockerfile,
only the one in memory for the lifetime of the build
process.

If the image name is a variable, do not replace that.

I also found our bash completions were missing several and a bad alpha ordering in the man page which has been corrected.
Addresses: #2007

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>