### PR TITLE
Make the commit id clear like Docker

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -558,7 +558,7 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 	if err := cleanup(); err != nil {
 		return "", nil, err
 	}
-
+	logrus.Debugf("printing final image id %q", imageID)
 	if b.iidfile != "" {
 		if err = ioutil.WriteFile(b.iidfile, []byte(imageID), 0644); err != nil {
 			return imageID, ref, errors.Wrapf(err, "failed to write image ID to file %q", b.iidfile)
@@ -568,7 +568,6 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 			return imageID, ref, errors.Wrapf(err, "failed to write image ID to stdout")
 		}
 	}
-
 	return imageID, ref, nil
 }
 

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -776,8 +776,12 @@ func (s *StageExecutor) Execute(ctx context.Context, stage imagebuilder.Stage, b
 		}
 	}
 	logImageID := func(imgID string) {
+		if len(imgID) > 11 {
+			imgID = imgID[0:11]
+		}
 		if s.executor.iidfile == "" {
-			fmt.Fprintf(s.executor.out, "%s\n", imgID)
+
+			fmt.Fprintf(s.executor.out, "--> %s\n", imgID)
 		}
 	}
 
@@ -1018,7 +1022,6 @@ func (s *StageExecutor) Execute(ctx context.Context, stage imagebuilder.Stage, b
 			}
 		}
 	}
-
 	return imgID, ref, nil
 }
 


### PR DESCRIPTION
Using this Dockerfile:
```
FROM alpine AS tommer
```
Docker does:
```
Sending build context to Docker daemon  17.92kB
Step 1/1 : FROM alpine AS tommer
latest: Pulling from library/alpine
c9b1b535fdd9: Pull complete
Digest: sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d
Status: Downloaded newer image for alpine:latest
 ---> e7d92cdc71fe
Successfully built e7d92cdc71fe
```

While Buildah does:
```
STEP 1: FROM alpine AS tommer
STEP 2: COMMIT tom
e7d92cdc71feacf90708cb59182d0df1b911f8ae022d29e8e95d75ca6a99776a
e7d92cdc71feacf90708cb59182d0df1b911f8ae022d29e8e95d75ca6a99776a
```
Per user requests, we've over time eliminated some of the "noisier" output that
Docker has, and that's now led to some confusion when we show an intermediate
image id (after the commit) and then as in the case, the same final
image id immediately afterwards.  We display only the full final image id to
make scripting easier per other user requests.

To aid with this, this pr will cause the intermediate image to be displayed
after an `-->` like Docker and will also show the 12 character short id.

If the `--quiet` option is used, this shorter id will not be displayed, only
the final longer one.

New behavior:
```
STEP 1: FROM alpine AS tommer
STEP 2: COMMIT tom
--> e7d92cdc71f
e7d92cdc71feacf90708cb59182d0df1b911f8ae022d29e8e95d75ca6a99776a
```
Fixes: https://github.com/containers/libpod/issues/5012