### PR TITLE
Bump to v1.14.11 in release-v1.14 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 # Changelog
 
+## v1.14.11 (2020-08-10)
+    Make imagebuildah.BuildOptions.Architecture/OS optional
+    blobcache: avoid an unnecessary NewImage()
+
 ## v1.14.10 (2020-06-18)
-    imagebuildah: stages shouldn't count as their base images 
+    imagebuildah: stages shouldn't count as their base images
 
 ## v1.14.9 (2020-05-11)
     Bump github.com/containers/common to 0.8.4

--- a/buildah.go
+++ b/buildah.go
@@ -27,7 +27,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.14.10"
+	Version = "1.14.11"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,13 @@
+- Changelog for v1.14.11 (2020-08-10)
+  * Make imagebuildah.BuildOptions.Architecture/OS optional
+  * blobcache: avoid an unnecessary NewImage()
+
+- Changelog for v1.14.10 (2020-06-18)
+  * imagebuildah: stages shouldn't count as their base images
+
+- Changelog for v1.14.9 (2020-05-11)
+  * Bump github.com/containers/common to 0.8.4
+
 - Changelog for v1.14.8 (2020-04-09)
   * Run (make vendor)
   * Run (make -C tests/tools vendor)

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in buildah.go too
-Version:        1.14.10
+Version:        1.14.11
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -99,6 +99,10 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Mon Aug 10, 2020 Tom Sweeney <tsweeney@redhat.com> 1.14.11-1
+- Make imagebuildah.BuildOptions.Architecture/OS optional
+- blobcache: avoid an unnecessary NewImage()
+
 * Thu Jun 18, 2020 Tom Sweeney <tsweeney@redhat.com> 1.14.10-1
 - imagebuildah: stages shouldn't count as their base images 
 


### PR DESCRIPTION
Bump to v1.14.11 for an update for OpenShift.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>



