### PR TITLE
BATS tests: make more robust

### DIFF
--- a/tests/from.bats
+++ b/tests/from.bats
@@ -328,8 +328,12 @@ load helpers
 
   # Try encrypted image without key should fail
   run_buildah 125 from oci:${TESTDIR}/tmp/busybox_enc
+  expect_output --substring "Error decrypting layer .* missing private key needed for decryption"
+
   # Try encrypted image with wrong key should fail
   run_buildah 125 from --decryption-key ${TESTDIR}/tmp/mykey2.pem oci:${TESTDIR}/tmp/busybox_enc
+  expect_output --substring "Error decrypting layer .* no suitable key unwrapper found or none of the private keys could be used for decryption"
+
   # Providing the right key should succeed
   run_buildah from  --decryption-key ${TESTDIR}/tmp/mykey.pem oci:${TESTDIR}/tmp/busybox_enc
 
@@ -346,8 +350,12 @@ load helpers
 
   # Try encrypted image without key should fail
   run_buildah 125 from --tls-verify=false --creds testuser:testpassword docker://localhost:5000/buildah/busybox_encrypted:latest
+  expect_output --substring "Error decrypting layer .* missing private key needed for decryption"
+
   # Try encrypted image with wrong key should fail
   run_buildah 125 from --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey2.pem docker://localhost:5000/buildah/busybox_encrypted:latest
+  expect_output --substring "Error decrypting layer .* no suitable key unwrapper found or none of the private keys could be used for decryption"
+
   # Providing the right key should succeed
   run_buildah from --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey.pem docker://localhost:5000/buildah/busybox_encrypted:latest
   run_buildah rmi localhost:5000/buildah/busybox_encrypted:latest

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -17,36 +17,36 @@ load helpers
   run_buildah 125 --registries-conf ${TESTSDIR}/registries.conf.block pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
   expect_output --substring "is blocked by configuration"
 
