### PR TITLE
Correct a couple of incorrect format specifiers

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -70,7 +70,7 @@ func init() {
 	layerFlags := buildahcli.GetLayerFlags(&layerFlagsResults)
 	fromAndBudFlags, err := buildahcli.GetFromAndBudFlags(&fromAndBudResults, &userNSResults, &namespaceResults)
 	if err != nil {
-		logrus.Errorf("failed to setup From and Bud flags: %e", err)
+		logrus.Errorf("failed to setup From and Bud flags: %v", err)
 		os.Exit(1)
 	}
 

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -81,7 +81,7 @@ func init() {
 	// Add in the common flags
 	fromAndBudFlags, err := buildahcli.GetFromAndBudFlags(&fromAndBudResults, &userNSResults, &namespaceResults)
 	if err != nil {
-		logrus.Errorf("failed to setup From and Bud flags: %e", err)
+		logrus.Errorf("failed to setup From and Bud flags: %v", err)
 		os.Exit(1)
 	}
 	flags.AddFlagSet(&fromAndBudFlags)


### PR DESCRIPTION
The fmt package treats %e as a format specifier for floating point numbers, not errors.  Use %v instead.