### PR TITLE
Fix errorf conventions

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
@@ -60,7 +59,7 @@ func getStore(c *cobra.Command) (storage.Store, error) {
 	// Differently, allow the mount if we are already in a userns, as the mount point will still
 	// be accessible once "buildah mount" exits.
 	if os.Geteuid() != 0 && options.GraphDriverName != "vfs" {
-		return nil, fmt.Errorf("cannot mount using driver %s in rootless mode. You need to run it in a `buildah unshare` session", options.GraphDriverName)
+		return nil, errors.Errorf("cannot mount using driver %s in rootless mode. You need to run it in a `buildah unshare` session", options.GraphDriverName)
 	}
 
 	// For uid/gid mappings, first we check the global definitions

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -188,21 +188,21 @@ func parseFilter(ctx context.Context, store storage.Store, images []storage.Imag
 			if pair[1] == "true" || pair[1] == "false" {
 				params.dangling = pair[1]
 			} else {
-				return nil, fmt.Errorf("invalid filter: '%s=[%s]'", pair[0], pair[1])
+				return nil, errors.Errorf("invalid filter: '%s=[%s]'", pair[0], pair[1])
 			}
 		case "label":
 			params.label = pair[1]
 		case "before":
 			beforeDate, err := setFilterDate(ctx, store, images, pair[1])
 			if err != nil {
-				return nil, fmt.Errorf("no such id: %s", pair[0])
+				return nil, errors.Errorf("no such id: %s", pair[0])
 			}
 			params.beforeDate = beforeDate
 			params.beforeImage = pair[1]
 		case "since":
 			sinceDate, err := setFilterDate(ctx, store, images, pair[1])
 			if err != nil {
-				return nil, fmt.Errorf("no such id: %s", pair[0])
+				return nil, errors.Errorf("no such id: %s", pair[0])
 			}
 			params.sinceDate = sinceDate
 			params.sinceImage = pair[1]
@@ -212,10 +212,10 @@ func parseFilter(ctx context.Context, store storage.Store, images []storage.Imag
 			if pair[1] == "true" || pair[1] == "false" {
 				params.readOnly = pair[1]
 			} else {
-				return nil, fmt.Errorf("invalid filter: '%s=[%s]'", pair[0], pair[1])
+				return nil, errors.Errorf("invalid filter: '%s=[%s]'", pair[0], pair[1])
 			}
 		default:
-			return nil, fmt.Errorf("invalid filter: '%s'", pair[0])
+			return nil, errors.Errorf("invalid filter: '%s'", pair[0])
 		}
 	}
 	return params, nil
@@ -228,23 +228,23 @@ func setFilterDate(ctx context.Context, store storage.Store, images []storage.Im
 				// Set the date to this image
 				ref, err := is.Transport.ParseStoreReference(store, image.ID)
 				if err != nil {
-					return time.Time{}, fmt.Errorf("error parsing reference to image %q: %v", image.ID, err)
+					return time.Time{}, errors.Wrapf(err, "error parsing reference to image %q", image.ID)
 				}
 				img, err := ref.NewImage(ctx, nil)
 				if err != nil {
-					return time.Time{}, fmt.Errorf("error reading image %q: %v", image.ID, err)
+					return time.Time{}, errors.Wrapf(err, "error reading image %q", image.ID)
 				}
 				defer img.Close()
 				inspect, err := img.Inspect(ctx)
 				if err != nil {
-					return time.Time{}, fmt.Errorf("error inspecting image %q: %v", image.ID, err)
+					return time.Time{}, errors.Wrapf(err, "error inspecting image %q", image.ID)
 				}
 				date := *inspect.Created
 				return date, nil
 			}
 		}
 	}
