### PR TITLE
Deduplicate environment variables

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -1967,7 +1967,7 @@ func (b *Builder) configureEnvironment(g *generate.Generator, options RunOptions
 		}
 	}
 
-	for _, envSpec := range append(append(defaultEnv, b.Env()...), options.Env...) {
+	for _, envSpec := range util.MergeEnv(util.MergeEnv(defaultEnv, b.Env()), options.Env) {
 		env := strings.SplitN(envSpec, "=", 2)
 		if len(env) > 1 {
 			g.AddProcessEnv(env[0], env[1])
@@ -2071,7 +2071,7 @@ func (b *Builder) runUsingRuntimeSubproc(isolation Isolation, options RunOptions
 	if cmd.Stderr == nil {
 		cmd.Stderr = os.Stderr
 	}
-	cmd.Env = append(os.Environ(), fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel()))
+	cmd.Env = util.MergeEnv(os.Environ(), []string{fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel())})
 	preader, pwriter, err := os.Pipe()
 	if err != nil {
 		return errors.Wrapf(err, "error creating configuration pipe")

--- a/util/util.go
+++ b/util/util.go
@@ -469,3 +469,19 @@ func FindLocalRuntime(runtime string) string {
 	}
 	return localRuntime
 }
+
+// MergeEnv merges two lists of environment variables, avoiding duplicates.
+func MergeEnv(defaults, overrides []string) []string {
+	s := make([]string, 0, len(defaults)+len(overrides))
+	index := make(map[string]int)
+	for _, envSpec := range append(defaults, overrides...) {
+		envVar := strings.SplitN(envSpec, "=", 2)
+		if i, ok := index[envVar[0]]; ok {
+			s[i] = envSpec
+			continue
+		}
+		s = append(s, envSpec)
+		index[envVar[0]] = len(s) - 1
+	}
+	return s
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMergeEnv(t *testing.T) {
+	tests := [][3][]string{
+		{
+			[]string{"A=B", "B=C", "C=D"},
+			nil,
+			[]string{"A=B", "B=C", "C=D"},
+		},
+		{
+			nil,
+			[]string{"A=B", "B=C", "C=D"},
+			[]string{"A=B", "B=C", "C=D"},
+		},
+		{
+			[]string{"A=B", "B=C", "C=D", "E=F"},
+			[]string{"B=O", "F=G"},
+			[]string{"A=B", "B=O", "C=D", "E=F", "F=G"},
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			result := MergeEnv(test[0], test[1])
+			if len(result) != len(test[2]) {
+				t.Fatalf("expected %v, got %v", test[2], result)
+			}
+			for i := range result {
+				if result[i] != test[2][i] {
+					t.Fatalf("expected %v, got %v", test[2], result)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

> /kind cleanup

#### What this PR does / why we need it:

When combining lists of environment variables read from base images with defaults supplied from our own configuration, ensure that the resulting environment we produce only contains one value for any given variable.  While adding variables to a runtime spec using `github.com/opencontainers/runtime-tools/generate.Generator.AddProcessEnv()` ensures that later values in the list override values that occur earlier, we shouldn't be depending on that.

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Related to https://github.com/openshift/imagebuilder/pull/169.

#### Does this PR introduce a user-facing change?

```
None
```