### PR TITLE
fix resolve docker image name as transport

### DIFF
--- a/tests/from.bats
+++ b/tests/from.bats
@@ -168,6 +168,9 @@ load helpers
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah rm $output
 
+  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker:latest
+  run_buildah rm $output
+
   run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine docker-archive:${TESTDIR}/docker-alp.tar:alpine
   run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine    oci-archive:${TESTDIR}/oci-alp.tar:alpine
   run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine            dir:${TESTDIR}/alp-dir

--- a/util/util.go
+++ b/util/util.go
@@ -74,7 +74,7 @@ func ResolveName(name string, firstRegistry string, sc *types.SystemContext, sto
 		return []string{strings.TrimPrefix(name, DefaultTransport)}, DefaultTransport, false, nil
 	}
 	split := strings.SplitN(name, ":", 2)
-	if len(split) == 2 {
+	if StartsWithValidTransport(name) && len(split) == 2 {
 		if trans := transports.Get(split[0]); trans != nil {
 			return []string{split[1]}, trans.Name(), false, nil
 		}
@@ -146,6 +146,12 @@ func ResolveName(name string, firstRegistry string, sc *types.SystemContext, sto
 		candidates = append(candidates, candidate)
 	}
 	return candidates, DefaultTransport, searchRegistriesAreEmpty, nil
+}
+
+// StartsWithValidTransport validates the name starts with Buildah supported transport
+// to avoid the corner case image name same as the transport name
+func StartsWithValidTransport(name string) bool {
+	return strings.HasPrefix(name, "dir:") || strings.HasPrefix(name, "docker://") || strings.HasPrefix(name, "docker-archive:") || strings.HasPrefix(name, "docker-daemon:") || strings.HasPrefix(name, "oci:") || strings.HasPrefix(name, "oci-archive:")
 }
 
 // ExpandNames takes unqualified names, parses them as image names, and returns


### PR DESCRIPTION
fix #2205 Validate the supported transports to fix the corner case. Do not use docker as transport if `docker:` is Docker Official Image

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

 /kind bug

#### What this PR does / why we need it:

#### How to verify it
`$ buildah from docker:stable`
#### Which issue(s) this PR fixes:
#2205 
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

