### PR TITLE
add CI jobs to check for 32bit arch builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,6 +21,8 @@ env:
     IN_PODMAN: 'false'
     # Not cross-compiling by default
     CROSS_TARGET: ""
+    # Not building for other arches by default
+    GOARCH: ""
 
     ####
     #### Cache-image names to test with
@@ -177,13 +179,18 @@ gce_instance:
     env:
         matrix:
             CROSS_TARGET: cross
+        matrix:
+          - env:
+            GOARCH: "arm"
+          - env:
+            GOARCH: "386"
 
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
     build_script: '${SCRIPT_BASE}/build.sh |& ${_TIMESTAMP}'
 
     binary_artifacts:
         path: ./bin/*
-
+          
 
 'cirrus-ci/required/testing_task':
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@ SELINUXTAG := $(shell ./selinux_tag.sh)
 APPARMORTAG := $(shell hack/apparmor_tag.sh)
 STORAGETAGS := $(shell ./btrfs_tag.sh) $(shell ./btrfs_installed_tag.sh) $(shell ./libdm_tag.sh)
 SECURITYTAGS ?= seccomp $(SELINUXTAG) $(APPARMORTAG)
+ifneq (or $(findstring 386,$(GOARCH)),$(findstring arm,$(GOARCH)))
+TAGS ?= containers_image_openpgp
+else
 TAGS ?= $(SECURITYTAGS) $(STORAGETAGS)
+endif
 BUILDTAGS += $(TAGS)
 PREFIX := /usr/local
 BINDIR := $(PREFIX)/bin
@@ -15,6 +19,7 @@ BUILDAH := buildah
 GO := go
 GO110 := 1.10
 GOVERSION := $(findstring $(GO110),$(shell go version))
+GOARCH ?= amd64
 # test for go module support
 ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
 export GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
@@ -56,7 +61,7 @@ static:
 
 .PHONY: bin/buildah
 bin/buildah:  $(SOURCES)
-	$(GO_BUILD) $(LDFLAGS) -o $@ $(BUILDFLAGS) ./cmd/buildah
+	GOARCH=$(GOARCH) $(GO_BUILD) $(LDFLAGS) -o $@ $(BUILDFLAGS) ./cmd/buildah
 
 .PHONY: buildah
 buildah: bin/buildah

--- a/contrib/cirrus/build.sh
+++ b/contrib/cirrus/build.sh
@@ -16,13 +16,13 @@ then
     in_podman --rm $IN_PODMAN_NAME $0
 else
     echo "Compiling buildah (\$GOSRC=$GOSRC)"
-    showrun make clean ${CROSS_TARGET:-all} ${CROSS_TARGET:+CGO_ENABLED=0}
+    showrun make clean GOARCH=${GOARCH:-amd64} ${CROSS_TARGET:-all} ${CROSS_TARGET:+CGO_ENABLED=0}
 
     echo "Installing buildah"
     mkdir -p bin
     if [[ -z "$CROSS_TARGET" ]]
     then
-        showrun make install PREFIX=/usr
+        showrun env GOARCH=${GOARCH} make install PREFIX=/usr
         showrun ./bin/buildah info
     fi
 fi

--- a/tests/tools/Makefile
+++ b/tests/tools/Makefile
@@ -6,6 +6,8 @@ else
 export GO_BUILD=$(GO) build
 endif
 
+GOARCH ?= amd64
+
 BUILDDIR := build
 
 all: $(BUILDDIR)
@@ -17,7 +19,7 @@ vendor:
 	GO111MODULE=on $(GO) mod verify
 
 define go-build
-	$(shell cd `pwd` && $(GO_BUILD) -o $(BUILDDIR)/$(shell basename $(1)) $(1))
+	$(shell cd `pwd` && GOARCH=$(GOARCH) $(GO_BUILD) -o $(BUILDDIR)/$(shell basename $(1)) $(1))
 	@echo > /dev/null
 endef
 


### PR DESCRIPTION
This commit adds 2 new Cirrus tasks to build for linux/arm and linux/386
os/arch combos. This should hopefully avoid situations where we notice
32bit failures only after a fedora koji build.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@cevich @nalind @TomSweeneyRedHat @edsantiago PTAL

#### What type of PR is this?

 /kind other

#### What this PR does / why we need it:

This PR will enable additional cirrus tasks to check if the source builds fine on 386 and arm arches.

#### How to verify it

CI should show 2 additional tasks for 386 and arm builds.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

```release-note
None
```

