### PR TITLE
Bump 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 # Changelog
 
 
+## v1.13.0 (2019-12-24)
+    Update container/storage to v1.15.4
+    Fix option handling for volumes in build
+    Rework overlay pkg for use with libpod
+    Fix buildahimage builds for buildah
+    Add support for FIPS-Mode backends
+    Set the TMPDIR for pulling/pushing image to $TMPDIR
+    WIP: safer test for pull --all-tags
+    BATS major cleanup: blobcache.bats: refactor
+    BATS major cleanup: part 4: manual stuff
+    BATS major cleanup, step 3: yet more run_buildah
+    BATS major cleanup, part 2: use more run_buildah
+    BATS major cleanup, part 1: log-level
+    Bump github.com/containers/image/v5 from 5.0.0 to 5.1.0
+    Bump github.com/containers/common from 0.0.3 to 0.0.5
+    Bump to v1.13.0-dev
+
 ## v1.12.0 (2019-12-13)
     Allow ADD to use http src
     Bump to c/storage v.1.15.3

--- a/buildah.go
+++ b/buildah.go
@@ -27,7 +27,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.13.0"
+	Version = "1.14.0-dev"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/buildah.go
+++ b/buildah.go
@@ -27,7 +27,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.13.0-dev"
+	Version = "1.13.0"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,20 @@
+- Changelog for v1.13.0 (2019-12-24)
+  * Update container/storage to v1.15.4
+  * Fix option handling for volumes in build
+  * Rework overlay pkg for use with libpod
+  * Fix buildahimage builds for buildah
+  * Add support for FIPS-Mode backends
+  * Set the TMPDIR for pulling/pushing image to $TMPDIR
+  * WIP: safer test for pull --all-tags
+  * BATS major cleanup: blobcache.bats: refactor
+  * BATS major cleanup: part 4: manual stuff
+  * BATS major cleanup, step 3: yet more run_buildah
+  * BATS major cleanup, part 2: use more run_buildah
+  * BATS major cleanup, part 1: log-level
+  * Bump github.com/containers/image/v5 from 5.0.0 to 5.1.0
+  * Bump github.com/containers/common from 0.0.3 to 0.0.5
+  * Bump to v1.13.0-dev
+
 - Changelog for v1.12.0 (2019-12-13)
   * Allow ADD to use http src
   * Bump to c/storage v.1.15.3

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in buildah.go too
-Version:        1.13.0
+Version:        1.14.0-dev
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -99,6 +99,8 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Tue Dec 24, 2019 Tom Sweeney <tsweeney@redhat.com> 1.14.0-dev-1
+
 * Tue Dec 24, 2019 Tom Sweeney <tsweeney@redhat.com> 1.13.0-1
 - Update container/storage to v1.15.4
 - Fix option handling for volumes in build

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in buildah.go too
-Version:        1.13.0-dev
+Version:        1.13.0
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -99,7 +99,22 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
-* Fri Dec 13, 2019 Tom Sweeney <tsweeney@redhat.com> 1.13.0-dev-1
+* Tue Dec 24, 2019 Tom Sweeney <tsweeney@redhat.com> 1.13.0-1
+- Update container/storage to v1.15.4
+- Fix option handling for volumes in build
+- Rework overlay pkg for use with libpod
+- Fix buildahimage builds for buildah
+- Add support for FIPS-Mode backends
+- Set the TMPDIR for pulling/pushing image to $TMPDIR
+- WIP: safer test for pull --all-tags
+- BATS major cleanup: blobcache.bats: refactor
+- BATS major cleanup: part 4: manual stuff
+- BATS major cleanup, step 3: yet more run_buildah
+- BATS major cleanup, part 2: use more run_buildah
+- BATS major cleanup, part 1: log-level
+- Bump github.com/containers/image/v5 from 5.0.0 to 5.1.0
+- Bump github.com/containers/common from 0.0.3 to 0.0.5
+- Bump to v1.13.0-dev
 
 * Fri Dec 13, 2019 Tom Sweeney <tsweeney@redhat.com> 1.12.0-1
 - Allow ADD to use http src


### PR DESCRIPTION
Bump to 1.13.0 to capture c/storage 1.15.4.  @rhatdan @vrothberg let me know if I should redo with c/storage 1.15.5.