### PR TITLE
info test: deal with random key order

### DIFF
--- a/tests/info.bats
+++ b/tests/info.bats
@@ -7,5 +7,9 @@ load helpers
   expect_output --substring "host"
 
   run_buildah info --format='{{.store}}'
-  expect_output --substring 'map.*ContainerStore.*GraphDriverName.*GraphRoot:.*RunRoot:'
+  # All of the following keys must be present in results. Order
+  # isn't guaranteed, nor is their value, but they must all exist.
+  for key in ContainerStore GraphDriverName GraphRoot RunRoot;do
+    expect_output --substring "map.*$key:"
+  done
 }


### PR DESCRIPTION
Looks like the order of keys in the .store map is not
guaranteed; it's causing CI failures in #2115. Keep
checking the results, but be more flexible about order.

Signed-off-by: Ed Santiago <santiago@redhat.com>