### PR TITLE
Handle COPY --from when an argument is used

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -296,6 +296,14 @@ func (s *StageExecutor) digestSpecifiedContent(ctx context.Context, node *parser
 			// container.  Update the ID mappings and
 			// all-content-comes-from-below-this-directory value.
 			from := strings.TrimPrefix(flag, "--from=")
+
+			// If from has an argument within it, resolve it to its
+			// value.  Otherwise just return the value found.
+			var fromErr error
+			from, fromErr = imagebuilder.ProcessWord(from, s.stage.Builder.Arguments())
+			if fromErr != nil {
+				return "", errors.Wrapf(fromErr, "unable to resolve argument %q", from)
+			}
 			if isStage, err := s.executor.waitForStage(ctx, from, s.stages[:s.index]); isStage && err != nil {
 				return "", err
 			}
@@ -886,6 +894,14 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				// If the source's name corresponds to the
 				// result of an earlier stage, wait for that
 				// stage to finish being built.
+
+				// If arr[1] has an argument within it, resolve it to its
+				// value.  Otherwise just return the value found.
+				var arr1Err error
+				arr[1], arr1Err = imagebuilder.ProcessWord(arr[1], s.stage.Builder.Arguments())
+				if arr1Err != nil {
+					return "", nil, errors.Wrapf(arr1Err, "unable to resolve argument %q", arr[1])
+				}
 				if isStage, err := s.executor.waitForStage(ctx, arr[1], s.stages[:s.index]); isStage && err != nil {
 					return "", nil, err
 				}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2157,3 +2157,16 @@ EOM
   run_buildah inspect --format '{{ index .Docker.Config.Labels "io.buildah.version"}}' $target
   expect_output "$buildah_version"
 }
+
+@test "run check --from with arg" {
+  skip_if_no_runtime
+
+  ${OCI} --version
+  _prefetch alpine 
+  _prefetch debian
+
+  run_buildah bud --build-arg base=alpine --build-arg toolchainname=busybox --build-arg destinationpath=/tmp --pull=false --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/from-with-arg/Containerfile .
+  expect_output --substring "FROM alpine"
+  expect_output --substring 'STEP 4: COPY --from=\$\{toolchainname\} \/ \$\{destinationpath\}'
+  run_buildah rm -a
+}

--- a/tests/bud/from-with-arg/Containerfile
+++ b/tests/bud/from-with-arg/Containerfile
@@ -1,0 +1,7 @@
+ARG base
+FROM ${base}
+
+ARG toolchainname
+ARG destinationpath
+
+COPY --from=${toolchainname} / ${destinationpath}


### PR DESCRIPTION
When an argument was passed into "COPY --from" command in
a Containerfile like

COPY --from=${toolchainname}

The argument was never resolved to the value that it had been
set to.

Addresses: #2496

It may also address #2404 but I've not yet tested.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

