### PR TITLE
Add buildah.IsContainer interface

### DIFF
--- a/util.go
+++ b/util.go
@@ -420,3 +420,21 @@ func ReserveSELinuxLabels(store storage.Store, id string) error {
 	}
 	return nil
 }
+
+// IsContainer identifies if the specified container id is a buildah container
+// in the specified store.
+func IsContainer(id string, store storage.Store) (bool, error) {
+	cdir, err := store.ContainerDirectory(id)
+	if err != nil {
+		return false, err
+	}
+	// Assuming that if the stateFile exists, that this is a Buildah
+	// container.
+	if _, err = os.Stat(filepath.Join(cdir, stateFile)); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, errors.Wrapf(err, "error stating %q", filepath.Join(cdir, stateFile))
+	}
+	return true, nil
+}


### PR DESCRIPTION
This interface will allow callers to specify a storage container id
and the store and return whether or not the container is a buildah
container.

We want to add the ability to for Podman to identify containers in storage
that it did not create or were created via podman build command.

Podman will use this information to help user identify where the container
came from.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

