### PR TITLE
Discard ReportWriter if user sets options.Quiet

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -152,6 +152,11 @@ func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Nod
 		jobs = *options.Jobs
 	}
 
+	writer := options.ReportWriter
+	if options.Quiet {
+		writer = ioutil.Discard
+	}
+
 	exec := Executor{
 		stages:                         make(map[string]*StageExecutor),
 		store:                          store,
@@ -174,7 +179,7 @@ func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Nod
 		in:                             options.In,
 		out:                            options.Out,
 		err:                            options.Err,
-		reportWriter:                   options.ReportWriter,
+		reportWriter:                   writer,
 		isolation:                      options.Isolation,
 		namespaceOptions:               options.NamespaceOptions,
 		configureNetwork:               options.ConfigureNetwork,


### PR DESCRIPTION
I can not seem to get this to happen locally, but if this
happens, I believe this should fix the problem.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

