### PR TITLE
run: adjust the order in which elements are added to $PATH

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -1944,7 +1944,7 @@ func (b *Builder) configureEnvironment(g *generate.Generator, options RunOptions
 		}
 	}
 
-	for _, envSpec := range append(b.Env(), append(defaultEnv, options.Env...)...) {
+	for _, envSpec := range append(append(defaultEnv, b.Env()...), options.Env...) {
 		env := strings.SplitN(envSpec, "=", 2)
 		if len(env) > 1 {
 			g.AddProcessEnv(env[0], env[1])


### PR DESCRIPTION
When building the slice of environment variables to add to the configuration for a container that we're about to run, if there are any conflicts, we want the values from the base image or working container to override the global defaults, and we want values that were passed to us through the API to override them both.

In cases of conflicts, values which occur later in the slice override values which occurred earlier, so we want to add them in this order:
* values from `containers.conf`
* values from the base image or working container
* values passed to us through the API

We previously applied the `containers.conf` defaults after the base image or working container's value, and that meant that `containers.conf`'s values always took precedence over the values in the image.

Fixes #2158.