### PR TITLE
Change namespace handling flags to better match podman commands

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -79,6 +79,7 @@ func init() {
 	flags.AddFlagSet(&budFlags)
 	flags.AddFlagSet(&layerFlags)
 	flags.AddFlagSet(&fromAndBudFlags)
+	flags.SetNormalizeFunc(buildahcli.AliasFlags)
 
 	rootCmd.AddCommand(budCommand)
 }

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -88,6 +88,7 @@ func init() {
 		os.Exit(1)
 	}
 	flags.AddFlagSet(&fromAndBudFlags)
+	flags.SetNormalizeFunc(buildahcli.AliasFlags)
 
 	rootCmd.AddCommand(fromCommand)
 }

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -78,6 +78,7 @@ func init() {
 
 	flags.AddFlagSet(&userFlags)
 	flags.AddFlagSet(&namespaceFlags)
+	flags.SetNormalizeFunc(buildahcli.AliasFlags)
 
 	rootCmd.AddCommand(runCommand)
 }

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -327,15 +327,16 @@ The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
 `k` (kilobytes), `m` (megabytes), or `g` (gigabytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
-**--net** *how*
-**--network** *how*
+**--network**, **--net**=*mode*
 
 Sets the configuration for network namespaces when handling `RUN` instructions.
-The configured value can be "" (the empty string) or "container" to indicate
-that a new network namespace should be created, or it can be "host" to indicate
-that the network namespace in which `buildah` itself is being run should be
-reused, or it can be the path to a network namespace which is already in use by
-another process.
+
+Valid _mode_ values are:
+
+- **none**: no networking;
+- **host**: use the Podman host network stack. Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure;
+- **ns:**_path_: path to a network namespace to join;
+- `private`: create a new namespace for the container (default)
 
 **--no-cache**
 
@@ -357,7 +358,7 @@ Set the OS of the image to the provided value instead of using the current opera
 **--pid** *how*
 
 Sets the configuration for PID namespaces when handling `RUN` instructions.
-The configured value can be "" (the empty string) or "container" to indicate
+The configured value can be "" (the empty string) or "private" to indicate
 that a new PID namespace should be created, or it can be "host" to indicate
 that the PID namespace in which `buildah` itself is being run should be reused,
 or it can be the path to a PID namespace which is already in use by another
@@ -492,7 +493,7 @@ include:
 **--userns** *how*
 
 Sets the configuration for user namespaces when handling `RUN` instructions.
-The configured value can be "" (the empty string) or "container" to indicate
+The configured value can be "" (the empty string) or "private" to indicate
 that a new user namespace should be created, it can be "host" to indicate that
 the user namespace in which `buildah` itself is being run should be reused, or
 it can be the path to an user namespace which is already in use by another

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -65,7 +65,7 @@ Set the hostname inside of the running container.
 **--ipc** *how*
 
 Sets the configuration for the IPC namespaces for the container.
-The configured value can be "" (the empty string) or "container" to indicate
+The configured value can be "" (the empty string) or "private" to indicate
 that a new IPC namespace should be created, or it can be "host" to indicate
 that the IPC namespace in which `buildah` itself is being run should be reused,
 or it can be the path to an IPC namespace which is already in use by another
@@ -116,20 +116,19 @@ Current supported mount TYPES are bind, and tmpfs. <sup>[[1]](#Footnote1)</sup>
 
               · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
 
-**--net** *how*
-**--network** *how*
+**--network**, **--net**=*mode*
 
 Sets the configuration for the network namespace for the container.
-The configured value can be "" (the empty string) or "container" to indicate
-that a new network namespace should be created, or it can be "host" to indicate
-that the network namespace in which `buildah` itself is being run should be
-reused, or it can be the path to a network namespace which is already in use by
-another process.
+
+- **none**: no networking;
+- **host**: use the Podman host network stack. Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure;
+- **ns:**_path_: path to a network namespace to join;
+- `private`: create a new namespace for the container (default)
 
 **--pid** *how*
 
 Sets the configuration for the PID namespace for the container.
-The configured value can be "" (the empty string) or "container" to indicate
+The configured value can be "" (the empty string) or "private" to indicate
 that a new PID namespace should be created, or it can be "host" to indicate
 that the PID namespace in which `buildah` itself is being run should be reused,
 or it can be the path to a PID namespace which is already in use by another
@@ -176,7 +175,7 @@ If names are used, the container should include entries for those names in its
 **--uts** *how*
 
 Sets the configuration for the UTS namespace for the container.
-The configured value can be "" (the empty string) or "container" to indicate
+The configured value can be "" (the empty string) or "private" to indicate
 that a new UTS namespace should be created, or it can be "host" to indicate
 that the UTS namespace in which `buildah` itself is being run should be reused,
 or it can be the path to a UTS namespace which is already in use by another

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -127,17 +127,12 @@ func GetUserNSFlags(flags *UserNSResults) pflag.FlagSet {
 // GetNameSpaceFlags returns the common flags for a namespace menu
 func GetNameSpaceFlags(flags *NameSpaceResults) pflag.FlagSet {
 	fs := pflag.FlagSet{}
-	fs.StringVar(&flags.IPC, string(specs.IPCNamespace), "", "'container', `path` of IPC namespace to join, or 'host'")
-	fs.StringVar(&flags.Network, string(specs.NetworkNamespace), "", "'container', `path` of network namespace to join, or 'host'")
-	// TODO How do we alias net and network?
-	fs.StringVar(&flags.Network, "net", "", "'container', `path` of network namespace to join, or 'host'")
-	if err := fs.MarkHidden("net"); err != nil {
-		panic(fmt.Sprintf("error marking net flag as hidden: %v", err))
-	}
+	fs.StringVar(&flags.IPC, string(specs.IPCNamespace), "", "'private', `path` of IPC namespace to join, or 'host'")
+	fs.StringVar(&flags.Network, string(specs.NetworkNamespace), "", "'private', 'none', 'ns:path' of network namespace to join, or 'host'")
 	fs.StringVar(&flags.CNIConfigDir, "cni-config-dir", util.DefaultCNIConfigDir, "`directory` of CNI configuration files")
 	fs.StringVar(&flags.CNIPlugInPath, "cni-plugin-path", util.DefaultCNIPluginPath, "`path` of CNI network plugins")
-	fs.StringVar(&flags.PID, string(specs.PIDNamespace), "", "container, `path` of PID namespace to join, or 'host'")
-	fs.StringVar(&flags.UTS, string(specs.UTSNamespace), "", "container, :`path` of UTS namespace to join, or 'host'")
+	fs.StringVar(&flags.PID, string(specs.PIDNamespace), "", "private, `path` of PID namespace to join, or 'host'")
+	fs.StringVar(&flags.UTS, string(specs.UTSNamespace), "", "private, :`path` of UTS namespace to join, or 'host'")
 	return fs
 }
 
@@ -283,4 +278,13 @@ func VerifyFlagsArgsOrder(args []string) error {
 		}
 	}
 	return nil
+}
+
+// aliasFlags is a function to handle backwards compatibility with old flags
+func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	switch name {
+	case "net":
+		name = "network"
+	}
+	return pflag.NormalizedName(name)
 }

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -784,11 +784,14 @@ func IDMappingOptions(c *cobra.Command, isolation buildah.Isolation) (usernsOpti
 	if c.Flag("userns").Changed {
 		how := c.Flag("userns").Value.String()
 		switch how {
-		case "", "container":
+		case "", "container", "private":
 			usernsOption.Host = false
 		case "host":
 			usernsOption.Host = true
 		default:
+			if strings.HasPrefix(how, "ns:") {
+				how = how[3:]
+			}
 			if _, err := os.Stat(how); err != nil {
 				return nil, nil, errors.Wrapf(err, "error checking for %s namespace at %q", string(specs.UserNamespace), how)
 			}
@@ -798,11 +801,8 @@ func IDMappingOptions(c *cobra.Command, isolation buildah.Isolation) (usernsOpti
 	}
 	usernsOptions = buildah.NamespaceOptions{usernsOption}
 
-	// Because --net and --network are technically two different flags, we need
-	// to check each for nil and .Changed
-	usernet := c.Flags().Lookup("net")
 	usernetwork := c.Flags().Lookup("network")
-	if (usernet != nil && usernetwork != nil) && (!usernet.Changed && !usernetwork.Changed) {
+	if usernetwork != nil && !usernetwork.Changed {
 		usernsOptions = append(usernsOptions, buildah.NamespaceOption{
 			Name: string(specs.NetworkNamespace),
 			Host: usernsOption.Host,
@@ -851,15 +851,15 @@ func parseIDMap(spec []string) (m [][3]uint32, err error) {
 func NamespaceOptions(c *cobra.Command) (namespaceOptions buildah.NamespaceOptions, networkPolicy buildah.NetworkConfigurationPolicy, err error) {
 	options := make(buildah.NamespaceOptions, 0, 7)
 	policy := buildah.NetworkDefault
-	for _, what := range []string{string(specs.IPCNamespace), "net", "network", string(specs.PIDNamespace), string(specs.UTSNamespace)} {
+	for _, what := range []string{string(specs.IPCNamespace), "network", string(specs.PIDNamespace), string(specs.UTSNamespace)} {
 		if c.Flags().Lookup(what) != nil && c.Flag(what).Changed {
 			how := c.Flag(what).Value.String()
 			switch what {
-			case "net", "network":
+			case "network":
 				what = string(specs.NetworkNamespace)
 			}
 			switch how {
-			case "", "container":
+			case "", "container", "private":
 				logrus.Debugf("setting %q namespace to %q", what, "")
 				options.AddOrReplace(buildah.NamespaceOption{
 					Name: what,
@@ -889,6 +889,9 @@ func NamespaceOptions(c *cobra.Command) (namespaceOptions buildah.NamespaceOptio
 						logrus.Debugf("setting network configuration to %q", how)
 						break
 					}
+				}
+				if strings.HasPrefix(how, "ns:") {
+					how = how[3:]
 				}
 				if _, err := os.Stat(how); err != nil {
 					return nil, buildah.NetworkDefault, errors.Wrapf(err, "error checking for %s namespace at %q", what, how)


### PR DESCRIPTION
Podman namespaces flags handle the options slightly differently.

Specifically namespace flag `container` is very different.
Replace the `container` option with `private` to better match podman
but continue to support `container`

Similarly Podman expects --network ns:/PATH to allow the indication of a
path to a precreated network namespace.  Buildah just supported
--network /PATH, buildah will now support both formats, but document
ns:/path.

Finally use Aliases for fix some duplicated code in buildah.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

