### PR TITLE
docs/buildah-commit.md: tweak some wording, add a --rm example

### DIFF
--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -10,7 +10,7 @@ buildah\-commit - Create an image from a working container.
 Writes a new image using the specified container's read-write layer and if it
 is based on an image, the layers of that image.  If *image* does not begin
 with a registry name component, `localhost` will be added to the name.  If
-*image* is not provided, the image will have no name.
+*image* is not provided, the image will have no name.  When an image has no name, the `buildah images` command will display `<none>` in the REPOSITORY and TAG columns. 
 
 ## RETURN VALUE
 The image ID of the image that was created.  On error, 1 is returned and errno is returned.

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -10,8 +10,7 @@ buildah\-commit - Create an image from a working container.
 Writes a new image using the specified container's read-write layer and if it
 is based on an image, the layers of that image.  If *image* does not begin
 with a registry name component, `localhost` will be added to the name.  If
-*image* is not provided, the values for the `REPOSITORY` and `TAG` values of
-the created image will each be set to `<none>`.
+*image* is not provided, the image will have no name.
 
 ## RETURN VALUE
 The image ID of the image that was created.  On error, 1 is returned and errno is returned.
@@ -61,7 +60,7 @@ Write the image ID to the file.
 When writing the output image, suppress progress output.
 
 **--rm**
-Remove the container and its content after committing it to an image.
+Remove the working container and its contents after creating the image.
 Default leaves the container and its content in place.
 
 **--sign-by** *fingerprint*
@@ -92,6 +91,9 @@ This example saves an image based on the container.
 
 This example saves an image named newImageName based on the container.
  `buildah commit --rm containerID newImageName`
+
+This example saves an image with no name, removes the working container, and creates a new container using the image's ID.
+ `buildah from $(buildah commit --rm containerID)`
 
 This example saves an image based on the container disabling compression.
  `buildah commit --disable-compression containerID`

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -10,7 +10,9 @@ buildah\-commit - Create an image from a working container.
 Writes a new image using the specified container's read-write layer and if it
 is based on an image, the layers of that image.  If *image* does not begin
 with a registry name component, `localhost` will be added to the name.  If
-*image* is not provided, the image will have no name.  When an image has no name, the `buildah images` command will display `<none>` in the REPOSITORY and TAG columns. 
+*image* is not provided, the image will have no name.  When an image has no
+name, the `buildah images` command will display `<none>` in the REPOSITORY and
+TAG columns.
 
 ## RETURN VALUE
 The image ID of the image that was created.  On error, 1 is returned and errno is returned.
@@ -140,4 +142,4 @@ registries.conf is the configuration file which specifies which container regist
 Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
-buildah(1), containers-policy.json(5), containers-registries.conf(5)
+buildah(1), buildah-images(1), containers-policy.json(5), containers-registries.conf(5)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Tweak wording in `docs/buildah-commit.md` to avoid suggesting that we add the actual text "<none>:<none>" as a name for images when a name isn't specified to `buildah commit`.

Add an example that uses `--rm` to the list of examples in `docs/buildah-commit.md`.

#### How to verify it

Visual inspection.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```
None
```