### PR TITLE
imagebuildah: return the right stage's image as the "final" image

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -531,19 +531,19 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 			go func() {
 				defer b.stagesSemaphore.Release(1)
 				defer wg.Done()
-				imageID, ref, err = b.buildStage(ctx, cleanupStages, stages, index)
-				if err != nil {
+				stageID, stageRef, stageErr := b.buildStage(ctx, cleanupStages, stages, index)
+				if stageErr != nil {
 					ch <- Result{
 						Index: index,
-						Error: err,
+						Error: stageErr,
 					}
 					return
 				}
 
 				ch <- Result{
 					Index:   index,
-					ImageID: imageID,
-					Ref:     ref,
+					ImageID: stageID,
+					Ref:     stageRef,
 					Error:   nil,
 				}
 			}()
@@ -579,6 +579,7 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 		}
 		if r.Index == len(stages)-1 {
 			imageID = r.ImageID
+			ref = r.Ref
 		}
 	}
 

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -44,6 +44,7 @@ import (
 // If we're naming the result of the build, only the last stage will apply that
 // name to the image that it produces.
 type StageExecutor struct {
+	ctx             context.Context
 	executor        *Executor
 	index           int
 	stages          imagebuilder.Stages
@@ -262,7 +263,7 @@ func (s *StageExecutor) volumeCacheRestore() error {
 // don't care about the details of where in the filesystem the content actually
 // goes, because we're not actually going to add it here, so this is less
 // involved than Copy().
-func (s *StageExecutor) digestSpecifiedContent(node *parser.Node, argValues []string, envValues []string) (string, error) {
+func (s *StageExecutor) digestSpecifiedContent(ctx context.Context, node *parser.Node, argValues []string, envValues []string) (string, error) {
 	// No instruction: done.
 	if node == nil {
 		return "", nil
@@ -295,6 +296,9 @@ func (s *StageExecutor) digestSpecifiedContent(node *parser.Node, argValues []st
 			// container.  Update the ID mappings and
 			// all-content-comes-from-below-this-directory value.
 			from := strings.TrimPrefix(flag, "--from=")
+			if isStage, err := s.executor.waitForStage(ctx, from, s.stages[:s.index]); isStage && err != nil {
+				return "", err
+			}
 			if other, ok := s.executor.stages[from]; ok && other.index < s.index {
 				contextDir = other.mountPoint
 				idMappingOptions = &other.builder.IDMappingOptions
@@ -422,6 +426,9 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 		var copyExcludes []string
 		contextDir := s.executor.contextDir
 		if len(copy.From) > 0 {
+			if isStage, err := s.executor.waitForStage(s.ctx, copy.From, s.stages[:s.index]); isStage && err != nil {
+				return err
+			}
 			if other, ok := s.executor.stages[copy.From]; ok && other.index < s.index {
 				contextDir = other.mountPoint
 				idMappingOptions = &other.builder.IDMappingOptions
@@ -763,12 +770,8 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 	// substitute that image's ID for the base image's name here.  If not,
 	// then go on assuming that it's just a regular image that's either in
 	// local storage, or one that we have to pull from a registry.
-	for _, previousStage := range s.stages[:s.index] {
-		if previousStage.Name == base {
-			if err := s.executor.waitForStage(ctx, previousStage.Name); err != nil {
-				return "", nil, err
-			}
-		}
+	if isStage, err := s.executor.waitForStage(ctx, base, s.stages[:s.index]); isStage && err != nil {
+		return "", nil, err
 	}
 	if stageImage, isPreviousStage := s.executor.imageMap[base]; isPreviousStage {
 		base = stageImage
@@ -876,10 +879,13 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				if len(arr) != 2 {
 					return "", nil, errors.Errorf("%s: invalid --from flag, should be --from=<name|stage>", command)
 				}
+				// If the source's name corresponds to the
+				// result of an earlier stage, wait for that
+				// stage to finish being built.
+				if isStage, err := s.executor.waitForStage(ctx, arr[1], s.stages[:s.index]); isStage && err != nil {
+					return "", nil, err
+				}
 				if otherStage, ok := s.executor.stages[arr[1]]; ok && otherStage.index < s.index {
-					if err := s.executor.waitForStage(ctx, otherStage.name); err != nil {
-						return "", nil, err
-					}
 					mountPoint = otherStage.mountPoint
 				} else if mountPoint, err = s.getImageRootfs(ctx, arr[1]); err != nil {
 					return "", nil, errors.Errorf("%s --from=%s: no stage or image found with that name", command, arr[1])
@@ -907,7 +913,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				return "", nil, errors.Wrapf(err, "error building at STEP \"%s\"", step.Message)
 			}
 			// In case we added content, retrieve its digest.
-			addedContentDigest, err := s.digestSpecifiedContent(node, ib.Arguments(), ib.Config().Env)
+			addedContentDigest, err := s.digestSpecifiedContent(ctx, node, ib.Arguments(), ib.Config().Env)
 			if err != nil {
 				return "", nil, err
 			}
@@ -956,7 +962,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		// cached images so far, look for one that matches what we
 		// expect to produce for this instruction.
 		if checkForLayers && !(s.executor.squash && lastInstruction && lastStage) {
-			addedContentDigest, err := s.digestSpecifiedContent(node, ib.Arguments(), ib.Config().Env)
+			addedContentDigest, err := s.digestSpecifiedContent(ctx, node, ib.Arguments(), ib.Config().Env)
 			if err != nil {
 				return "", nil, err
 			}
@@ -1014,7 +1020,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				return "", nil, errors.Wrapf(err, "error building at STEP \"%s\"", step.Message)
 			}
 			// In case we added content, retrieve its digest.
-			addedContentDigest, err := s.digestSpecifiedContent(node, ib.Arguments(), ib.Config().Env)
+			addedContentDigest, err := s.digestSpecifiedContent(ctx, node, ib.Arguments(), ib.Config().Env)
 			if err != nil {
 				return "", nil, err
 			}


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

When building multiple stages, we weren't ensuring that the image reference we returned to our caller was a reference of the final stage we built.  If a different stage actually finished before the "final" one, its ID and reference would overwrite the values that would otherwise have been returned.

When checking if a name specified for a FROM instruction, or a source for a COPY instruction, was a stage for which it needed to wait, StageExecutor was checking the Executor's stages list, to which stages are added only as they're started.  This could cause it to mistakenly write off a name if the corresponding stage hadn't yet been started, and assume that the named stage was actually an image.

#### How to verify it

This would manifest as a flake in multi-stage builds, particularly with `--jobs` values other than 1.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```

