### PR TITLE
Fix ownership of content copied using COPY --from

### DIFF
--- a/add.go
+++ b/add.go
@@ -29,8 +29,12 @@ import (
 type AddAndCopyOptions struct {
 	// Chown is a spec for the user who should be given ownership over the
 	// newly-added content, potentially overriding permissions which would
-	// otherwise match those of local files and directories being copied.
+	// otherwise be set to 0:0.
 	Chown string
+	// PreserveOwnership, if Chown is not set, tells us to avoid setting
+	// ownership of copied items to 0:0, instead using whatever ownership
+	// information is already set.  Not meaningful for remote sources.
+	PreserveOwnership bool
 	// All of the data being copied will pass through Hasher, if set.
 	// If the sources are URLs or files, their contents will be passed to
 	// Hasher.
@@ -208,6 +212,10 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	}
 	chownDirs = &idtools.IDPair{UID: int(user.UID), GID: int(user.GID)}
 	chownFiles = &idtools.IDPair{UID: int(user.UID), GID: int(user.GID)}
+	if options.Chown == "" && options.PreserveOwnership {
+		chownDirs = nil
+		chownFiles = nil
+	}
 
 	// If we have a single source archive to extract, or more than one
 	// source item, or the destination has a path separator at the end of

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -277,6 +277,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 		var copyExcludes []string
 		stripSetuid := false
 		stripSetgid := false
+		preserveOwnership := false
 		contextDir := s.executor.contextDir
 		if len(copy.From) > 0 {
 			// If from has an argument within it, resolve it to its
@@ -297,6 +298,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 			} else {
 				return errors.Errorf("the stage %q has not been built", copy.From)
 			}
+			preserveOwnership = true
 			copyExcludes = excludes
 		} else {
 			copyExcludes = append(s.executor.excludes, excludes...)
@@ -317,12 +319,13 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 			}
 		}
 		options := buildah.AddAndCopyOptions{
-			Chown:            copy.Chown,
-			ContextDir:       contextDir,
-			Excludes:         copyExcludes,
-			IDMappingOptions: idMappingOptions,
-			StripSetuidBit:   stripSetuid,
-			StripSetgidBit:   stripSetgid,
+			Chown:             copy.Chown,
+			PreserveOwnership: preserveOwnership,
+			ContextDir:        contextDir,
+			Excludes:          copyExcludes,
+			IDMappingOptions:  idMappingOptions,
+			StripSetuidBit:    stripSetuid,
+			StripSetgidBit:    stripSetgid,
 		}
 		if err := s.builder.Add(copy.Dest, copy.Download, options, sources...); err != nil {
 			return errors.Wrapf(err, "error adding sources %v", sources)

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -2395,4 +2395,48 @@ var internalTestCases = []testCase{
 			`        name4="value4a\\nvalue4b" \`,
 		}, "\n"),
 	},
+
+	{
+		name: "copy-from-owner", // from issue #2518
+		dockerfileContents: strings.Join([]string{
+			`FROM alpine`,
+			`RUN set -ex; touch /test; chown 65:65 /test`,
+			`FROM scratch`,
+			`USER 66:66`,
+			`COPY --from=0 /test /test`,
+		}, "\n"),
+		fsSkip: []string{"test:mtime"},
+	},
+
+	{
+		name: "copy-from-owner-with-chown", // issue #2518, but with chown to override
+		dockerfileContents: strings.Join([]string{
+			`FROM alpine`,
+			`RUN set -ex; touch /test; chown 65:65 /test`,
+			`FROM scratch`,
+			`USER 66:66`,
+			`COPY --from=0 --chown=1:1 /test /test`,
+		}, "\n"),
+		fsSkip: []string{"test:mtime"},
+	},
+
+	{
+		name:       "copy-for-user", // flip side of issue #2518
+		contextDir: "copy",
+		dockerfileContents: strings.Join([]string{
+			`FROM alpine`,
+			`USER 66:66`,
+			`COPY /script /script`,
+		}, "\n"),
+	},
+
+	{
+		name:       "copy-for-user-with-chown", // flip side of issue #2518, but with chown to override
+		contextDir: "copy",
+		dockerfileContents: strings.Join([]string{
+			`FROM alpine`,
+			`USER 66:66`,
+			`COPY --chown=1:1 /script /script`,
+		}, "\n"),
+	},
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

COPY --from was incorrectly discarding ownership information on files copied from other layers, which unlike content copied from the build context, should not default to being owned by 0:0.

#### How to verify it

We've added conformance tests to ensure that we do what `docker build` does.

#### Which issue(s) this PR fixes:

Fixes #2518.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```