### PR TITLE
BATS : in teardown, umount stale mounts

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -41,6 +41,16 @@ function stophttpd() {
 
 function teardown() {
 	stophttpd
+
+        # Workaround for #1991 - buildah + overlayfs leaks mount points.
+        # Many tests leave behind /var/tmp/.../root/overlay and sub-mounts;
+        # let's find those and clean them up, otherwise 'rm -rf' fails.
+        # 'sort -r' guarantees that we umount deepest subpaths first.
+        mount |\
+            awk '$3 ~ testdir { print $3 }' testdir="^${TESTDIR}/" |\
+            sort -r |\
+            xargs --no-run-if-empty --max-lines=1 umount
+
 	rm -fr ${TESTDIR}
 }
 


### PR DESCRIPTION
Workaround for #1991, in which buildah leaves behind stale
mounts under overlayfs, which causes the 'rm -fr' in teardown()
to barf with EBUSY. Here we amend teardown() to look for
mounts underneath our temp dir and to umount them. With
this, bats runs cleanly even with STORAGE_DRIVER=overlay

Signed-off-by: Ed Santiago <santiago@redhat.com>