### PR TITLE
Add CVE-2020-10696 to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 
 ## v1.14.4 (2020-03-25)
     Fix fips-mode check for RHEL8 boxes
-    Fix potential CVE in tarfile w/ symlink
+    Fix potential CVE in tarfile w/ symlink (Edit 02-Jun-2020: Addresses CVE-2020-10696)
     Fix .dockerignore with globs and ! commands
     update install steps for Amazon Linux 2
     Bump github.com/openshift/imagebuilder from 1.1.2 to 1.1.3

--- a/changelog.txt
+++ b/changelog.txt
@@ -38,7 +38,7 @@
 
 - Changelog for v1.14.4 (2020-03-25)
   * Fix fips-mode check for RHEL8 boxes
-  * Fix potential CVE in tarfile w/ symlink
+  * Fix potential CVE in tarfile w/ symlink (Edit 02-Jun-2020: Addresses CVE-2020-10696)
   * Fix .dockerignore with globs and ! commands
   * update install steps for Amazon Linux 2
   * Bump github.com/openshift/imagebuilder from 1.1.2 to 1.1.3


### PR DESCRIPTION
Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


/kind documentation


#### What this PR does / why we need it:

As the security vulnerability have now gotten a CVE Entry
(CVE-2020-10696)
mention it in CHANGELOG.md

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None
<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

