### PR TITLE
[nix] Add nix derivation for static builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -157,7 +157,7 @@ gce_instance:
 
     env:
         matrix:
-            CROSS_TARGET: darwin
+            CROSS_TARGET: bin/buildah.darwin
 
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
     build_script: '${SCRIPT_BASE}/build.sh |& ${_TIMESTAMP}'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/tools/build
 Dockerfile*
 !/tests/bud/*/Dockerfile*
 *.swp
+result

--- a/contrib/cirrus/build.sh
+++ b/contrib/cirrus/build.sh
@@ -20,10 +20,9 @@ else
     mkdir -p bin
     if [[ -z "$CROSS_TARGET" ]]
     then
-        ln -v buildah bin/buildah
         showrun make install PREFIX=/usr
         showrun ./bin/buildah info
     else
-        ln -v buildah.${CROSS_TARGET} bin/buildah
+        ln -v ${CROSS_TARGET} bin/buildah
     fi
 fi

--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -17,8 +17,8 @@ case $1 in
     df) showrun df -lhTx tmpfs ;;
     journal) showrun journalctl -b ;;
     podman) showrun podman system info ;;
-    buildah_version) showrun $GOSRC/buildah version;;
-    buildah_info) showrun $GOSRC/buildah info;;
+    buildah_version) showrun $GOSRC/bin/buildah version;;
+    buildah_info) showrun $GOSRC/bin/buildah info;;
     packages)
         # These names are common to Fedora and Ubuntu
         PKG_NAMES=(\

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,53 @@
+{ system ? builtins.currentSystem }:
+let
+  pkgs = (import ./nixpkgs.nix {
+    config = {
+      packageOverrides = pkg: {
+        gpgme = (static pkg.gpgme);
+        libassuan = (static pkg.libassuan);
+        libgpgerror = (static pkg.libgpgerror);
+        libseccomp = (static pkg.libseccomp);
+        glib = pkg.glib.overrideAttrs(x: {
+          outputs = [ "bin" "out" "dev" ];
+          mesonFlags = [
+            "-Ddefault_library=static"
+            "-Ddevbindir=${placeholder ''dev''}/bin"
+            "-Dgtk_doc=false"
+            "-Dnls=disabled"
+          ];
+        });
+      };
+    };
+  });
+
+  static = pkg: pkg.overrideAttrs(x: {
+    configureFlags = (x.configureFlags or []) ++
+      [ "--without-shared" "--disable-shared" ];
+    dontDisableStatic = true;
+    enableSharedExecutables = false;
+    enableStatic = true;
+  });
+
+  self = with pkgs; buildGoPackage rec {
+    name = "buildah";
+    src = ./..;
+    goPackagePath = "github.com/containers/buildah";
+    doCheck = false;
+    enableParallelBuilding = true;
+    nativeBuildInputs = [ git installShellFiles pkg-config ];
+    buildInputs = [ glib glibc glibc.static gpgme libapparmor libassuan libgpgerror libseccomp libselinux ];
+    prePatch = ''
+      export LDFLAGS='-s -w -static-libgcc -static'
+      export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
+      export BUILDTAGS='static netgo apparmor selinux seccomp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper'
+    '';
+    buildPhase = ''
+      pushd go/src/${goPackagePath}
+      patchShebangs .
+      make bin/buildah
+    '';
+    installPhase = ''
+      install -Dm755 bin/buildah $out/bin/buildah
+    '';
+  };
+in self

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/nixos/nixpkgs",
+  "rev": "78e324d2726127828a15f87a75b4d3199a8955ec",
+  "date": "2020-06-16T18:23:14-07:00",
+  "path": "/nix/store/bwhp0061k3fk00j8fskpfak261jdcjl6-nixpkgs",
+  "sha256": "1j58aa9ngdmvbnds4x4a497nynj390dzqyb5yrvmhjc7k9anq6jm",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,8 @@
+let
+  json = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  nixpkgs = import (builtins.fetchTarball {
+    name = "nixos-unstable";
+    url = "${json.url}/archive/${json.rev}.tar.gz";
+    inherit (json) sha256;
+  });
+in nixpkgs

--- a/tests/e2e/buildah_suite_test.go
+++ b/tests/e2e/buildah_suite_test.go
@@ -95,7 +95,7 @@ func CreateTempDirInTempDir() (string, error) {
 func BuildahCreate(tempDir string) BuildAhTest {
 	cwd, _ := os.Getwd()
 
-	buildAhBinary := filepath.Join(cwd, "../../buildah")
+	buildAhBinary := filepath.Join(cwd, "../../bin/buildah")
 	if os.Getenv("BUILDAH_BINARY") != "" {
 		buildAhBinary = os.Getenv("BUILDAH_BINARY")
 	}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-BUILDAH_BINARY=${BUILDAH_BINARY:-$(dirname ${BASH_SOURCE})/../buildah}
-IMGTYPE_BINARY=${IMGTYPE_BINARY:-$(dirname ${BASH_SOURCE})/../imgtype}
+BUILDAH_BINARY=${BUILDAH_BINARY:-$(dirname ${BASH_SOURCE})/../bin/buildah}
+IMGTYPE_BINARY=${IMGTYPE_BINARY:-$(dirname ${BASH_SOURCE})/../bin/imgtype}
 TESTSDIR=${TESTSDIR:-$(dirname ${BASH_SOURCE})}
 STORAGE_DRIVER=${STORAGE_DRIVER:-vfs}
 PATH=$(dirname ${BASH_SOURCE})/..:${PATH}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind feature

#### What this PR does / why we need it:

Similar PR goes for crun/conmon/libpod/cri-o/etc, too.


Also see:
  - ~~https://github.com/containers/crun/pull/372~~
  - ~~https://github.com/containers/conmon/pull/161~~
  - ~~https://github.com/containers/skopeo/pull/932~~
  - https://github.com/containers/buildah/pull/2380
  - https://github.com/containers/libpod/pull/6402
  - https://github.com/cri-o/cri-o/pull/3804


Static binaries:
  - [crun-0.13-linux-amd64](https://github.com/alvistack/crun/releases/download/0.13/crun-0.13-linux-amd64)
  - [conmon-v2.0.17-linux-amd64](https://github.com/alvistack/conmon/releases/download/v2.0.17/conmon-v2.0.17-linux-amd64)
  - [skopeo-v1.0.0-linux-amd64](https://github.com/alvistack/skopeo/releases/download/v1.0.0/skopeo-v1.0.0-linux-amd64)
  - [buildah-v1.15.0-linux-amd64](https://github.com/alvistack/buildah/releases/download/v1.15.0/buildah-v1.15.0-linux-amd64)
  - [podman-v1.9.3-linux-amd64](https://github.com/alvistack/libpod/releases/download/v1.9.3/podman-v1.9.3-linux-amd64)
  - [cri-o-v1.17.4-linux-amd64.tar.gz](https://github.com/alvistack/cri-o/releases/download/v1.17.4/cri-o-v1.17.4-linux-amd64.tar.gz)
  - [cri-o-v1.18.1-linux-amd64.tar.gz](https://github.com/alvistack/cri-o/releases/download/v1.18.1/cri-o-v1.18.1-linux-amd64.tar.gz)

Ansible Roles:
  - https://github.com/alvistack/ansible-role-crun
  - https://github.com/alvistack/ansible-role-conmon
  - https://github.com/alvistack/ansible-role-skopeo
  - https://github.com/alvistack/ansible-role-buildah 
  - https://github.com/alvistack/ansible-role-podman
  - https://github.com/alvistack/ansible-role-cri_o


#### How to verify it

```
nix build -f nix/
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:


Here I skip the btrfs and lvm2 support for static binary, because:
1. btrfs will not support in CentOS 8
2. With skopeo experience both btrfs and lvm2 are not easy for compile as static binary

Also see:
- https://github.com/containers/libpod/pull/6402#discussion_r431398382

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