-  run_buildah --registries-conf ${TESTSDIR}/registries.conf       pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
+  run_buildah --retry --registries-conf ${TESTSDIR}/registries.conf       pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
 }
 
 @test "pull-from-registry" {
-  run_buildah pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json busybox:glibc
+  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json busybox:glibc
   run_buildah pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json busybox
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "busybox:glibc"
   expect_output --substring "busybox:latest"
 
-  run_buildah pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/alpine_nginx:latest
+  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/alpine_nginx:latest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine_nginx:latest"
 
   run_buildah rmi quay.io/libpod/alpine_nginx:latest
-  run_buildah pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/alpine_nginx
+  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/alpine_nginx
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine_nginx:latest"
 
-  run_buildah pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json alpine@sha256:1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe
+  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json alpine@sha256:1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe
   run_buildah 125 pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json fakeimage/fortest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   [[ ! "$output" =~ "fakeimage/fortest" ]]
 }
 
 @test "pull-from-docker-archive" {
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah --retry pull --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah push --signature-policy ${TESTSDIR}/policy.json docker.io/library/alpine:latest docker-archive:${TESTDIR}/alp.tar:alpine:latest
   run_buildah rmi alpine
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json docker-archive:${TESTDIR}/alp.tar
+  run_buildah --retry pull --signature-policy ${TESTSDIR}/policy.json docker-archive:${TESTDIR}/alp.tar
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine"
   run_buildah 125 pull --all-tags --signature-policy ${TESTSDIR}/policy.json docker-archive:${TESTDIR}/alp.tar
@@ -54,7 +54,7 @@ load helpers
 }
 
 @test "pull-from-oci-archive" {
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah --retry pull --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah push --signature-policy ${TESTSDIR}/policy.json docker.io/library/alpine:latest oci-archive:${TESTDIR}/alp.tar:alpine
   run_buildah rmi alpine
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json oci-archive:${TESTDIR}/alp.tar
@@ -66,7 +66,7 @@ load helpers
 
 @test "pull-from-local-directory" {
   mkdir ${TESTDIR}/buildahtest
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah --retry pull --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah push --signature-policy ${TESTSDIR}/policy.json docker.io/library/alpine:latest dir:${TESTDIR}/buildahtest
   run_buildah rmi alpine
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json dir:${TESTDIR}/buildahtest
@@ -102,7 +102,7 @@ load helpers
 
   # setup: pull alpine, and push it repeatedly to localhost using those tags
   opts="--signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword"
-  run_buildah pull --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah --retry pull --quiet --signature-policy ${TESTSDIR}/policy.json alpine
   for tag in "${tags[@]}"; do
       run_buildah push $opts alpine localhost:5000/myalpine:$tag
   done
@@ -136,7 +136,7 @@ load helpers
 }
 
 @test "pull-from-oci-directory" {
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah --retry pull --signature-policy ${TESTSDIR}/policy.json alpine
   run_buildah push --signature-policy ${TESTSDIR}/policy.json docker.io/library/alpine:latest oci:${TESTDIR}/alpine
   run_buildah rmi alpine
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json oci:${TESTDIR}/alpine
@@ -178,8 +178,12 @@ load helpers
 
   # Try to pull encrypted image without key should fail
   run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json oci:${TESTDIR}/tmp/busybox_enc
+  expect_output --substring "Error decrypting layer .* missing private key needed for decryption"
+
   # Try to pull encrypted image with wrong key should fail
   run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --decryption-key ${TESTDIR}/tmp/mykey2.pem oci:${TESTDIR}/tmp/busybox_enc
+  expect_output --substring "Error decrypting layer .* no suitable key unwrapper found or none of the private keys could be used for decryption"
+
   # Providing the right key should succeed
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json --decryption-key ${TESTDIR}/tmp/mykey.pem oci:${TESTDIR}/tmp/busybox_enc
 
@@ -196,10 +200,15 @@ load helpers
 
   # Try to pull encrypted image without key should fail
   run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword docker://localhost:5000/buildah/busybox_encrypted:latest
-  # Try to pull encrypted image with wrong key should fail
+  expect_output --substring "Error decrypting layer .* missing private key needed for decryption"
+
+  # Try to pull encrypted image with wrong key should fail, with diff. msg
   run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey2.pem docker://localhost:5000/buildah/busybox_encrypted:latest
+  expect_output --substring "Error decrypting layer .* no suitable key unwrapper found or none of the private keys could be used for decryption"
+
   # Providing the right key should succeed
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey.pem docker://localhost:5000/buildah/busybox_encrypted:latest
+
   run_buildah rmi localhost:5000/buildah/busybox_encrypted:latest
 
   rm -rf ${TESTDIR}/tmp
@@ -209,6 +218,7 @@ load helpers
  _prefetch busybox
   mkdir ${TESTDIR}/tmp
   openssl genrsa -out ${TESTDIR}/tmp/mykey.pem 1024
+  openssl genrsa -out ${TESTDIR}/tmp/mykey2.pem 1024
   openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
   cid=$output
@@ -216,10 +226,15 @@ load helpers
 
   # Try to pull encrypted image without key should fail
   run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword docker://localhost:5000/buildah/busybox_encrypted:latest
+  expect_output --substring "Error decrypting layer .* missing private key needed for decryption"
+
   # Try to pull encrypted image with wrong key should fail
   run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey2.pem docker://localhost:5000/buildah/busybox_encrypted:latest
+  expect_output --substring "Error decrypting layer .* no suitable key unwrapper found or none of the private keys could be used for decryption"
+
   # Providing the right key should succeed
   run_buildah pull --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey.pem docker://localhost:5000/buildah/busybox_encrypted:latest
+
   run_buildah rmi localhost:5000/buildah/busybox_encrypted:latest
 
   rm -rf ${TESTDIR}/tmp

--- a/tests/registries.bats
+++ b/tests/registries.bats
@@ -8,11 +8,11 @@ load helpers
     image2=$2
 
     # Create a container by specifying the image with one name.
-    run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image1
+    run_buildah --retry from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image1
     cid1=$output
 
     # Create a container by specifying the image with another name.
-    run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image2
+    run_buildah --retry from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image2
     cid2=$output
 
     # Get their image IDs.  They should be the same one.


### PR DESCRIPTION
Add a --retry flag to run_buildah; intended for tests which
really need to pull an image, and can't rely on prefetch().
It will try a failed buildah command three times, waiting
thirty seconds between retries.

This is imperfect: there's no way to specify the number of
retries, no way to specify the timeout, and no way to
combine --retry with an expected (i.e. nonzero) exit
status. (FWIW I can't think of any possible use for that).
It is, though, quick, minimal-impact, easy to remember
and use.

Add --retry option to various tests in pull.bats and
registries.bats.

And, while I'm at it, add expect_output checks to many
of the new encryption checks in pull.bats and from.bats.
This actually caught a bug in a test, a check that was
failing (expected) but for the wrong reason (missing
file, not wrong key). Have I mentioned, lately, that
tests should check error message strings, not just
exit status?

Fixes: #2473

Signed-off-by: Ed Santiago <santiago@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

