### PR TITLE
[release-1.15] in_podman: don't get tripped up by CIRRUS_CHANGE_TITLE

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -234,6 +234,7 @@ in_podman() {
     for envname in $(awk 'BEGIN{for(v in ENVIRON) print v}' | \
                      egrep "$envrx" | \
                      egrep -v "CIRRUS_.+_MESSAGE" | \
+                     egrep -v "CIRRUS_.+_TITLE" | \
                      egrep -v "$SECRET_ENV_RE")
     do
         envvalue="${!envname}"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In CI, we don't handle passing environment values that contain whitespace through to tests that we run inside of podman, so we need to screen out $CIRRUS_CHANGE_TITLE.

#### How to verify it

Check if the `in_podman` task passes for this PR in CI.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Cherry-picked from #2553.

#### Does this PR introduce a user-facing change?

```
None
```