### PR TITLE
run: propagate intermediate mountns mounts

### DIFF
--- a/bind/mount.go
+++ b/bind/mount.go
@@ -36,11 +36,6 @@ func SetupIntermediateMountNamespace(spec *specs.Spec, bundlePath string) (unmou
 		return nil, errors.Wrapf(err, "error creating new mount namespace for %v", spec.Process.Args)
 	}
 
-	// Make all of our mounts private to our namespace.
-	if err := mount.MakeRPrivate("/"); err != nil {
-		return nil, errors.Wrapf(err, "error making mounts private to mount namespace for %v", spec.Process.Args)
-	}
-
 	// Make sure the bundle directory is searchable.  We created it with
 	// TempDir(), so it should have started with permissions set to 0700.
 	info, err := os.Stat(bundlePath)


### PR DESCRIPTION
propagate mounts happening in the intermediate mount namespace to the
host so they are accessible from kata-runtime.

Closes: https://github.com/containers/buildah/issues/2524

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug

#### What this PR does / why we need it:

so we can use kata-runtime

#### How to verify it

follow the reproducer here: https://github.com/containers/buildah/issues/2524

#### Which issue(s) this PR fixes:

Fixes #2524

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
buildah run works with kata-runtime
```
