### PR TITLE
Return exit code from failed containers

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -3,9 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
-	"syscall"
 
 	"github.com/containers/buildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
@@ -157,11 +155,6 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 	runerr := builder.Run(args, options)
 	if runerr != nil {
 		logrus.Debugf("error running %v in container %q: %v", args, builder.Container, runerr)
-	}
-	if ee, ok := (errors.Cause(runerr)).(*exec.ExitError); ok {
-		if w, ok := ee.Sys().(syscall.WaitStatus); ok {
-			os.Exit(w.ExitStatus())
-		}
 	}
 	if runerr == nil {
 		shell := "/bin/sh -c"

--- a/pkg/cli/exec_codes.go
+++ b/pkg/cli/exec_codes.go
@@ -1,0 +1,13 @@
+package cli
+
+const (
+	// ExecErrorCodeGeneric is the default error code to return from an exec session if libpod failed
+	// prior to calling the runtime
+	ExecErrorCodeGeneric = 125
+	// ExecErrorCodeCannotInvoke is the error code to return when the runtime fails to invoke a command
+	// an example of this can be found by trying to execute a directory:
+	// `podman exec -l /etc`
+	ExecErrorCodeCannotInvoke = 126
+	// ExecErrorCodeNotFound is the error code to return when a command cannot be found
+	ExecErrorCodeNotFound = 127
+)

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -3,13 +3,13 @@
 load helpers
 
 @test "add-flags-order-verification" {
-  run_buildah 1 add container1 -q /tmp/container1
+  run_buildah 125 add container1 -q /tmp/container1
   check_options_flag_err "-q"
 
-  run_buildah 1 add container1 --chown /tmp/container1 --quiet
+  run_buildah 125 add container1 --chown /tmp/container1 --quiet
   check_options_flag_err "--chown"
 
-  run_buildah 1 add container1 /tmp/container1 --quiet
+  run_buildah 125 add container1 /tmp/container1 --quiet
   check_options_flag_err "--quiet"
 }
 
@@ -30,8 +30,8 @@ load helpers
   # Copy two files to a specific subdirectory
   run_buildah add $cid ${TESTDIR}/randomfile ${TESTDIR}/other-randomfile /other-subdir
   # Copy two files to a specific location, which fails because it's not a directory.
-  run_buildah 1 add ${TESTDIR}/randomfile ${TESTDIR}/other-randomfile $cid /notthereyet-subdir
-  run_buildah 1 add ${TESTDIR}/randomfile $cid ${TESTDIR}/other-randomfile /randomfile
+  run_buildah 125 add ${TESTDIR}/randomfile ${TESTDIR}/other-randomfile $cid /notthereyet-subdir
+  run_buildah 125 add ${TESTDIR}/randomfile $cid ${TESTDIR}/other-randomfile /randomfile
   # Copy a file to a different working directory
   run_buildah config --workingdir=/cwd $cid
   run_buildah add $cid ${TESTDIR}/randomfile

--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -18,7 +18,7 @@ load helpers
 @test "logout should fail with nonexist authfile" {
   run_buildah 0 login --username testuserfoo --password testpassword docker.io
 
-  run_buildah 1 logout --authfile /tmp/nonexist docker.io
+  run_buildah 125 logout --authfile /tmp/nonexist docker.io
 
   run_buildah 0 logout docker.io
 }
@@ -30,10 +30,10 @@ load helpers
   run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword alpine localhost:5000/my-alpine
 
   # This should fail
-  run_buildah 1 push  --signature-policy ${TESTSDIR}/policy.json --tls-verify=true localhost:5000/my-alpine
+  run_buildah 125 push  --signature-policy ${TESTSDIR}/policy.json --tls-verify=true localhost:5000/my-alpine
 
   # This should fail
-  run_buildah 1 from --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds baduser:badpassword localhost:5000/my-alpine
+  run_buildah 125 from --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds baduser:badpassword localhost:5000/my-alpine
 
   # This should work
   run_buildah from --name "my-alpine" --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword localhost:5000/my-alpine
@@ -50,7 +50,7 @@ EOM
   run_buildah rmi -f --all
 
   # bud test bad password should fail
-  run_buildah 1 bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds=testuser:badpassword
+  run_buildah 125 bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds=testuser:badpassword
 
   # bud test this should work
   run_buildah bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds=testuser:testpassword .

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -32,7 +32,7 @@ load helpers
 }
 
 @test "from-nopull" {
-  run_buildah 1 from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah 125 from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
 }
 
 @test "mount" {
@@ -81,7 +81,7 @@ load helpers
   cp ${TESTDIR}/other-randomfile $newroot/other-randomfile
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:other-new-image
   # Not an allowed ordering of arguments and flags.  Check that it's rejected.
-  run_buildah 1 commit $newcid --signature-policy ${TESTSDIR}/policy.json containers-storage:rejected-new-image
+  run_buildah 125 commit $newcid --signature-policy ${TESTSDIR}/policy.json containers-storage:rejected-new-image
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:another-new-image
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid yet-another-new-image
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:gratuitous-new-image
@@ -121,7 +121,7 @@ load helpers
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
   newcid=$output
   run_buildah commit --rm --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:remove-container-image
-  run_buildah 1 mount $newcid
+  run_buildah 125 mount $newcid
 
   run_buildah rmi remove-container-image
   run_buildah rmi containers-storage:other-new-image

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -89,16 +89,16 @@ symlink(subdir)"
 }
 
 @test "bud-flags-order-verification" {
-  run_buildah 1 bud /tmp/tmpdockerfile/ -t blabla
+  run_buildah 125 bud /tmp/tmpdockerfile/ -t blabla
   check_options_flag_err "-t"
 
-  run_buildah 1 bud /tmp/tmpdockerfile/ -q -t blabla
+  run_buildah 125 bud /tmp/tmpdockerfile/ -q -t blabla
   check_options_flag_err "-q"
 
-  run_buildah 1 bud /tmp/tmpdockerfile/ --force-rm
+  run_buildah 125 bud /tmp/tmpdockerfile/ --force-rm
   check_options_flag_err "--force-rm"
 
-  run_buildah 1 bud /tmp/tmpdockerfile/ --userns=cnt1
+  run_buildah 125 bud /tmp/tmpdockerfile/ --userns=cnt1
   check_options_flag_err "--userns=cnt1"
 }
 
