### PR TITLE
conformance testing: ignore buildah.BuilderIdentityAnnotation labels

### DIFF
--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -434,6 +434,21 @@ func testConformanceInternalBuild(ctx context.Context, t *testing.T, cwd string,
 	if t.Failed() {
 		t.FailNow()
 	}
+	deleteLabel := func(config map[string]interface{}, label string) {
+		for _, configName := range []string{"config", "container_config"} {
+			if configStruct, ok := config[configName]; ok {
+				if configMap, ok := configStruct.(map[string]interface{}); ok {
+					if labels, ok := configMap["Labels"]; ok {
+						if labelMap, ok := labels.(map[string]interface{}); ok {
+							delete(labelMap, label)
+						}
+					}
+				}
+			}
+		}
+	}
+	deleteLabel(originalBuildahConfig, buildah.BuilderIdentityAnnotation)
+	deleteLabel(ociBuildahConfig, buildah.BuilderIdentityAnnotation)
 
 	var originalDockerConfig, ociDockerConfig, fsDocker map[string]interface{}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Ignore the buildah.BuilderIdentityAnnotation label when comparing images that we build with images built using other tools, which of course don't automatically set that label.

#### How to verify it:

Conformance tests should now account for #2510.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The conformance tests don't all pass even with this change; that's ongoing work.

#### Does this PR introduce a user-facing change?

```
None
```