### PR TITLE
Makefile: use customizable env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 export GOPROXY=https://proxy.golang.org
 
-SELINUXTAG := $(shell ./selinux_tag.sh)
-APPARMORTAG := $(shell hack/apparmor_tag.sh)
-STORAGETAGS := $(shell ./btrfs_tag.sh) $(shell ./btrfs_installed_tag.sh) $(shell ./libdm_tag.sh)
+SELINUXTAG ?= $(shell ./selinux_tag.sh)
+APPARMORTAG ?= $(shell hack/apparmor_tag.sh)
+STORAGETAGS ?= $(shell ./btrfs_tag.sh) $(shell ./btrfs_installed_tag.sh) $(shell ./libdm_tag.sh)
 SECURITYTAGS ?= seccomp $(SELINUXTAG) $(APPARMORTAG)
 TAGS ?= $(SECURITYTAGS) $(STORAGETAGS)
 BUILDTAGS += $(TAGS)
-PREFIX := /usr/local
-BINDIR := $(PREFIX)/bin
-BASHINSTALLDIR = $(PREFIX)/share/bash-completion/completions
-BUILDFLAGS := -tags "$(BUILDTAGS)"
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+BASHINSTALLDIR ?= $(PREFIX)/share/bash-completion/completions
+BUILDFLAGS ?= -tags "$(BUILDTAGS)"
 BUILDAH := buildah
 
 GO := go


### PR DESCRIPTION
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

I thought this was done before but apparently not.

@rhatdan @nalind @TomSweeneyRedHat @vrothberg PTAL

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

will help me reuse Makefile targets in packaging

#### How to verify it

upstream doesn't really need to care

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

