### PR TITLE
Add VFS additional image store to container

### DIFF
--- a/contrib/buildahimage/centos7/Dockerfile
+++ b/contrib/buildahimage/centos7/Dockerfile
@@ -14,7 +14,7 @@ ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahi
 
 # Adjust storage.conf to enable Fuse storage.
 RUN chmod 644 /etc/containers/containers.conf; sed -i -e '/size = ""/amount_program = "/usr/bin/fuse-overlayfs"' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
-RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock; touch /var/lib/shared/vfs-images/images.lock; touch /var/lib/shared/vfs-layers/layers.lock
 
 # Set an environment variable to default to chroot isolation for RUN
 # instructions and "buildah run".

--- a/contrib/buildahimage/stable/Dockerfile
+++ b/contrib/buildahimage/stable/Dockerfile
@@ -17,7 +17,7 @@ ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahi
 
 # Adjust storage.conf to enable Fuse storage.
 RUN chmod 644 /etc/containers/containers.conf; sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
-RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock; touch /var/lib/shared/vfs-images/images.lock; touch /var/lib/shared/vfs-layers/layers.lock
 
 # Set an environment variable to default to chroot isolation for RUN
 # instructions and "buildah run".

--- a/contrib/buildahimage/stablebyhand/Containerfile.buildahstable
+++ b/contrib/buildahimage/stablebyhand/Containerfile.buildahstable
@@ -29,7 +29,7 @@ ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahi
 
 # Adjust storage.conf to enable Fuse storage.
 RUN chmod 644 /etc/containers/containers.conf; sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
-RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock; touch /var/lib/shared/vfs-images/images.lock; touch /var/lib/shared/vfs-layers/layers.lock
 
 # Set an environment variable to default to chroot isolation for RUN
 # instructions and "buildah run".

--- a/contrib/buildahimage/testing/Dockerfile
+++ b/contrib/buildahimage/testing/Dockerfile
@@ -19,7 +19,7 @@ ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahi
 
 # Adjust storage.conf to enable Fuse storage.
 RUN chmod 644 /etc/containers/containers.conf; sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
-RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock; touch /var/lib/shared/vfs-images/images.lock; touch /var/lib/shared/vfs-layers/layers.lock
 
 # Set an environment variable to default to chroot isolation for RUN
 # instructions and "buildah run".

--- a/contrib/buildahimage/upstream/Dockerfile
+++ b/contrib/buildahimage/upstream/Dockerfile
@@ -47,7 +47,7 @@ ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahi
 
 # Adjust storage.conf to enable Fuse storage.
 RUN chmod 644 /etc/containers/containers.conf; sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
-RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock; touch /var/lib/shared/vfs-images/images.lock; touch /var/lib/shared/vfs-layers/layers.lock
 
 # Set an environment variable to default to chroot isolation for RUN
 # instructions and "buildah run".


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

For the overlay driver, the buildah container was given an additional
image store. Unfortunatley, overlay doesn't work out-of-the-box in a
Kubernetes cluster do to the lack of appropriate access to /dev/fuse.
In Minikube, it's non-trivial to provide that access, but it is trivial
to use the VFS storage driver.

Previously, the VFS storage driver would fail due to not having the
appropriate directory structure and required files in the additional
image store. This commit adds those files to the pre-built container
images to allow for easy use in Kubernetes.

#### How to verify it

1. Create a fresh Minikube cluster
1. Create a Kubernetes Job in `job.yaml` that uses Buildah to build an image

    ```job.yaml
    ---
    apiVersion: batch/v1
    kind: Job
    metadata:
      name: build
    spec:
      template:
        spec:
          containers:
            - name: buildah
              image: quay.io/buildah/upstream:latest
              command:
                - /bin/bash
                - -uex
                - -c
                - container=$(buildah from scratch)
              env:
                - name: STORAGE_DRIVER
                  value: vfs
          restartPolicy: Never
      backoffLimit: 0
    ```

1. Run the job with `kubectl apply -f job.yaml`

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I'm not sure if there's a better way to solve this.
Approaches I have considered:
1. Use a separate `RUN` line to create the VFS image store. This has an advantage of clarity, but a disadvantage of adding another layer.
1. Add the additional image store solely to the overlay configuration. I haven't checked to see if that's possible.
1. Figure out and document how to easily use the overlay driver in Minikube. Ideally this should work with the Docker container runtime (as it's the default) as well as cri-o and containerd.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the buildah container images when used with the VFS storage driver.
```

