### PR TITLE
Evaluate symlinks in build context directory

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -191,6 +191,11 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		contextDir = filepath.Dir(dockerFile)
 	}
 
+	contextDir, err = filepath.EvalSymlinks(contextDir)
+	if err != nil {
+		return errors.Wrapf(err, "error evaluating symlinks in build context path")
+	}
+
 	var stdin, stdout, stderr, reporter *os.File
 	stdin = os.Stdin
 	stdout = os.Stdout


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

During a file copy, symlinks in file path are evaluated, so the resulting path cannot match against .dockerignore patterns. Indeed, symlinks in the build context directory are not evaluated. This PR adds symlink evaluation of the build context directory.

#### How to verify it

On Fedora Silverblue, make a directory in your home, like /home/user/podman-test (ensure you're inside /home and not /var/home). The actual directory is /var/home/user/podman-test since /home is a symlink to /var/home. In this directory execute the following commands:

```
echo a > .dockerignore
cat <<EOF > Dockerfile
FROM alpine
WORKDIR test
COPY . .
EOF
touch a b
podman build -t test .
podman run -ti --rm test ls -la
```

You will see

```
total 16
drwxrwxr-x    2 root     root          4096 May  8 18:55 .
drwxr-xr-x   20 root     root          4096 May  8 18:56 ..
-rw-rw-r--    1 root     root             2 May  8 18:55 .dockerignore
-rw-rw-r--    1 root     root            34 May  8 18:55 Dockerfile
-rw-rw-r--    1 root     root             0 May  8 18:55 a
-rw-rw-r--    1 root     root             0 May  8 18:55 b
```

Whereas the expected result is

```
total 16
drwxrwxr-x    2 root     root          4096 May  8 18:55 .
drwxr-xr-x   20 root     root          4096 May  8 18:56 ..
-rw-rw-r--    1 root     root             2 May  8 18:55 .dockerignore
-rw-rw-r--    1 root     root            34 May  8 18:55 Dockerfile
-rw-rw-r--    1 root     root             0 May  8 18:55 b
```

The file `a` shouldn't have been copied to the image since it's excluded by a `.dockerignore` entry.

#### Additional informations

During my investigations, I came across this portion of code: https://github.com/containers/buildah/blob/b4380504b06c709cc4214a2597c268d1a7c90afe/add.go#L222
I'm wondering if it's useful since the build context directory is not prepended to .dockerignore and the resulting regexp will never match (unless I missed something). Furthermore, .dockerignore is not excluded by default when using Docker.

(@TomSweeneyRedHat made a few small edits for formatting purposes)