### PR TITLE
Fix potential CVE in tarfile w/ symlink

### DIFF
--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/containers/buildah"
 	"github.com/containers/storage/pkg/chrootarchive"
+	"github.com/containers/storage/pkg/ioutils"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -57,7 +58,7 @@ func downloadToDirectory(url, dir string) error {
 		}
 		dockerfile := filepath.Join(dir, "Dockerfile")
 		// Assume this is a Dockerfile
-		if err := ioutil.WriteFile(dockerfile, body, 0600); err != nil {
+		if err := ioutils.AtomicWriteFile(dockerfile, body, 0600); err != nil {
 			return errors.Wrapf(err, "Failed to write %q to %q", url, dockerfile)
 		}
 	}
@@ -75,7 +76,7 @@ func stdinToDirectory(dir string) error {
 	if err := chrootarchive.Untar(reader, dir, nil); err != nil {
 		dockerfile := filepath.Join(dir, "Dockerfile")
 		// Assume this is a Dockerfile
-		if err := ioutil.WriteFile(dockerfile, b, 0600); err != nil {
+		if err := ioutils.AtomicWriteFile(dockerfile, b, 0600); err != nil {
 			return errors.Wrapf(err, "Failed to write bytes to %q", dockerfile)
 		}
 	}


### PR DESCRIPTION
Stealing @nalind 's workaround to avoid refetching
content after a file read failure.  Under the right
circumstances that could be a symlink to a file meant
to overwrite a good file with bad data.

Testing:
```
# cat /tmp/dont_overwrite_me.txt
goodstuff

# python3 webserver.py &
[1] 14901

# buildah bud http://localhost:8000
127.0.0.1 - - [24/Mar/2020 20:15:50] "GET / HTTP/1.1" 200 -
127.0.0.1 - - [24/Mar/2020 20:15:50] "GET / HTTP/1.1" 200 -
no FROM statement found

# cat /tmp/dont_overwrite_me.txt
goodstuff

```

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

