### PR TITLE
Fix a help string

### DIFF
--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -23,7 +23,7 @@ var (
 		Long:  unshareDescription,
 		RunE:  unshareCmd,
 		Example: `buildah unshare id
-  buildah unshare cat /proc/self/uid_map,
+  buildah unshare cat /proc/self/uid_map
   buildah unshare buildah-script.sh`,
 	}
 	unshareMounts []string


### PR DESCRIPTION
#### What type of PR is this?

> /kind documentation

#### What this PR does / why we need it:

Remove an errant "," from the output of `buildah unshare --help`.

#### How to verify it

Visual inspection should be fine.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```

