### PR TITLE
fix error info about get signatures for containerImageSource

### DIFF
--- a/image.go
+++ b/image.go
@@ -586,16 +586,10 @@ func (i *containerImageSource) Reference() types.ImageReference {
 }
 
 func (i *containerImageSource) GetSignatures(ctx context.Context, instanceDigest *digest.Digest) ([][]byte, error) {
-	if instanceDigest != nil {
-		return nil, errors.Errorf("containerImageSource does not support manifest lists")
-	}
 	return nil, nil
 }
 
 func (i *containerImageSource) GetManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, string, error) {
-	if instanceDigest != nil {
-		return nil, "", errors.Errorf("containerImageSource does not support manifest lists")
-	}
 	return i.manifest, i.manifestType, nil
 }
 


### PR DESCRIPTION
Remove these error checks since the instanceDigest is not used
and can just be ignored.

Signed-off-by: zvier <liuzekun0524@163.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
/kind cleanup

Replaces: https://github.com/containers/buildah/pull/2297
