### PR TITLE
Preserve volume uid and gid through subsequent commands

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/containers/buildah"
@@ -238,7 +239,13 @@ func (s *StageExecutor) volumeCacheRestore() error {
 			if err := os.Chmod(archivedPath, st.Mode()); err != nil {
 				return errors.Wrapf(err, "error restoring permissions on %q", archivedPath)
 			}
-			if err := os.Chown(archivedPath, 0, 0); err != nil {
+			uid := 0
+			gid := 0
+			if st.Sys() != nil {
+				uid = int(st.Sys().(*syscall.Stat_t).Uid)
+				gid = int(st.Sys().(*syscall.Stat_t).Gid)
+			}
+			if err := os.Chown(archivedPath, uid, gid); err != nil {
 				return errors.Wrapf(err, "error setting ownership on %q", archivedPath)
 			}
 			if err := os.Chtimes(archivedPath, st.ModTime(), st.ModTime()); err != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -599,6 +599,18 @@ load helpers
   expect_output "41ed" "stat($root/vol/subvol) [0x41ed = 040755]"
 }
 
+@test "bud-volume-ownership" {
+  # This Dockerfile needs us to be able to handle a working RUN instruction.
+  skip_if_no_runtime
+
+  _prefetch alpine
+  target=volume-image
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/volume-ownership
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  cid=$output
+  run_buildah run $cid test-ownership
+}
+
 @test "bud-from-glob" {
   _prefetch alpine
   target=alpine-image

--- a/tests/bud/volume-ownership/Dockerfile
+++ b/tests/bud/volume-ownership/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine
+ADD test-ownership /usr/bin/
+RUN adduser -D -H testuser && addgroup testgroup
+RUN mkdir -p /vol/subvol
+RUN chown testuser:testgroup /vol/subvol
+VOLUME /vol/subvol
+RUN touch /test

--- a/tests/bud/volume-ownership/test-ownership
+++ b/tests/bud/volume-ownership/test-ownership
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+MY_USER=$(stat -c "%U" /vol/subvol) && [[ "$MY_USER" == "testuser" ]]
+MY_GROUP=$(stat -c "%G" /vol/subvol) && [[ "$MY_GROUP" == "testgroup" ]]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:

This PR pulls the UID and GID fields from the stored file stat when reconstructing a volume after subsequent commands

#### How to verify it
Build the following Dockerfile:
```Dockerfile
FROM centos:8
RUN dnf -y install --setopt=tsflags=nodocs postgresql-server
VOLUME [ "/var/lib/pgsql/data" ]
RUN touch /root/test
```

Observe the output of the following command:
```bash
$ podman run --rm <image> ls -l /var/lib/pgsql
total 0
drwx------. 1 postgres postgres 0 May 31  2019 backups
drwx------. 1 postgres postgres 0 Mar 10 23:37 data
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

Fixes #2202

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

