### PR TITLE
Bump to v1.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Changelog
 
+## v1.15.2 (2020-09-03)
+    in_podman: don't get tripped up by CIRRUS_CHANGE_TITLE
+    blobcache: avoid an unnecessary NewImage()
+
 ## v1.15.1 (2020-07-27)
     Mask over the /sys/fs/selinux in mask branch
     chroot: do not use setgroups if it is blocked

--- a/buildah.go
+++ b/buildah.go
@@ -28,7 +28,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.15.1"
+	Version = "1.15.2"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,19 @@
+- Changelog for v1.15.2 (2020-09-03)
+  * in_podman: don't get tripped up by CIRRUS_CHANGE_TITLE
+  * blobcache: avoid an unnecessary NewImage()
+
+- Changelog for v1.15.1 (2020-07-27)
+  * Mask over the /sys/fs/selinux in mask branch
+  * chroot: do not use setgroups if it is blocked
+  * chroot, run: not fail on bind mounts from /sys
+  * Allow "readonly" as alias to "ro" in mount options
+  * Add VFS additional image store to container
+  * Ignore OS X specific consistency mount option
+  * vendor golang.org/x/text@v0.3.3
+  * Cirrus: Fix missing htpasswd in registry img
+  * Switch scripts to use containers.conf
+  * Make imagebuildah.BuildOptions.Architecture/OS optional
+
 - Changelog for v1.15.0 (2020-06-17)
   * Mask over the /sys/fs/selinux in mask branch
   * chroot: do not use setgroups if it is blocked

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in buildah.go too
-Version:        1.15.1
+Version:        1.15.2
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -99,6 +99,10 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Thu Sep 3 2020 Nalin Dahyabhai <nalin@redhat.com> 1.15.2-1
+- in_podman: don't get tripped up by CIRRUS_CHANGE_TITLE
+- blobcache: avoid an unnecessary NewImage()
+
 * Mon Jul 17, 2020 Tom Sweeney <tsweeney@redhat.com> 1.15.1-1
 - Mask over the /sys/fs/selinux in mask branch 
 - chroot: do not use setgroups if it is blocked


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Bump our version number v1.15.2 for tagging a new release.

#### How to verify it

Verify that I didn't miss a spot where we report that we're an earlier 1.15 release.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is basically about rolling #2501 into a tagged release.  Users who aren't using the hidden `--blob-cache` option should be the only ones who are impacted at all.

#### Does this PR introduce a user-facing change?

```
None
```