### PR TITLE
copier: add Mkdir()

### DIFF
--- a/copier/syscall_unix.go
+++ b/copier/syscall_unix.go
@@ -28,10 +28,6 @@ func chroot(root string) (bool, error) {
 	return false, nil
 }
 
-func getcwd() (string, error) {
-	return unix.Getwd()
-}
-
 func chrMode(mode os.FileMode) uint32 {
 	return uint32(unix.S_IFCHR | mode)
 }
@@ -52,6 +48,18 @@ func mknod(path string, mode uint32, dev int) error {
 	return unix.Mknod(path, mode, dev)
 }
 
+func chmod(path string, mode os.FileMode) error {
+	return os.Chmod(path, mode)
+}
+
+func chown(path string, uid, gid int) error {
+	return os.Chown(path, uid, gid)
+}
+
+func lchown(path string, uid, gid int) error {
+	return os.Lchown(path, uid, gid)
+}
+
 func lutimes(isSymlink bool, path string, atime, mtime time.Time) error {
 	if atime.IsZero() || mtime.IsZero() {
 		now := time.Now()
@@ -64,3 +72,8 @@ func lutimes(isSymlink bool, path string, atime, mtime time.Time) error {
 	}
 	return unix.Lutimes(path, []unix.Timeval{unix.NsecToTimeval(atime.UnixNano()), unix.NsecToTimeval(mtime.UnixNano())})
 }
+
+const (
+	testModeMask           = int64(os.ModePerm)
+	testIgnoreSymlinkDates = false
+)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a function to the copier package for doing Mkdir-possibly-in-a-chroot, for ensuring that a directory exists without having to possibly create it directly from outside of a chroot.  It also attempts to address some review comments from #2486:

* Check for ERANGE instead of E2BIG errors from llistxattr() and lgetxattr() as indicators that the buffer we passed to them is too small.
* Factor an `isRelevantXattr` helper out of Lgetxattrs() and Lsetxattrs().
* Drop our getcwd() function in favor of using os.Getwd().
* Adjust the comment describing the GetOptions.KeepDirectoryNames field.
* Clean hdr.Name before attempting to compute where an item being extracted should go.
* When writing items to the filesystem, create with 0?00 permissions, set ownership, then set the correct permissions.
* Merge StatResponse.Error, GetResponse.Error, and PutResponse.Error into Response.Error.
* When reading items from the filesystem, if a glob matches multiple items, and one of the items is excluded, continue checking the other items.
* Make sure we always Wait() on a child process if we spawned one.
* Clean up the cleanup logic for pipes that we use to communicate with a child process.
* Clean up the kill-the-child-process logic we call when we encounter an error communicating with the child process.
* Drop the separate Options structure, use helper methods to simplify pulling out the right ID maps and exclusions list for the request.

#### How to verify it:

There are new and updated unit tests in the package.  They should all pass.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is another chunk of #2480.

#### Does this PR introduce a user-facing change?

```
None
```