### PR TITLE
copy: check for .dockerignore specifically

### DIFF
--- a/add.go
+++ b/add.go
@@ -215,7 +215,12 @@ func dockerIgnoreMatcher(lines []string, contextDir string) (*fileutils.PatternM
 	if contextDir == "" {
 		return nil, nil
 	}
-	patterns := []string{".dockerignore"}
+	// If there's no .dockerignore file, then we don't have to add a
+	// pattern to tell copy logic to ignore it later.
+	var patterns []string
+	if _, err := os.Stat(filepath.Join(contextDir, ".dockerignore")); err == nil || !os.IsNotExist(err) {
+		patterns = []string{".dockerignore"}
+	}
 	for _, ignoreSpec := range lines {
 		ignoreSpec = strings.TrimSpace(ignoreSpec)
 		// ignore comments passed back from .dockerignore
@@ -224,7 +229,8 @@ func dockerIgnoreMatcher(lines []string, contextDir string) (*fileutils.PatternM
 		}
 		// if the spec starts with '!' it means the pattern
 		// should be included. make a note so that we can move
-		// it to the front of the updated pattern
+		// it to the front of the updated pattern, and insert
+		// the context dir's path in between
 		includeFlag := ""
 		if strings.HasPrefix(ignoreSpec, "!") {
 			includeFlag = "!"
@@ -236,7 +242,7 @@ func dockerIgnoreMatcher(lines []string, contextDir string) (*fileutils.PatternM
 		patterns = append(patterns, includeFlag+filepath.Join(contextDir, ignoreSpec))
 	}
 	// if there are no patterns, save time by not constructing the object
-	if len(patterns) == 1 {
+	if len(patterns) == 0 {
 		return nil, nil
 	}
 	// return a matcher object

--- a/add.go
+++ b/add.go
@@ -349,7 +349,6 @@ func (b *Builder) addHelper(excludes *fileutils.PatternMatcher, extract bool, de
 				continue
 			}
 
-			b.ContentDigester.Start("file")
 			// This source is a file
 			// Check if the path matches the .dockerignore
 			if excludes != nil {
@@ -362,6 +361,8 @@ func (b *Builder) addHelper(excludes *fileutils.PatternMatcher, extract bool, de
 					return nil
 				}
 			}
+
+			b.ContentDigester.Start("file")
 
 			if !extract || !archive.IsArchivePath(esrc) {
 				// This source is a file, and either it's not an

--- a/util.go
+++ b/util.go
@@ -165,11 +165,6 @@ func (b *Builder) copyFileWithTar(tarIDMappingOptions *IDMappingOptions, chownOp
 				if err != nil {
 					return errors.Wrapf(err, "error opening %q to copy its contents", src)
 				}
-				defer func() {
-					if err := f.Close(); err != nil {
-						logrus.Debugf("error closing %s: %v", fi.Name(), err)
-					}
-				}()
 			}
 		}
 
@@ -200,6 +195,9 @@ func (b *Builder) copyFileWithTar(tarIDMappingOptions *IDMappingOptions, chownOp
 					logrus.Debugf("error copying contents of %s: %v", fi.Name(), err)
 					copyErr = err
 				}
+				if err = srcFile.Close(); err != nil {
+					logrus.Debugf("error closing %s: %v", fi.Name(), err)
+				}
 			}
 			if err = writer.Close(); err != nil {
 				logrus.Debugf("error closing write pipe for %s: %v", hdr.Name, err)
@@ -213,7 +211,6 @@ func (b *Builder) copyFileWithTar(tarIDMappingOptions *IDMappingOptions, chownOp
 		if err == nil {
 			err = copyErr
 		}
-		f = nil
 		if pipeWriter != nil {
 			pipeWriter.Close()
 		}


### PR DESCRIPTION
When generating the list of exclusions to process .dockerignore contents, don't include .dockerignore if we don't have a .dockerignore file in the context directory.  That way, if the file doesn't exist, and the caller didn't pass in any patterns, we get no patterns instead of just one ".dockerignore" pattern, and we can hit the faster copy path.  This should help with https://bugzilla.redhat.com/show_bug.cgi?id=1788982.

Don't start digesting the contents of any file that we end up skipping.