### PR TITLE
copier: split StripSetidBits into StripSetuidBit/StripSetgidBit/StripStickyBit

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -175,7 +175,9 @@ type GetOptions struct {
 	UIDMap, GIDMap     []idtools.IDMap // map from hostIDs to containerIDs in the output archive
 	Excludes           []string        // contents to pretend don't exist
 	ExpandArchives     bool            // extract the contents of named items that are archives
-	StripSetidBits     bool            // strip the setuid/setgid/sticky bits off of items being copied. no effect on archives being extracted
+	StripSetuidBit     bool            // strip the setuid bit off of items being copied. no effect on archives being extracted
+	StripSetgidBit     bool            // strip the setgid bit off of items being copied. no effect on archives being extracted
+	StripStickyBit     bool            // strip the sticky bit off of items being copied. no effect on archives being extracted
 	StripXattrs        bool            // don't record extended attributes of items being copied. no effect on archives being extracted
 	KeepDirectoryNames bool            // export directories as directories containing items rather than as the items they contain
 }
@@ -997,8 +999,14 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 	if name != "" {
 		hdr.Name = name
 	}
-	if options.StripSetidBits {
-		hdr.Mode &^= (cISUID | cISGID | cISVTX)
+	if options.StripSetuidBit {
+		hdr.Mode &^= cISUID
+	}
+	if options.StripSetgidBit {
+		hdr.Mode &^= cISGID
+	}
+	if options.StripStickyBit {
+		hdr.Mode &^= cISVTX
 	}
 	// read extended attributes
 	var xattrs map[string]string


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

For the sake of conformance tests, callers need to be able to strip setuid and setgid bits from contents being copied from the build context while leaving the sticky bit intact.  Split the `StripSetidBits` option for `copier.Get()` into three separate flags (`StripSetuidBit`/`StripSetgidBit`/`StripStickyBit`).

#### How to verify it

The `copier` package's unit tests have been expanded to test that we strip the bits as requested.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```