### PR TITLE
add version centos7 for compatible

### DIFF
--- a/contrib/buildahimage/README.md
+++ b/contrib/buildahimage/README.md
@@ -44,3 +44,13 @@ buildah images
 
 exit
 ```
+
+## Compatible with old versions
+For compatibility reasons, some Linux distributions with a kernel version of 3.10.0 and less will not work when using the stable image that is based on fedora:32. This centos7 image can be used to work on those distributions.
+
+Changes between it and stable:
+- change base image from `fedora:latest` to `centos:7`
+- remove `--exclude container-selinux` when installing `buildah` and `fuse-overlayfs`, for details pls check [here](https://bugzilla.redhat.com/show_bug.cgi?id=1806044)
+- update the sed logic of storage.conf (the final result is the same, this change just changes the methodology)
+
+> for more details of the compatible discussion pls check the [issue: 2393](https://github.com/containers/buildah/issues/2393)

--- a/contrib/buildahimage/centos7/Dockerfile
+++ b/contrib/buildahimage/centos7/Dockerfile
@@ -1,0 +1,21 @@
+# centos7/Dockerfile
+#
+# Build a Buildah container image from the compatible
+# version of Buildah on the Centos 7 System.
+# This image can be used to create a secured container
+# that runs safely with privileges within the container.
+FROM centos:7
+
+# Remove directories used by yum that are just taking
+# up space.
+RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install buildah fuse-overlayfs; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
+
+ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahimage/stable/containers.conf /etc/containers/
+
+# Adjust storage.conf to enable Fuse storage.
+RUN chmod 644 /etc/containers/containers.conf; sed -i -e '/size = ""/amount_program = "/usr/bin/fuse-overlayfs"' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+
+# Set an environment variable to default to chroot isolation for RUN
+# instructions and "buildah run".
+ENV BUILDAH_ISOLATION=chroot


### PR DESCRIPTION
Signed-off-by: xiaotuanyu120 <zhaopeiwu@outlook.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake

/kind other

#### What this PR does / why we need it:
add a new image branch centos7 / for compatible with centos7 and other distribution which kernel version is 3.10.0 and less

#### How to verify it
``` bash
# os version: centos7
# user: root

# git clone repo to local
mkdir storage
buildah -t buildah-centos7 bud buildah/contrib/buildahimage/centos7
podman run --rm -it --device /dev/fuse:rw -v ./storage:/var/lib/containers:Z buildah-centos7 bash
echo -e "From fedora\nRUN echo test" > Dockerfile
buildah -t test bud .
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->


Fixes #2393 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->


```release-note
For centos7, change image url from `quay.io/buildah/stable` to `quay.io/buildah/centos7`
```

