### PR TITLE
fix spelling mistake in "info" command result display

### DIFF
--- a/docs/buildah-info.md
+++ b/docs/buildah-info.md
@@ -28,7 +28,7 @@ $ buildah info
             "version": "18.04"
         },
         "MemTotal": 16702980096,
-        "MenFree": 309428224,
+        "MemFree": 309428224,
         "SwapFree": 2146693120,
         "SwapTotal": 2147479552,
         "arch": "amd64",

--- a/info.go
+++ b/info.go
@@ -64,12 +64,12 @@ func hostInfo() map[string]interface{} {
 	if err != nil {
 		logrus.Error(err, "err reading memory info")
 		info["MemTotal"] = ""
-		info["MenFree"] = ""
+		info["MemFree"] = ""
 		info["SwapTotal"] = ""
 		info["SwapFree"] = ""
 	} else {
 		info["MemTotal"] = mi.MemTotal
-		info["MenFree"] = mi.MemFree
+		info["MemFree"] = mi.MemFree
 		info["SwapTotal"] = mi.SwapTotal
 		info["SwapFree"] = mi.SwapFree
 	}


### PR DESCRIPTION
MenFree -> MemFree

Signed-off-by: xiadanni <xiadanni1@huawei.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?
bug

#### What this PR does / why we need it:
fix spelling mistake in "info" comamnd.

#### How to verify it
`buildah info`
`{
    "host": {
        "CgroupVersion": "v1",
        "Distribution": {
            "distribution": "\"euleros\"",
            "version": "2.0"
        },
        "MemTotal": 10299949056,
        "MemFree": 1330028544,
...`

#### Which issue(s) this PR fixes:
Menfree -> Memfree



