### PR TITLE
imagebuildah: don’t blank out destination names when COPYing

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -487,7 +487,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 						}
 						// If we've a tar file, it will create a directory using the name of the tar
 						// file if we don't blank it out.
-						if strings.HasSuffix(srcName, ".tar") || strings.HasSuffix(srcName, ".gz") {
+						if copy.Download && (strings.HasSuffix(srcName, ".tar") || strings.HasSuffix(srcName, ".gz")) {
 							srcName = ""
 						}
 						if err := s.builder.Add(filepath.Join(copy.Dest, srcName), copy.Download, options, srcSecure); err != nil {

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1356,6 +1356,12 @@ var internalTestCases = []testCase{
 	},
 
 	{
+		name:       "copy from symlink source",
+		contextDir: "copysymlink",
+		fsSkip:     []string{},
+	},
+
+	{
 		name:       "copy from subdir to new directory",
 		contextDir: "copydir",
 		dockerfileContents: strings.Join([]string{

--- a/tests/conformance/testdata/copysymlink/Dockerfile
+++ b/tests/conformance/testdata/copysymlink/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry.centos.org/centos/centos:centos7
+COPY file-link.tar.gz /

--- a/tests/conformance/testdata/copysymlink/file-link.tar.gz
+++ b/tests/conformance/testdata/copysymlink/file-link.tar.gz
@@ -1,0 +1,1 @@
+file.tar.gz

--- a/tests/conformance/testdata/copysymlink/file.tar.gz
+++ b/tests/conformance/testdata/copysymlink/file.tar.gz
@@ -1,0 +1,1 @@
+hello, world


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When ADDing an archive file, the stage executor blanks out the destination file name of recognized archive files to ensure that archive contents are extracted in-place. However, when COPYing an archive-file, we don’t want to blank out the destination filename, since this would result in copying under the name of the symlink’s target.

#### How to verify it

Run the reproduction steps from #2549 and observe that the issue can no longer be reproduced.

A corresponding conformance test case as well as a bud test case have been included.

#### Which issue(s) this PR fixes:

Fixes #2549 

#### Special notes for your reviewer:

I wasn’t sure about the appropriate values to set for `fsSkip` in the conformance test case list.

#### Does this PR introduce a user-facing change?

None

