### PR TITLE
set $HOME to /root on chroot-isolation

### DIFF
--- a/pkg/chrootuser/user.go
+++ b/pkg/chrootuser/user.go
@@ -25,9 +25,11 @@ func GetUser(rootdir, userspec string) (uint32, uint32, string, error) {
 	spec := strings.SplitN(userspec, ":", 2)
 	userspec = spec[0]
 	groupspec := ""
+
 	if userspec == "" {
-		return 0, 0, "/", nil
+		userspec = "0"
 	}
+
 	if len(spec) > 1 {
 		groupspec = spec[1]
 	}


### PR DESCRIPTION
closes #2005 

When isolation is set to chroot we are passing to `chroot.RunUsingChroot` the `homeDir` argument which is given by `configureUIDGID` that eventually gets it from `chroot.GetUser`.

In `chroot.GetUser` the default homeDir is set to `/` which that's why the `$HOME` env variable is `/` when using chroot isolation.