### PR TITLE
Use v0.9.0 c/common/pkg/auth in login/logout

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -10,6 +10,7 @@ import (
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
+	"github.com/containers/common/pkg/auth"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -103,7 +104,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 			tags = tags[1:]
 		}
 	}
-	if err := buildahcli.CheckAuthFile(iopts.BudResults.Authfile); err != nil {
+	if err := auth.CheckAuthFile(iopts.BudResults.Authfile); err != nil {
 		return err
 	}
 

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -10,6 +10,7 @@ import (
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
+	"github.com/containers/common/pkg/auth"
 	"github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
@@ -56,7 +57,7 @@ func init() {
 	flags := commitCommand.Flags()
 	flags.SetInterspersed(false)
 
-	flags.StringVar(&opts.authfile, "authfile", buildahcli.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	flags.StringVar(&opts.authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	flags.StringVar(&opts.blobCache, "blob-cache", "", "assume image blobs in the specified directory will be available for pushing")
 
 	if err := flags.MarkHidden("blob-cache"); err != nil {
@@ -99,7 +100,7 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
 		return err
 	}
-	if err := buildahcli.CheckAuthFile(iopts.authfile); err != nil {
+	if err := auth.CheckAuthFile(iopts.authfile); err != nil {
 		return err
 	}
 

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/buildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/config"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/pkg/errors"
@@ -62,7 +63,7 @@ func init() {
 
 	flags := fromCommand.Flags()
 	flags.SetInterspersed(false)
-	flags.StringVar(&opts.authfile, "authfile", buildahcli.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	flags.StringVar(&opts.authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	flags.StringVar(&opts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	flags.StringVar(&opts.cidfile, "cidfile", "", "write the container ID to the file")
 	flags.StringVar(&opts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
@@ -186,7 +187,7 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 		return errors.Errorf("too many arguments specified")
 	}
 
-	if err := buildahcli.CheckAuthFile(iopts.authfile); err != nil {
+	if err := auth.CheckAuthFile(iopts.authfile); err != nil {
 		return err
 	}
 	systemContext, err := parse.SystemContextFromOptions(c)

--- a/cmd/buildah/logout.go
+++ b/cmd/buildah/logout.go
@@ -1,23 +1,20 @@
 package main
 
 import (
-	"fmt"
+	"os"
 
-	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
-	"github.com/containers/image/v5/pkg/docker/config"
+	"github.com/containers/common/pkg/auth"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-type logoutReply struct {
-	authfile string
-	all      bool
-}
-
 func init() {
 	var (
-		opts              logoutReply
+		opts = auth.LogoutOptions{
+			Stdin:  os.Stdin,
+			Stdout: os.Stdout,
+		}
 		logoutDescription = "Remove the cached username and password for the registry."
 	)
 	logoutCommand := &cobra.Command{
@@ -31,18 +28,17 @@ func init() {
 	}
 	logoutCommand.SetUsageTemplate(UsageTemplate())
 
-	flags := logoutCommand.Flags()
+	flags := auth.GetLogoutFlags(&opts)
 	flags.SetInterspersed(false)
-	flags.StringVar(&opts.authfile, "authfile", buildahcli.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
-	flags.BoolVarP(&opts.all, "all", "a", false, "Remove the cached credentials for all registries in the auth file")
+	logoutCommand.Flags().AddFlagSet(flags)
 	rootCmd.AddCommand(logoutCommand)
 }
 
-func logoutCmd(c *cobra.Command, args []string, iopts *logoutReply) error {
+func logoutCmd(c *cobra.Command, args []string, iopts *auth.LogoutOptions) error {
 	if len(args) > 1 {
 		return errors.Errorf("too many arguments, logout takes at most 1 argument")
 	}
-	if len(args) == 0 && !iopts.all {
+	if len(args) == 0 && !iopts.All {
 		return errors.Errorf("registry must be given")
 	}
 
@@ -52,33 +48,11 @@ func logoutCmd(c *cobra.Command, args []string, iopts *logoutReply) error {
 
 	var server string
 	if len(args) == 1 {
-		server = parse.ScrubServer(args[0])
+		server = args[0]
 	}
-	if err := buildahcli.CheckAuthFile(iopts.authfile); err != nil {
-		return err
-	}
-
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
 		return errors.Wrapf(err, "error building system context")
 	}
-
-	if iopts.all {
-		if err := config.RemoveAllAuthentication(systemContext); err != nil {
-			return err
-		}
-		fmt.Println("Removed login credentials for all registries")
-		return nil
-	}
-
-	err = config.RemoveAuthentication(systemContext, server)
-	switch err {
-	case nil:
-		fmt.Printf("Removed login credentials for %s\n", server)
-		return nil
-	case config.ErrNotLoggedIn:
-		return errors.Errorf("Not logged into %s\n", server)
-	default:
-		return errors.Wrapf(err, "error logging out of %q", server)
-	}
+	return auth.Logout(systemContext, iopts, server)
 }

--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	"github.com/containers/buildah/manifests"
-	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
+	"github.com/containers/common/pkg/auth"
 	cp "github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/transports"
@@ -192,7 +192,7 @@ func init() {
 	flags = manifestPushCommand.Flags()
 	flags.BoolVar(&manifestPushOpts.purge, "purge", false, "remove the manifest list if push succeeds")
 	flags.BoolVar(&manifestPushOpts.all, "all", false, "also push the images in the list")
-	flags.StringVar(&manifestPushOpts.authfile, "authfile", buildahcli.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	flags.StringVar(&manifestPushOpts.authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	flags.StringVar(&manifestPushOpts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	flags.StringVar(&manifestPushOpts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	flags.StringVar(&manifestPushOpts.digestfile, "digestfile", "", "after copying the image, write the digest of the resulting digest to the file")
@@ -620,7 +620,7 @@ func manifestInspectCmd(c *cobra.Command, args []string, opts manifestInspectOpt
 }
 
 func manifestPushCmd(c *cobra.Command, args []string, opts manifestPushOpts) error {
-	if err := buildahcli.CheckAuthFile(opts.authfile); err != nil {
+	if err := auth.CheckAuthFile(opts.authfile); err != nil {
 		return err
 	}
 

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/buildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/pkg/auth"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -51,7 +52,7 @@ func init() {
 	flags := pullCommand.Flags()
 	flags.SetInterspersed(false)
 	flags.BoolVarP(&opts.allTags, "all-tags", "a", false, "download all tagged images in the repository")
-	flags.StringVar(&opts.authfile, "authfile", buildahcli.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	flags.StringVar(&opts.authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	flags.StringVar(&opts.blobCache, "blob-cache", "", "store copies of pulled image blobs in the specified directory")
 	flags.StringVar(&opts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	flags.StringVar(&opts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
@@ -87,7 +88,7 @@ func pullCmd(c *cobra.Command, args []string, iopts pullOptions) error {
 	if len(args) > 1 {
 		return errors.Errorf("too many arguments specified")
 	}
-	if err := buildahcli.CheckAuthFile(iopts.authfile); err != nil {
+	if err := auth.CheckAuthFile(iopts.authfile); err != nil {
 		return err
 	}
 

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -11,6 +11,7 @@ import (
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
+	"github.com/containers/common/pkg/auth"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -65,7 +66,7 @@ func init() {
 
 	flags := pushCommand.Flags()
 	flags.SetInterspersed(false)
-	flags.StringVar(&opts.authfile, "authfile", buildahcli.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	flags.StringVar(&opts.authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	flags.StringVar(&opts.blobCache, "blob-cache", "", "assume image blobs in the specified directory will be available for pushing")
 	flags.StringVar(&opts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	flags.StringVar(&opts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
@@ -93,7 +94,7 @@ func pushCmd(c *cobra.Command, args []string, iopts pushOptions) error {
 	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
 		return err
 	}
-	if err := buildahcli.CheckAuthFile(iopts.authfile); err != nil {
+	if err := auth.CheckAuthFile(iopts.authfile); err != nil {
 		return err
 	}
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
+	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/config"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -150,7 +151,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs := pflag.FlagSet{}
 	fs.StringVar(&flags.Arch, "arch", runtime.GOARCH, "set the ARCH of the image to the provided value instead of the architecture of the host")
 	fs.StringArrayVar(&flags.Annotation, "annotation", []string{}, "Set metadata for an image (default [])")
-	fs.StringVar(&flags.Authfile, "authfile", GetDefaultAuthFile(), "path of the authentication file.")
+	fs.StringVar(&flags.Authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file.")
 	fs.StringArrayVar(&flags.BuildArg, "build-arg", []string{}, "`argument=value` to supply to the builder")
 	fs.StringVar(&flags.CacheFrom, "cache-from", "", "Images to utilise as potential cache sources. The build process does not currently support caching so this is a NOOP.")
 	fs.StringVar(&flags.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
@@ -275,20 +276,6 @@ func VerifyFlagsArgsOrder(args []string) error {
 		if strings.HasPrefix(arg, "-") {
 			return errors.Errorf("No options (%s) can be specified after the image or container name", arg)
 		}
-	}
-	return nil
-}
-
-func GetDefaultAuthFile() string {
-	return os.Getenv("REGISTRY_AUTH_FILE")
-}
-
-func CheckAuthFile(authfile string) error {
-	if authfile == "" {
-		return nil
-	}
-	if _, err := os.Stat(authfile); err != nil {
-		return errors.Wrapf(err, "error checking authfile path %s", authfile)
 	}
 	return nil
 }

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -927,25 +927,6 @@ func IsolationOption(isolation string) (buildah.Isolation, error) {
 	return defaultIsolation()
 }
 
-// ScrubServer removes 'http://' or 'https://' from the front of the
-// server/registry string if either is there.  This will be mostly used
-// for user input from 'buildah login' and 'buildah logout'.
-func ScrubServer(server string) string {
-	server = strings.TrimPrefix(server, "https://")
-	return strings.TrimPrefix(server, "http://")
-}
-
-// RegistryFromFullName gets the registry from the input. If the input is of the form
-// quay.io/myuser/myimage, it will parse it and just return quay.io
-// It also returns true if a full image name was given
-func RegistryFromFullName(input string) string {
-	split := strings.Split(input, "/")
-	if len(split) > 1 {
-		return split[0]
-	}
-	return split[0]
-}
-
 // Device parses device mapping string to a src, dest & permissions string
 // Valid values for device looklike:
 //    '/dev/sdc"

--- a/vendor/github.com/containers/common/pkg/auth/auth.go
+++ b/vendor/github.com/containers/common/pkg/auth/auth.go
@@ -1,0 +1,182 @@
+package auth
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/pkg/docker/config"
+	"github.com/containers/image/v5/types"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// GetDefaultAuthFile returns env value REGISTRY_AUTH_FILE as default --authfile path
+// used in multiple --authfile flag definitions
+func GetDefaultAuthFile() string {
+	return os.Getenv("REGISTRY_AUTH_FILE")
+}
+
+// CheckAuthFile validates filepath given by --authfile
+// used by command has --authfile flag
+func CheckAuthFile(authfile string) error {
+	if authfile == "" {
+		return nil
+	}
+	if _, err := os.Stat(authfile); err != nil {
+		return errors.Wrapf(err, "error checking authfile path %s", authfile)
+	}
+	return nil
+}
+
+// Login login to the server with creds from Stdin or CLI
+func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginOptions, registry string) error {
+	server := getRegistryName(registry)
+	authConfig, err := config.GetCredentials(systemContext, server)
+	if err != nil {
+		return errors.Wrapf(err, "error reading auth file")
+	}
+	if opts.GetLoginSet {
+		if authConfig.Username == "" {
+			return errors.Errorf("not logged into %s", server)
+		}
+		fmt.Fprintf(opts.Stdout, "%s\n", authConfig.Username)
+		return nil
+	}
+	if authConfig.IdentityToken != "" {
+		return errors.Errorf("currently logged in, auth file contains an Identity token")
+	}
+
+	password := opts.Password
+	if opts.StdinPassword {
+		var stdinPasswordStrBuilder strings.Builder
+		if opts.Password != "" {
+			return errors.Errorf("Can't specify both --password-stdin and --password")
+		}
+		if opts.Username == "" {
+			return errors.Errorf("Must provide --username with --password-stdin")
+		}
+		scanner := bufio.NewScanner(opts.Stdin)
+		for scanner.Scan() {
+			fmt.Fprint(&stdinPasswordStrBuilder, scanner.Text())
+		}
+		password = stdinPasswordStrBuilder.String()
+	}
+
+	// If no username and no password is specified, try to use existing ones.
+	if opts.Username == "" && password == "" && authConfig.Username != "" && authConfig.Password != "" {
+		fmt.Println("Authenticating with existing credentials...")
+		if err := docker.CheckAuth(ctx, systemContext, authConfig.Username, authConfig.Password, server); err == nil {
+			fmt.Fprintln(opts.Stdout, "Existing credentials are valid. Already logged in to", server)
+			return nil
+		}
+		fmt.Fprintln(opts.Stdout, "Existing credentials are invalid, please enter valid username and password")
+	}
+
+	username, password, err := getUserAndPass(opts, password, authConfig.Username)
+	if err != nil {
+		return errors.Wrapf(err, "error getting username and password")
+	}
+
+	if err = docker.CheckAuth(ctx, systemContext, username, password, server); err == nil {
+		// Write the new credentials to the authfile
+		if err = config.SetAuthentication(systemContext, server, username, password); err != nil {
+			return err
+		}
+	}
+	if err == nil {
+		fmt.Fprintln(opts.Stdout, "Login Succeeded!")
+		return nil
+	}
+	if unauthorized, ok := err.(docker.ErrUnauthorizedForCredentials); ok {
+		logrus.Debugf("error logging into %q: %v", server, unauthorized)
+		return errors.Errorf("error logging into %q: invalid username/password", server)
+	}
+	return errors.Wrapf(err, "error authenticating creds for %q", server)
+}
+
+// getRegistryName scrubs and parses the input to get the server name
+func getRegistryName(server string) string {
+	// removes 'http://' or 'https://' from the front of the
+	// server/registry string if either is there.  This will be mostly used
+	// for user input from 'Buildah login' and 'Buildah logout'.
+	server = strings.TrimPrefix(strings.TrimPrefix(server, "https://"), "http://")
+	// gets the registry from the input. If the input is of the form
+	// quay.io/myuser/myimage, it will parse it and just return quay.io
+	split := strings.Split(server, "/")
+	if len(split) > 1 {
+		return split[0]
+	}
+	return split[0]
+}
+
+// getUserAndPass gets the username and password from STDIN if not given
+// using the -u and -p flags.  If the username prompt is left empty, the
+// displayed userFromAuthFile will be used instead.
+func getUserAndPass(opts *LoginOptions, password, userFromAuthFile string) (string, string, error) {
+	var err error
+	reader := bufio.NewReader(opts.Stdin)
+	username := opts.Username
+	if username == "" {
+		if userFromAuthFile != "" {
+			fmt.Fprintf(opts.Stdout, "Username (%s): ", userFromAuthFile)
+		} else {
+			fmt.Fprint(opts.Stdout, "Username: ")
+		}
+		username, err = reader.ReadString('\n')
+		if err != nil {
+			return "", "", errors.Wrapf(err, "error reading username")
+		}
+		// If the user just hit enter, use the displayed user from the
+		// the authentication file.  This allows to do a lazy
+		// `$ buildah login -p $NEW_PASSWORD` without specifying the
+		// user.
+		if strings.TrimSpace(username) == "" {
+			username = userFromAuthFile
+		}
+	}
+	if password == "" {
+		fmt.Fprint(opts.Stdout, "Password: ")
+		pass, err := terminal.ReadPassword(0)
+		if err != nil {
+			return "", "", errors.Wrapf(err, "error reading password")
+		}
+		password = string(pass)
+		fmt.Fprintln(opts.Stdout)
+	}
+	return strings.TrimSpace(username), password, err
+}
+
+// Logout removes the authentication of server from authfile
+// removes all authtication if specifies all in the options
+func Logout(systemContext *types.SystemContext, opts *LogoutOptions, server string) error {
+	if server != "" {
+		server = getRegistryName(server)
+	}
+	if err := CheckAuthFile(opts.AuthFile); err != nil {
+		return err
+	}
+
+	if opts.All {
+		if err := config.RemoveAllAuthentication(systemContext); err != nil {
+			return err
+		}
+		fmt.Fprintln(opts.Stdout, "Removed login credentials for all registries")
+		return nil
+	}
+
+	err := config.RemoveAuthentication(systemContext, server)
+	switch err {
+	case nil:
+		fmt.Fprintf(opts.Stdout, "Removed login credentials for %s\n", server)
+		return nil
+	case config.ErrNotLoggedIn:
+		return errors.Errorf("Not logged into %s\n", server)
+	default:
+		return errors.Wrapf(err, "error logging out of %q", server)
+	}
+}

--- a/vendor/github.com/containers/common/pkg/auth/cli.go
+++ b/vendor/github.com/containers/common/pkg/auth/cli.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"io"
+
+	"github.com/spf13/pflag"
+)
+
+// LoginOptions represents common flags in login
+// caller should define bool or optionalBool fields for flags --get-login and --tls-verify
+type LoginOptions struct {
+	AuthFile      string
+	CertDir       string
+	GetLoginSet   bool
+	Password      string
+	Username      string
+	StdinPassword bool
+	Stdin         io.Reader
+	Stdout        io.Writer
+}
+
+// LogoutOptions represents the results for flags in logout
+type LogoutOptions struct {
+	AuthFile string
+	All      bool
+	Stdin    io.Reader
+	Stdout   io.Writer
+}
+
+// GetLoginFlags defines and returns login flags for containers tools
+func GetLoginFlags(flags *LoginOptions) *pflag.FlagSet {
+	fs := pflag.FlagSet{}
+	fs.StringVar(&flags.AuthFile, "authfile", GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	fs.StringVar(&flags.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
+	fs.StringVarP(&flags.Password, "password", "p", "", "Password for registry")
+	fs.StringVarP(&flags.Username, "username", "u", "", "Username for registry")
+	fs.BoolVar(&flags.StdinPassword, "password-stdin", false, "Take the password from stdin")
+	return &fs
+}
+
+// GetLogoutFlags defines and returns logout flags for containers tools
+func GetLogoutFlags(flags *LogoutOptions) *pflag.FlagSet {
+	fs := pflag.FlagSet{}
+	fs.StringVar(&flags.AuthFile, "authfile", GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	fs.BoolVarP(&flags.All, "all", "a", false, "Remove the cached credentials for all registries in the auth file")
+	return &fs
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -55,6 +55,7 @@ github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
 # github.com/containers/common v0.9.0
 github.com/containers/common/pkg/apparmor
+github.com/containers/common/pkg/auth
 github.com/containers/common/pkg/capabilities
 github.com/containers/common/pkg/cgroupv2
 github.com/containers/common/pkg/config


### PR DESCRIPTION
- upgrade  c/common v0.9.0
- use shared code for login/logout from c/common v0.9.0
Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

