### PR TITLE
CI: expand cross-compile checks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -176,7 +176,7 @@ gce_instance:
 
     env:
         matrix:
-            CROSS_TARGET: bin/buildah.darwin
+            CROSS_TARGET: cross
 
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
     build_script: '${SCRIPT_BASE}/build.sh |& ${_TIMESTAMP}'

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,13 @@ bin/buildah:  $(SOURCES)
 .PHONY: buildah
 buildah: bin/buildah
 
-.PHONY: bin/buildah.darwin
-bin/buildah.darwin:
-	GOOS=darwin $(GO_BUILD) $(LDFLAGS) -o $@ -tags "containers_image_openpgp" ./cmd/buildah
+.PHONY: cross
+cross: bin/buildah.darwin bin/buildah.darwin.386 bin/buildah.darwin.amd64 bin/buildah.linux.386 bin/buildah.linux.amd64 bin/buildah.linux.arm64 bin/buildah.linux.arm bin/buildah.linux.mips64 bin/buildah.linux.mips64le bin/buildah.linux.mips bin/buildah.linux.mipsle bin/buildah.linux.ppc64 bin/buildah.linux.ppc64le bin/buildah.linux.riscv64 bin/buildah.linux.s390x
+
+.PHONY: bin/buildah.%
+bin/buildah.%:
+	mkdir -p ./bin
+	GOOS=$(shell echo $@ | awk -F. '{print $$2}') GOARCH=$(shell echo $@ | awk -F. '{ print $$3 }') $(GO_BUILD) $(LDFLAGS) -o $@ -tags "containers_image_openpgp" ./cmd/buildah
 
 .PHONY: bin/imgtype
 bin/imgtype: *.go docker/*.go util/*.go tests/imgtype/imgtype.go

--- a/bind/mount.go
+++ b/bind/mount.go
@@ -270,7 +270,7 @@ func UnmountMountpoints(mountpoint string, mountpointsToRemove []string) error {
 			}
 			return errors.Wrapf(err, "error checking if %q is mounted", mount.Mountpoint)
 		}
-		if mount.Major != int(unix.Major(st.Dev)) || mount.Minor != int(unix.Minor(st.Dev)) {
+		if uint64(mount.Major) != uint64(st.Dev) || uint64(mount.Minor) != uint64(st.Dev) { // nolint:unconvert (required for some OS/arch combinations)
 			logrus.Debugf("%q is apparently not really mounted, skipping", mount.Mountpoint)
 			continue
 		}

--- a/contrib/cirrus/test.sh
+++ b/contrib/cirrus/test.sh
@@ -34,7 +34,7 @@ then
             export GITVALIDATE_TIP="$CIRRUS_CHANGE_IN_REPO"
             echo "Linting & Validating from $GITVALIDATE_EPOCH to $GITVALIDATE_TIP"
             # TODO: This will fail if PR HEAD != upstream branch head
-            showrun make lint LINTFLAGS="--deadline=20m --color=always"
+            showrun make lint LINTFLAGS="--deadline=20m --color=always -j1"
             showrun make validate
             ;;
         unit)

--- a/util/util_not_uint64.go
+++ b/util/util_not_uint64.go
@@ -1,4 +1,4 @@
-// +build darwin
+// +build darwin linux,mips linux,mipsle linux,mips64 linux,mips64le
 
 package util
 

--- a/util/util_uint64.go
+++ b/util/util_uint64.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!mips,!mipsle,!mips64,!mips64le
 
 package util
 


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Prompted by #2581, expand the list of OS/architecture combinations we check when we're checking if we can successfully be cross-compiled, and fix up a couple of places that wouldn't pass otherwise.

#### How to verify it

The "cross" test should be building more OS/architecture combinations than it did before.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

For the sake of podman, we'll want to add `darwin.arm` and `darwin.arm64` sooner or later.

#### Does this PR introduce a user-facing change?

```
None
```