### PR TITLE
Update unshare man page to fix script example

### DIFF
--- a/docs/buildah-unshare.md
+++ b/docs/buildah-unshare.md
@@ -43,12 +43,13 @@ If you want to use buildah with a mount command then you can create a script tha
 
 ```
 cat buildah-script.sh << _EOF
+#!/bin/sh
 ctr=$(buildah from scratch)
 mnt=$(buildah mount $ctr)
 dnf -y install --installroot=$mnt PACKAGES
 dnf -y clean all --installroot=$mnt
 buildah config --entrypoint="/bin/PACKAGE" --env "FOO=BAR" $ctr
-buildah commit $ctr IMAGENAME
+buildah commit $ctr imagename
 buildah unmount $ctr
 _EOF
 ```


### PR DESCRIPTION
The example showing how to use unshare to mount a volume
was no longer working.  Updated to make it work.

Fixes: #2218

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

