### PR TITLE
docs: fix references to containers-*.5

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -708,4 +708,4 @@ registries.conf is the configuration file which specifies which container regist
 Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
-buildah(1), CPP(1), buildah-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7), crun(1), runc(8)
+buildah(1), CPP(1), buildah-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), containers-policy.json(5), containers-registries.conf(5), user\_namespaces(7), crun(1), runc(8)

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -133,4 +133,4 @@ registries.conf is the configuration file which specifies which container regist
 Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
-buildah(1), policy.json(5), registries.conf(5)
+buildah(1), containers-policy.json(5), containers-registries.conf(5)

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -35,7 +35,7 @@ Multiple transports are supported:
 ### DEPENDENCIES
 
 Buildah resolves the path to the registry to pull from by using the /etc/containers/registries.conf
-file, registries.conf(5).  If the `buildah from` command fails with an "image not known" error,
+file, containers-registries.conf(5).  If the `buildah from` command fails with an "image not known" error,
 first verify that the registries.conf file is installed and configured appropriately.
 
 ## RETURN VALUE
@@ -571,4 +571,4 @@ registries.conf is the configuration file which specifies which container regist
 Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
-buildah(1), buildah-pull(1), buildah-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), policy.json(5), registries.conf(5), user\_namespaces(7)
+buildah(1), buildah-pull(1), buildah-login(1), docker-login(1), namespaces(7), pid\_namespaces(7), containers-policy.json(5), containers-registries.conf(5), user\_namespaces(7)

--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -34,7 +34,7 @@ Multiple transports are supported:
 ### DEPENDENCIES
 
 Buildah resolves the path to the registry to pull from by using the /etc/containers/registries.conf
-file, registries.conf(5).  If the `buildah pull` command fails with an "image not known" error,
+file, containers-registries.conf(5).  If the `buildah pull` command fails with an "image not known" error,
 first verify that the registries.conf file is installed and configured appropriately.
 
 ## RETURN VALUE
@@ -125,4 +125,4 @@ registries.conf is the configuration file which specifies which container regist
 Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
-buildah(1), buildah-from(1), buildah-login(1), docker-login(1), policy.json(5), registries.conf(5)
+buildah(1), buildah-from(1), buildah-login(1), docker-login(1), containers-policy.json(5), containers-registries.conf(5)

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -148,4 +148,4 @@ registries.conf is the configuration file which specifies which container regist
 Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
-buildah(1), buildah-login(1), policy.json(5), docker-login(1), registries.conf(5)
+buildah(1), buildah-login(1), containers-policy.json(5), docker-login(1), containers-registries.conf(5)

--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -58,4 +58,4 @@ storage.conf is the storage configuration file for all tools using containers/st
 The storage configuration file specifies all of the available container storage options for tools using shared container storage.
 
 ## SEE ALSO
-buildah(1), registries.conf(5), containers-storage.conf(5)
+buildah(1), containers-registries.conf(5), containers-storage.conf(5)

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -118,7 +118,6 @@ Print the version
 | buildah-umount(1)     | Unmount a working container's root file system.                                                      |
 | buildah-unshare(1)    | Launch a command in a user namespace with modified ID mappings.                                      |
 | buildah-version(1)    | Display the Buildah Version Information                                                              |
-| storage.conf(5)       | Syntax of Container Storage configuration file                                                       |
 
 
 ## Files


### PR DESCRIPTION
Fix man page instances of 'registries.conf(5)' et al.
The correct man page is containers-registries.conf(5).

Found via:

  $ for i in registries.conf storage.conf policy.json ; do grep $i.5 docs/*.md | grep -v containers-$i;done

In buildah.md, I simply removed the storage.conf line from
the 'Commands' table because it's not a command.

Signed-off-by: Ed Santiago <santiago@redhat.com>