### PR TITLE
Travis: rm go 1.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 dist: xenial
 sudo: required
 go:
-    - 1.12.x
     - 1.13.x
     - tip
 go_import_path: github.com/containers/buildah


### PR DESCRIPTION
Remove go 1.12.x from the testing matrix to consume less resources from
Travis and save some energy.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @TomSweeneyRedHat @nalind PTAL