### PR TITLE
blobcache: avoid an unnecessary NewImage()

### DIFF
--- a/pkg/blobcache/blobcache.go
+++ b/pkg/blobcache/blobcache.go
@@ -275,12 +275,11 @@ func (s *blobCacheSource) LayerInfosForCopy(ctx context.Context, instanceDigest 
 		return nil, errors.Wrapf(err, "error getting layer infos for copying image %q through cache", transports.ImageName(s.reference))
 	}
 	if infos == nil {
-		image, err := s.reference.NewImage(ctx, &s.sys)
+		img, err := image.FromUnparsedImage(ctx, &s.sys, image.UnparsedInstance(s.source, instanceDigest))
 		if err != nil {
 			return nil, errors.Wrapf(err, "error opening image to get layer infos for copying image %q through cache", transports.ImageName(s.reference))
 		}
-		defer image.Close()
-		infos = image.LayerInfos()
+		infos = img.LayerInfos()
 	}
 
 	if canReplaceBlobs && s.reference.compress != types.PreserveOriginal {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Avoid calling `NewImage()` on the source reference when the `ImageSource` that we already have returns `nil` from its `LayerInfosForCopy()` method.

For our container-as-image references, that causes a re-extraction of uncached blobs, recomputing their digests, rebuilding the config blobs and manifests.

The image library's `copy.Image()` function then asks the source reference that we're wrapping for blobs that we listed in the rebuilt manifest, and if any of those values differ, we fail to read them.

This would have only affected builds that specified a blob cache.

#### How to verify it

Build an image with `buildah bud` with debugging enabled, using the hidden `--blob-cache` option.  Observe that before this fix is applied, for each layer we commit, the layers list is computed twice, temporary directories are created twice, and the config blobs and manifests are generated twice.  With the fix applied, these things should only happen once.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```