@@ -323,18 +323,18 @@ symlink(subdir)"
 
 @test "bud with --force-rm flag" {
   _prefetch alpine
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --force-rm --layers -t test1 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json --force-rm --layers -t test1 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
   run_buildah containers
   expect_line_count 1
 
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
   run_buildah containers
   expect_line_count 2
 }
 
 @test "bud --layers with non-existent/down registry" {
   _prefetch alpine
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --force-rm --layers -t test1 -f Dockerfile.non-existent-registry ${TESTSDIR}/bud/use-layers
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json --force-rm --layers -t test1 -f Dockerfile.non-existent-registry ${TESTSDIR}/bud/use-layers
   expect_output --substring "no such host"
 }
 
@@ -696,7 +696,7 @@ function _test_http() {
 @test "bud-unrecognized-instruction" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/unrecognized
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/unrecognized
   expect_output --substring "BOGUS"
 }
 
@@ -851,7 +851,7 @@ function _test_http() {
 @test "bud with ENTRYPOINT and empty RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.entrypoint-empty-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah 2 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.entrypoint-empty-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "error building at STEP"
 }
 
@@ -866,7 +866,7 @@ function _test_http() {
 @test "bud with CMD and empty RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.cmd-empty-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah 2 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.cmd-empty-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "error building at STEP"
 }
 
@@ -881,7 +881,7 @@ function _test_http() {
 @test "bud with ENTRYPOINT, CMD and empty RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-empty-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah 2 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-empty-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "error building at STEP"
 }
 
