### PR TITLE
[release-v1.14] Make imagebuildah.BuildOptions.Architecture/OS optional

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1229,8 +1229,12 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	}
 	s.builder.SetHostname(config.Hostname)
 	s.builder.SetDomainname(config.Domainname)
-	s.builder.SetArchitecture(s.executor.architecture)
-	s.builder.SetOS(s.executor.os)
+	if s.executor.architecture != "" {
+		s.builder.SetArchitecture(s.executor.architecture)
+	}
+	if s.executor.os != "" {
+		s.builder.SetOS(s.executor.os)
+	}
 	s.builder.SetUser(config.User)
 	s.builder.ClearPorts()
 	for p := range config.ExposedPorts {


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

When committing an image, the Architecture and OS fields in the imagebuildah.BuildOptions structure were applied unconditionally, even when they were empty, which would overwrite the usually-non-empty values supplied by the base image.

#### How to verify it

Build an image by calling the imagebuildah API, like OpenShift does.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Cherry-picked from #2435.

#### Does this PR introduce a user-facing change?

```
None
```