### PR TITLE
Fix error info about get signatures for containerImageSource

### DIFF
--- a/image.go
+++ b/image.go
@@ -587,7 +587,7 @@ func (i *containerImageSource) Reference() types.ImageReference {
 
 func (i *containerImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
 	if instanceDigest != nil {
-		return nil, errors.Errorf("containerImageSource does not support manifest lists")
+		return nil, errors.Errorf("containerImageSource does not support signature lists")
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Signed-off-by: zvier <liuzekun0524@163.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind cleanup

#### What this PR does / why we need it:
For a containerImageSource instance, if call GetSignatures method failed, it returns the error with the message "containerImageSource does not support manifest lists". If the message is "containerImageSource does not support signature lists", I think it shoud be more accurate.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