@@ -927,7 +927,7 @@ function _test_http() {
 @test "bud with Dockerfile from invalid URL" {
   target=url-image
   url=https://raw.githubusercontent.com/containers/buildah/master/tests/bud/from-scratch/Dockerfile.bogus
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${url}
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${url}
 }
 
 # When provided with a -f flag and directory, buildah will look for the alternate Dockerfile name in the supplied directory
@@ -952,12 +952,12 @@ function _test_http() {
 
 @test "bud with --cpu-shares flag, no argument" {
   target=bud-flag
-  run_buildah 1 bud --cpu-shares --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 bud --cpu-shares --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile ${TESTSDIR}/bud/from-scratch
 }
 
 @test "bud with --cpu-shares flag, invalid argument" {
   target=bud-flag
-  run_buildah 1 bud --cpu-shares bogus --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 bud --cpu-shares bogus --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile ${TESTSDIR}/bud/from-scratch
   expect_output --substring "invalid argument \"bogus\" for "
 }
 
@@ -969,12 +969,12 @@ function _test_http() {
 
 @test "bud with --cpu-shares short flag (-c), no argument" {
   target=bud-flag
-  run_buildah 1 bud -c --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 bud -c --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile ${TESTSDIR}/bud/from-scratch
 }
 
 @test "bud with --cpu-shares short flag (-c), invalid argument" {
   target=bud-flag
-  run_buildah 1 bud -c bogus --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 bud -c bogus --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Dockerfile ${TESTSDIR}/bud/from-scratch
   expect_output --substring "invalid argument \"bogus\" for "
 }
 
@@ -1089,7 +1089,7 @@ function _test_http() {
 
 @test "bud-with-rejected-name" {
   target=ThisNameShouldBeRejected
-  run_buildah 1 bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
   expect_output --substring "must be lower"
 }
 
@@ -1113,7 +1113,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${imgName} -f ${TESTSDIR}/bud/copy-chown/Dockerfile.bad ${TESTSDIR}/bud/copy-chown
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${imgName} -f ${TESTSDIR}/bud/copy-chown/Dockerfile.bad ${TESTSDIR}/bud/copy-chown
   expect_output --substring "COPY only supports the --chown=<uid:gid> and the --from=<image|stage> flags"
 }
 
@@ -1137,7 +1137,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${imgName} -f ${TESTSDIR}/bud/add-chown/Dockerfile.bad ${TESTSDIR}/bud/add-chown
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${imgName} -f ${TESTSDIR}/bud/add-chown/Dockerfile.bad ${TESTSDIR}/bud/add-chown
   expect_output --substring "ADD only supports the --chown=<uid:gid> flag"
 }
 
@@ -1303,13 +1303,13 @@ function _test_http() {
 
 @test "bud with dir for file but no Dockerfile in dir" {
   target=alpine-image
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/empty-dir ${TESTSDIR}/bud/empty-dir
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/empty-dir ${TESTSDIR}/bud/empty-dir
   expect_output --substring "no such file or directory"
 }
 
 @test "bud with bad dir Dockerfile" {
   target=alpine-image
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/baddirname ${TESTSDIR}/baddirname
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/baddirname ${TESTSDIR}/baddirname
   expect_output --substring "no such file or directory"
 }
 
@@ -1375,7 +1375,7 @@ function _test_http() {
 @test "bud with copy-from with bad from flag in Dockerfile with --layers" {
   _prefetch php:7.2
   target=php-image
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile.bad ${TESTSDIR}/bud/copy-from
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile.bad ${TESTSDIR}/bud/copy-from
   expect_output --substring "COPY only supports the --chown=<uid:gid> and the --from=<image|stage> flags"
 }
 
@@ -1551,7 +1551,7 @@ function _test_http() {
   target=foo
 
   # A deny-all policy should prevent us from pulling the base image.
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/deny.json -t ${target} -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/deny.json -t ${target} -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
   expect_output --substring 'Source image rejected: Running image .* rejected by policy.'
 
   # A docker-only policy should allow us to pull the base image and commit.
@@ -1716,26 +1716,26 @@ _EOF
 
 @test "bud without any arguments should fail when no Dockerfile exist" {
   cd $(mktemp -d)
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json
   expect_output --substring "no such file or directory"
 }
 
 @test "bud with specified context should fail if directory contains no Dockerfile" {
   DIR=$(mktemp -d)
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json "$DIR"
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json "$DIR"
   expect_output --substring "no such file or directory"
 }
 
 @test "bud with specified context should fail if assumed Dockerfile is a directory" {
   DIR=$(mktemp -d)
   mkdir -p "$DIR"/Dockerfile
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json "$DIR"
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json "$DIR"
   expect_output --substring "is not a file"
 }
 
 @test "bud with specified context should fail if context contains not-existing Dockerfile" {
   DIR=$(mktemp -d)
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json "$DIR"/Dockerfile
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json "$DIR"/Dockerfile
   expect_output --substring "no such file or directory"
 }
 
@@ -1923,7 +1923,7 @@ _EOF
 
 @test "bud pull never" {
   target=pull
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull-never ${TESTSDIR}/bud/pull
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull-never ${TESTSDIR}/bud/pull
   expect_output --substring "no such image"
 
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull ${TESTSDIR}/bud/pull
@@ -1941,7 +1941,7 @@ _EOF
 
 @test "bud with Containerfile should fail with nonexist authfile" {
   target=alpine-image
-  run_buildah 1 bud --authfile /tmp/nonexist --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
+  run_buildah 125 bud --authfile /tmp/nonexist --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
 }
 
 @test "bud COPY with URL should fail" {
@@ -1952,7 +1952,7 @@ FROM alpine:latest
 COPY https://getfedora.org/index.html .
 EOM
 
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy/Dockerfile.url ${TESTSDIR}/bud/copy
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy/Dockerfile.url ${TESTSDIR}/bud/copy
   rm -r ${TESTSDIR}/bud/copy
 }
 
@@ -2038,7 +2038,7 @@ EOM
 }
 
 @test "bud file above context directory" {
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json -t testctr ${TESTSDIR}/bud/context-escape-dir/testdir
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json -t testctr ${TESTSDIR}/bud/context-escape-dir/testdir
   expect_output --substring "escaping context directory error"
 }
 

--- a/tests/bud/exit42/Containerfile
+++ b/tests/bud/exit42/Containerfile
@@ -1,0 +1,2 @@
+FROM alpine
+RUN sh -c "exit 42"

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -3,16 +3,16 @@
 load helpers
 
 @test "commit-flags-order-verification" {
-  run_buildah 1 commit cnt1 --tls-verify
+  run_buildah 125 commit cnt1 --tls-verify
   check_options_flag_err "--tls-verify"
 
-  run_buildah 1 commit cnt1 -q
+  run_buildah 125 commit cnt1 -q
   check_options_flag_err "-q"
 
-  run_buildah 1 commit cnt1 -f=docker --quiet --creds=bla:bla
+  run_buildah 125 commit cnt1 -f=docker --quiet --creds=bla:bla
   check_options_flag_err "-f=docker"
 
-  run_buildah 1 commit cnt1 --creds=bla:bla
+  run_buildah 125 commit cnt1 --creds=bla:bla
   check_options_flag_err "--creds=bla:bla"
 }
 
@@ -48,7 +48,7 @@ load helpers
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json --rm $cid alpine-image
-  run_buildah 1 rm $cid
+  run_buildah 125 rm $cid
   expect_output --substring "error removing container \"alpine-working-container\": error reading build container: container not known"
 }
 
@@ -66,7 +66,7 @@ load helpers
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  run_buildah 1 commit --signature-policy ${TESTSDIR}/policy.json $cid ThisNameShouldBeRejected
+  run_buildah 125 commit --signature-policy ${TESTSDIR}/policy.json $cid ThisNameShouldBeRejected
   expect_output --substring "must be lower"
 }
 
@@ -109,7 +109,7 @@ load helpers
   _prefetch alpine
   run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  run_buildah 1 commit --authfile /tmp/nonexist --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
+  run_buildah 125 commit --authfile /tmp/nonexist --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
 }
 
 @test "commit-builder-identity" {

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -3,16 +3,16 @@
 load helpers
 
 @test "config-flags-order-verification" {
-  run_buildah 1 config cnt1 --author=user1
+  run_buildah 125 config cnt1 --author=user1
   check_options_flag_err "--author=user1"
 
-  run_buildah 1 config cnt1 --arch x86_54
+  run_buildah 125 config cnt1 --arch x86_54
   check_options_flag_err "--arch"
 
-  run_buildah 1 config cnt1 --created-by buildahcli --cmd "/usr/bin/run.sh" --hostname "localhost1"
+  run_buildah 125 config cnt1 --created-by buildahcli --cmd "/usr/bin/run.sh" --hostname "localhost1"
   check_options_flag_err "--created-by"
 
-  run_buildah 1 config cnt1 --annotation=service=cache
+  run_buildah 125 config cnt1 --annotation=service=cache
   check_options_flag_err "--annotation=service=cache"
 }
 

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -3,13 +3,13 @@
 load helpers
 
 @test "copy-flags-order-verification" {
-  run_buildah 1 copy container1 -q /tmp/container1
+  run_buildah 125 copy container1 -q /tmp/container1
   check_options_flag_err "-q"
 
-  run_buildah 1 copy container1 --chown /tmp/container1 --quiet
+  run_buildah 125 copy container1 --chown /tmp/container1 --quiet
   check_options_flag_err "--chown"
 
-  run_buildah 1 copy container1 /tmp/container1 --quiet
+  run_buildah 125 copy container1 /tmp/container1 --quiet
   check_options_flag_err "--quiet"
 }
 
@@ -24,7 +24,7 @@ load helpers
   root=$output
   run_buildah config --workingdir / $cid
   run_buildah copy $cid ${TESTDIR}/randomfile
-  run_buildah 1 copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile
+  run_buildah 125 copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile
   run_buildah rm $cid
 
   _prefetch alpine
@@ -213,6 +213,6 @@ load helpers
   echo FROM busybox AS builder                                >> ${TESTDIR}/Dockerfile
   echo FROM scratch                                           >> ${TESTDIR}/Dockerfile
   echo COPY --from=builder /bin/-no-such-file-error- /usr/bin >> ${TESTDIR}/Dockerfile
-  run_buildah 1 build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json ${TESTDIR}
+  run_buildah 125 build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json ${TESTDIR}
   expect_output --substring "no such file or directory"
 }

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -3,19 +3,19 @@
 load helpers
 
 @test "from-flags-order-verification" {
-  run_buildah 1 from scratch -q
+  run_buildah 125 from scratch -q
   check_options_flag_err "-q"
 
-  run_buildah 1 from scratch --pull
+  run_buildah 125 from scratch --pull
   check_options_flag_err "--pull"
 
-  run_buildah 1 from scratch --ulimit=1024
+  run_buildah 125 from scratch --ulimit=1024
   check_options_flag_err "--ulimit=1024"
 
-  run_buildah 1 from scratch --name container-name-irrelevant
+  run_buildah 125 from scratch --name container-name-irrelevant
   check_options_flag_err "--name"
 
-  run_buildah 1 from scratch --cred="fake fake" --name small
+  run_buildah 125 from scratch --cred="fake fake" --name small
   check_options_flag_err "--cred=fake fake"
 }
 
@@ -75,7 +75,7 @@ load helpers
   rm -rf ${TESTDIR}/auth
 
   # This should fail
-  run_buildah 1 from localhost:5000/my-alpine --cert-dir ${TESTDIR}/auth  --tls-verify true
+  run_buildah 125 from localhost:5000/my-alpine --cert-dir ${TESTDIR}/auth  --tls-verify true
 
   # Clean up
 #  docker rm -f $(docker ps --all -q)
@@ -110,7 +110,7 @@ load helpers
 #  docker logout localhost:5000
 
   # This should fail
-  run_buildah 1 from localhost:5000/my-alpine --cert-dir ${TESTDIR}/auth  --tls-verify true
+  run_buildah 125 from localhost:5000/my-alpine --cert-dir ${TESTDIR}/auth  --tls-verify true
 
   # This should work
 #  ctrid=$(buildah from localhost:5000/my-alpine --cert-dir ${TESTDIR}/auth  --tls-verify true --creds=testuser:testpassword)
@@ -347,7 +347,7 @@ load helpers
 }
 
 @test "from pull never" {
-  run_buildah 1 from --signature-policy ${TESTSDIR}/policy.json --pull-never busybox
+  run_buildah 125 from --signature-policy ${TESTSDIR}/policy.json --pull-never busybox
   echo "$output"
   expect_output --substring "no such image"
 
@@ -369,7 +369,7 @@ load helpers
 }
 
 @test "from with nonexistent authfile: fails" {
-  run_buildah 1 from --authfile /no/such/file --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah 125 from --authfile /no/such/file --pull --signature-policy ${TESTSDIR}/policy.json alpine
   expect_output "error checking authfile path /no/such/file: stat /no/such/file: no such file or directory"
 }
 
@@ -379,7 +379,7 @@ load helpers
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc --pull-always docker.io/busybox
   expect_output --substring "Getting"
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json busyboxc fakename-img
-  run_buildah 1 from --signature-policy ${TESTSDIR}/policy.json --pull-always fakename-img
+  run_buildah 125 from --signature-policy ${TESTSDIR}/policy.json --pull-always fakename-img
 }
 
 @test "from --quiet: should not emit progress messages" {

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -276,7 +276,7 @@ function expect_line_count() {
 
 function check_options_flag_err() {
     flag="$1"
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 125 ]
     [[ $output = *"No options ($flag) can be specified after"* ]]
 }
 

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -5,13 +5,13 @@ load helpers
 @test "images-flags-order-verification" {
   run_buildah images --all
 
-  run_buildah 1 images img1 -n
+  run_buildah 125 images img1 -n
   check_options_flag_err "-n"
 
-  run_buildah 1 images img1 --filter="service=redis" img2
+  run_buildah 125 images img1 --filter="service=redis" img2
   check_options_flag_err "--filter=service=redis"
 
-  run_buildah 1 images img1 img2 img3 -q
+  run_buildah 125 images img1 img2 img3 -q
   check_options_flag_err "-q"
 }
 
@@ -142,7 +142,7 @@ load helpers
 }
 
 @test "specify a nonexistent image" {
-  run_buildah 1 images alpine
+  run_buildah 125 images alpine
   expect_output --from="${lines[0]}" "No such image alpine"
   expect_line_count 1
 }

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -3,13 +3,13 @@
 load helpers
 
 @test "inspect-flags-order-verification" {
-  run_buildah 1 inspect img1 -f "{{.ContainerID}}" -t="container"
+  run_buildah 125 inspect img1 -f "{{.ContainerID}}" -t="container"
   check_options_flag_err "-f"
 
-  run_buildah 1 inspect img1 --format="{{.ContainerID}}"
+  run_buildah 125 inspect img1 --format="{{.ContainerID}}"
   check_options_flag_err "--format={{.ContainerID}}"
 
-  run_buildah 1 inspect img1 -t="image"
+  run_buildah 125 inspect img1 -t="image"
   check_options_flag_err "-t=image"
 }
 

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -23,7 +23,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 @test "manifest-add-one" {
     run_buildah manifest create foo
     run_buildah manifest add --override-arch=arm64 foo ${IMAGE_LIST_INSTANCE}
-    run_buildah 1 inspect foo
+    run_buildah 125 inspect foo
     expect_output --substring "does not exist"
     run_buildah manifest inspect foo
     expect_output --substring ${IMAGE_LIST_ARM64_INSTANCE_DIGEST}
@@ -58,7 +58,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 @test "manifest-remove-not-found" {
     run_buildah manifest create foo
     run_buildah manifest add foo ${IMAGE_LIST}
-    run_buildah 1 manifest remove foo sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    run_buildah 125 manifest remove foo sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 }
 
 @test "manifest-push" {
@@ -94,14 +94,14 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest add --override-arch=arm64 foo ${IMAGE_LIST}
     run_buildah manifest inspect foo
     run_buildah manifest push --signature-policy ${TESTSDIR}/policy.json --purge foo dir:${TESTDIR}/pushed
-    run_buildah 1 manifest inspect foo
+    run_buildah 125 manifest inspect foo
 }
 
 @test "manifest-push should fail with nonexist authfile" {
     run_buildah manifest create foo
     run_buildah manifest add --override-arch=arm64 foo ${IMAGE_LIST}
     run_buildah manifest inspect foo
-    run_buildah 1 manifest push --authfile /tmp/nonexist --signature-policy ${TESTSDIR}/policy.json --purge foo dir:${TESTDIR}/pushed
+    run_buildah 125 manifest push --authfile /tmp/nonexist --signature-policy ${TESTSDIR}/policy.json --purge foo dir:${TESTDIR}/pushed
 
 }
 

--- a/tests/loglevel.bats
+++ b/tests/loglevel.bats
@@ -23,6 +23,6 @@ load helpers
 }
 
 @test "log-level set to invalid" {
-  run_buildah 1 --log-level=invalid images -q
+  run_buildah 125 --log-level=invalid images -q
   expect_output --substring "unable to parse log level"
 }

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -3,13 +3,13 @@
 load helpers
 
 @test "mount-flags-order-verification" {
-  run_buildah 1 mount cnt1 --notruncate path1
+  run_buildah 125 mount cnt1 --notruncate path1
   check_options_flag_err "--notruncate"
 
-  run_buildah 1 mount cnt1 --notruncate
+  run_buildah 125 mount cnt1 --notruncate
   check_options_flag_err "--notruncate"
 
-  run_buildah 1 mount cnt1 path1 --notruncate
+  run_buildah 125 mount cnt1 path1 --notruncate
   check_options_flag_err "--notruncate"
 }
 
