### PR TITLE
digest test : make more robust

### DIFF
--- a/tests/digest.bats
+++ b/tests/digest.bats
@@ -3,21 +3,23 @@
 load helpers
 
 fromreftest() {
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json $1
+  local img=$1
+
+  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json $img
   cid=$output
 
   # If image includes '_v2sN', verify that image is schema version N
-  expected_schemaversion=$(expr "$1" : '.*_v2s\([0-9]\)')
+  local expected_schemaversion=$(expr "$img" : '.*_v2s\([0-9]\)')
   if [ -n "$expected_schemaversion" ]; then
-      actual_schemaversion=$(imgtype -expected-manifest-type '*' -show-manifest $1 | jq .schemaVersion)
+      actual_schemaversion=$(imgtype -expected-manifest-type '*' -show-manifest $img | jq .schemaVersion)
       expect_output --from="$actual_schemaversion" "$expected_schemaversion" \
-                    ".schemaversion of $1"
+                    ".schemaversion of $img"
   fi
 
   # This is all we test: basically, that buildah doesn't crash when pushing
   pushdir=${TESTDIR}/fromreftest
   mkdir -p ${pushdir}/{1,2,3}
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json $1 dir:${pushdir}/1
+  run_buildah push --signature-policy ${TESTSDIR}/policy.json $img dir:${pushdir}/1
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid new-image
   run_buildah push --signature-policy ${TESTSDIR}/policy.json new-image dir:${pushdir}/2
   run_buildah rmi new-image
@@ -32,17 +34,21 @@ fromreftest() {
 }
 
 @test "from-by-digest-s1-a-discarded-layer" {
-  IMG=quay.io/libpod/testdigest_v2s1_with_dups@sha256:70d6c767101c907aa251c21fded459c0f1a481685eb764ca2f7a6162e24dd81a
+  IMG=quay.io/libpod/testdigest_v2s1_with_dups@sha256:2c619fffbed29d8677e246798333e7d1b288333cb61c020575f6372c76fdbb52
 
   fromreftest ${IMG}
 
   # Verify that image meets our expectations (duplicate layers)
   # Surprisingly, we do this after fromreftest, not before, because fromreftest
   # has to pull the image for us.
-  dups=$(imgtype -expected-manifest-type '*' -show-manifest ${IMG} | jq .fsLayers|grep blobSum|sort|uniq -cd)
-  if [[ -z "$dups" ]]; then
-      die "Image ${IMG} does not have any duplicate layers (expected: one dup)"
-  fi
+  #
+  # Check that the first and second .fsLayers and .history elements are dups
+  local manifest=$(imgtype -expected-manifest-type '*' -show-manifest ${IMG})
+  for element in fsLayers history; do
+      local first=$(jq ".${element}[0]" <<<"$manifest")
+      local second=$(jq ".${element}[1]" <<<"$manifest")
+      expect_output --from="$second" "$first" "${IMG}: .${element}[1] == [0]"
+  done
 }
 
 @test "from-by-tag-s1" {

--- a/tests/digest.bats
+++ b/tests/digest.bats
@@ -3,9 +3,18 @@
 load helpers
 
 fromreftest() {
-  _prefetch $1
   run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json $1
   cid=$output
+
+  # If image includes '_v2sN', verify that image is schema version N
+  expected_schemaversion=$(expr "$1" : '.*_v2s\([0-9]\)')
+  if [ -n "$expected_schemaversion" ]; then
+      actual_schemaversion=$(imgtype -expected-manifest-type '*' -show-manifest $1 | jq .schemaVersion)
+      expect_output --from="$actual_schemaversion" "$expected_schemaversion" \
+                    ".schemaversion of $1"
+  fi
+
+  # This is all we test: basically, that buildah doesn't crash when pushing
   pushdir=${TESTDIR}/fromreftest
   mkdir -p ${pushdir}/{1,2,3}
   run_buildah push --signature-policy ${TESTSDIR}/policy.json $1 dir:${pushdir}/1
@@ -13,30 +22,41 @@ fromreftest() {
   run_buildah push --signature-policy ${TESTSDIR}/policy.json new-image dir:${pushdir}/2
   run_buildah rmi new-image
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${pushdir}/3
+
   run_buildah rm $cid
   rm -fr ${pushdir}
 }
 
 @test "from-by-digest-s1" {
-  fromreftest k8s.gcr.io/pause@sha256:bbeaef1d40778579b7b86543fe03e1ec041428a50d21f7a7b25630e357ec9247
+  fromreftest quay.io/libpod/testdigest_v2s1@sha256:816563225d7baae4782653efc9410579341754fe32cbe20f7600b39fc37d8ec7
 }
 
 @test "from-by-digest-s1-a-discarded-layer" {
-  fromreftest libpod/whalesay@sha256:2413c2ffc29fb01d51c27a91b804079995d6037eed9e4b632249fce8c8708eb4
+  IMG=quay.io/libpod/testdigest_v2s1_with_dups@sha256:70d6c767101c907aa251c21fded459c0f1a481685eb764ca2f7a6162e24dd81a
+
+  fromreftest ${IMG}
+
+  # Verify that image meets our expectations (duplicate layers)
+  # Surprisingly, we do this after fromreftest, not before, because fromreftest
+  # has to pull the image for us.
+  dups=$(imgtype -expected-manifest-type '*' -show-manifest ${IMG} | jq .fsLayers|grep blobSum|sort|uniq -cd)
+  if [[ -z "$dups" ]]; then
+      die "Image ${IMG} does not have any duplicate layers (expected: one dup)"
+  fi
 }
 
 @test "from-by-tag-s1" {
-  fromreftest k8s.gcr.io/pause:0.8.0
+  fromreftest quay.io/libpod/testdigest_v2s1:20200210
 }
 
 @test "from-by-digest-s2" {
-  fromreftest alpine@sha256:e9cec9aec697d8b9d450edd32860ecd363f2f3174c8338beb5f809422d182c63
+  fromreftest quay.io/libpod/testdigest_v2s2@sha256:755f4d90b3716e2bf57060d249e2cd61c9ac089b1233465c5c2cb2d7ee550fdb
 }
 
 @test "from-by-tag-s2" {
-  fromreftest alpine:2.6
+  fromreftest quay.io/libpod/testdigest_v2s2:20200210
 }
 
 @test "from-by-repo-only-s2" {
-  fromreftest alpine
+  fromreftest quay.io/libpod/testdigest_v2s2
 }

--- a/tests/digest/README.md
+++ b/tests/digest/README.md
@@ -1,0 +1,28 @@
+This subdirectory contains a script used to create images for testing.
+
+To rephrase: this script is used **before testing**, not used **in** testing.
+_Much_ before testing (days/weeks/months/years), and manually.
+
+The script is `make-v2sN` but it is never invoked as such. Instead,
+various different symlinks point to the script, and the script
+figures out its use by picking apart the name under which it is called.
+
+As of the initial commit on 2020-02-10 there are three symlinks:
+
+* make-v2s1 - Create a schema 1 image
+* make-v2s2 - Create a schema 2 image
+* make-v2s1-with-dups - Create a schema 1 image with two identical layers
+
+If the script is successful, it will emit instructions on how to
+push the images to quay and what else you might need to do.
+
+Updating
+========
+
+Should you need new image types, e.g. schema version 3 or an image
+with purple elephant GIFs in it:
+
+1. Decide on a name. Create a new symlink pointing to `make-v2sN`
+1. Add the relevant code to `make-v2sN`: a conditional check at the top, the actual image-creating code, and if possible a new test to make sure the generated image is good
+1. Run the script. Verify that the generated image is what you expect.
+1. Add new test(s) to `digest.bats`

--- a/tests/digest/make-v2s1
+++ b/tests/digest/make-v2s1
@@ -1,0 +1,1 @@
+make-v2sN

--- a/tests/digest/make-v2s1-with-dups
+++ b/tests/digest/make-v2s1-with-dups
@@ -1,0 +1,1 @@
+make-v2sN

--- a/tests/digest/make-v2s2
+++ b/tests/digest/make-v2s2
@@ -1,0 +1,1 @@
+make-v2sN

--- a/tests/digest/make-v2sN
+++ b/tests/digest/make-v2sN
@@ -22,7 +22,7 @@ test -n "$schemaversion"    || die "Could not find 'v2s[12]' in basename"
 test "$schemaversion" = "N" && die "Script must be invoked via symlink"
 
 dup=
-if expr "$ME" : ".*-dup" >&/dev/null; then
+if expr "$ME" : ".*-dup" &>/dev/null; then
     dup="_with_dups"
 fi
 
@@ -78,17 +78,7 @@ buildah umount $cid2
 buildah commit -q $cid2 interim2
 
 layers="interim2 interim1"
-
-# If a dup layer is requested, create it now
-if [ -n "$dup" ]; then
-    cid3=$(buildah from interim2)
-    buildah commit -q $cid3 interim3
-    layers="interim3 $layers"
-
-    buildah tag interim3 my_image
-else
-    buildah tag interim2 my_image
-fi
+buildah tag interim2 my_image
 
 ###############################################################################
 #
@@ -109,9 +99,26 @@ buildah push $push_flags my_image dir:${TMPDIR}/${IMGNAME}
 buildah rm -a
 buildah rmi -f my_image $layers
 
+if [ -n "$dup" ]; then
+    manifest=${TMPDIR}/${IMGNAME}/manifest.json
+    cat $manifest |
+        jq -c '.fsLayers |= [.[0]] + .' |
+        jq -c '.history |= [.[0]] + .'  |
+        tr -d '\012' >$manifest.tmp
+    mv               $manifest $manifest.BAK
+    mv $manifest.tmp $manifest
+fi
+
+# Delete possibly-existing image, because 'buildah pull' will not overwrite it
+buildah rmi -f localhost/${IMGNAME}:latest &>/dev/null || true
+
 # Reload the image
 (cd $TMPDIR && buildah pull dir:${IMGNAME})
-rm -rf ${TMPDIR}
+
+# Leave the tmpdir behind for the -dup image!
+if [ -z "$dup" ]; then
+    rm -rf ${TMPDIR}
+fi
 
 ###############################################################################
 #
@@ -131,18 +138,17 @@ if type -p jq >&/dev/null; then
         die "Expected .schemaVersion $schemaversion, got '$actual_schemaversion'"
     fi
 
-    if [ -n "$dup" ]; then
-        # Check that there's one layer listed twice
-        dup_layers=$(jq .fsLayers <<<"$manifest" | grep blobSum | sort | uniq -cd)
-        if [ -z "$dup_layers" ]; then
-            die "Did not find any duplicate layers in image"
-        fi
-    fi
-
     echo "Image localhost/${IMGNAME} looks OK; feel free to:"
     echo
-    echo "    buildah push localhost/${IMGNAME} quay.io/libpod/${IMGNAME}:$(date +%Y%m%d)"
-    echo "    buildah push localhost/${IMGNAME} quay.io/libpod/${IMGNAME}:latest"
+
+    if [ -n "$dup" ]; then
+        echo "    \$SKOPEO copy dir:${TMPDIR}/${IMGNAME} docker://quay.io/libpod/${IMGNAME}:\$(date +%Y%m%d)"
+        echo "    ^^^^^^^--- must be specially-crafted skopeo(*), see below"
+    else
+        echo "    buildah push localhost/${IMGNAME} quay.io/libpod/${IMGNAME}:$(date +%Y%m%d)"
+        echo "    buildah push localhost/${IMGNAME} quay.io/libpod/${IMGNAME}:latest"
+    fi
+
     echo
     echo "You may then need to log in to the https://quay.io/ web UI"
     echo "make those images public, then update tags and/or SHAs"
@@ -158,6 +164,17 @@ if type -p jq >&/dev/null; then
     echo "NOTE: the first push to quay.io sometimes fails with some sort of"
     echo "500 error, trying to reuse blob, blah blah. Just ignore it and"
     echo "retry. IME it works the second time."
+
+    if [ -n "$dup" ]; then
+        echo
+        echo "(*) skopeo WILL NOT push an image with dup layers. To get it to"
+        echo "    do that, build a custom skopeo using the patch here:"
+        echo "      https://gist.github.com/nalind/b491204ff05c3c3f3b6ef014b333a60c"
+        echo "    ...then use that skopeo in the above 'copy' command."
+        # And, for posterity should the gist ever disappear:
+        #   vendor/github.com/containers/image/v5/manifest/docker_schema1.go
+        #   - remove lines 66-68 ('if ... s1.fixManifestLayers()...')
+    fi
 else
     echo "WARNING: 'jq' not found; unable to verify built image" >&2
 fi

--- a/tests/digest/make-v2sN
+++ b/tests/digest/make-v2sN
@@ -1,0 +1,163 @@
+#!/bin/bash
+#
+# make-v2sN - create a v2sN image, possibly with dups
+#
+# This is a helper script used for creating custom images for buildah testing.
+# The images are used in the digest.bats test.
+#
+ME=$(basename $0)
+
+die() {
+    echo "$ME: $*" >&2
+    exit 1
+}
+
+###############################################################################
+#
+# From the script name, determine the desired schema version (1 or 2) and
+# whether or not we want duplicate layers.
+
+schemaversion=$(expr "$ME" : ".*-v2s\([12]\)")
+test -n "$schemaversion"    || die "Could not find 'v2s[12]' in basename"
+test "$schemaversion" = "N" && die "Script must be invoked via symlink"
+
+dup=
+if expr "$ME" : ".*-dup" >&/dev/null; then
+    dup="_with_dups"
+fi
+
+IMGNAME=testdigest_v2s${schemaversion}${dup}
+
+###############################################################################
+# Create the image.
+
+set -e
+
+# First layer
+cid=$(buildah from scratch)
+buildah commit -q $cid interim1
+
+# Create a second layer containing this script and a README
+cid2=$(buildah from interim1)
+mp=$(buildah mount $cid2)
+cp $0 $mp/
+cat <<EOF >$mp/README
+This is a test image used for buildah testing.
+
+EOF
+
+# In the README include creation timestamp, user, script name, git tree state
+function add_to_readme() {
+    printf " %-12s : %s\n" "$1" "$2" >>$mp/README
+}
+
+add_to_readme "Created" "$(date --iso-8601=seconds)"
+
+# FIXME: do we really need to know? Will it ever, in practice, be non-root?
+user=$(id -un)
+if [ -n "$user" -a "$user" != "root" ]; then
+    add_to_readme "By (user)" "$user"
+fi
+
+create_script=$(cd $(dirname $0) && git ls-files --full-name $ME)
+if [ -z "$create_script" ]; then
+    create_script=$0
+fi
+add_to_readme "By (script)" "$create_script"
+
+git_state=$(cd $(dirname $0) && git describe --dirty)
+if [ -n "$git_state" ]; then
+    add_to_readme "git state" "$git_state"
+fi
+
+echo "-----------------------------------------------------------------"
+cat $mp/README
+echo "-----------------------------------------------------------------"
+
+buildah umount $cid2
+buildah commit -q $cid2 interim2
+
+layers="interim2 interim1"
+
+# If a dup layer is requested, create it now
+if [ -n "$dup" ]; then
+    cid3=$(buildah from interim2)
+    buildah commit -q $cid3 interim3
+    layers="interim3 $layers"
+
+    buildah tag interim3 my_image
+else
+    buildah tag interim2 my_image
+fi
+
+###############################################################################
+#
+# Push/pull the image to/from a tempdir. This is a kludge allowing us to
+# clean up interim layers. It's also necessary for dealing with v2s1 layers.
+
+TMPDIR=$(mktemp --tmpdir -d $(basename $0).XXXXXXX)
+push_flags=
+if [[ $schemaversion -eq 1 ]]; then
+    # buildah can't actually create a v2s1 image; only v2s2. To create v2s1,
+    # dir-push it to a tmpdir using '--format v2s1'; that will be inherited
+    # when we reload it
+    push_flags="--format v2s1"
+fi
+buildah push $push_flags my_image dir:${TMPDIR}/${IMGNAME}
+
+# Clean up containers and images
+buildah rm -a
+buildah rmi -f my_image $layers
+
+# Reload the image
+(cd $TMPDIR && buildah pull dir:${IMGNAME})
+rm -rf ${TMPDIR}
+
+###############################################################################
+#
+# We should now have a 'localhost/IMGNAME' image with desired SchemaVersion
+# and other features as requested.
+#
+# Now verify what we have what we intended.
+echo
+if type -p jq >&/dev/null; then
+    # Manifest is embedded in the image but as a string, not actual JSON;
+    # the eval-echo converts it to usable JSON
+    manifest=$(eval echo $(buildah inspect ${IMGNAME} | jq .Manifest))
+
+    # Check desired schema version:
+    actual_schemaversion=$(jq .schemaVersion <<<"$manifest")
+    if [[ $actual_schemaversion -ne $schemaversion ]]; then
+        die "Expected .schemaVersion $schemaversion, got '$actual_schemaversion'"
+    fi
+
+    if [ -n "$dup" ]; then
+        # Check that there's one layer listed twice
+        dup_layers=$(jq .fsLayers <<<"$manifest" | grep blobSum | sort | uniq -cd)
+        if [ -z "$dup_layers" ]; then
+            die "Did not find any duplicate layers in image"
+        fi
+    fi
+
+    echo "Image localhost/${IMGNAME} looks OK; feel free to:"
+    echo
+    echo "    buildah push localhost/${IMGNAME} quay.io/libpod/${IMGNAME}:$(date +%Y%m%d)"
+    echo "    buildah push localhost/${IMGNAME} quay.io/libpod/${IMGNAME}:latest"
+    echo
+    echo "You may then need to log in to the https://quay.io/ web UI"
+    echo "make those images public, then update tags and/or SHAs"
+    echo "in test/digest.bats."
+    echo
+    echo "Note that the Digest SHA on quay.io != the SHA on the locally"
+    echo "created image. You can get the real SHA on quay.io by clicking"
+    echo "on the image name, then the luggage-tag icon on the left,"
+    echo "then the gray box with the text 'SHA256' (not the actual"
+    echo "hash shown in blue to its right), and copy-pasting the SHA"
+    echo "from the popup window."
+    echo
+    echo "NOTE: the first push to quay.io sometimes fails with some sort of"
+    echo "500 error, trying to reuse blob, blah blah. Just ignore it and"
+    echo "retry. IME it works the second time."
+else
+    echo "WARNING: 'jq' not found; unable to verify built image" >&2
+fi


### PR DESCRIPTION
Instead of relying on random images from various separate
repositories, some of which are actually not the schema
version we thought we were testing (and some of which are
on unreliable registries, which causes test flakes),
craft our own images and store them all on quay.io

This commit:

  1) Adds a new script (tests/digest/make-v2sN) that
     crafts a custom image with the desired attributes:
     schema version 1 or 2, possibly with a duplicate
     layer. Script decides based on its name, that is,
     we are expected to have symlinks pointing to it.

  2) Updates digest.bats to use these newly-made images.

  3) Extends digest.bats by adding a check for 'v2s*'
     in the image name; if found, we now use 'imgtype'
     to extract the manifest and confirm that the
     pulled image has the expected schema version (1 or 2).

  4) Extends digest.bats by adding a check for duplicate
     layers in the one test that requires them.

Pushing the generated images to quay.io is left as an
exercise for the reader; as is updating the Digest SHAs
and/or tags in the individual tests in digest.bats

Fixes: #2147

Signed-off-by: Ed Santiago <santiago@redhat.com>