### PR TITLE
Allow "readonly" as alias to "ro" in mount options

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -343,6 +343,9 @@ func GetBindMount(args []string) (specs.Mount, error) {
 			// TODO: detect duplication of these options.
 			// (Is this necessary?)
 			newMount.Options = append(newMount.Options, kv[0])
+		case "readonly":
+			// Alias for "ro"
+			newMount.Options = append(newMount.Options, "ro")
 		case "shared", "rshared", "private", "rprivate", "slave", "rslave", "Z", "z":
 			newMount.Options = append(newMount.Options, kv[0])
 		case "bind-propagation":
@@ -404,6 +407,9 @@ func GetTmpfsMount(args []string) (specs.Mount, error) {
 		switch kv[0] {
 		case "ro", "nosuid", "nodev", "noexec":
 			newMount.Options = append(newMount.Options, kv[0])
+		case "readonly":
+			// Alias for "ro"
+			newMount.Options = append(newMount.Options, "ro")
 		case "tmpfs-mode":
 			if len(kv) == 1 {
 				return newMount, errors.Wrapf(optionArgError, kv[0])


### PR DESCRIPTION
Apparently docker supports this as well, see [Use a read-only volume](https://docs.docker.com/storage/volumes/#use-a-read-only-volume) in the docker docs.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
To be fully compatible with docker in this regard.

#### How to verify it

With a mount option like `type=bind,source=/var/source,target=/src,readonly`.

```release-note
None
```

