### PR TITLE
Show error on copied file above context directory in build

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -316,8 +316,12 @@ func (s *StageExecutor) digestSpecifiedContent(node *parser.Node, argValues []st
 		} else {
 			// Source is not a URL, so it's a location relative to
 			// the all-content-comes-from-below-this-directory
-			// directory.
+			// directory.  Also raise an error if the src escapes
+			// the context directory.
 			contextSrc, err := securejoin.SecureJoin(contextDir, src)
+			if err == nil && strings.HasPrefix(src, "../") {
+				err = errors.New("escaping context directory error")
+			}
 			if err != nil {
 				return "", errors.Wrapf(err, "forbidden path for %q, it is outside of the build context %q", src, contextDir)
 			}
@@ -435,8 +439,12 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 				// Treat the source, which is not a URL, as a
 				// location relative to the
 				// all-content-comes-from-below-this-directory
-				// directory.
+				// directory.  Also raise an error if the src
+				// escapes the context directory.
 				srcSecure, err := securejoin.SecureJoin(contextDir, src)
+				if err == nil && strings.HasPrefix(src, "../") {
+					err = errors.New("escaping context directory error")
+				}
 				if err != nil {
 					return errors.Wrapf(err, "forbidden path for %q, it is outside of the build context %q", src, contextDir)
 				}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1926,3 +1926,8 @@ EOM
   run_buildah rm -a
   run_buildah rmi -a -f
 }
+
+@test "bud file above context direcotry" {
+  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t testctr ${TESTSDIR}/bud/context-escape-dir/testdir
+  expect_output --substring "escaping context directory error"
+}

--- a/tests/bud/context-escape-dir/testdir/Containerfile
+++ b/tests/bud/context-escape-dir/testdir/Containerfile
@@ -1,0 +1,2 @@
+FROM alpine
+COPY ../upperfile.txt /

--- a/tests/bud/context-escape-dir/upperfile.txt
+++ b/tests/bud/context-escape-dir/upperfile.txt
@@ -1,0 +1,3 @@
+This is a text file to be used in Buildah testing.
+This will be used to ensure that a file from above the context
+directory can not be copied during the build phase.


### PR DESCRIPTION
When a COPY command in a Container file looked like "../file.txt"
SecureJoin would secure the file by lopping off the "../".
However, the code would then append that file name to the passed in
context directory and look for the file.  That would fail as in most
cases there was no `{context-dir}/file.txt`, rather the file was at
`{context-dir}/../file.txt`.  Using a relative directory like this
outside of the context directory can be a security risk.  Docker
doesn't allow it nor should we.

This change now errors out when a file that starts with `../` is
presented as a copy from target.

Addresses: https://github.com/containers/libpod/issues/5035

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>