### PR TITLE
cpp: use -traditional and -undef flags

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -280,7 +280,7 @@ func preprocessDockerfileContents(r io.Reader, ctxDir string) (rdrCloser *io.Rea
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
-	cmd := exec.Command(cppPath, "-E", "-iquote", ctxDir, "-")
+	cmd := exec.Command(cppPath, "-E", "-iquote", ctxDir, "-traditional", "-undef", "-")
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 


### PR DESCRIPTION
@tanzislam noted [1] that Buildah should be using the -traditional flag
to prevent CPP from removing trailing backslashes in non-directive lines
and the -undef flag to prevent built-in macros from expansion (e.g.,
"linux" to "1").

[1] https://github.com/moby/moby/issues/735#issuecomment-568720297

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>