### PR TITLE
StageExecutor.intermediateImageExists: recognize cached images based on scratch

### DIFF
--- a/tests/bud/cache-scratch/Dockerfile
+++ b/tests/bud/cache-scratch/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine as build
+
+FROM scratch
+COPY --from=build / /
+COPY --from=build / /

--- a/tests/bud/cache-scratch/Dockerfile.config
+++ b/tests/bud/cache-scratch/Dockerfile.config
@@ -1,0 +1,8 @@
+FROM alpine as build
+MAINTAINER root@localhost
+
+FROM scratch
+MAINTAINER root@localhost
+COPY --from=build / /
+MAINTAINER root@localhost
+COPY --from=build / /

--- a/tests/bud/cache-scratch/Dockerfile.different1
+++ b/tests/bud/cache-scratch/Dockerfile.different1
@@ -1,0 +1,6 @@
+FROM alpine as build
+
+FROM scratch
+COPY --from=build / /
+RUN touch cache-invalidating-difference
+COPY --from=build / /

--- a/tests/bud/cache-scratch/Dockerfile.different2
+++ b/tests/bud/cache-scratch/Dockerfile.different2
@@ -1,0 +1,6 @@
+FROM alpine as build
+RUN touch cache-invalidating-difference
+
+FROM scratch
+COPY --from=build / /
+COPY --from=build / /


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Update `imagebuildah.StageExecutor.intermediateImageExists()` to recognize images based on "scratch" as viable candidates for cache images when we ourselves are based on "scratch".

#### How to verify it

We add a couple of integration tests.  Tests which were there before should continue to pass.

#### Which issue(s) this PR fixes:

Fixes #2403.

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?

```
None
```