### PR TITLE
Fail the build on a missing build arguments

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -3,6 +3,7 @@ package imagebuildah
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -21,6 +22,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/openshift/imagebuilder"
+	"github.com/openshift/imagebuilder/dockerfile/parser"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -253,6 +255,9 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options BuildOpt
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "error parsing main Dockerfile")
 	}
+
+	warnOnUnsetBuildArgs(mainNode, options.Args)
+
 	for _, d := range dockerfiles[1:] {
 		additionalNode, err := imagebuilder.ParseDockerfile(d)
 		if err != nil {
@@ -282,6 +287,20 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options BuildOpt
 		stages = stagesTargeted
 	}
 	return exec.Build(ctx, stages)
+}
+
+func warnOnUnsetBuildArgs(node *parser.Node, args map[string]string) {
+	for _, child := range node.Children {
+		switch strings.ToUpper(child.Value) {
+		case "ARG":
+			argName := child.Next.Value
+			if _, ok := args[argName]; !strings.Contains(argName, "=") && !ok {
+				logrus.Warnf("missing %q build argument. Try adding %q to the command line", argName, fmt.Sprintf("--build-arg %s=<VALUE>", argName))
+			}
+		default:
+			continue
+		}
+	}
 }
 
 // preprocessDockerfileContents runs CPP(1) in preprocess-only mode on the input

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2098,3 +2098,9 @@ EOM
 
   rm -rf ${TESTDIR}/tmp
 }
+
+@test "bud with --build-arg" {
+  _prefetch alpine
+  run_buildah --log-level "warn" bud --signature-policy ${TESTSDIR}/policy.json -t test ${TESTSDIR}/bud/build-arg
+  expect_output --substring 'missing .+ build argument'
+}


### PR DESCRIPTION
#### What type of PR is this?
fixes #2349 

/kind bug

#### What this PR does / why we need it:

Allow to fail the build if ARG is specified in Dockerfile without a default value and it's not passed through "build-argument"

#### How to verify it

Build the following Dockerfile
```
FROM scratch
ARG arg1
```
and run `buildah bud --build-args-mandatory -t test -f /path/to/Dockerfile`