### PR TITLE
Fix option handling for volumes in build

### DIFF
--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -209,7 +209,7 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 	fs.StringArrayVar(&flags.SecurityOpt, "security-opt", []string{}, "security options (default [])")
 	fs.StringVar(&flags.ShmSize, "shm-size", "65536k", "size of '/dev/shm'. The format is `<number><unit>`.")
 	fs.StringSliceVar(&flags.Ulimit, "ulimit", []string{}, "ulimit options (default [])")
-	fs.StringSliceVarP(&flags.Volumes, "volume", "v", []string{}, "bind mount a volume into the container (default [])")
+	fs.StringArrayVarP(&flags.Volumes, "volume", "v", []string{}, "bind mount a volume into the container (default [])")
 
 	// Add in the usernamespace and namespaceflags
 	usernsFlags := GetUserNSFlags(usernsResults)

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -102,7 +102,7 @@ func CommonBuildOptions(c *cobra.Command) (*buildah.CommonBuildOptions, error) {
 	if _, err := units.FromHumanSize(c.Flag("shm-size").Value.String()); err != nil {
 		return nil, errors.Wrapf(err, "invalid --shm-size")
 	}
-	volumes, _ := c.Flags().GetStringSlice("volume")
+	volumes, _ := c.Flags().GetStringArray("volume")
 	if err := Volumes(volumes); err != nil {
 		return nil, err
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1350,6 +1350,10 @@ load helpers
 @test "buidah bud --volume" {
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
   expect_output --substring "/testdir"
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -v ${TESTSDIR}:/testdir:rw ${TESTSDIR}/bud/mount
+  expect_output --substring "/testdir"
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -v ${TESTSDIR}:/testdir:rw,z ${TESTSDIR}/bud/mount
+  expect_output --substring "/testdir"
 }
 
 @test "bud-copy-dot with --layers picks up changed file" {


### PR DESCRIPTION
If the volume option was specified like: `--volume "${HOME}/.cache/zae9ujei:/myvol:rw,Z"`,
the COBRA code that processed the input from the user was considering the value to be a
SliceVar with two volumes `${HOME}/.cache/zae9ujei:/myvol:rw` and `Z` due to the comma.

Converted the COBRA code to consider the input as an ArrayVar instead and the value is
handled appropriately.  Also increased the testing to catch this going forward.

Addresses: #2000

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>