### PR TITLE
Fix build for 32bit platforms

### DIFF
--- a/util/util_linux.go
+++ b/util/util_linux.go
@@ -2,17 +2,18 @@ package util
 
 import (
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // IsCgroup2UnifiedMode returns whether we are running in cgroup 2 cgroup2 mode.
 func IsCgroup2UnifiedMode() (bool, error) {
 	isUnifiedOnce.Do(func() {
-		_cgroup2SuperMagic := int64(0x63677270)
 		var st syscall.Statfs_t
 		if err := syscall.Statfs("/sys/fs/cgroup", &st); err != nil {
 			isUnified, isUnifiedErr = false, err
 		} else {
-			isUnified, isUnifiedErr = st.Type == _cgroup2SuperMagic, nil
+			isUnified, isUnifiedErr = st.Type == unix.CGROUP2_SUPER_MAGIC, nil
 		}
 	})
 	return isUnified, isUnifiedErr


### PR DESCRIPTION
Reproducible via:
```
> podman run --override-arch=386 -it quay.io/crio/crio-build-386-go1.13:master-1.1.6 bash -c "go get -d github.com/containers/buildah && make -C src/github.com/containers/buildah"
make: Entering directory '/go/src/github.com/containers/buildah'
GO111MODULE=on go build -mod=vendor -ldflags '-X main.GitCommit=6417a9a0 -X main.buildInfo=1579618525 -X main.cniVersion=v0.7.1'  -o buildah -tags "seccomp selinux apparmor   " ./cmd/buildah
# github.com/containers/buildah/util
util/util_linux.go:15:38: invalid operation: st.Type == _cgroup2SuperMagic (mismatched types int32 and int64)
make: *** [Makefile:46: binary] Error 2
make: Leaving directory '/go/src/github.com/containers/buildah'
```