-	return time.Time{}, fmt.Errorf("could not locate image %q", imgName)
+	return time.Time{}, errors.Errorf("could not locate image %q", imgName)
 }
 
 func outputHeader(opts imageOptions) string {

--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -679,7 +679,7 @@ func manifestPushCmd(c *cobra.Command, args []string, opts manifestPushOpts) err
 		case "v2s2", "docker":
 			manifestType = manifest.DockerV2Schema2MediaType
 		default:
-			return fmt.Errorf("unknown format %q. Choose on of the supported formats: 'oci' or 'v2s2'", opts.format)
+			return errors.Errorf("unknown format %q. Choose on of the supported formats: 'oci' or 'v2s2'", opts.format)
 		}
 	}
 

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -63,7 +63,7 @@ func mountCmd(c *cobra.Command, args []string, noTruncate bool) error {
 		// Differently, allow the mount if we are already in a userns, as the mount point will still
 		// be accessible once "buildah mount" exits.
 		if os.Geteuid() != 0 && store.GraphDriverName() != "vfs" {
-			return fmt.Errorf("cannot mount using driver %s in rootless mode. You need to run it in a `buildah unshare` session", store.GraphDriverName())
+			return errors.Errorf("cannot mount using driver %s in rootless mode. You need to run it in a `buildah unshare` session", store.GraphDriverName())
 		}
 
 		for _, name := range args {

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -160,7 +160,7 @@ func pushCmd(c *cobra.Command, args []string, iopts pushOptions) error {
 		case "v2s2", "docker":
 			manifestType = manifest.DockerV2Schema2MediaType
 		default:
-			return fmt.Errorf("unknown format %q. Choose on of the supported formats: 'oci', 'v2s1', or 'v2s2'", iopts.format)
+			return errors.Errorf("unknown format %q. Choose on of the supported formats: 'oci', 'v2s1', or 'v2s2'", iopts.format)
 		}
 	}
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -3,7 +3,6 @@ package imagebuildah
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -323,7 +322,7 @@ func preprocessDockerfileContents(r io.Reader, ctxDir string) (rdrCloser *io.Rea
 	pipe.Close()
 	if err = cmd.Wait(); err != nil {
 		if stderr.Len() > 0 {
-			err = fmt.Errorf("%v: %s", err, strings.TrimSpace(stderr.String()))
+			err = errors.Wrapf(err, "%v", strings.TrimSpace(stderr.String()))
 		}
 		return nil, errors.Wrapf(err, "error pre-processing Dockerfile")
 	}

--- a/info.go
+++ b/info.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/system"
 	"github.com/containers/storage/pkg/unshare"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -184,7 +185,7 @@ func readUptime() (string, error) {
 	}
 	f := bytes.Fields(buf)
 	if len(f) < 1 {
-		return "", fmt.Errorf("invalid uptime")
+		return "", errors.Errorf("invalid uptime")
 	}
 	return string(f[0]), nil
 }

--- a/new.go
+++ b/new.go
@@ -196,7 +196,7 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 				logrus.Debugf("no such image %q: %v", transports.ImageName(ref), err)
 				failures = append(failures, failure{
 					resolvedImageName: image,
-					err:               fmt.Errorf("no such image %q", transports.ImageName(ref)),
+					err:               errors.Errorf("no such image %q", transports.ImageName(ref)),
 				})
 				continue
 			}
@@ -212,7 +212,7 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 	}
 
 	if len(failures) != len(candidates) {
-		return nil, "", nil, fmt.Errorf("internal error: %d candidates (%#v) vs. %d failures (%#v)", len(candidates), candidates, len(failures), failures)
+		return nil, "", nil, errors.Errorf("internal error: %d candidates (%#v) vs. %d failures (%#v)", len(candidates), candidates, len(failures), failures)
 	}
 
 	registriesConfPath := sysregistriesv2.ConfigPath(systemContext)
@@ -221,7 +221,7 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 		if searchRegistriesWereUsedButEmpty {
 			return nil, "", nil, errors.Errorf("image name %q is a short name and no search registries are defined in %s.", options.FromImage, registriesConfPath)
 		}
