### PR TITLE
Cirrus: Temporarily disable Ubuntu 19 testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -181,7 +181,8 @@ gce_instance:
             image_name: "${FEDORA_CACHE_IMAGE_NAME}"
             # TODO: Re-enable once prior image is F30 and above is F31
             # image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
-            image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
+            # TODO: Re-enable when package repositories functional
+            #image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
             image_name: "${PRIOR_UBUNTU_CACHE_IMAGE_NAME}"
 
     # Separate scripts for separate outputs, makes debugging easier.


### PR DESCRIPTION
Due to some unknown problem with package repositories, all ubuntu 19
testing is failing.  This commit temporarily disables that part of the
matrix until a fix can be discovered and implemented.

Signed-off-by: Chris Evich <cevich@redhat.com>