### PR TITLE
Fix:buildah skips the directory when the ignore pattern matches and o…

### DIFF
--- a/add.go
+++ b/add.go
@@ -354,7 +354,7 @@ func (b *Builder) addHelper(excludes *fileutils.PatternMatcher, extract bool, de
 				}
 				// Skip the file if the pattern matches
 				if res.IsMatched() {
-					return nil
+					continue
 				}
 			}
 


### PR DESCRIPTION
Fix:buildah skips the directory when the ignore pattern matches and other files will not be added