@@ -21,7 +21,7 @@ load helpers
 }
 
 @test "mount bad container" {
-  run_buildah 1 mount badcontainer
+  run_buildah 125 mount badcontainer
 }
 
 @test "mount multi images" {
@@ -43,7 +43,7 @@ load helpers
   cid2=$output
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid3=$output
-  run_buildah 1 mount "$cid1" badcontainer "$cid2" "$cid3"
+  run_buildah 125 mount "$cid1" badcontainer "$cid2" "$cid3"
 }
 
 @test "list currently mounted containers" {

--- a/tests/overlay.bats
+++ b/tests/overlay.bats
@@ -23,7 +23,7 @@ load helpers
   run_buildah run $cid rm /lower/foo
 
   # This should fail, second runs of containers go back to original
-  run_buildah 1 run $cid ls /lower/bar
+  run_buildah 125 run $cid ls /lower/bar
 
   # This should fail
   run ls ${TESTDIR}/lower/bar

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -3,18 +3,18 @@
 load helpers
 
 @test "pull-flags-order-verification" {
-  run_buildah 1 pull image1 --tls-verify
+  run_buildah 125 pull image1 --tls-verify
   check_options_flag_err "--tls-verify"
 
-  run_buildah 1 pull image1 --authfile=/tmp/somefile
+  run_buildah 125 pull image1 --authfile=/tmp/somefile
   check_options_flag_err "--authfile=/tmp/somefile"
 
-  run_buildah 1 pull image1 -q --cred bla:bla --authfile=/tmp/somefile
+  run_buildah 125 pull image1 -q --cred bla:bla --authfile=/tmp/somefile
   check_options_flag_err "-q"
 }
 
 @test "pull-blocked" {
-  run_buildah 1 --registries-conf ${TESTSDIR}/registries.conf.block pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
+  run_buildah 125 --registries-conf ${TESTSDIR}/registries.conf.block pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
   expect_output --substring "is blocked by configuration"
 
   run_buildah --registries-conf ${TESTSDIR}/registries.conf       pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
@@ -37,7 +37,7 @@ load helpers
   expect_output --substring "alpine_nginx:latest"
 
   run_buildah pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json alpine@sha256:1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe
-  run_buildah 1 pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json fakeimage/fortest
+  run_buildah 125 pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json fakeimage/fortest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   [[ ! "$output" =~ "fakeimage/fortest" ]]
 }
@@ -49,7 +49,7 @@ load helpers
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json docker-archive:${TESTDIR}/alp.tar
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine"
-  run_buildah 1 pull --all-tags --signature-policy ${TESTSDIR}/policy.json docker-archive:${TESTDIR}/alp.tar
+  run_buildah 125 pull --all-tags --signature-policy ${TESTSDIR}/policy.json docker-archive:${TESTDIR}/alp.tar
   expect_output "Non-docker transport is not supported, for --all-tags pulling"
 }
 
