### PR TITLE
Make imagebuildah.BuildOptions.Jobs optional

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -353,7 +353,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		Target:                  iopts.Target,
 		TransientMounts:         iopts.Volumes,
 		OciDecryptConfig:        decConfig,
-		Jobs:                    iopts.Jobs,
+		Jobs:                    &iopts.Jobs,
 	}
 
 	if iopts.Quiet {

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -177,9 +177,8 @@ type BuildOptions struct {
 	// OciDecryptConfig contains the config that can be used to decrypt an image if it is
 	// encrypted if non-nil. If nil, it does not attempt to decrypt an image.
 	OciDecryptConfig *encconfig.DecryptConfig
-
 	// Jobs is the number of stages to run in parallel.  If not specified it defaults to 1.
-	Jobs int
+	Jobs *int
 }
 
 // BuildDockerfiles parses a set of one or more Dockerfiles (which may be


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind api-change

#### What this PR does / why we need it:
When building an image, an unset value for the `Jobs` field in the imagebuildah.BuildOptions structure was treated as an indication that every stage should be built in parallel, despite the API documentation stating that an unset value would be interpreted as 1.

#### How to verify it
Build an image by calling the imagebuildah API, like OpenShift does.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```
None

```

