### PR TITLE
Don't setup excludes, if their is only one pattern to match

### DIFF
--- a/add.go
+++ b/add.go
@@ -236,7 +236,7 @@ func dockerIgnoreMatcher(lines []string, contextDir string) (*fileutils.PatternM
 		patterns = append(patterns, includeFlag+filepath.Join(contextDir, ignoreSpec))
 	}
 	// if there are no patterns, save time by not constructing the object
-	if len(patterns) == 0 {
+	if len(patterns) == 1 {
 		return nil, nil
 	}
 	// return a matcher object


### PR DESCRIPTION
We are always adding .dockerignore to the pattern list, if this is the only pattern
then no patterns we added to the list, and we should return nil.

This is causing a major slowdown in buildah, since it is not using the optimized tar for
copying.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>