-		return nil, "", nil, fmt.Errorf("internal error: no pull candidates were available for %q for an unknown reason", options.FromImage)
+		return nil, "", nil, errors.Errorf("internal error: no pull candidates were available for %q for an unknown reason", options.FromImage)
 
 	case 1:
 		err := failures[0].err

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -537,10 +537,10 @@ func validateExtraHost(val string) error {
 	// allow for IPv6 addresses in extra hosts by only splitting on first ":"
 	arr := strings.SplitN(val, ":", 2)
 	if len(arr) != 2 || len(arr[0]) == 0 {
-		return fmt.Errorf("bad format for add-host: %q", val)
+		return errors.Errorf("bad format for add-host: %q", val)
 	}
 	if _, err := validateIPAddress(arr[1]); err != nil {
-		return fmt.Errorf("invalid IP address in add-host: %q", arr[1])
+		return errors.Errorf("invalid IP address in add-host: %q", arr[1])
 	}
 	return nil
 }
@@ -552,7 +552,7 @@ func validateIPAddress(val string) (string, error) {
 	if ip != nil {
 		return ip.String(), nil
 	}
-	return "", fmt.Errorf("%s is not an ip address", val)
+	return "", errors.Errorf("%s is not an ip address", val)
 }
 
 // SystemContextFromOptions returns a SystemContext populated with values
@@ -814,20 +814,20 @@ func parseIDMap(spec []string) (m [][3]uint32, err error) {
 	for _, s := range spec {
 		args := strings.FieldsFunc(s, func(r rune) bool { return !unicode.IsDigit(r) })
 		if len(args)%3 != 0 {
-			return nil, fmt.Errorf("mapping %q is not in the form containerid:hostid:size[,...]", s)
+			return nil, errors.Errorf("mapping %q is not in the form containerid:hostid:size[,...]", s)
 		}
 		for len(args) >= 3 {
 			cid, err := strconv.ParseUint(args[0], 10, 32)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing container ID %q from mapping %q as a number: %v", args[0], s, err)
+				return nil, errors.Wrapf(err, "error parsing container ID %q from mapping %q as a number", args[0], s)
 			}
 			hostid, err := strconv.ParseUint(args[1], 10, 32)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing host ID %q from mapping %q as a number: %v", args[1], s, err)
+				return nil, errors.Wrapf(err, "error parsing host ID %q from mapping %q as a number", args[1], s)
 			}
 			size, err := strconv.ParseUint(args[2], 10, 32)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing %q from mapping %q as a number: %v", args[2], s, err)
+				return nil, errors.Wrapf(err, "error parsing %q from mapping %q as a number", args[2], s)
 			}
 			m = append(m, [3]uint32{uint32(cid), uint32(hostid), uint32(size)})
 			args = args[3:]