@@ -60,7 +60,7 @@ load helpers
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json oci-archive:${TESTDIR}/alp.tar
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine"
-  run_buildah 1 pull --all-tags --signature-policy ${TESTSDIR}/policy.json oci-archive:${TESTDIR}/alp.tar
+  run_buildah 125 pull --all-tags --signature-policy ${TESTSDIR}/policy.json oci-archive:${TESTDIR}/alp.tar
   expect_output "Non-docker transport is not supported, for --all-tags pulling"
 }
 
@@ -72,7 +72,7 @@ load helpers
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json dir:${TESTDIR}/buildahtest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "localhost${TESTDIR}/buildahtest:latest"
-  run_buildah 1 pull --all-tags --signature-policy ${TESTSDIR}/policy.json dir:${TESTDIR}/buildahtest
+  run_buildah 125 pull --all-tags --signature-policy ${TESTSDIR}/policy.json dir:${TESTDIR}/buildahtest
   expect_output "Non-docker transport is not supported, for --all-tags pulling"
 }
 
@@ -93,7 +93,7 @@ load helpers
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine:latest"
   run_buildah rmi alpine
-  run_buildah 1 pull --all-tags --signature-policy ${TESTSDIR}/policy.json docker-daemon:docker.io/library/alpine:latest
+  run_buildah 125 pull --all-tags --signature-policy ${TESTSDIR}/policy.json docker-daemon:docker.io/library/alpine:latest
   expect_output --substring "Non-docker transport is not supported, for --all-tags pulling"
 }
 
