### PR TITLE
Search for local runtime per values in containers.conf

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/buildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
-	"github.com/containers/buildah/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -62,7 +61,8 @@ func init() {
 	flags.StringSliceVar(&opts.capDrop, "cap-drop", []string{}, "drop the specified capability (default [])")
 	flags.StringVar(&opts.hostname, "hostname", "", "set the hostname inside of the container")
 	flags.StringVar(&opts.isolation, "isolation", buildahcli.DefaultIsolation(), "`type` of process isolation to use. Use BUILDAH_ISOLATION environment variable to override.")
-	flags.StringVar(&opts.runtime, "runtime", util.Runtime(), "`path` to an alternate OCI runtime")
+	// Do not set a default runtime here, we'll do that later in the processing.
+	flags.StringVar(&opts.runtime, "runtime", "", "`path` to an alternate OCI runtime")
 	flags.StringSliceVar(&opts.runtimeFlag, "runtime-flag", []string{}, "add global flags for the container runtime")
 	flags.BoolVar(&opts.noPivot, "no-pivot", false, "do not use pivot root to jail process inside rootfs")
 	flags.StringArrayVar(&opts.securityOption, "security-opt", []string{}, "security options (default [])")

--- a/run_linux.go
+++ b/run_linux.go
@@ -678,6 +678,11 @@ func runUsingRuntime(isolation Isolation, options RunOptions, configureNetwork b
 	runtime := options.Runtime
 	if runtime == "" {
 		runtime = util.Runtime()
+
+		localRuntime := util.FindLocalRuntime(runtime)
+		if localRuntime != "" {
+			runtime = localRuntime
+		}
 	}
 
 	// Default to just passing down our stdio.


### PR DESCRIPTION
After determining the type of runtime to use,
either "runc" or "crun" dependent upon the system, search
the list of that type of runtime in the containers.conf
file.  It includes the location of those runtimes in a
number of different architectures.  Once found, set the
runtime to use to that value.

Fixes: #2113

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>