### PR TITLE
Makefile: fix install.cni.sudo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ install.libseccomp.sudo: gopath
 install.cni.sudo: gopath
 	rm -rf ../../containernetworking/plugins
 	git clone https://github.com/containernetworking/plugins ../../containernetworking/plugins
-	cd ../../containernetworking/plugins && ./build.sh && mkdir -p /opt/cni/bin && sudo install -v -m755 bin/* /opt/cni/bin/
+	cd ../../containernetworking/plugins && ./build_linux.sh && sudo install -D -v -m755 -t /opt/cni/bin/ bin/*
 
 .PHONY: install
 install:


### PR DESCRIPTION
github.com/containernetworking/plugins has no build.sh but
build_[linux|windows].sh. Call build_linux.sh directly to fix
install.cni.sudo.

While we're at it, create /opt/cni/bin with 'install' to encapsulate with
privileges.

Fixes: #2153

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>