@@ -142,28 +142,28 @@ load helpers
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json oci:${TESTDIR}/alpine
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "localhost${TESTDIR}/alpine:latest"
-  run_buildah 1 pull --all-tags --signature-policy ${TESTSDIR}/policy.json oci:${TESTDIR}/alpine
+  run_buildah 125 pull --all-tags --signature-policy ${TESTSDIR}/policy.json oci:${TESTDIR}/alpine
   expect_output "Non-docker transport is not supported, for --all-tags pulling"
 }
 
 @test "pull-denied-by-registry-sources" {
   export BUILD_REGISTRY_SOURCES='{"blockedRegistries": ["docker.io"]}'
 
-  run_buildah 1 pull --signature-policy ${TESTSDIR}/policy.json --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
+  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
   expect_output --substring 'pull from registry at "docker.io" denied by policy: it is in the blocked registries list'
 
-  run_buildah 1 pull --signature-policy ${TESTSDIR}/policy.json --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
+  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
   expect_output --substring 'pull from registry at "docker.io" denied by policy: it is in the blocked registries list'
 
   export BUILD_REGISTRY_SOURCES='{"allowedRegistries": ["some-other-registry.example.com"]}'
 
-  run_buildah 1 pull --signature-policy ${TESTSDIR}/policy.json --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
+  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
   expect_output --substring 'pull from registry at "docker.io" denied by policy: not in allowed registries list'
 
-  run_buildah 1 pull --signature-policy ${TESTSDIR}/policy.json --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
+  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
   expect_output --substring 'pull from registry at "docker.io" denied by policy: not in allowed registries list'
 }
 
 @test "pull should fail with nonexist authfile" {
-  run_buildah 1 pull --authfile /tmp/nonexist --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah 125 pull --authfile /tmp/nonexist --signature-policy ${TESTSDIR}/policy.json alpine
 }

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -3,16 +3,16 @@
 load helpers
 
 @test "push-flags-order-verification" {
-  run_buildah 1 push img1 dest1 -q
+  run_buildah 125 push img1 dest1 -q
   check_options_flag_err "-q"
 
-  run_buildah 1 push img1 --tls-verify dest1
+  run_buildah 125 push img1 --tls-verify dest1
   check_options_flag_err "--tls-verify"
 
-  run_buildah 1 push img1 dest1 arg3 --creds user1:pass1
+  run_buildah 125 push img1 dest1 arg3 --creds user1:pass1
   check_options_flag_err "--creds"
 
-  run_buildah 1 push img1 --creds=user1:pass1 dest1
+  run_buildah 125 push img1 --creds=user1:pass1 dest1
   check_options_flag_err "--creds=user1:pass1"
 }
 
@@ -82,7 +82,7 @@ load helpers
 @test "push without destination" {
   _prefetch busybox
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
-  run_buildah 1 push --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah 125 push --signature-policy ${TESTSDIR}/policy.json busybox
   expect_output --substring "docker://busybox"
 }
 
@@ -92,7 +92,7 @@ load helpers
   cid=$output
   run_buildah images -q
   imageid=$output
-  run_buildah 1 push --signature-policy ${TESTSDIR}/policy.json --authfile /tmp/nonexsit $imageid dir:${TESTDIR}/my-tmp-dir
+  run_buildah 125 push --signature-policy ${TESTSDIR}/policy.json --authfile /tmp/nonexsit $imageid dir:${TESTDIR}/my-tmp-dir
 }
 
 @test "push-denied-by-registry-sources" {
@@ -102,22 +102,22 @@ load helpers
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json --quiet busybox
   cid=$output
-  run_buildah 1 commit --signature-policy ${TESTSDIR}/policy.json ${cid} docker://registry.example.com/busierbox
+  run_buildah 125 commit --signature-policy ${TESTSDIR}/policy.json ${cid} docker://registry.example.com/busierbox
   expect_output --substring 'commit to registry at "registry.example.com" denied by policy: it is in the blocked registries list'
 
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json --quiet busybox
-  run_buildah 1 push --signature-policy ${TESTSDIR}/policy.json busybox docker://registry.example.com/evenbusierbox
+  run_buildah 125 push --signature-policy ${TESTSDIR}/policy.json busybox docker://registry.example.com/evenbusierbox
   expect_output --substring 'push to registry at "registry.example.com" denied by policy: it is in the blocked registries list'
 
   export BUILD_REGISTRY_SOURCES='{"allowedRegistries": ["some-other-registry.example.com"]}'
 
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json --quiet busybox
   cid=$output
-  run_buildah 1 commit --signature-policy ${TESTSDIR}/policy.json ${cid} docker://registry.example.com/busierbox
+  run_buildah 125 commit --signature-policy ${TESTSDIR}/policy.json ${cid} docker://registry.example.com/busierbox
   expect_output --substring 'commit to registry at "registry.example.com" denied by policy: not in allowed registries list'
 
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json --quiet busybox
-  run_buildah 1 push --signature-policy ${TESTSDIR}/policy.json busybox docker://registry.example.com/evenbusierbox
+  run_buildah 125 push --signature-policy ${TESTSDIR}/policy.json busybox docker://registry.example.com/evenbusierbox
   expect_output --substring 'push to registry at "registry.example.com" denied by policy: not in allowed registries list'
 }
 

--- a/tests/rename.bats
+++ b/tests/rename.bats
@@ -22,7 +22,7 @@ load helpers
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  run_buildah 1 rename ${cid} ${cid}
+  run_buildah 125 rename ${cid} ${cid}
   expect_output 'renaming a container with the same name as its current name'
 }
 
@@ -32,6 +32,6 @@ load helpers
   cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
   cid2=$output
-  run_buildah 1 rename ${cid1} ${cid2}
+  run_buildah 125 rename ${cid1} ${cid2}
   expect_output --substring " already in use by "
 }

