### PR TITLE
conformance: add a test for COPY from subdirectory

### DIFF
--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1341,6 +1341,16 @@ var internalTestCases = []testCase{
 	},
 
 	{
+		name:       "copy from subdir to new directory",
+		contextDir: "copydir",
+		dockerfileContents: strings.Join([]string{
+			"FROM scratch",
+			"COPY dir/file /subdir/",
+		}, "\n"),
+		fsSkip: []string{"(dir):subdir"},
+	},
+
+	{
 		name:       "copy to renamed file",
 		contextDir: "copyrename",
 		fsSkip:     []string{"(dir):usr:(dir):bin:mtime"},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add a conformance test for https://github.com/containers/podman/issues/6847, making sure that we test copying from a subdirectory of the build context to a new directory.

#### How to verify it

Compare the combination of build context and Dockerfile content to the reported issue, and if doesn't look like we're doing the same thing here, we'll need to correct the test.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The test doesn't need to pass, since we're not requiring that conformance tests pass in CI yet, but this ensures that when we do make it a requirement, we don't miss the case.

#### Does this PR introduce a user-facing change?

```
None
```

