### PR TITLE
build-using-dockerfile: add a hidden --log-rusage flag

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -356,6 +356,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		TransientMounts:         iopts.Volumes,
 		OciDecryptConfig:        decConfig,
 		Jobs:                    &iopts.Jobs,
+		LogRusage:               iopts.LogRusage,
 	}
 
 	if iopts.Quiet {

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -183,6 +183,8 @@ type BuildOptions struct {
 	OciDecryptConfig *encconfig.DecryptConfig
 	// Jobs is the number of stages to run in parallel.  If not specified it defaults to 1.
 	Jobs *int
+	// LogRusage logs resource usage for each step.
+	LogRusage bool
 }
 
 // BuildDockerfiles parses a set of one or more Dockerfiles (which may be

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -110,6 +110,7 @@ type Executor struct {
 	stagesLock                     sync.Mutex
 	stagesSemaphore                *semaphore.Weighted
 	jobs                           int
+	logRusage                      bool
 }
 
 // NewExecutor creates a new instance of the imagebuilder.Executor interface.
@@ -213,6 +214,7 @@ func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Nod
 		ociDecryptConfig:               options.OciDecryptConfig,
 		terminatedStage:                make(map[string]struct{}),
 		jobs:                           jobs,
+		logRusage:                      options.LogRusage,
 	}
 	if exec.err == nil {
 		exec.err = os.Stderr

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -82,6 +82,7 @@ type BudResults struct {
 	Target              string
 	TLSVerify           bool
 	Jobs                int
+	LogRusage           bool
 }
 
 // FromAndBugResults represents the results for common flags
@@ -181,6 +182,10 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.Target, "target", "", "set the target build stage to build")
 	fs.BoolVar(&flags.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	fs.IntVar(&flags.Jobs, "jobs", 1, "how many stages to run in parallel")
+	fs.BoolVar(&flags.LogRusage, "log-rusage", false, "log resource usage at each build step")
+	if err := fs.MarkHidden("log-rusage"); err != nil {
+		panic(fmt.Sprintf("error marking the log-rusage flag as hidden: %v", err))
+	}
 	return fs
 }
 

--- a/pkg/rusage/rusage.go
+++ b/pkg/rusage/rusage.go
@@ -1,0 +1,48 @@
+package rusage
+
+import (
+	"fmt"
+	"time"
+
+	units "github.com/docker/go-units"
+)
+
+// Rusage is a subset of a Unix-style resource usage counter for the current
+// process and its children.  The counters are always 0 on platforms where the
+// system call is not available (i.e., systems where getrusage() doesn't
+// exist).
+type Rusage struct {
+	Date              time.Time
+	Elapsed           time.Duration
+	Utime, Stime      time.Duration
+	Inblock, Outblock int64
+}
+
+// FormatDiff formats the result of rusage.Rusage.Subtract() for logging.
+func FormatDiff(diff Rusage) string {
+	return fmt.Sprintf("%s(system) %s(user) %s(elapsed) %s input %s output", diff.Stime.Round(time.Millisecond), diff.Utime.Round(time.Millisecond), diff.Elapsed.Round(time.Millisecond), units.HumanSize(float64(diff.Inblock*512)), units.HumanSize(float64(diff.Outblock*512)))
+}
+
+// Subtract subtracts the items in delta from r, and returns the difference.
+// The Date field is zeroed for easier comparison with the zero value for the
+// Rusage type.
+func (r Rusage) Subtract(baseline Rusage) Rusage {
+	return Rusage{
+		Elapsed:  r.Date.Sub(baseline.Date),
+		Utime:    r.Utime - baseline.Utime,
+		Stime:    r.Stime - baseline.Stime,
+		Inblock:  r.Inblock - baseline.Inblock,
+		Outblock: r.Outblock - baseline.Outblock,
+	}
+}
+
+// Get returns the counters for the current process and its children,
+// subtracting any values in the passed in "since" value, or an error.
+// The Elapsed field will always be set to zero.
+func Get() (Rusage, error) {
+	counters, err := get()
+	if err != nil {
+		return Rusage{}, err
+	}
+	return counters, nil
+}

