### PR TITLE
getDateAndDigestAndSize(): handle creation time not being set

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -193,7 +193,7 @@ func getDateAndDigestAndSize(ctx context.Context, sys *types.SystemContext, stor
 	inspectable, inspectableErr := image.FromUnparsedImage(ctx, sys, image.UnparsedInstance(img, nil))
 	if inspectableErr == nil && inspectable != nil {
 		inspectInfo, inspectErr := inspectable.Inspect(ctx)
-		if inspectErr == nil && inspectInfo != nil {
+		if inspectErr == nil && inspectInfo != nil && inspectInfo.Created != nil {
 			created = *inspectInfo.Created
 		}
 	}


### PR DESCRIPTION
The image creation timestamp that we get back as part of the result structure from `github.com/containers/image/types/Image.Inspect()` can be unset (i.e., `nil`), since it's optional in the OCI image spec.  This means we should check that the creation timestamp isn't a `nil` pointer before attempting to dereference it.

Fixes #2130.