### PR TITLE
Cirrus: Fix missing htpasswd command in registry image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 docs/buildah*.1
+/bin
 /buildah
 /imgtype
 /build/

--- a/contrib/cirrus/build.sh
+++ b/contrib/cirrus/build.sh
@@ -22,7 +22,8 @@ else
     then
         showrun make install PREFIX=/usr
         showrun ./bin/buildah info
-    else
-        ln -v ${CROSS_TARGET} bin/buildah
+    else  # some tooling expects the binary to be here
+        rm -vf buildah  # failure ok
+        ln -sv bin/buildah ./
     fi
 fi

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -316,12 +316,10 @@ execute_local_registry() {
     cp $authdirpath/domain.crt $certdirpath/localhost:5000/domain.crt
 
     echo "Creating http credentials file"
-    podman run --entrypoint htpasswd $REGISTRY_FQIN \
-        -Bbn testuser testpassword \
-        > $authdirpath/htpasswd
+    showrun htpasswd -Bbn testuser testpassword > $authdirpath/htpasswd
 
     echo "Starting up the local 'registry' container"
-    podman run -d -p 5000:5000 --name registry \
+    showrun podman run -d -p 5000:5000 --name registry \
         -v $authdirpath:$authdirpath:Z \
         -e "REGISTRY_AUTH=htpasswd" \
         -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -27,6 +27,9 @@ case "$OS_RELEASE_ID" in
         if [[ -z "$CONTAINER" ]]; then
             warn "Adding secondary testing partition & growing root filesystem"
             bash $SCRIPT_BASE/add_second_partition.sh
+
+            warn "TODO: Add (for htpasswd) to VM images (in libpod repo)"
+            dnf install -y httpd-tools
         fi
 
         warn "Hard-coding podman to use crun"
@@ -35,11 +38,13 @@ case "$OS_RELEASE_ID" in
         # Executing tests in a container requires SELinux boolean set on the host
         if [[ "$IN_PODMAN" == "true" ]]
         then
-            setsebool -P container_manage_cgroup true
+            showrun setsebool -P container_manage_cgroup true
         fi
         ;;
     ubuntu)
-        : # no-op
+        warn "TODO: Add to VM images (in libpod repo)"
+        $SHORT_APTGET update
+        $SHORT_APTGET install apache2-utils
         ;;
     *)
         bad_os_id_ver


### PR DESCRIPTION
Recently the registry image was updated significantly with breaking
changes.  Most were caught, this one was not.  Instead of relying on the
(clearly) unreliable container image, simply install the package
providing the htpasswd command locally.

Signed-off-by: Chris Evich <cevich@redhat.com>