### PR TITLE
Don't force tests to use runc

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -5,6 +5,7 @@ IMGTYPE_BINARY=${IMGTYPE_BINARY:-$(dirname ${BASH_SOURCE})/../imgtype}
 TESTSDIR=${TESTSDIR:-$(dirname ${BASH_SOURCE})}
 STORAGE_DRIVER=${STORAGE_DRIVER:-vfs}
 PATH=$(dirname ${BASH_SOURCE})/..:${PATH}
+OCI=$(${BUILDAH_BINARY} info --format '{{.host.OCIRuntime}}' || command -v runc || command -v crun)
 
 # Default timeout for a buildah command.
 BUILDAH_TIMEOUT=${BUILDAH_TIMEOUT:-300}
@@ -302,14 +303,11 @@ function skip_if_rootless() {
 #  skip_if_no_runtime  #  'buildah run' can't work without a runtime
 ########################
 function skip_if_no_runtime() {
-    # FIXME: if #1964 gets fixed, use 'buildah info' to determine runtime
-    # FIXME: right now we just rely on runc
-    runtime=runc
-    if type -p $runtime &> /dev/null; then
+    if type -p "${OCI}" &> /dev/null; then
         return
     fi
 
-    skip "runtime '$runtime' not found"
+    skip "runtime \"$OCI\" not found"
 }
 
 ##################

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -319,7 +319,7 @@ general_namespace() {
   skip_if_rootless
 
   _prefetch alpine
-  # mnt is always per-container, cgroup isn't a thing runc lets us configure
+  # mnt is always per-container, cgroup isn't a thing OCI runtime lets us configure
   for ipc in host container ; do
     for net in host container ; do
       for pid in host container ; do
@@ -327,7 +327,7 @@ general_namespace() {
           for uts in host container ; do
 
             if test $userns == container -a $pid == host ; then
-              # We can't mount a fresh /proc, and runc won't let us bind mount the host's.
+              # We can't mount a fresh /proc, and OCI runtime won't let us bind mount the host's.
               continue
             fi
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -6,7 +6,7 @@ load helpers
 	skip_if_no_runtime
 
 	_prefetch alpine
-	runc --version
+	${OCI} --version
 	createrandom ${TESTDIR}/randomfile
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
@@ -218,7 +218,7 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	_prefetch alpine
-	runc --version
+	${OCI} --version
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah run $cid hostname
@@ -236,7 +236,7 @@ function configure_and_check_user() {
 			zflag=z
 		fi
 	fi
-	runc --version
+	${OCI} --version
 	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
@@ -262,7 +262,7 @@ function configure_and_check_user() {
 			zflag=z
 		fi
 	fi
-	runc --version
+	${OCI} --version
 	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
@@ -281,7 +281,7 @@ function configure_and_check_user() {
 @test "run symlinks" {
 	skip_if_no_runtime
 
-	runc --version
+	${OCI} --version
 	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
@@ -294,7 +294,7 @@ function configure_and_check_user() {
 @test "run --cap-add/--cap-drop" {
 	skip_if_no_runtime
 
-	runc --version
+	${OCI} --version
 	_prefetch alpine
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output

--- a/tests/test_buildah_rpm.sh
+++ b/tests/test_buildah_rpm.sh
@@ -9,9 +9,7 @@ load helpers
 }
 
 @test "rpm-build CentOS 7" {
-        if ! which runc ; then
-                skip
-        fi
+        skip_if_no_runtime
 
         # Build a container to use for building the binaries.
         image=registry.centos.org/centos/centos:centos7
@@ -64,9 +62,7 @@ load helpers
 }
 
 @test "rpm-build Fedora latest" {
-        if ! which runc ; then
-                skip
-        fi
+        skip_if_no_runtime
 
         # Build a container to use for building the binaries.
         image=registry.fedoraproject.org/fedora:latest


### PR DESCRIPTION
We should default to what buildah info reports else use runc or crun.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

