### PR TITLE
Add bud regression tests

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2104,3 +2104,15 @@ EOM
   run_buildah --log-level "warn" bud --signature-policy ${TESTSDIR}/policy.json -t test ${TESTSDIR}/bud/build-arg
   expect_output --substring 'missing .+ build argument'
 }
+
+@test "bud arg and env var with same name" {
+  # Regresion test for https://github.com/containers/buildah/issues/2345
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t testctr ${TESTSDIR}/bud/dupe-arg-env-name
+  expect_output --substring "https://example.org/bar"
+}
+
+@test "bud copy chown with newuser" {
+  # Regression test for https://github.com/containers/buildah/issues/2192
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t testctr -f ${TESTSDIR}/bud/copy-chown/Containerfile.chown_user ${TESTSDIR}/bud/copy-chown
+  expect_output --substring "myuser myuser"
+}

--- a/tests/bud/copy-chown/Containerfile.chown_user
+++ b/tests/bud/copy-chown/Containerfile.chown_user
@@ -1,0 +1,8 @@
+FROM ubuntu:latest
+
+ENV MYUSER=myuser
+
+RUN useradd --create-home --home /"${MYUSER}" "${MYUSER}"
+COPY --chown="${MYUSER}" ./copychown.txt /somewhere
+
+RUN ls -alF /somewhere

--- a/tests/bud/dupe-arg-env-name/Containerfile
+++ b/tests/bud/dupe-arg-env-name/Containerfile
@@ -1,0 +1,7 @@
+FROM centos:8
+ARG FOO=bar
+ARG WEBROOT=https://example.org/
+
+ENV WEBROOT="$WEBROOT$FOO"
+
+RUN echo "${WEBROOT}"


### PR DESCRIPTION
We recently made a couple of commits to the imagebuilder
project to address #2345 and #2192.  Tests were created
in that project, but I thought it best to add some
regression tests here in Buildah too.

FYI: @petr-motejlek and @tachoknight

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

