### PR TITLE
Add --omit-timestamp flag to buildah bud

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -310,6 +310,9 @@ type CommonBuildOptions struct {
 	// LabelOpts is the a slice of fields of an SELinux context, given in "field:pair" format, or "disable".
 	// Recognized field names are "role", "type", and "level".
 	LabelOpts []string
+	// OmitTimestamp forces epoch 0 as created timestamp to allow for
+	// deterministic, content-addressable builds.
+	OmitTimestamp bool
 	// SeccompProfilePath is the pathname of a seccomp profile.
 	SeccompProfilePath string
 	// ApparmorProfile is the name of an apparmor profile.

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -335,6 +335,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		MaxPullPushRetries:      maxPullPushRetries,
 		NamespaceOptions:        namespaceOptions,
 		NoCache:                 iopts.NoCache,
+		OmitTimestamp:           iopts.OmitTimestamp,
 		OS:                      imageOS,
 		Out:                     stdout,
 		Output:                  output,

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -365,6 +365,7 @@ return 1
      -h
      --layers
      --no-cache
+     --omit-timestamp
      --pull
      --pull-always
      --pull-never

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -180,7 +180,7 @@ value can be entered.  The password is entered without echo.
 
 **--decryption-key** *key[:passphrase]*
 
-The [key[:passphrase]] to be used for decryption of images. Key can point to keys and/or certificates. Decryption will be tried with all keys. If the key is protected by a passphrase, it is required to be passed in the argument and ommitted otherwise.
+The [key[:passphrase]] to be used for decryption of images. Key can point to keys and/or certificates. Decryption will be tried with all keys. If the key is protected by a passphrase, it is required to be passed in the argument and omitted otherwise.
 
 **--device**=*device*
 
@@ -340,6 +340,15 @@ another process.
 **--no-cache**
 
 Do not use existing cached images for the container build. Build from the start with a new set of cached layers.
+
+**--omit-timestamp** *bool-value*
+
+Set the create timestamp to epoch 0 to allow for deterministic builds (defaults to false).
+By default, the created timestamp is changed and written into the image manifest with every commit,
+causing the image's sha256 hash to be different even if the sources are exactly the same otherwise.
+When --omit-timestamp is set to true, the created timestamp is always set to the epoch and therefore not
+changed, allowing the image's sha256 to remain the same. All files committed to the layers of the image
+will get the epoch 0 timestamp.
 
 **--os**="OS"
 

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -82,7 +82,8 @@ Set the create timestamp to epoch 0 to allow for deterministic builds (defaults 
 By default, the created timestamp is changed and written into the image manifest with every commit,
 causing the image's sha256 hash to be different even if the sources are exactly the same otherwise.
 When --omit-timestamp is set to true, the created timestamp is always set to the epoch and therefore not
-changed, allowing the image's sha256 to remain the same.
+changed, allowing the image's sha256 to remain the same. All files committed to the layers of the image
+will get the epoch 0 timestamp.
 
 ## EXAMPLE
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -170,7 +170,7 @@ value can be entered.  The password is entered without echo.
 
 **--decryption-key** *key[:passphrase]*
 
-The [key[:passphrase]] to be used for decryption of images. Key can point to keys and/or certificates. Decryption will be tried with all keys. If the key is protected by a passphrase, it is required to be passed in the argument and ommitted otherwise.
+The [key[:passphrase]] to be used for decryption of images. Key can point to keys and/or certificates. Decryption will be tried with all keys. If the key is protected by a passphrase, it is required to be passed in the argument and omitted otherwise.
 
 **--device**=*device*
 

--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -64,7 +64,7 @@ value can be entered.  The password is entered without echo.
 
 **--decryption-key** *key[:passphrase]*
 
-The [key[:passphrase]] to be used for decryption of images. Key can point to keys and/or certificates. Decryption will be tried with all keys. If the key is protected by a passphrase, it is required to be passed in the argument and ommitted otherwise.
+The [key[:passphrase]] to be used for decryption of images. Key can point to keys and/or certificates. Decryption will be tried with all keys. If the key is protected by a passphrase, it is required to be passed in the argument and omitted otherwise.
 
 **--quiet, -q**
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -168,6 +168,9 @@ type BuildOptions struct {
 	SignBy string
 	// Architecture specifies the target architecture of the image to be built.
 	Architecture string
+	// OmitTimestamp forces epoch 0 as created timestamp to allow for
+	// deterministic, content-addressable builds.
+	OmitTimestamp bool
 	// OS is the specifies the operating system of the image to be built.
 	OS string
 	// MaxPullPushRetries is the maximum number of attempts we'll make to pull or push any one

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -100,6 +100,7 @@ type Executor struct {
 	devices                        []configs.Device
 	signBy                         string
 	architecture                   string
+	omitTimestamp                  bool
 	os                             string
 	maxPullPushRetries             int
 	retryPullPushDelay             time.Duration
@@ -200,6 +201,7 @@ func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Nod
 		devices:                        devices,
 		signBy:                         options.SignBy,
 		architecture:                   options.Architecture,
+		omitTimestamp:                  options.OmitTimestamp,
 		os:                             options.OS,
 		maxPullPushRetries:             options.MaxPullPushRetries,
 		retryPullPushDelay:             options.PullPushRetryDelay,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1348,6 +1348,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		SignBy:                s.executor.signBy,
 		MaxRetries:            s.executor.maxPullPushRetries,
 		RetryDelay:            s.executor.retryPullPushDelay,
+		OmitTimestamp:         s.executor.omitTimestamp,
 	}
 	imgID, _, manifestDigest, err := s.builder.Commit(ctx, imageRef, options)
 	if err != nil {

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -65,6 +65,7 @@ type BudResults struct {
 	Logfile             string
 	Loglevel            int
 	NoCache             bool
+	OmitTimestamp       bool
 	OS                  string
 	Platform            string
 	Pull                bool
@@ -168,6 +169,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.BoolVar(&flags.NoCache, "no-cache", false, "Do not use existing cached images for the container build. Build from the start with a new set of cached layers.")
 	fs.StringVar(&flags.Logfile, "logfile", "", "log to `file` instead of stdout/stderr")
 	fs.IntVar(&flags.Loglevel, "loglevel", 0, "adjust logging level (range from -2 to 3)")
+	fs.BoolVar(&flags.OmitTimestamp, "omit-timestamp", false, "set created timestamp to epoch 0 to allow for deterministic builds")
 	fs.StringVar(&flags.OS, "os", runtime.GOOS, "set the OS to the provided value instead of the current operating system of the host")
 	fs.StringVar(&flags.Platform, "platform", parse.DefaultPlatform(), "set the OS/ARCH to the provided value instead of the current operating system and architecture of the host (for example `linux/arm`)")
 	fs.BoolVar(&flags.Pull, "pull", true, "pull the image from the registry if newer or not present in store, if false, only pull the image if not present")

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2170,3 +2170,21 @@ EOM
   expect_output --substring 'STEP 4: COPY --from=\$\{toolchainname\} \/ \$\{destinationpath\}'
   run_buildah rm -a
 }
+
+@test "bud omit-timestamp" {
+  _prefetch alpine
+  run_buildah bud --omit-timestamp --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t omit -f Dockerfile.1 bud/cache-stages
+  cid=$output
+  run_buildah inspect --format '{{ .Docker.Created }}' omit
+  expect_output --substring "1970-01-01"
+  run_buildah inspect --format '{{ .OCIv1.Created }}' omit
+  expect_output --substring "1970-01-01"
+
+
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json omit
+  cid=$output
+  run_buildah run $cid ls -l /tmpfile
+  expect_output --substring "1970"
+
+  rm -rf ${TESTDIR}/tmp
+}


### PR DESCRIPTION
Currently you can only do deterministic builds with commit command
this change will cause the metadata in the container image to be
epoch 0.

Next step is to save the data in the tar balls as 0.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

