### PR TITLE
Fix a race we hit during conformance tests

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -578,7 +578,9 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 		// If this is an intermediate stage, make a note of the ID, so
 		// that we can look it up later.
 		if r.Index < len(stages)-1 && r.ImageID != "" {
+			b.stagesLock.Lock()
 			b.imageMap[stage.Name] = r.ImageID
+			b.stagesLock.Unlock()
 			// We're not populating the cache with intermediate
 			// images, so add this one to the list of images that
 			// we'll remove later.


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

The imagebuilder.Executor.imageMap map is written in one goroutine which waits on StageExecutors, and is read from the goroutines that run the  StageExecutors, so we need to synchronize access to the map.

#### How to verify it

Found by running conformance tests with race detection enabled.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```

