### PR TITLE
Repair buildah so it can use containers.conf on the server side

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/pkg/umask"
-	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/unshare"
 	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
@@ -22,10 +21,8 @@ import (
 )
 
 var (
-	// defaultContainerConfig structure defines the default container
 	// configuration, including customizations made in containers.conf
-	defaultContainerConfig = getDefaultConfig()
-	needToShutdownStore    = false
+	needToShutdownStore = false
 )
 
 func getStore(c *cobra.Command) (storage.Store, error) {
@@ -442,14 +439,4 @@ Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 {{end}}
 `
-}
-
-func getDefaultConfig() *config.Config {
-	var err error
-	conf, err := config.NewConfig("")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading container config %v\n", err)
-		os.Exit(1)
-	}
-	return conf
 }

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -108,7 +108,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 		return errors.Wrapf(err, "error reading build container %q", name)
 	}
 
-	isolation, err := parse.IsolationOption(c)
+	isolation, err := parse.IsolationOption(c.Flag("isolation").Value.String())
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,6 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 	}
 
 	options := buildah.RunOptions{
-		Env:              defaultContainerConfig.Containers.Env,
 		Hostname:         iopts.hostname,
 		Runtime:          iopts.runtime,
 		Args:             runtimeFlags,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/blang/semver v3.5.0+incompatible // indirect
 	github.com/containernetworking/cni v0.7.1
-	github.com/containers/common v0.1.4
+	github.com/containers/common v0.2.0
 	github.com/containers/image/v5 v5.2.0
 	github.com/containers/storage v1.15.8
 	github.com/cyphar/filepath-securejoin v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/containers/common v0.1.2 h1:EYAgJsQgH3akh6kdlN4c2t09bqRgyzpxyWmlFTf1I
 github.com/containers/common v0.1.2/go.mod h1:ss8uGpUsaDE4DPmaVFOjzKrlgf5eUnSAWL+d/PYGaoM=
 github.com/containers/common v0.1.4 h1:6tizbvX9BJTnJ0S3pe65Vcu8gJagbm6oFBCmwUIiOE4=
 github.com/containers/common v0.1.4/go.mod h1:ss8uGpUsaDE4DPmaVFOjzKrlgf5eUnSAWL+d/PYGaoM=
+github.com/containers/common v0.2.0 h1:umTbAiX39/0oNxHn10ia0RyXrZCs/CnjJQlRiTdiXb8=
+github.com/containers/common v0.2.0/go.mod h1:ss8uGpUsaDE4DPmaVFOjzKrlgf5eUnSAWL+d/PYGaoM=
 github.com/containers/image/v4 v4.0.1 h1:idNGHChj0Pyv3vLrxul2oSVMZLeFqpoq3CjLeVgapSQ=
 github.com/containers/image/v4 v4.0.1/go.mod h1:0ASJH1YgJiX/eqFZObqepgsvIA4XjCgpyfwn9pDGafA=
 github.com/containers/image/v5 v5.0.0 h1:arnXgbt1ucsC/ndtSpiQY87rA0UjhF+/xQnPzqdBDn4=
@@ -420,6 +422,10 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.5 h1:3+auTFlqw+ZaQYJARz6ArODtkaIwtvBTx3N2NehQlL8=
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
+github.com/rhatdan/common v0.0.3-0.20200203010855-77d72c3e2feb h1:pABQ1OA6mO8XrdHran0oaTEvSb2aZpM+bI8+NfcjALQ=
+github.com/rhatdan/common v0.0.3-0.20200203010855-77d72c3e2feb/go.mod h1:ss8uGpUsaDE4DPmaVFOjzKrlgf5eUnSAWL+d/PYGaoM=
+github.com/rhatdan/common v0.0.3-0.20200208104512-837f7aa36449 h1:3uEI2WT7ZUWIKbbyKjm7etLgSSMOmdiJ4cqksVnuV9A=
+github.com/rhatdan/common v0.0.3-0.20200208104512-837f7aa36449/go.mod h1:ss8uGpUsaDE4DPmaVFOjzKrlgf5eUnSAWL+d/PYGaoM=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/saschagrunert/storage v1.12.3-0.20191015073819-a34ddea087da h1:5aEGhStFh+0r/t0kT0utSi5C6MIMHBgMHkeIu1JUvfA=

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -183,8 +183,13 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	return fs
 }
 
-func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, namespaceResults *NameSpaceResults, defaultConfig *config.Config) pflag.FlagSet {
+func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, namespaceResults *NameSpaceResults) (pflag.FlagSet, error) {
 	fs := pflag.FlagSet{}
+	defaultContainerConfig, err := config.Default()
+	if err != nil {
+		return fs, errors.Wrapf(err, "failed to get container config")
+	}
+
 	fs.StringSliceVar(&flags.AddHost, "add-host", []string{}, "add a custom host-to-IP mapping (`host:ip`) (default [])")
 	fs.StringVar(&flags.BlobCache, "blob-cache", "", "assume image blobs in the specified directory will be available for pushing")
 	if err := fs.MarkHidden("blob-cache"); err != nil {
@@ -198,10 +203,10 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 	fs.Uint64VarP(&flags.CPUShares, "cpu-shares", "c", 0, "CPU shares (relative weight)")
 	fs.StringVar(&flags.CPUSetCPUs, "cpuset-cpus", "", "CPUs in which to allow execution (0-3, 0,1)")
 	fs.StringVar(&flags.CPUSetMems, "cpuset-mems", "", "memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.")
-	fs.StringArrayVar(&flags.Devices, "device", defaultConfig.Containers.AdditionalDevices, "Additional devices to be used within containers (default [])")
-	fs.StringSliceVar(&flags.DNSSearch, "dns-search", defaultConfig.Containers.DNSSearches, "Set custom DNS search domains")
-	fs.StringSliceVar(&flags.DNSServers, "dns", defaultConfig.Containers.DNSServers, "Set custom DNS servers or disable it completely by setting it to 'none', which prevents the automatic creation of `/etc/resolv.conf`.")
-	fs.StringSliceVar(&flags.DNSOptions, "dns-option", defaultConfig.Containers.DNSOptions, "Set custom DNS options")
+	fs.StringArrayVar(&flags.Devices, "device", defaultContainerConfig.Containers.AdditionalDevices, "Additional devices to be used within containers (default [])")
+	fs.StringSliceVar(&flags.DNSSearch, "dns-search", defaultContainerConfig.Containers.DNSSearches, "Set custom DNS search domains")
+	fs.StringSliceVar(&flags.DNSServers, "dns", defaultContainerConfig.Containers.DNSServers, "Set custom DNS servers or disable it completely by setting it to 'none', which prevents the automatic creation of `/etc/resolv.conf`.")
+	fs.StringSliceVar(&flags.DNSOptions, "dns-option", defaultContainerConfig.Containers.DNSOptions, "Set custom DNS options")
 	fs.BoolVar(&flags.HTTPProxy, "http-proxy", true, "pass through HTTP Proxy environment variables")
 	fs.StringVar(&flags.Isolation, "isolation", DefaultIsolation(), "`type` of process isolation to use. Use BUILDAH_ISOLATION environment variable to override.")
 	fs.StringVarP(&flags.Memory, "memory", "m", "", "memory limit (format: <number>[<unit>], where unit = b, k, m or g)")
@@ -215,9 +220,9 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 		panic(fmt.Sprintf("error marking override-arch as hidden: %v", err))
 	}
 	fs.StringArrayVar(&flags.SecurityOpt, "security-opt", []string{}, "security options (default [])")
-	fs.StringVar(&flags.ShmSize, "shm-size", defaultConfig.Containers.ShmSize, "size of '/dev/shm'. The format is `<number><unit>`.")
-	fs.StringSliceVar(&flags.Ulimit, "ulimit", defaultConfig.Containers.DefaultUlimits, "ulimit options")
-	fs.StringArrayVarP(&flags.Volumes, "volume", "v", defaultConfig.Containers.AdditionalVolumes, "bind mount a volume into the container")
+	fs.StringVar(&flags.ShmSize, "shm-size", defaultContainerConfig.Containers.ShmSize, "size of '/dev/shm'. The format is `<number><unit>`.")
+	fs.StringSliceVar(&flags.Ulimit, "ulimit", defaultContainerConfig.Containers.DefaultUlimits, "ulimit options")
+	fs.StringArrayVarP(&flags.Volumes, "volume", "v", defaultContainerConfig.Containers.AdditionalVolumes, "bind mount a volume into the container")
 
 	// Add in the usernamespace and namespaceflags
 	usernsFlags := GetUserNSFlags(usernsResults)
@@ -225,7 +230,7 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 	fs.AddFlagSet(&usernsFlags)
 	fs.AddFlagSet(&namespaceFlags)
 
-	return fs
+	return fs, nil
 }
 
 // UseLayers returns true if BUILDAH_LAYERS is set to "1" or "true"

--- a/pkg/parse/parse_unix.go
+++ b/pkg/parse/parse_unix.go
@@ -3,7 +3,6 @@
 package parse
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -11,20 +10,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
-
-func getDefaultProcessLimits() []string {
-	rlim := unix.Rlimit{Cur: 1048576, Max: 1048576}
-	defaultLimits := []string{}
-	if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &rlim); err == nil {
-		defaultLimits = append(defaultLimits, fmt.Sprintf("nofile=%d:%d", rlim.Cur, rlim.Max))
-	}
-	if err := unix.Setrlimit(unix.RLIMIT_NPROC, &rlim); err == nil {
-		defaultLimits = append(defaultLimits, fmt.Sprintf("nproc=%d:%d", rlim.Cur, rlim.Max))
-	}
-	return defaultLimits
-}
 
 func DeviceFromPath(device string) ([]configs.Device, error) {
 	var devs []configs.Device

--- a/run_test.go
+++ b/run_test.go
@@ -75,7 +75,7 @@ func TestAddRlimits(t *testing.T) {
 
 	for _, tst := range tt {
 		g, _ := generate.New("linux")
-		err := addRlimits(tst.ulimit, &g)
+		err := addRlimits(tst.ulimit, &g, []string{})
 		if testErr := tst.test(err, &g); testErr != nil {
 			t.Errorf("test %#v failed: %v", tst.name, testErr)
 		}

--- a/vendor/github.com/containers/common/pkg/config/default_linux.go
+++ b/vendor/github.com/containers/common/pkg/config/default_linux.go
@@ -27,7 +27,7 @@ const (
 	oldMaxSize = uint64(1048576)
 )
 
-// getDefaultProcessLimits returns the nofile and nproc for the current process in ulimits format
+// getDefaultProcessLimits returns the nproc for the current process in ulimits format
 // Note that nfile sometimes cannot be set to unlimited, and the limit is hardcoded
 // to (oldMaxSize) 1048576 (2^20), see: http://stackoverflow.com/a/1213069/1811501
 // In rootless containers this will fail, and the process will just use its current limits
@@ -44,13 +44,6 @@ func getDefaultProcessLimits() []string {
 		}
 	}
 	defaultLimits := []string{}
-	if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &rlim); err == nil {
-		defaultLimits = append(defaultLimits, fmt.Sprintf("nofile=%d:%d", rlim.Cur, rlim.Max))
-	} else {
-		if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &oldrlim); err == nil {
-			defaultLimits = append(defaultLimits, fmt.Sprintf("nofile=%d:%d", oldrlim.Cur, oldrlim.Max))
-		}
-	}
 	if err := unix.Setrlimit(unix.RLIMIT_NPROC, &rlim); err == nil {
 		defaultLimits = append(defaultLimits, fmt.Sprintf("nproc=%d:%d", rlim.Cur, rlim.Max))
 	} else {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -50,7 +50,7 @@ github.com/containernetworking/cni/pkg/types
 github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/version
-# github.com/containers/common v0.1.4
+# github.com/containers/common v0.2.0
 github.com/containers/common/pkg/caps
 github.com/containers/common/pkg/config
 github.com/containers/common/pkg/unshare


### PR DESCRIPTION
In porting containers.conf to libpod, we found that buildah needed
to handle the containers.conf on the server side rather then from
the CLI.

Since the `podman-remote build` would probably not have the same content
as containers.conf on the server, the processesing of the defaults needs
to be handled in imagebuildah.  The CapAdd and CapDrop values need to be
passed in.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>