### PR TITLE
Replace unix with syscall to allow vendoring into libpod

### DIFF
--- a/common.go
+++ b/common.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/containers/common/pkg/unshare"
@@ -20,7 +21,6 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -94,8 +94,8 @@ func isRetryable(err error) bool {
 	if url, ok := err.(*url.Error); ok {
 		return isRetryable(url.Err)
 	}
-	if errno, ok := err.(unix.Errno); ok {
-		if errno == unix.ECONNREFUSED {
+	if errno, ok := err.(syscall.Errno); ok {
+		if errno == syscall.ECONNREFUSED {
 			return false
 		}
 	}


### PR DESCRIPTION
unix constants do not work when vendored into libpod, because
libpod can potentially be used on non unix platforms, so
compilation blows up.  Switching to syscall should fix this issue.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>