--- a/tests/rm.bats
+++ b/tests/rm.bats
@@ -3,15 +3,15 @@
 load helpers
 
 @test "rm-flags-order-verification" {
-  run_buildah 1 rm cnt1 -a
+  run_buildah 125 rm cnt1 -a
   check_options_flag_err "-a"
 
-  run_buildah 1 rm cnt1 --all cnt2
+  run_buildah 125 rm cnt1 --all cnt2
   check_options_flag_err "--all"
 }
 
 @test "remove multiple containers errors" {
-  run_buildah 1 rm mycontainer1 mycontainer2 mycontainer3
+  run_buildah 125 rm mycontainer1 mycontainer2 mycontainer3
   expect_output --from="${lines[0]}" "error removing container \"mycontainer1\": error reading build container: container not known" "output line 1"
   expect_output --from="${lines[1]}" "error removing container \"mycontainer2\": error reading build container: container not known" "output line 2"
   expect_output --from="${lines[2]}" "error removing container \"mycontainer3\": error reading build container: container not known" "output line 3"
@@ -49,6 +49,6 @@ load helpers
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
-  run_buildah 1 rm -a "$cid"
+  run_buildah 125 rm -a "$cid"
   expect_output --substring "when using the --all switch, you may not pass any containers names or IDs"
 }

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -3,13 +3,13 @@
 load helpers
 
 @test "rmi-flags-order-verification" {
-  run_buildah 1 rmi img1 -f
+  run_buildah 125 rmi img1 -f
   check_options_flag_err "-f"
 
-  run_buildah 1 rmi img1 --all img2
+  run_buildah 125 rmi img1 --all img2
   check_options_flag_err "--all"
 
-  run_buildah 1 rmi img1 img2 --force
+  run_buildah 125 rmi img1 img2 --force
   check_options_flag_err "--force"
 }
 
@@ -29,7 +29,7 @@ load helpers
   cid2=$output
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
   cid3=$output
-  run_buildah 1 rmi alpine busybox
+  run_buildah 125 rmi alpine busybox
   run_buildah images -q
   [ "$output" != "" ]
 
@@ -39,7 +39,7 @@ load helpers
 }
 
 @test "remove multiple non-existent images errors" {
-  run_buildah 1 rmi image1 image2 image3
+  run_buildah 125 rmi image1 image2 image3
   expect_output --from="${lines[0]}" "could not get image \"image1\": identifier is not an image" "output line 1"
   expect_output --from="${lines[1]}" "could not get image \"image2\": identifier is not an image" "output line 2"
   expect_output --from="${lines[2]}" "could not get image \"image3\": identifier is not an image" "output line 3"
@@ -65,7 +65,7 @@ load helpers
   cid2=$output
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
   cid3=$output
-  run_buildah 1 rmi --all
+  run_buildah 125 rmi --all
   run_buildah images -q
   [ "$output" != "" ]
 
@@ -119,19 +119,19 @@ load helpers
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah rm "$cid"
-  run_buildah 1 rmi -a alpine
+  run_buildah 125 rmi -a alpine
   expect_output --substring "when using the --all switch, you may not pass any images names or IDs"
 
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah rm "$cid"
-  run_buildah 1 rmi -p alpine
+  run_buildah 125 rmi -p alpine
   expect_output --substring "when using the --prune switch, you may not pass any images names or IDs"
 
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   run_buildah rm "$cid"
-  run_buildah 1 rmi -a -p
+  run_buildah 125 rmi -a -p
   expect_output --substring "when using the --all switch, you may not use --prune switch"
   run_buildah rmi --all
 }
@@ -143,7 +143,7 @@ load helpers
   run_buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid new-image
   run_buildah rm -a
-  run_buildah 1 rmi alpine
+  run_buildah 125 rmi alpine
   expect_line_count 2
   run_buildah images -q
   expect_line_count 1
@@ -151,7 +151,7 @@ load helpers
   expect_line_count 2
 
   local try_to_delete=${lines[1]}
-  run_buildah 1 rmi $try_to_delete
+  run_buildah 125 rmi $try_to_delete
   expect_output --substring "unable to delete \"$try_to_delete.*\" \(cannot be forced\) - image has dependent child images"
   run_buildah rmi new-image
 }
@@ -171,7 +171,7 @@ load helpers
   run_buildah images -a -q
   expect_line_count 1
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
-  run_buildah 1 rmi alpine
+  run_buildah 125 rmi alpine
   expect_line_count 2
   run_buildah rmi test3
   run_buildah images -a -q

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -34,7 +34,7 @@ load helpers
 	cid=$output
 
 	# This should fail, because buildah run doesn't have a -n flag.
-	run_buildah 1 run -n $cid echo test
+	run_buildah 125 run -n $cid echo test
 
 	# This should succeed, because buildah run stops caring at the --, which is preserved as part of the command.
 	run_buildah run $cid echo -- -n test
@@ -67,57 +67,57 @@ load helpers
 	# empty entrypoint, configured cmd, empty run arguments
 	run_buildah config --entrypoint "" $cid
 	run_buildah config --cmd pwd $cid
-	run_buildah 1 run $cid
+	run_buildah 125 run $cid
 	expect_output --substring "command must be specified" "empty entrypoint, cmd, no args"
 
 	# empty entrypoint, configured cmd, empty run arguments, end parsing option
 	run_buildah config --entrypoint "" $cid
 	run_buildah config --cmd pwd $cid
-	run_buildah 1 run $cid --
+	run_buildah 125 run $cid --
 	expect_output --substring "command must be specified" "empty entrypoint, cmd, no args, --"
 
 	# configured entrypoint, empty cmd, empty run arguments
 	run_buildah config --entrypoint pwd $cid
 	run_buildah config --cmd "" $cid
-	run_buildah 1 run $cid
+	run_buildah 125 run $cid
 	expect_output --substring "command must be specified" "entrypoint, empty cmd, no args"
 
 	# configured entrypoint, empty cmd, empty run arguments, end parsing option
 	run_buildah config --entrypoint pwd $cid
 	run_buildah config --cmd "" $cid
-	run_buildah 1 run $cid --
+	run_buildah 125 run $cid --
 	expect_output --substring "command must be specified" "entrypoint, empty cmd, no args, --"
 
 	# configured entrypoint only, empty run arguments
 	run_buildah config --entrypoint pwd $cid
-	run_buildah 1 run $cid
+	run_buildah 125 run $cid
 	expect_output --substring "command must be specified" "entrypoint, no args"
 
 	# configured entrypoint only, empty run arguments, end parsing option
 	run_buildah config --entrypoint pwd $cid