@@ -960,7 +960,7 @@ func Device(device string) (string, string, string, error) {
 	switch len(arr) {
 	case 3:
 		if !isValidDeviceMode(arr[2]) {
-			return "", "", "", fmt.Errorf("invalid device mode: %s", arr[2])
+			return "", "", "", errors.Errorf("invalid device mode: %s", arr[2])
 		}
 		permissions = arr[2]
 		fallthrough
@@ -969,7 +969,7 @@ func Device(device string) (string, string, string, error) {
 			permissions = arr[1]
 		} else {
 			if len(arr[1]) == 0 || arr[1][0] != '/' {
-				return "", "", "", fmt.Errorf("invalid device mode: %s", arr[1])
+				return "", "", "", errors.Errorf("invalid device mode: %s", arr[1])
 			}
 			dst = arr[1]
 		}
@@ -981,7 +981,7 @@ func Device(device string) (string, string, string, error) {
 		}
 		fallthrough
 	default:
-		return "", "", "", fmt.Errorf("invalid device specification: %s", device)
+		return "", "", "", errors.Errorf("invalid device specification: %s", device)
 	}
 
 	if dst == "" {

--- a/pkg/parse/parse_unsupported.go
+++ b/pkg/parse/parse_unsupported.go
@@ -3,9 +3,8 @@
 package parse
 
 import (
-	"fmt"
-
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/pkg/errors"
 )
 
 func getDefaultProcessLimits() []string {
@@ -13,5 +12,5 @@ func getDefaultProcessLimits() []string {
 }
 
 func DeviceFromPath(device string) ([]configs.Device, error) {
-	return []configs.Device{}, fmt.Errorf("devices not supported")
+	return []configs.Device{}, errors.Errorf("devices not supported")
 }

--- a/run_linux.go
+++ b/run_linux.go
@@ -2142,7 +2142,7 @@ func checkAndOverrideIsolationOptions(isolation Isolation, options *RunOptions) 
 		pidns := options.NamespaceOptions.Find(string(specs.PIDNamespace))
 		userns := options.NamespaceOptions.Find(string(specs.UserNamespace))
 		if (pidns == nil || pidns.Host) && (userns != nil && !userns.Host) {
-			return fmt.Errorf("not allowed to mix host PID namespace with container user namespace")
+			return errors.Errorf("not allowed to mix host PID namespace with container user namespace")
 		}
 	}
 	return nil

--- a/run_test.go
+++ b/run_test.go
@@ -1,11 +1,11 @@
 package buildah
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/pkg/errors"
 )
 
 func TestAddRlimits(t *testing.T) {
@@ -26,11 +26,11 @@ func TestAddRlimits(t *testing.T) {
 			ulimit: []string{"bla"},
 			test: func(e error, g *generate.Generator) error {
 				if e == nil {
-					return fmt.Errorf("expected to receive an error but got nil")
+					return errors.Errorf("expected to receive an error but got nil")
 				}
 				errMsg := "invalid ulimit argument"
 				if !strings.Contains(e.Error(), errMsg) {
-					return fmt.Errorf("expected error message to include %#v in %#v", errMsg, e.Error())
+					return errors.Errorf("expected error message to include %#v in %#v", errMsg, e.Error())
 				}
 				return nil
 			},
@@ -40,11 +40,11 @@ func TestAddRlimits(t *testing.T) {
 			ulimit: []string{"bla=hard"},
 			test: func(e error, g *generate.Generator) error {
 				if e == nil {
-					return fmt.Errorf("expected to receive an error but got nil")
+					return errors.Errorf("expected to receive an error but got nil")
 				}
 				errMsg := "invalid ulimit type"
 				if !strings.Contains(e.Error(), errMsg) {
-					return fmt.Errorf("expected error message to include %#v in %#v", errMsg, e.Error())
+					return errors.Errorf("expected error message to include %#v in %#v", errMsg, e.Error())
 				}
 				return nil
 			},
@@ -60,15 +60,15 @@ func TestAddRlimits(t *testing.T) {
 				for _, rlimit := range rlimits {
 					if rlimit.Type == "RLIMIT_FSIZE" {
 						if rlimit.Hard != 4096 {
-							return fmt.Errorf("expected spec to have %#v hard limit set to %v but got %v", rlimit.Type, 4096, rlimit.Hard)
+							return errors.Errorf("expected spec to have %#v hard limit set to %v but got %v", rlimit.Type, 4096, rlimit.Hard)
 						}
 						if rlimit.Soft != 1024 {
-							return fmt.Errorf("expected spec to have %#v hard limit set to %v but got %v", rlimit.Type, 1024, rlimit.Soft)
+							return errors.Errorf("expected spec to have %#v hard limit set to %v but got %v", rlimit.Type, 1024, rlimit.Soft)
 						}
 						return nil
 					}
 				}
-				return fmt.Errorf("expected spec to have RLIMIT_FSIZE")
+				return errors.Errorf("expected spec to have RLIMIT_FSIZE")
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Brandon Lum <lumjjb@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


/kind cleanup

#### What this PR does / why we need it:

Follow a single convention of using `github.com/pkg/errors` instead of `fmt` for errors.

#### How to verify it

Run to check no files:
`grep -r "fmt\.Errorf" * | grep -v vendor`

#### Which issue(s) this PR fixes:

NONE
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

