### PR TITLE
imagebuildah: fix inheriting multi-stage builds

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -46,7 +46,7 @@ import (
 type StageExecutor struct {
 	executor        *Executor
 	index           int
-	stages          int
+	stages          imagebuilder.Stages
 	name            string
 	builder         *buildah.Builder
 	preserved       int
@@ -753,16 +753,23 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 	stage := s.stage
 	ib := stage.Builder
 	checkForLayers := s.executor.layers && s.executor.useCache
-	moreStages := s.index < s.stages-1
+	moreStages := s.index < len(s.stages)-1
 	lastStage := !moreStages
 	imageIsUsedLater := moreStages && (s.executor.baseMap[stage.Name] || s.executor.baseMap[fmt.Sprintf("%d", stage.Position)])
 	rootfsIsUsedLater := moreStages && (s.executor.rootfsMap[stage.Name] || s.executor.rootfsMap[fmt.Sprintf("%d", stage.Position)])
 
 	// If the base image's name corresponds to the result of an earlier
-	// stage, substitute that image's ID for the base image's name here.
-	// If not, then go on assuming that it's just a regular image that's
-	// either in local storage, or one that we have to pull from a
-	// registry.
+	// stage, make sure that stage has finished building an image, and
+	// substitute that image's ID for the base image's name here.  If not,
+	// then go on assuming that it's just a regular image that's either in
+	// local storage, or one that we have to pull from a registry.
+	for _, previousStage := range s.stages[:s.index] {
+		if previousStage.Name == base {
+			if err := s.executor.waitForStage(ctx, previousStage.Name); err != nil {
+				return "", nil, err
+			}
+		}
+	}
 	if stageImage, isPreviousStage := s.executor.imageMap[base]; isPreviousStage {
 		base = stageImage
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
When building stages in parallel, stages which are based on images built by earlier stages don't wait for those earlier stages to complete before attempting to start, causing them to attempt to pull an image with the same name as the previous stage's nickname, leading to unpredictable results.

#### How to verify it
Build using a Dockerfile that looks something like `tests/conformance/testdata/Dockerfile.reusebase` with a `--jobs` value other than 1.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```