### PR TITLE
fix bug Add check .dockerignore COPY file

### DIFF
--- a/add.go
+++ b/add.go
@@ -344,6 +344,18 @@ func (b *Builder) addHelper(excludes *fileutils.PatternMatcher, extract bool, de
 			}
 
 			b.ContentDigester.Start("file")
+			// This source is a file
+			// Check if the path matches the .dockerignore
+			if excludes != nil {
+				res, err := excludes.MatchesResult(esrc)
+				if err != nil {
+					return errors.Wrapf(err, "error checking if %s is an excluded path", esrc)
+				}
+				// Skip the file if the pattern matches
+				if res.IsMatched() {
+					return nil
+				}
+			}
 
 			if !extract || !archive.IsArchivePath(esrc) {
 				// This source is a file, and either it's not an

--- a/tests/bud/dockerignore3/Dockerfile
+++ b/tests/bud/dockerignore3/Dockerfile
@@ -1,4 +1,5 @@
 FROM busybox
 COPY . /upload/
 COPY src /upload/src2/
+COPY test1.txt /upload/test1.txt
 RUN echo "CUT HERE"; /bin/find /upload | LANG=en_US.UTF-8 sort; echo "CUT HERE"


### PR DESCRIPTION
fix #2060 
fix the bug that buildah does not check .dockerignore file if the source of COPY instruction is a filepath. This patch will skip the path if the overall result of the dockerignore matcher is true.

Signed-off-by: Qi Wang <qiwan@redhat.com>