### PR TITLE
Fix COPY in containerfile with envvar

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1738,3 +1738,15 @@ EOM
   expect_line_count 1
   expect_output --substring '^[0-9a-f]{64}$'
 }
+
+@test "bud COPY with Env Var in Containerfile" {
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t testctr ${TESTSDIR}/bud/copy-envvar
+  run_buildah from testctr
+  run_buildah run testctr-working-container ls /file-0.0.1.txt
+  run_buildah rm -a
+
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t testctr ${TESTSDIR}/bud/copy-envvar
+  run_buildah from testctr
+  run_buildah run testctr-working-container ls /file-0.0.1.txt
+  run_buildah rm -a
+}

--- a/tests/bud/copy-envvar/Containerfile
+++ b/tests/bud/copy-envvar/Containerfile
@@ -1,0 +1,3 @@
+FROM alpine 
+ENV VERSION=0.0.1
+COPY file-${VERSION}.txt /


### PR DESCRIPTION
If a Containerfile had lines like:

```
FROM alpine
ENV VERSION=0.0.1
COPY file-${VERSION}.txt /
```

Buildah would not resolve the VERSION variable in the copy statement.
If the 'ENV' in the above Containerfile was changed to ARG, then this
would work.

A recent change to the handling of variables now only looks at variables
set by 'ARG' and not the ones set by the 'ENV' command.  This PR
adds the variables set by the `ENV` to the list of `ARG` variables
when those variables are being resolved by the code.

This also includes added tests to guard against this regression in the future.

Addresses:  https://github.com/containers/libpod/issues/4878

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>