### PR TITLE
imagebuildah: stages shouldn't count as their base images

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -230,7 +230,7 @@ func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Nod
 
 // startStage creates a new stage executor that will be referenced whenever a
 // COPY or ADD statement uses a --from=NAME flag.
-func (b *Executor) startStage(stage *imagebuilder.Stage, stages int, from, output string) *StageExecutor {
+func (b *Executor) startStage(stage *imagebuilder.Stage, stages int, output string) *StageExecutor {
 	if b.stages == nil {
 		b.stages = make(map[string]*StageExecutor)
 	}
@@ -245,7 +245,6 @@ func (b *Executor) startStage(stage *imagebuilder.Stage, stages int, from, outpu
 		stage:           stage,
 	}
 	b.stages[stage.Name] = stageExec
-	b.stages[from] = stageExec
 	if idx := strconv.Itoa(stage.Position); idx != stage.Name {
 		b.stages[idx] = stageExec
 	}
@@ -418,7 +417,7 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 			output = b.output
 		}
 
-		stageExecutor := b.startStage(&stage, len(stages), base, output)
+		stageExecutor := b.startStage(&stage, len(stages), output)
 
 		// If this a single-layer build, or if it's a multi-layered
 		// build and b.forceRmIntermediateCtrs is set, make sure we

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -295,7 +295,7 @@ func (s *StageExecutor) digestSpecifiedContent(node *parser.Node, argValues []st
 			// container.  Update the ID mappings and
 			// all-content-comes-from-below-this-directory value.
 			from := strings.TrimPrefix(flag, "--from=")
-			if other, ok := s.executor.stages[from]; ok {
+			if other, ok := s.executor.stages[from]; ok && other.index < s.index {
 				contextDir = other.mountPoint
 				idMappingOptions = &other.builder.IDMappingOptions
 			} else if builder, ok := s.executor.containerMap[from]; ok {
@@ -868,13 +868,10 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				if len(arr) != 2 {
 					return "", nil, errors.Errorf("%s: invalid --from flag, should be --from=<name|stage>", command)
 				}
-				otherStage, ok := s.executor.stages[arr[1]]
-				if !ok {
-					if mountPoint, err = s.getImageRootfs(ctx, arr[1]); err != nil {
-						return "", nil, errors.Errorf("%s --from=%s: no stage or image found with that name", command, arr[1])
-					}
-				} else {
+				if otherStage, ok := s.executor.stages[arr[1]]; ok && otherStage.index < s.index {
 					mountPoint = otherStage.mountPoint
+				} else if mountPoint, err = s.getImageRootfs(ctx, arr[1]); err != nil {
+					return "", nil, errors.Errorf("%s --from=%s: no stage or image found with that name", command, arr[1])
 				}
 				s.copyFrom = mountPoint
 				break

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1379,6 +1379,20 @@ function _test_http() {
   expect_output --substring "COPY only supports the --chown=<uid:gid> and the --from=<image|stage> flags"
 }
 
+@test "bud with copy-from referencing the base image" {
+  _prefetch busybox
+  target=busybox-derived
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile3 ${TESTSDIR}/bud/copy-from
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile4 ${TESTSDIR}/bud/copy-from
+}
+
+@test "bud with copy-from referencing the current stage" {
+  _prefetch busybox
+  target=busybox-derived
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile2.bad ${TESTSDIR}/bud/copy-from
+  expect_output --substring "COPY --from=build: no stage or image found with that name"
+}
+
 @test "bud-target" {
   _prefetch alpine ubuntu
   target=target

--- a/tests/bud/copy-from/Dockerfile2.bad
+++ b/tests/bud/copy-from/Dockerfile2.bad
@@ -1,0 +1,6 @@
+FROM busybox AS test
+USER 1001
+FROM busybox AS build
+COPY --from=test /bin/cut /test/
+COPY --from=build /bin/cp /test/
+COPY --from=busybox /bin/paste /test/

--- a/tests/bud/copy-from/Dockerfile3
+++ b/tests/bud/copy-from/Dockerfile3
@@ -1,0 +1,4 @@
+FROM docker.io/library/busybox AS build
+RUN rm -f /bin/paste
+USER 1001
+COPY --from=docker.io/library/busybox /bin/paste /test/

--- a/tests/bud/copy-from/Dockerfile4
+++ b/tests/bud/copy-from/Dockerfile4
@@ -1,0 +1,4 @@
+FROM docker.io/library/busybox AS test
+RUN rm -f /bin/nl
+FROM docker.io/library/alpine AS final
+COPY --from=docker.io/library/busybox /bin/nl /test/


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

When initializing a build stage, we were recording the stage as a possible source for content from its base image, which wouldn't necessarily be true once we started processing the instructions for that stage.

We also didn't consistently enforce the rule that stages named in the "--from" argument to COPY instructions had to have been completed _before_ the stage which contains the COPY instruction, for compatibility with "docker build".

#### How to verify it

Our tests now include tests that ensure that `COPY --from=_image_` references an image, not a stage that uses it as a base.
```
FROM docker.io/library/busybox AS build
RUN rm -f /bin/paste
USER 1001
COPY --from=docker.io/library/busybox /bin/paste /test/
```
```
FROM docker.io/library/busybox AS test
RUN rm -f /bin/nl
FROM docker.io/library/alpine AS final
COPY --from=docker.io/library/busybox /bin/nl /test/
```
The tests also now include a still-expected-to-fail test that attempts to `COPY --from` the current stage:
```
FROM busybox AS test
USER 1001
FROM busybox AS build
COPY --from=test /bin/cut /test/
COPY --from=build /bin/cp /test/
COPY --from=busybox /bin/paste /test/
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```
None
```

