### PR TITLE
WIP: commit: optionally create layers for ADD/COPY/RUN/WORKDIR

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -79,6 +79,9 @@ type CommitOptions struct {
 	// EmptyLayer tells the builder to omit the diff for the working
 	// container.
 	EmptyLayer bool
+	// EmptyLayerIfRedundant tells the builder to compute the diff for the
+	// working container, and to omit the layer if the diff is empty.
+	EmptyLayerIfRedundant bool
 	// OmitTimestamp forces epoch 0 as created timestamp to allow for
 	// deterministic, content-addressable builds.
 	// Deprecated use HistoryTimestamp instead.

--- a/tests/conformance/testdata/layers/base-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+ADD . .
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-arg-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-arg-plus-add/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox
+ARG A=B
+LABEL B=$ARG
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-arg/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-arg/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+ARG A=B
+LABEL B=$ARG

--- a/tests/conformance/testdata/layers/base-plus-cmd-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-cmd-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+CMD ["/bin/sh"]
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-cmd/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-cmd/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+CMD ["/bin/sh"]

--- a/tests/conformance/testdata/layers/base-plus-copy/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-copy/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+COPY . .
+COPY . .

--- a/tests/conformance/testdata/layers/base-plus-entrypoint-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-entrypoint-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+ENTRYPOINT ["/bin/sh"]
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-entrypoint/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-entrypoint/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+ENTRYPOINT ["/bin/sh"]

--- a/tests/conformance/testdata/layers/base-plus-env-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-env-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+ENV FOO=BAR
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-env/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-env/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+ENV FOO=BAR

--- a/tests/conformance/testdata/layers/base-plus-expose-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-expose-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+EXPOSE 8080
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-expose/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-expose/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+EXPOSE 8080

--- a/tests/conformance/testdata/layers/base-plus-from-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-from-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+FROM busybox
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-from/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-from/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+FROM busybox

--- a/tests/conformance/testdata/layers/base-plus-healthcheck-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-healthcheck-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+HEALTHCHECK NONE
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-healthcheck/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-healthcheck/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+HEALTHCHECK NONE

--- a/tests/conformance/testdata/layers/base-plus-label-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-label-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+LABEL FOO=BAR
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-label/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-label/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+LABEL FOO=BAR

--- a/tests/conformance/testdata/layers/base-plus-maintainer-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-maintainer-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+MAINTAINER a cast of thousands
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-maintainer/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-maintainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+MAINTAINER a cast of thousands

--- a/tests/conformance/testdata/layers/base-plus-onbuild-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-onbuild-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+ONBUILD LABEL foo=bar
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-onbuild/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-onbuild/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+ONBUILD LABEL foo=bar

--- a/tests/conformance/testdata/layers/base-plus-run-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-run-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+RUN pwd
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-run/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-run/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+RUN pwd
+RUN pwd

--- a/tests/conformance/testdata/layers/base-plus-shell-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-shell-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+SHELL ["/bin/sh"]
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-shell/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-shell/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+SHELL ["/bin/sh"]

--- a/tests/conformance/testdata/layers/base-plus-stopsignal-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-stopsignal-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+STOPSIGNAL STOP
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-stopsignal/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-stopsignal/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+STOPSIGNAL STOP

--- a/tests/conformance/testdata/layers/base-plus-user-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-user-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+USER 1:1
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-user/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-user/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+USER 1:1

--- a/tests/conformance/testdata/layers/base-plus-volume-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-volume-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+VOLUME /volume
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-volume/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-volume/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+VOLUME /volume

--- a/tests/conformance/testdata/layers/base-plus-workdir-plus-add/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-workdir-plus-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+WORKDIR /workdir
+ADD . .

--- a/tests/conformance/testdata/layers/base-plus-workdir/Dockerfile
+++ b/tests/conformance/testdata/layers/base-plus-workdir/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+WORKDIR /workdir

--- a/tests/conformance/testdata/layers/workdir-after-add/Dockerfile
+++ b/tests/conformance/testdata/layers/workdir-after-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+ADD . .
+WORKDIR /workdir

--- a/tests/conformance/testdata/layers/workdir-after-run/Dockerfile
+++ b/tests/conformance/testdata/layers/workdir-after-run/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+RUN pwd
+WORKDIR /workdir

--- a/tests/conformance/testdata/layers/workdir-alone/Dockerfile
+++ b/tests/conformance/testdata/layers/workdir-alone/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+WORKDIR /workdir

--- a/tests/conformance/testdata/layers/workdir-before-add/Dockerfile
+++ b/tests/conformance/testdata/layers/workdir-before-add/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+WORKDIR /workdir
+ADD . .

--- a/tests/conformance/testdata/layers/workdir-before-config/Dockerfile
+++ b/tests/conformance/testdata/layers/workdir-before-config/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+USER 1:1
+WORKDIR /workdir
+MAINTAINER bob smith

--- a/tests/conformance/testdata/layers/workdir-before-run/Dockerfile
+++ b/tests/conformance/testdata/layers/workdir-before-run/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+WORKDIR /workdir
+RUN pwd

--- a/tests/conformance/testdata/layers/workdir-before-run/Dockerfile2
+++ b/tests/conformance/testdata/layers/workdir-before-run/Dockerfile2
@@ -1,0 +1,3 @@
+FROM busybox
+WORKDIR /workdir
+RUN touch new-file

--- a/tests/conformance/testdata/layers/workdir-in-image-owner/Dockerfile
+++ b/tests/conformance/testdata/layers/workdir-in-image-owner/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+USER 1:1
+WORKDIR /workdir
+COPY script .

--- a/tests/conformance/testdata/layers/workdir-in-image-owner/script
+++ b/tests/conformance/testdata/layers/workdir-in-image-owner/script
@@ -1,0 +1,2 @@
+#!/bin/true
+Nope, this doesn't matter.

--- a/tests/conformance/testdata/layers/workdir-in-image/Dockerfile
+++ b/tests/conformance/testdata/layers/workdir-in-image/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY script /directory/totes/exists/
+WORKDIR /directory/totes/exists

--- a/tests/conformance/testdata/layers/workdir-in-image/script
+++ b/tests/conformance/testdata/layers/workdir-in-image/script
@@ -1,0 +1,2 @@
+#!/bin/true
+Nope, this doesn't matter.

--- a/tests/conformance/testdata/layers/workdir-not-in-image/Dockerfile
+++ b/tests/conformance/testdata/layers/workdir-not-in-image/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY script .
+WORKDIR /directory/does/not/exist

--- a/tests/conformance/testdata/layers/workdir-not-in-image/script
+++ b/tests/conformance/testdata/layers/workdir-not-in-image/script
@@ -1,0 +1,2 @@
+#!/bin/true
+Nope, this doesn't matter.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In multi-layer mode, only add layers when ADD, COPY, RUN, or WORKDIR make changes to the container's rootfs.

#### How to verify it

Building an image using `--layers=true` and a Dockerfile containing
```
FROM fedora
WORKDIR /testdir
```
should produce an image with two layers, rather than just the base image's single layer.

Conformance tests have been extended to compare how many layers we generate in comparison to `docker build`, though it makes exceptions for items we create as targets for bind mounts when handling RUN instructions.

#### Which issue(s) this PR fixes:

Fixes #2402

#### Special notes for your reviewer:

The `workdir-in-image-owner` and `workdir-not-in-image` conformance tests should exercise this.

#### Does this PR introduce a user-facing change?

```
Instead of always creating new layers for ADD, COPY, and RUN instructions, `buildah build-using-dockerfile --layers` will now avoid adding new layers when those instructions make no changes to the filesystem.
```