--- a/pkg/rusage/rusage_test.go
+++ b/pkg/rusage/rusage_test.go
@@ -1,0 +1,48 @@
+package rusage
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/containers/storage/pkg/reexec"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	noopCommand = "noop"
+)
+
+func noopMain() {
+}
+
+func init() {
+	reexec.Register(noopCommand, noopMain)
+}
+
+func TestMain(m *testing.M) {
+	if reexec.Init() {
+		return
+	}
+	flag.Parse()
+	if testing.Verbose() {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	os.Exit(m.Run())
+}
+
+func TestRusage(t *testing.T) {
+	if !Supported() {
+		t.Skip("not supported on this platform")
+	}
+	before, err := Get()
+	require.Nil(t, err, "unexpected error from GetRusage before running child: %v", err)
+	cmd := reexec.Command(noopCommand)
+	err = cmd.Run()
+	require.Nil(t, err, "unexpected error running child process: %v", err)
+	after, err := Get()
+	require.Nil(t, err, "unexpected error from GetRusage after running child: %v", err)
+	t.Logf("rusage from child: %#v", FormatDiff(after.Subtract(before)))
+	require.NotZero(t, after.Subtract(before), "running a child process didn't use any resources?")
+}

--- a/pkg/rusage/rusage_unix.go
+++ b/pkg/rusage/rusage_unix.go
@@ -1,0 +1,35 @@
+// +build !windows
+
+package rusage
+
+import (
+	"syscall"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func mkduration(tv syscall.Timeval) time.Duration {
+	return time.Duration(tv.Sec)*time.Second + time.Duration(tv.Usec)*time.Microsecond
+}
+
+func get() (Rusage, error) {
+	var rusage syscall.Rusage
+	err := syscall.Getrusage(syscall.RUSAGE_CHILDREN, &rusage)
+	if err != nil {
+		return Rusage{}, errors.Wrapf(err, "error getting resource usage")
+	}
+	r := Rusage{
+		Date:     time.Now(),
+		Utime:    mkduration(rusage.Utime),
+		Stime:    mkduration(rusage.Stime),
+		Inblock:  rusage.Inblock,
+		Outblock: rusage.Oublock,
+	}
+	return r, nil
+}
+
+// Supported returns true if resource usage counters are supported on this OS.
+func Supported() bool {
+	return true
+}

--- a/pkg/rusage/rusage_unsupported.go
+++ b/pkg/rusage/rusage_unsupported.go
@@ -1,0 +1,18 @@
+// +build windows
+
+package rusage
+
+import (
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+func get() (Rusage, error) {
+	return Rusage{}, errors.Wrapf(syscall.ENOTSUP, "error getting resource usage")
+}
+
+// Supported returns true if resource usage counters are supported on this OS.
+func Supported() bool {
+	return false
+}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2197,3 +2197,11 @@ EOM
 
   rm -rf ${TESTDIR}/tmp
 }
+
+@test "bud with-rusage" {
+  _prefetch alpine
+  run_buildah bud --log-rusage --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json bud/shell
+  cid=$output
+  # expect something that looks like it was formatted using pkg/rusage.FormatDiff()
+  expect_output --substring ".*\(system\).*\(user\).*\(elapsed\).*input.*output"
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

We were seeing some unexplained slowdowns in builds that ran in OpenShift when the memory controller was configured to limit the amount of memory available to us.  When pulling an image, either for use as a base or to supply content for COPY --from, we write all of the image's blobs to temporary files as they're fetched in parallel, read them back in order to create the image's layers on disk in order, and then delete the temporary files.  The working theory is that when these writes-then-reads-then-deletes don't al fit within the kernel's cache (the amount of memory available for use by the cache being subject to control group limits), the data ends up having to be flushed all the way to disk and then read back from disk, and the additional I/O is what makes the build slower.  Being able to log how much I/O is done for a particular step during a build would be very helpful for diagnosing these cases.

This PR adds a flag to `imagebuildah.BuildOptions` that will tell us to log timing and I/O information at each step of the build process, and which enables it if the CLI is run with the `--log-rusage` flag.

#### How to verify it

We add an integration test to ensure that we see output that matches our expected output formatting string when we use the flag.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
If `buildah build-with-dockerfile` is given the `--log-rusage` flag, resource usage information will be logged for every step.
```