### PR TITLE
CHANGELOG.md: Fix markdown formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -608,7 +608,6 @@
     Bump back to 1.8-dev
 
 ## v1.7.3 (2019-04-16)
-* Tue Apr 16, 2019 Tom Sweeney <tsweeney@redhat.com> 1.7.3
     imagebuildah: don't leak image structs
     Add Dockerfiles for buildahimages
     Bump to Replace golang 1.10 with 1.12


### PR DESCRIPTION
## What type of PR is this?

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design

/kind documentation

> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
It appears this line is there by mistake?  No similar lines in other release sections, nor in changelog.txt.

This line makes following indented lines parse as continuation of a list item, instead of literal block:
https://github.com/containers/buildah/blob/master/CHANGELOG.md#v173-2019-04-16

#### How to verify it
https://github.com/cben/buildah/blob/patch-1/CHANGELOG.md#v173-2019-04-16

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

@TomSweeneyRedHat you are the obvious person to review this diff :wink:

#### Does this PR introduce a user-facing change?

```release-note
None
```
