### PR TITLE
Add Containerfile to build a versioned stable image for quay.io

### DIFF
--- a/contrib/buildahimage/README.md
+++ b/contrib/buildahimage/README.md
@@ -13,6 +13,7 @@ using the latest Fedora and then Buildah is installed into them:
   * quay.io/buildah/stable - This image is built using the latest stable version of Buildah in a Fedora based container.  Built with buildahimage/stable/Dockerfile.
   * quay.io/buildah/upstream - This image is built using the latest code found in this GitHub repository.  When someone creates a commit and pushes it, the image is created.  Due to that the image changes frequently and is not guaranteed to be stable.  Built with buildahimage/upstream/Dockerfile.
   * quay.io/buildah/testing - This image is built using the latest version of Buildah that is or was in updates testing for Fedora.  At times this may be the same as the stable image.  This container image will primarily be used by the development teams for verification testing when a new package is created.  Built with buildahimage/testing/Dockerfile.
+  * quay.io/buildah/stable:version - This image is built 'by hand' using a Fedora based container.  An RPM is first pulled from the [Fedora Updates System](https://bodhi.fedoraproject.org/) and the image is built from there.  For more details, see the Containerfile used to build it, buildahimage/stablebyhand/Containerfile.buildahstable
 
 ## Sample Usage
 

--- a/contrib/buildahimage/stablebyhand/Containerfile.buildahstable
+++ b/contrib/buildahimage/stablebyhand/Containerfile.buildahstable
@@ -1,0 +1,34 @@
+# stablebyhand/Containerfile.buildahstable
+#
+# Build a Buildah container image from a particular
+# stable version of Buildah on the Fedora Updates System.
+# https://bodhi.fedoraproject.org/updates/?search=buildah
+# This image can be used to create a secured container
+# that runs safely with privileges within the container.
+# This Containerfile builds verison 1.11.3, the version and
+# the RPM name would need to be adjusted before a run as
+# appropriate.
+#
+# To use, 'podman build -f ~/Containerfile.buildahstable -t quay.io/buildah/stable:v1.11.3 .'
+#
+FROM fedora:latest
+
+# Build a version:  Copy tar file from bohdi to `/root/tmp` then run
+# `podman build -t quay.io/stable:v1.11.3 -f ~/Containerfile.buildahstable .`
+
+# Don't include container-selinux and remove directories
+# used by yum that are just taking up space.
+# Make sure next two lines match the RPM name and version in command.
+# Once complete:
+# `podman push quay.io/buildah/stable:v1.11.3 docker://quay.io/buildah/stable:v1.11.3`
+#
+COPY /tmp/buildah-1.11.3-2.fc30.x86_64.rpm /tmp
+RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install /tmp/buildah-1.11.3-2.fc30.x86_64.rpm fuse-overlayfs --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.* /tmp/buildah*.rpm
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+
+# Set an environment variable to default to chroot isolation for RUN
+# instructions and "buildah run".
+ENV BUILDAH_ISOLATION=chroot


### PR DESCRIPTION
I've been using this Containerfile to build versioned stable images
of Buildah for quay.io.  I build these images if I miss grabbing the
'latest' image before the next version goes to latest, or if we've
made changes to how the image is built and I need to redo the older
versions.

As we've had a few updates by different people to the Containerfiles
in these directories, I thought I'd add this one too so it can be
updated by others if needed.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>