### PR TITLE
Update gitignore to exclude test Dockerfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ docs/buildah*.1
 /build/
 tests/tools/build
 Dockerfile*
+!/tests/bud/*/Dockerfile*
 *.swp


### PR DESCRIPTION
Signed-off-by: Brandon Lum <lumjjb@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

Test Dockerfiles are not currently being tracked as part of the git repository. 

#### How to verify it

1. Modify test Dockerfile in `tests/bud/*` 
2. Run `git status` and verify that the change is tracked.

#### Which issue(s) this PR fixes:

None
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

