### PR TITLE
manifest push --format: force an image type, not a list type

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -645,9 +645,9 @@ func manifestPushCmd(c *cobra.Command, args []string, opts manifestPushOpts) err
 	if opts.format != "" {
 		switch opts.format {
 		case "oci":
-			manifestType = imgspecv1.MediaTypeImageIndex
+			manifestType = imgspecv1.MediaTypeImageManifest
 		case "v2s2", "docker":
-			manifestType = manifest.DockerV2ListMediaType
+			manifestType = manifest.DockerV2Schema2MediaType
 		default:
 			return fmt.Errorf("unknown format %q. Choose on of the supported formats: 'oci' or 'v2s2'", opts.format)
 		}

--- a/manifests/manifests.go
+++ b/manifests/manifests.go
@@ -203,6 +203,18 @@ func (l *list) Push(ctx context.Context, dest types.ImageReference, options Push
 		}
 	}()
 
+	// If we were given a media type that corresponds to a multiple-images
+	// type, reset it to a valid corresponding single-image type, since we
+	// already expect the image library to infer the list type from the
+	// image type that we're telling it to force.
+	singleImageManifestType := options.ManifestType
+	switch singleImageManifestType {
+	case v1.MediaTypeImageIndex:
+		singleImageManifestType = v1.MediaTypeImageManifest
+	case manifest.DockerV2ListMediaType:
+		singleImageManifestType = manifest.DockerV2Schema2MediaType
+	}
+
 	// Build a source reference for our list and grab bag full of blobs.
 	src, err := l.Reference(options.Store, options.ImageListSelection, options.Instances)
 	if err != nil {
@@ -216,7 +228,7 @@ func (l *list) Push(ctx context.Context, dest types.ImageReference, options Push
 		ReportWriter:          options.ReportWriter,
 		RemoveSignatures:      options.RemoveSignatures,
 		SignBy:                options.SignBy,
-		ForceManifestMIMEType: options.ManifestType,
+		ForceManifestMIMEType: singleImageManifestType,
 	}
 
 	// Copy whatever we were asked to copy.


### PR DESCRIPTION
The image library's image copying API expects the type of a single image in the options structure's `ForceManifestMIMEType` field, and it infers the corresponding list type when it's copying multiple images.

Previously, though, we were passing in a _list_ MIME type, which was also being used as the target type when converting single images, which would fail.  Switch to passing in the single image type instead, and infer the single-image type in our internal API if a consumer passes us a list type.

This makes it easier to notice that we force v2s1 images to be converted to v2s2 images when we push them as part of a list, even if the registry doesn't reject v2s1 images.