### PR TITLE
Avoid feeding run_buildah to pipe

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1237,7 +1237,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.invalid_from -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths || true
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.invalid_from -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
   expect_output --substring "COPY only supports the --chown=<uid:gid> and the --from=<image|stage> flags"
 }
 
@@ -2162,7 +2162,7 @@ EOM
   skip_if_no_runtime
 
   ${OCI} --version
-  _prefetch alpine 
+  _prefetch alpine
   _prefetch debian
 
   run_buildah bud --build-arg base=alpine --build-arg toolchainname=busybox --build-arg destinationpath=/tmp --pull=false --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/from-with-arg/Containerfile .

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -31,8 +31,12 @@ load helpers
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-oci
   run_buildah commit --format docker --disable-compression=false --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-docker
 
-  run_buildah inspect --type=image --format '{{.Manifest}}' alpine-image-oci | grep "application/vnd.oci.image.layer.v1.tar"
-  run_buildah inspect --type=image --format '{{.Manifest}}' alpine-image-docker | grep "application/vnd.docker.image.rootfs.diff.tar.gzip"
+  run_buildah inspect --type=image --format '{{.Manifest}}' alpine-image-oci
+  mediatype=$(jq -r '.layers[0].mediaType' <<<"$output")
+  expect_output --from="$mediatype" "application/vnd.oci.image.layer.v1.tar"
+  run_buildah inspect --type=image --format '{{.Manifest}}' alpine-image-docker
+  mediatype=$(jq -r '.layers[1].mediaType' <<<"$output")
+  expect_output --from="$mediatype" "application/vnd.docker.image.rootfs.diff.tar.gzip"
 }
 
 @test "commit quiet test" {

--- a/tests/history.bats
+++ b/tests/history.bats
@@ -11,9 +11,11 @@ function testconfighistory() {
   run_buildah config $config --add-history "$container"
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json "$container" "$image"
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image"
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image" | grep "$expected"
+  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image"
+  expect_output --substring "$expected"
   if test "$3" != "not-oci" ; then
-    run_buildah inspect --format '{{range .OCIv1.History}}{{println .CreatedBy}}{{end}}' "$image" | grep "$expected"
+      run_buildah inspect --format '{{range .OCIv1.History}}{{println .CreatedBy}}{{end}}' "$image"
+      expect_output --substring "$expected"
   fi
 }
 


### PR DESCRIPTION
The usage 'run_buildah ... | grep' (or pipe whatever) works,
but it's a super bad pattern. Replace all instances of it
with a one-two of 'run_buildah' and 'expect_output'. Some
of these needed a little minor massaging.

Also: 'run_buildah ... || true' -> 'run_buildah 125 ...'.
I don't review all buildah PRs, so this one slipped by me.

Also: clean up trailing whitespace

Digression: why is 'run_buildah | grep' bad? Because:
  - it is inaccurate. run_buildah does 'echo $output',
    but it also emits other output (the buildah command
    itself, and possible expected-status mismatch).
    It is possible that a pipe-grep could trigger
    on one of these.
  - the reason run_buildah emits these things is so
    a human can look at debug output on failure and
    recognize what command was run, what the output
    was. If we pipe-grep, we lose that.
  - it is possible that a pipe-grep will mask
    a failing run_buildah (I'm not sure about this)
  - expect_output is more precise anyway, hence
    makes a better test.

Signed-off-by: Ed Santiago <santiago@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

