### PR TITLE
manifest push: add --format option

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -825,6 +825,8 @@ return 1
      --cert-dir
      --creds
      --digestfile
+     --format
+     -f
      --purge
      --sign-by
      --tls-verify

--- a/docs/buildah-manifest-push.md
+++ b/docs/buildah-manifest-push.md
@@ -43,6 +43,10 @@ value can be entered.  The password is entered without echo.
 
 After copying the image, write the digest of the resulting image to the file.
 
+**--format, -f**
+
+Manifest list type (oci or v2s2) to use when pushing the list (default is oci).
+
 **--purge**
 
 Delete the manifest list or image index from local storage if pushing succeeds.

--- a/manifests/manifests.go
+++ b/manifests/manifests.go
@@ -55,6 +55,7 @@ type PushOptions struct {
 	ReportWriter       io.Writer             // will be used to log the writing of the list and any blobs
 	SignBy             string                // fingerprint of GPG key to use to sign images
 	RemoveSignatures   bool                  // true to discard signatures in images
+	ManifestType       string                // the format to use when saving the list - possible options are oci, v2s1, and v2s2
 }
 
 // Create creates a new list containing information about the specified image,
@@ -208,13 +209,14 @@ func (l *list) Push(ctx context.Context, dest types.ImageReference, options Push
 		return nil, "", err
 	}
 	copyOptions := &cp.Options{
-		ImageListSelection: options.ImageListSelection,
-		Instances:          options.Instances,
-		SourceCtx:          options.SystemContext,
-		DestinationCtx:     options.SystemContext,
-		ReportWriter:       options.ReportWriter,
-		RemoveSignatures:   options.RemoveSignatures,
-		SignBy:             options.SignBy,
+		ImageListSelection:    options.ImageListSelection,
+		Instances:             options.Instances,
+		SourceCtx:             options.SystemContext,
+		DestinationCtx:        options.SystemContext,
+		ReportWriter:          options.ReportWriter,
+		RemoveSignatures:      options.RemoveSignatures,
+		SignBy:                options.SignBy,
+		ForceManifestMIMEType: options.ManifestType,
 	}
 
 	// Copy whatever we were asked to copy.


### PR DESCRIPTION
Add a --format option, which takes the same values as the --format option for `buildah push`, to `buildah manifest push`, for cases where we can't detect the right type to use.