### PR TITLE
WIP - DO NOT MERGE - Make pull-always always pull

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -319,7 +319,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 	}
 
 	var manifestBytes []byte
-	if manifestBytes, err = retryCopyImage(ctx, policyContext, maybeCachedDest, maybeCachedSrc, dest, "push", getCopyOptions(b.store, options.ReportWriter, nil, systemContext, "", false, options.SignBy), options.MaxRetries, options.RetryDelay); err != nil {
+	if manifestBytes, err = retryCopyImage(ctx, policyContext, maybeCachedDest, maybeCachedSrc, dest, "push", getCopyOptions(b.store, options.ReportWriter, nil, systemContext, "", false, options.SignBy, false), options.MaxRetries, options.RetryDelay); err != nil {
 		return imgID, nil, "", errors.Wrapf(err, "error copying layers and metadata for container %q", b.ContainerID)
 	}
 	// If we've got more names to attach, and we know how to do that for
@@ -451,7 +451,7 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 		systemContext.DirForceCompress = true
 	}
 	var manifestBytes []byte
-	if manifestBytes, err = retryCopyImage(ctx, policyContext, dest, maybeCachedSrc, dest, "push", getCopyOptions(options.Store, options.ReportWriter, nil, systemContext, options.ManifestType, options.RemoveSignatures, options.SignBy), options.MaxRetries, options.RetryDelay); err != nil {
+	if manifestBytes, err = retryCopyImage(ctx, policyContext, dest, maybeCachedSrc, dest, "push", getCopyOptions(options.Store, options.ReportWriter, nil, systemContext, options.ManifestType, options.RemoveSignatures, options.SignBy, false), options.MaxRetries, options.RetryDelay); err != nil {
 		return nil, "", errors.Wrapf(err, "error copying layers and metadata from %q to %q", transports.ImageName(maybeCachedSrc), transports.ImageName(dest))
 	}
 	if options.ReportWriter != nil {

--- a/common.go
+++ b/common.go
@@ -30,7 +30,7 @@ const (
 	DOCKER = "docker"
 )
 
-func getCopyOptions(store storage.Store, reportWriter io.Writer, sourceSystemContext *types.SystemContext, destinationSystemContext *types.SystemContext, manifestType string, removeSignatures bool, addSigner string) *cp.Options {
+func getCopyOptions(store storage.Store, reportWriter io.Writer, sourceSystemContext *types.SystemContext, destinationSystemContext *types.SystemContext, manifestType string, removeSignatures bool, addSigner string, pullAlways bool) *cp.Options {
 	sourceCtx := getSystemContext(store, nil, "")
 	if sourceSystemContext != nil {
 		*sourceCtx = *sourceSystemContext
@@ -47,6 +47,7 @@ func getCopyOptions(store storage.Store, reportWriter io.Writer, sourceSystemCon
 		ForceManifestMIMEType: manifestType,
 		RemoveSignatures:      removeSignatures,
 		SignBy:                addSigner,
+		PullAlways:            pullAlways,
 	}
 }
 

--- a/new.go
+++ b/new.go
@@ -36,6 +36,10 @@ func pullAndFindImage(ctx context.Context, store storage.Store, srcRef types.Ima
 		BlobDirectory: options.BlobDirectory,
 		MaxRetries:    options.MaxPullRetries,
 		RetryDelay:    options.PullRetryDelay,
+		PullAlways:    false,
+	}
+	if options.PullPolicy == PullAlways {
+		pullOptions.PullAlways = true
 	}
 	ref, err := pullImage(ctx, store, srcRef, pullOptions, sc)
 	if err != nil {

--- a/pull.go
+++ b/pull.go
@@ -56,6 +56,9 @@ type PullOptions struct {
 	MaxRetries int
 	// RetryDelay is how long to wait before retrying a pull attempt.
 	RetryDelay time.Duration
+	// PullAlways is a boolean value that determines if the image is always
+	// pulled from the container repository.  The default is false.
+	PullAlways bool
 }
 
 func localImageNameForReference(ctx context.Context, store storage.Store, srcRef types.ImageReference) (string, error) {
@@ -275,7 +278,7 @@ func pullImage(ctx context.Context, store storage.Store, srcRef types.ImageRefer
 	}()
 
 	logrus.Debugf("copying %q to %q", transports.ImageName(srcRef), destName)
-	if _, err := retryCopyImage(ctx, policyContext, maybeCachedDestRef, srcRef, srcRef, "pull", getCopyOptions(store, options.ReportWriter, sc, nil, "", options.RemoveSignatures, ""), options.MaxRetries, options.RetryDelay); err != nil {
+	if _, err := retryCopyImage(ctx, policyContext, maybeCachedDestRef, srcRef, srcRef, "pull", getCopyOptions(store, options.ReportWriter, sc, nil, "", options.RemoveSignatures, "", options.PullAlways), options.MaxRetries, options.RetryDelay); err != nil {
 		logrus.Debugf("error copying src image [%q] to dest image [%q] err: %v", transports.ImageName(srcRef), destName, err)
 		return nil, err
 	}


### PR DESCRIPTION
I've changed the vendor piece of c/storage that will need to change
with this commit.  If @mtrmac is agreeable with this concept, I'll
work up a proper PR for c/storage.

The motivation for this changes is we currently say in our docs that
`--pull-always` always pulls from the registry regardless of what's
locally stored.

That turns out to NOT be the case, we do reuse some of the images/layers
if they are present locally.

This change passes the `--pull-always` flag down to the c/storage code
so it can decide what to do.

