### PR TITLE
Fix buildahimage builds for buildah

### DIFF
--- a/contrib/buildahimage/stable/Dockerfile
+++ b/contrib/buildahimage/stable/Dockerfile
@@ -9,9 +9,9 @@
 FROM fedora:latest
 
 # Don't include container-selinux and remove
-# directories used by dnf that are just taking
+# directories used by yum that are just taking
 # up space.
-RUN yum -y install buildah fuse-overlayfs --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install buildah fuse-overlayfs --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # Adjust storage.conf to enable Fuse storage.
 RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf

--- a/contrib/buildahimage/testing/Dockerfile
+++ b/contrib/buildahimage/testing/Dockerfile
@@ -11,9 +11,9 @@
 FROM fedora:latest
 
 # Don't include container-selinux and remove 
-# directories used by dnf that are just taking
+# directories used by yum that are just taking
 # up space.
-RUN yum -y install buildah fuse-overlayfs --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install buildah fuse-overlayfs --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # Adjust storage.conf to enable Fuse storage.
 RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf

--- a/contrib/buildahimage/upstream/Dockerfile
+++ b/contrib/buildahimage/upstream/Dockerfile
@@ -17,7 +17,7 @@ ENV GOPATH=/root/buildah
 # to the container.
 # Finally remove the buildah directory and a few other packages
 # that are needed for building but not running Buildah
-RUN dnf -y install --enablerepo=updates-testing \
+RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install --enablerepo=updates-testing \
      make \
      golang \
      bats \
@@ -40,8 +40,8 @@ RUN dnf -y install --enablerepo=updates-testing \
      make;\
      make install;\
      rm -rf /root/buildah/*; \
-     dnf -y remove bats git golang go-md2man make; \
-     dnf clean all;
+     yum -y remove bats git golang go-md2man make; \
+     yum clean all;
 
 # Adjust storage.conf to enable Fuse storage.
 RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf


### PR DESCRIPTION
1 We need to update all packages in the buildah image to make sure they are
up2date.
2 reinstall shadow-utils.  For some reason the fedora base image does not
include the file capabilities assigned to /usr/bin/newuidmap and
/usr/bin/newgidmap.  Reinstalling shadow-utils, brings them back.
3 Add a default user `build` to the system. This will create the
/etc/subuid and /etc/subgid maps get created correctly.

Once we have this we should be able to build a container starting with a non
privileged user

podman run -ti --user build --device=/dev/fuse -v ./Dockerfile:/Dockerfile:z quay.io/buildahi/stable buildah bud /

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>