### PR TITLE
Clear the right variable in buildahimage

### DIFF
--- a/contrib/buildahimage/stable/Dockerfile
+++ b/contrib/buildahimage/stable/Dockerfile
@@ -17,7 +17,6 @@ RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install 
 RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
 RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
 
-# Set up environment variables to note that this is
-# not starting with usernamespace and default to
-# isolate the filesystem with chroot.
-ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
+# Set an environment variable to default to chroot isolation for RUN
+# instructions and "buildah run".
+ENV BUILDAH_ISOLATION=chroot

--- a/contrib/buildahimage/testing/Dockerfile
+++ b/contrib/buildahimage/testing/Dockerfile
@@ -19,7 +19,6 @@ RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install 
 RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
 RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
 
-# Set up environment variables to note that this is
-# not starting with usernamespace and default to 
-# isolate the filesystem with chroot.
-ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
+# Set an environment variable to default to chroot isolation for RUN
+# instructions and "buildah run".
+ENV BUILDAH_ISOLATION=chroot

--- a/contrib/buildahimage/upstream/Dockerfile
+++ b/contrib/buildahimage/upstream/Dockerfile
@@ -47,7 +47,6 @@ RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install 
 RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
 RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
 
-# Set up environment variables to note that this is
-# not starting with usernamespace and default to 
-# isolate the filesystem with chroot.
-ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
+# Set an environment variable to default to chroot isolation for RUN
+# instructions and "buildah run".
+ENV BUILDAH_ISOLATION=chroot


### PR DESCRIPTION
These Dockerfiles attempted to ensure that the _BUILDAH_STARTED_IN_USERNS variable was set to an empty value, but the variable that we check was changed to _CONTAINERS_USERNS_CONFIGURED some time ago.

The logic that checks for the variable, though, treats it not being set and being set to an empty value the same way, so we needn't bother setting it.