### PR TITLE
Use --timestamp rather then --omit-timestamp

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/containers/buildah/imagebuildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
@@ -336,7 +337,6 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		MaxPullPushRetries:      maxPullPushRetries,
 		NamespaceOptions:        namespaceOptions,
 		NoCache:                 iopts.NoCache,
-		OmitTimestamp:           iopts.OmitTimestamp,
 		OS:                      imageOS,
 		Out:                     stdout,
 		Output:                  output,
@@ -357,6 +357,10 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		OciDecryptConfig:        decConfig,
 		Jobs:                    &iopts.Jobs,
 		LogRusage:               iopts.LogRusage,
+	}
+	if c.Flag("timestamp").Changed {
+		timestamp := time.Unix(iopts.Timestamp, 0).UTC()
+		options.Timestamp = &timestamp
 	}
 
 	if iopts.Quiet {

--- a/commit.go
+++ b/commit.go
@@ -79,6 +79,7 @@ type CommitOptions struct {
 	EmptyLayer bool
 	// OmitTimestamp forces epoch 0 as created timestamp to allow for
 	// deterministic, content-addressable builds.
+	// Deprecated use HistoryTimestamp instead.
 	OmitTimestamp bool
 	// SignBy is the fingerprint of a GPG key to use for signing the image.
 	SignBy string
@@ -231,6 +232,13 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 	// want to compute here because we'll have to do it again when
 	// cp.Image() instantiates a source image, and we don't want to do the
 	// work twice.
+	if options.OmitTimestamp {
+		if options.HistoryTimestamp != nil {
+			return imgID, nil, "", errors.Errorf("OmitTimestamp ahd HistoryTimestamp can not be used together")
+		}
+		timestamp := time.Unix(0, 0).UTC()
+		options.HistoryTimestamp = &timestamp
+	}
 	nameToRemove := ""
 	if dest == nil {
 		nameToRemove = stringid.GenerateRandomID() + "-tmp"

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -342,14 +342,12 @@ Valid _mode_ values are:
 
 Do not use existing cached images for the container build. Build from the start with a new set of cached layers.
 
-**--omit-timestamp** *bool-value*
+**--timestamp** *seconds*
 
-Set the create timestamp to epoch 0 to allow for deterministic builds (defaults to false).
+Set the create timestamp to seconds since epoch to allow for deterministic builds (defaults to current time).
 By default, the created timestamp is changed and written into the image manifest with every commit,
 causing the image's sha256 hash to be different even if the sources are exactly the same otherwise.
-When --omit-timestamp is set to true, the created timestamp is always set to the epoch and therefore not
-changed, allowing the image's sha256 to remain the same. All files committed to the layers of the image
-will get the epoch 0 timestamp.
+When --timestamp is set, the created timestamp is always set to the time specified and therefore not changed, allowing the image's sha256 to remain the same. All files committed to the layers of the image will be created with the timestamp.
 
 **--os**="OS"
 
@@ -666,6 +664,8 @@ buildah bud -f Containerfile .
 cat ~/Dockerfile | buildah bud -f - .
 
 buildah bud -f Dockerfile.simple -f Dockerfile.notsosimple .
+
+buildah bud --timestamp=$(date '+%s') -t imageName .
 
 buildah bud -t imageName .
 

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -77,14 +77,12 @@ Squash all of the new image's layers (including those inherited from a base imag
 
 Require HTTPS and verify certificates when talking to container registries (defaults to true)
 
-**--omit-timestamp** *bool-value*
+**--timestamp** *secconds*
 
-Set the create timestamp to epoch 0 to allow for deterministic builds (defaults to false).
+Set the create timestamp to seconds since epoch to allow for deterministic builds (defaults to current time).
 By default, the created timestamp is changed and written into the image manifest with every commit,
 causing the image's sha256 hash to be different even if the sources are exactly the same otherwise.
-When --omit-timestamp is set to true, the created timestamp is always set to the epoch and therefore not
-changed, allowing the image's sha256 to remain the same. All files committed to the layers of the image
-will get the epoch 0 timestamp.
+When --timestamp is set, the created timestamp is always set to the time specified and therefore not changed, allowing the image's sha256 to remain the same. All files committed to the layers of the image will be created with the timestamp.
 
 ## EXAMPLE
 
@@ -111,6 +109,9 @@ This example commits the container to the image on the local registry using cred
 
 This example commits the container to the image on the local registry using credentials from the /tmp/auths/myauths.json file and certificates for authentication.
  `buildah commit --authfile /tmp/auths/myauths.json --cert-dir ~/auth  --tls-verify=true --creds=username:password containerID docker://localhost:5000/imageName`
+
+This example saves an image based on the container, but stores dates based on epoch time.
+`buildah commit --timestamp=0 containerID newImageName`
 
 ## ENVIRONMENT
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -168,9 +168,9 @@ type BuildOptions struct {
 	SignBy string
 	// Architecture specifies the target architecture of the image to be built.
 	Architecture string
-	// OmitTimestamp forces epoch 0 as created timestamp to allow for
-	// deterministic, content-addressable builds.
-	OmitTimestamp bool
+	// Timestamp sets the created timestamp to the specified time, allowing
+	// for deterministic, content-addressable builds.
+	Timestamp *time.Time
 	// OS is the specifies the operating system of the image to be built.
 	OS string
 	// MaxPullPushRetries is the maximum number of attempts we'll make to pull or push any one

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -100,7 +100,7 @@ type Executor struct {
 	devices                        []configs.Device
 	signBy                         string
 	architecture                   string
-	omitTimestamp                  bool
+	timestamp                      *time.Time
 	os                             string
 	maxPullPushRetries             int
 	retryPullPushDelay             time.Duration
@@ -207,7 +207,7 @@ func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Nod
 		devices:                        devices,
 		signBy:                         options.SignBy,
 		architecture:                   options.Architecture,
-		omitTimestamp:                  options.OmitTimestamp,
+		timestamp:                      options.Timestamp,
 		os:                             options.OS,
 		maxPullPushRetries:             options.MaxPullPushRetries,
 		retryPullPushDelay:             options.PullPushRetryDelay,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1211,7 +1211,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		SignBy:                s.executor.signBy,
 		MaxRetries:            s.executor.maxPullPushRetries,
 		RetryDelay:            s.executor.retryPullPushDelay,
-		OmitTimestamp:         s.executor.omitTimestamp,
+		HistoryTimestamp:      s.executor.timestamp,
 	}
 	imgID, _, manifestDigest, err := s.builder.Commit(ctx, imageRef, options)
 	if err != nil {

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -65,7 +65,7 @@ type BudResults struct {
 	Logfile             string
 	Loglevel            int
 	NoCache             bool
-	OmitTimestamp       bool
+	Timestamp           int64
 	OS                  string
 	Platform            string
 	Pull                bool
@@ -165,7 +165,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.BoolVar(&flags.NoCache, "no-cache", false, "Do not use existing cached images for the container build. Build from the start with a new set of cached layers.")
 	fs.StringVar(&flags.Logfile, "logfile", "", "log to `file` instead of stdout/stderr")
 	fs.IntVar(&flags.Loglevel, "loglevel", 0, "adjust logging level (range from -2 to 3)")
-	fs.BoolVar(&flags.OmitTimestamp, "omit-timestamp", false, "set created timestamp to epoch 0 to allow for deterministic builds")
+	fs.Int64Var(&flags.Timestamp, "timestamp", 0, "set created timestamp to the specified epoch seconds to allow for deterministic builds, defaults to current time")
 	fs.StringVar(&flags.OS, "os", runtime.GOOS, "set the OS to the provided value instead of the current operating system of the host")
 	fs.StringVar(&flags.Platform, "platform", parse.DefaultPlatform(), "set the OS/ARCH to the provided value instead of the current operating system and architecture of the host (for example `linux/arm`)")
 	fs.BoolVar(&flags.Pull, "pull", true, "pull the image from the registry if newer or not present in store, if false, only pull the image if not present")

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2180,20 +2180,31 @@ EOM
   run_buildah rm -a
 }
 
-@test "bud omit-timestamp" {
+@test "bud timestamp" {
   _prefetch alpine
-  run_buildah bud --omit-timestamp --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t omit -f Dockerfile.1 bud/cache-stages
+  run_buildah bud --timestamp=0 --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 bud/cache-stages
   cid=$output
-  run_buildah inspect --format '{{ .Docker.Created }}' omit
+  run_buildah inspect --format '{{ .Docker.Created }}' timestamp
   expect_output --substring "1970-01-01"
-  run_buildah inspect --format '{{ .OCIv1.Created }}' omit
+  run_buildah inspect --format '{{ .OCIv1.Created }}' timestamp
   expect_output --substring "1970-01-01"
 
-
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json omit
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json timestamp
   cid=$output
   run_buildah run $cid ls -l /tmpfile
   expect_output --substring "1970"
+
+  rm -rf ${TESTDIR}/tmp
+}
+
+@test "bud timestamp compare" {
+  _prefetch alpine
+  TIMESTAMP=$(date '+%s')
+  run_buildah bud --timestamp=${TIMESTAMP} --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 bud/cache-stages
+  cid=$output
+
+  run_buildah bud --timestamp=${TIMESTAMP} --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 bud/cache-stages
+  expect_output "$cid"
 
   rm -rf ${TESTDIR}/tmp
 }

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -223,3 +223,23 @@ load helpers
 
   rm -rf ${TESTDIR}/tmp
 }
+
+@test "commit timestamp" {
+  _prefetch busybox
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  cid=$output
+  run_buildah run $cid touch /test
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --timestamp 0 -q $cid omit
+  run_buildah inspect --format '{{ .Docker.Created }}' omit
+  expect_output --substring "1970-01-01"
+  run_buildah inspect --format '{{ .OCIv1.Created }}' omit
+  expect_output --substring "1970-01-01"
+
+
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json omit
+  cid=$output
+  run_buildah run $cid ls -l /test
+  expect_output --substring "1970"
+
+  rm -rf ${TESTDIR}/tmp
+}


### PR DESCRIPTION
We recieved feedback on the --omit-timestamp that
users would rather specify the timestamp seconds
rather then just use EPOCH.

This PR removes --omit-timestamp from buildah bud
since this has never been released.

We also hide --omit-timestamp from buildah commit
and allow users to continue to use it, but it conflicts
with --timestamp.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

