### PR TITLE
buildahimage: specify fuse-overlayfs mount options

### DIFF
--- a/contrib/buildahimage/stable/Dockerfile
+++ b/contrib/buildahimage/stable/Dockerfile
@@ -14,7 +14,7 @@ FROM fedora:latest
 RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install buildah fuse-overlayfs --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # Adjust storage.conf to enable Fuse storage.
-RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
 RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
 
 # Set up environment variables to note that this is

--- a/contrib/buildahimage/testing/Dockerfile
+++ b/contrib/buildahimage/testing/Dockerfile
@@ -16,7 +16,7 @@ FROM fedora:latest
 RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install buildah fuse-overlayfs --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # Adjust storage.conf to enable Fuse storage.
-RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
 RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
 
 # Set up environment variables to note that this is

--- a/contrib/buildahimage/upstream/Dockerfile
+++ b/contrib/buildahimage/upstream/Dockerfile
@@ -44,7 +44,7 @@ RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install 
      yum clean all;
 
 # Adjust storage.conf to enable Fuse storage.
-RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
 RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
 
 # Set up environment variables to note that this is


### PR DESCRIPTION
tweak the storage.conf file to use fuse-overlayfs specific mount
options.  In particular, disable any sync operation on the files on
fuse-overlayfs.

sync is an expensive operation and there is no gain in sync'ing files
when doing a build as if the build fails we don't store the
intermediate result.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>