### PR TITLE
buildah bud --volume: run from tmpdir, not source dir

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1348,11 +1348,14 @@ load helpers
 }
 
 @test "buidah bud --volume" {
-  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
+  voldir=${TESTDIR}/bud-volume
+  mkdir -p ${voldir}
+
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -v ${voldir}:/testdir ${TESTSDIR}/bud/mount
   expect_output --substring "/testdir"
-  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -v ${TESTSDIR}:/testdir:rw ${TESTSDIR}/bud/mount
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -v ${voldir}:/testdir:rw ${TESTSDIR}/bud/mount
   expect_output --substring "/testdir"
-  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -v ${TESTSDIR}:/testdir:rw,z ${TESTSDIR}/bud/mount
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -v ${voldir}:/testdir:rw,z ${TESTSDIR}/bud/mount
   expect_output --substring "/testdir"
 }
 


### PR DESCRIPTION
PR #2039 broke system tests, because they're installed in /usr:
```console
# buildah bud -v /usr/share/buildah/test/system:/testdir:rw,z /usr/share/buildah/test/system/bud/mount
...
error building at STEP "RUN mount": error resolving mountpoints for container "173c5e567e95f2604b5ea677f5e5364839d5b455a9081cdb4101f20242997e5e": relabeling "/usr/share/buildah/test/system" failed: relabeling content in /usr is not allowed
```
Solution: mount a volume from TESTDIR (singular), which is in TMPDIR,
not TESTSDIR (plural), which is our test source dir.

Signed-off-by: Ed Santiago <santiago@redhat.com>