-	run_buildah 1 run $cid --
+	run_buildah 125 run $cid --
 	expect_output --substring "command must be specified" "entrypoint, no args, --"
 
 	# configured cmd only, empty run arguments
 	run_buildah config --cmd pwd $cid
-	run_buildah 1 run $cid
+	run_buildah 125 run $cid
 	expect_output --substring "command must be specified" "cmd, no args"
 
 	# configured cmd only, empty run arguments, end parsing option
 	run_buildah config --cmd pwd $cid
-	run_buildah 1 run $cid --
+	run_buildah 125 run $cid --
 	expect_output --substring "command must be specified" "cmd, no args, --"
 
 	# configured entrypoint, configured cmd, empty run arguments
 	run_buildah config --entrypoint "pwd" $cid
 	run_buildah config --cmd "whoami" $cid
-	run_buildah 1 run $cid
+	run_buildah 125 run $cid
 	expect_output --substring "command must be specified" "entrypoint, cmd, no args"
 
 	# configured entrypoint, configured cmd, empty run arguments, end parsing option
 	run_buildah config --entrypoint "pwd" $cid
 	run_buildah config --cmd "whoami" $cid
-	run_buildah 1 run $cid --
+	run_buildah 125 run $cid --
 	expect_output --substring "command must be specified"  "entrypoint, cmd, no args"
 
 
@@ -201,14 +201,14 @@ function configure_and_check_user() {
         configure_and_check_user "${testuid}:${testgroupid}"    $testuid      $testgroupid
 
         run_buildah config -u ${testbogususer} $cid
-        run_buildah 1 run -- $cid id -u
+        run_buildah 125 run -- $cid id -u
         expect_output --substring "unknown user" "id -u (bogus user)"
-        run_buildah 1 run -- $cid id -g
+        run_buildah 125 run -- $cid id -g
         expect_output --substring "unknown user" "id -g (bogus user)"
 
 	ln -vsf /etc/passwd $root/etc/passwd
 	run_buildah config -u ${testuser}:${testgroup} $cid
-	run_buildah 1 run -- $cid id -u
+	run_buildah 125 run -- $cid id -u
 	echo "$output"
 	expect_output --substring "unknown user" "run as unknown user"
 }
@@ -372,6 +372,15 @@ function configure_and_check_user() {
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah 42 run ${cid} sh -c 'exit 42'
+}
+
+@test "run-exit-status on non executable" {
+	skip_if_no_runtime
+
+	_prefetch alpine
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	cid=$output
+	run_buildah 1 run ${cid} /etc
 }
 
 @test "Verify /run/.containerenv exist" {

--- a/tests/sign.bats
+++ b/tests/sign.bats
@@ -54,7 +54,7 @@ function _gpg_setup() {
 
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid unsigned-alpine-image
   # Pushing with --sign-by should fail add the signature to a dir: location, if it tries to add them.
-  run_buildah 1 push --signature-policy ${TESTSDIR}/policy.json --sign-by amanda@localhost unsigned-alpine-image dir:${TESTDIR}/signed-image
+  run_buildah 125 push --signature-policy ${TESTSDIR}/policy.json --sign-by amanda@localhost unsigned-alpine-image dir:${TESTDIR}/signed-image
   expect_output --substring "Cannot determine canonical Docker reference"
 
   # Clear out images, so that we don't have leftover signatures when we pull in an image that will end up
@@ -71,7 +71,7 @@ function _gpg_setup() {
   # Build a manifest list and try to push the list with signatures.
   run_buildah manifest create list
   run_buildah manifest add list $imageID
-  run_buildah 1 manifest push --signature-policy ${TESTSDIR}/policy.json --sign-by amanda@localhost --all list dir:${TESTDIR}/signed-image
+  run_buildah 125 manifest push --signature-policy ${TESTSDIR}/policy.json --sign-by amanda@localhost --all list dir:${TESTDIR}/signed-image
   expect_output --substring "Cannot determine canonical Docker reference"
   run_buildah manifest push --signature-policy ${TESTSDIR}/policy.json --all list dir:${TESTDIR}/unsigned-image
 }

--- a/tests/tag.bats
+++ b/tests/tag.bats
@@ -6,7 +6,7 @@ load helpers
   run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json "$cid" scratch-image
-  run_buildah 1 inspect --type image tagged-image
+  run_buildah 125 inspect --type image tagged-image
   run_buildah tag scratch-image tagged-image tagged-also-image named-image
   run_buildah inspect --type image tagged-image
   run_buildah inspect --type image tagged-also-image

--- a/tests/umount.bats
+++ b/tests/umount.bats
@@ -3,13 +3,13 @@
 load helpers
 
 @test "umount-flags-order-verification" {
-  run_buildah 1 umount cnt1 -a
+  run_buildah 125 umount cnt1 -a
   check_options_flag_err "-a"
 
-  run_buildah 1 umount cnt1 --all cnt2
+  run_buildah 125 umount cnt1 --all cnt2
   check_options_flag_err "--all"
 
-  run_buildah 1 umount cnt1 cnt2 --all
+  run_buildah 125 umount cnt1 cnt2 --all
   check_options_flag_err "--all"
 }
 
@@ -22,7 +22,7 @@ load helpers
 }
 
 @test "umount bad image" {
-  run_buildah 1 umount badcontainer
+  run_buildah 125 umount badcontainer
 }
 
 @test "umount multi images" {
@@ -64,5 +64,5 @@ load helpers
   run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
   cid3=$output
   run_buildah mount "$cid3"
-  run_buildah 1 umount "$cid1" badcontainer "$cid2" "$cid3"
+  run_buildah 125 umount "$cid1" badcontainer "$cid2" "$cid3"
 }


### PR DESCRIPTION
Buildah run was exiting with the correct exit code, when a container
failed.  Buildah bud was not, so this should fix this.

Also switched to the proper exit codes when containers fail.  When
Buildah fails to execute it will exit with a 125 exit code like
Podman does.  If a command fails to execute inside of a container
we will exit with a 126. Currently we do not support the 127 for
exiting when the command does not exist.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

