### PR TITLE
fix XDG_RUNTIME_DIR for authfile

### DIFF
--- a/cmd/buildah/login.go
+++ b/cmd/buildah/login.go
@@ -61,6 +61,11 @@ func loginCmd(c *cobra.Command, args []string, iopts *loginReply) error {
 	if len(args) == 0 {
 		return errors.Errorf("please specify a registry to login to")
 	}
+
+	if err := setXDGRuntimeDir(); err != nil {
+		return err
+	}
+
 	server := parse.RegistryFromFullName(parse.ScrubServer(args[0]))
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {

--- a/cmd/buildah/logout.go
+++ b/cmd/buildah/logout.go
@@ -45,6 +45,11 @@ func logoutCmd(c *cobra.Command, args []string, iopts *logoutReply) error {
 	if len(args) == 0 && !iopts.all {
 		return errors.Errorf("registry must be given")
 	}
+
+	if err := setXDGRuntimeDir(); err != nil {
+		return err
+	}
+
 	var server string
 	if len(args) == 1 {
 		server = parse.ScrubServer(args[0])

--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -8,6 +8,13 @@ load helpers
   run_buildah 0 logout docker.io
 }
 
+@test "login/logout should succeed with XDG_RUNTIME_DIR unset" {
+  unset XDG_RUNTIME_DIR
+  run_buildah 0 login --username testuserfoo --password testpassword docker.io
+
+  run_buildah 0 logout docker.io
+}
+
 @test "logout should fail with nonexist authfile" {
   run_buildah 0 login --username testuserfoo --password testpassword docker.io
 


### PR DESCRIPTION
fix bug https://bugzilla.redhat.com/show_bug.cgi?id=1798343
log/logout fails after running `unset XDG_RUNTIME_DIR`. This patch calls getStore() to set XDG_RUNTIME_DIR in the code.

Signed-off-by: Qi Wang <qiwan@redhat.com>