### PR TITLE
Scope build args to a single stage in a multi-stage build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/buildah*.1
 /build/
 tests/tools/build
 Dockerfile*
+*.swp

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/opencontainers/runtime-tools v0.9.0
 	github.com/opencontainers/selinux v1.4.0
 	github.com/openshift/api v0.0.0-20200106203948-7ab22a2c8316
-	github.com/openshift/imagebuilder v1.1.3
+	github.com/openshift/imagebuilder v1.1.4
 	github.com/pkg/errors v0.9.1
 	github.com/seccomp/containers-golang v0.0.0-20190312124753-8ca8945ccf5f
 	github.com/seccomp/libseccomp-golang v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,10 @@ github.com/openshift/imagebuilder v1.1.2 h1:vCO8hZQR/4uzo+j0PceBH5aKFcvCDM43UzUG
 github.com/openshift/imagebuilder v1.1.2/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
 github.com/openshift/imagebuilder v1.1.3 h1:8TiphsD2wboU7tygtGZ5ZBfCP9FH2ZtvEAli67V2PJ4=
 github.com/openshift/imagebuilder v1.1.3/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
+github.com/openshift/imagebuilder v1.1.4-0.20200325224900-8de717452756 h1:bLnwfDdZrktbiPp6tGNiaU4wvlhwSysHibmSJVO4j7o=
+github.com/openshift/imagebuilder v1.1.4-0.20200325224900-8de717452756/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
+github.com/openshift/imagebuilder v1.1.4 h1:LUg8aTjyXMtlDx6IbtvaqofFGZ6aYqe+VIeATE735LM=
+github.com/openshift/imagebuilder v1.1.4/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913 h1:TnbXhKzrTOyuvWrjI8W6pcoI9XPbLHFXCdN2dtUw7Rw=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -165,11 +165,3 @@ func convertMounts(mounts []Mount) []specs.Mount {
 	}
 	return specmounts
 }
-
-func copyStringStringMap(m map[string]string) map[string]string {
-	n := map[string]string{}
-	for k, v := range m {
-		n[k] = v
-	}
-	return n
-}

--- a/run_linux.go
+++ b/run_linux.go
@@ -1972,10 +1972,6 @@ func (b *Builder) configureEnvironment(g *generate.Generator, options RunOptions
 			g.AddProcessEnv(env[0], env[1])
 		}
 	}
-
-	for src, dest := range b.Args {
-		g.AddProcessEnv(src, dest)
-	}
 }
 
 func setupRootlessSpecChanges(spec *specs.Spec, bundleDir string, shmSize string) error {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1989,3 +1989,11 @@ EOM
   run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t testctr ${TESTSDIR}/bud/context-escape-dir/testdir
   expect_output --substring "escaping context directory error"
 }
+
+@test "bud-multi-stage-args" {
+  _prefetch alpine
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t multi-stage-args --build-arg SECRET=secretthings -f Dockerfile.arg ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah from --name test-container multi-stage-args
+  run_buildah run test-container -- cat test_file
+  expect_output ""
+}

--- a/tests/bud/build-arg/Dockerfile3
+++ b/tests/bud/build-arg/Dockerfile3
@@ -10,4 +10,6 @@ ARG CODE
 ARG PGDATA
 ARG PORT=55555
 
+RUN echo this-should-not-be-cached-when-args-change
+
 CMD ["/container-run"]

--- a/tests/bud/multi-stage-builds/Dockerfile.arg
+++ b/tests/bud/multi-stage-builds/Dockerfile.arg
@@ -1,0 +1,6 @@
+FROM alpine
+ARG SECRET
+RUN echo $SECRET
+
+FROM alpine
+RUN echo "$SECRET" > test_file

--- a/vendor/github.com/openshift/imagebuilder/dispatchers.go
+++ b/vendor/github.com/openshift/imagebuilder/dispatchers.go
@@ -216,7 +216,7 @@ func from(b *Builder, args []string, attributes map[string]bool, flagArgs []stri
 
 	// Support ARG before from
 	argStrs := []string{}
-	for n, v := range b.Args {
+	for n, v := range b.HeadingArgs {
 		argStrs = append(argStrs, n+"="+v)
 	}
 	var err error
@@ -598,10 +598,16 @@ func arg(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	// add the arg to allowed list of build-time args from this step on.
 	b.AllowedArgs[name] = true
 
+	// If there is still no default value, a value can be assigned from the heading args
+	if val, ok := b.HeadingArgs[name]; ok && !hasDefault {
+		b.Args[name] = val
+	}
+
 	// If there is a default value associated with this arg then add it to the
-	// b.buildArgs if one is not already passed to the builder. The args passed
-	// to builder override the default value of 'arg'.
-	if _, ok := b.Args[name]; !ok && hasDefault {
+	// b.buildArgs, later default values for the same arg override earlier ones.
+	// The args passed to builder (UserArgs) override the default value of 'arg'
+	// Don't add them here as they were already set in NewBuilder.
+	if _, ok := b.UserArgs[name]; !ok && hasDefault {
 		b.Args[name] = value
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -335,7 +335,7 @@ github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
 # github.com/openshift/api v0.0.0-20200106203948-7ab22a2c8316
 github.com/openshift/api/config/v1
-# github.com/openshift/imagebuilder v1.1.3
+# github.com/openshift/imagebuilder v1.1.4
 github.com/openshift/imagebuilder
 github.com/openshift/imagebuilder/dockerfile/command
 github.com/openshift/imagebuilder/dockerfile/parser


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

This PR uses the changes made in https://github.com/openshift/imagebuilder/pull/151 to handle arguments the same way `docker build` does. In particular, it scopes arguments to the stage in which they are defined and only records arguments in a layer's history if they could have been used in that layer.

#### How to verify it
```
$ cat Dockerfile 
FROM alpine
ARG THING

FROM alpine
RUN echo "$THING" > things
        
$ buildah bud --layers --build-arg THING=things
STEP 1: FROM alpine
STEP 2: ARG THING
--> Using cache 232af6ca4a94e52dbef13f6da08c62b4172eaff7ee2e93cab08aceb4b00e6f81
STEP 3: FROM alpine
STEP 4: RUN echo "$THING" > things
--> Using cache fad9788d65a3062cc823516c8fff73b39e914463c709149a2855cbea61a10abe
fad9788d65a3062cc823516c8fff73b39e914463c709149a2855cbea61a10abe
$ podman run --rm fad9788d65a3062cc823516c8fff73b39e914463c709149a2855cbea61a10abe cat things
things
```

The above `podman run` command should return an empty file

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->


Fixes #2210

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Yes, it significantly changes the way arguments behave. While it's not a change to how `buildah` would be used. Images built with the same Dockerfile before and after this change could be very different.

```release-note
Altered the behavior of the `--build-arg` flag and `ARG` commands to mirror `docker build`.
In particular, the following behaviors have changed:

- An ARG is only available after its ARG command in the current stage.
    - Previously, anything provided using the --build-arg flag could be accessed in any stage. After this change, accessing a build arg provided on the command line will require a corresponding `ARG` command in the stage before it is accessed.
    - Additionally, "heading" args (ARG commands before the first FROM) also now require an additional ARG declaration in the stage to be accessed. Previously, they were accessible without the additional ARG command.

- A later ARG default value should override an earlier one in the same stage

FROM alpine
ARG FOO=foo
ARG FOO=bar
RUN echo "$FOO"

The above Dockerfile should print "bar". Previously, the behavior was the opposite, an arg was not changed once set.

Generally this makes buildah handle args as described in https://docs.docker.com/engine/reference/builder/#arg
```