### PR TITLE
Ignore OS X specific consistency mount option

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -368,6 +368,10 @@ func GetBindMount(args []string) (specs.Mount, error) {
 			}
 			newMount.Destination = kv[1]
 			setDest = true
+		case "consistency":
+			// Option for OS X only, has no meaning on other platforms
+			// and can thus be safely ignored.
+			// See also the handling of the equivalent "delegated" and "cached" in ValidateVolumeOpts
 		default:
 			return newMount, errors.Wrapf(errBadMntOption, kv[0])
 		}


### PR DESCRIPTION
Per [Configure mount consistency for macOS](https://docs.docker.com/storage/bind-mounts/#configure-mount-consistency-for-macos) this is just another way to specify the already ignored "cached" and "delegated" mount options.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
To be fully compatible with docker in this regard.

#### How to verify it

With a mount option like `type=bind,source=/var/source,target=/src,consistency=delegated`.

```release-note
None
```

