### PR TITLE
Fix imageNamePrefix to give consistent names in buildah-from

### DIFF
--- a/new.go
+++ b/new.go
@@ -68,13 +68,13 @@ func getImageName(name string, img *storage.Image) string {
 
 func imageNamePrefix(imageName string) string {
 	prefix := imageName
-	s := strings.Split(imageName, "/")
-	if len(s) > 0 {
-		prefix = s[len(s)-1]
-	}
-	s = strings.Split(prefix, ":")
+	s := strings.Split(prefix, ":")
 	if len(s) > 0 {
 		prefix = s[0]
+	}
+	s = strings.Split(prefix, "/")
+	if len(s) > 0 {
+		prefix = s[len(s)-1]
 	}
 	s = strings.Split(prefix, "@")
 	if len(s) > 0 {

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -195,12 +195,12 @@ load helpers
   run_buildah rmi alpine
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json docker-archive:${TESTDIR}/docker-alp.tar
-  expect_output "docker-alp.tar-working-container"       # 2028
+  expect_output "docker-archive-working-container"
   run_buildah rm $output
   run_buildah rmi -a
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json oci-archive:${TESTDIR}/oci-alp.tar
-  expect_output "oci-alp.tar-working-container"
+  expect_output "oci-archive-working-container"
   run_buildah rm $output
   run_buildah rmi -a
 }


### PR DESCRIPTION
closes #2028 

By first removing the tag from the image name and then doing `split("/")` the problem in #2028 is fixed.