### PR TITLE
Extend flags of `manifest add`

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -737,12 +737,16 @@ return 1
   "
 
      local options_with_args="
+     --authfile
      --annotation
      --arch
+     --cert-dir
+     --creds
      --features
      --os
      --os-features
      --os-version
+     --tls-verify
      --variant
   "
 

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -734,6 +734,7 @@ return 1
      --help
      -h
      --all
+     --tls-verify
   "
 
      local options_with_args="
@@ -746,7 +747,6 @@ return 1
      --os
      --os-features
      --os-version
-     --tls-verify
      --variant
   "
 
@@ -827,6 +827,7 @@ return 1
      -h
      --all
      --remove-signatures
+     --tls-verify
   "
 
      local options_with_args="
@@ -838,7 +839,6 @@ return 1
      -f
      --purge
      --sign-by
-     --tls-verify
   "
 
      local all_options="$options_with_args $boolean_options"

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -85,7 +85,7 @@ given.
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+The default certificates directory is _/etc/containers/certs.d_.
 
 **--cgroup-parent**=""
 

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -27,7 +27,7 @@ If the authorization state is not found there, $HOME/.docker/config.json is chec
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+The default certificates directory is _/etc/containers/certs.d_.
 
 **--creds** *creds*
 
@@ -75,7 +75,7 @@ Squash all of the new image's layers (including those inherited from a base imag
 
 **--tls-verify** *bool-value*
 
-Require HTTPS and verify certificates when talking to container registries (defaults to true)
+Require HTTPS and verify certificates when talking to container registries (defaults to true).
 
 **--timestamp** *secconds*
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -324,7 +324,7 @@ If you omit the unit, the system uses bytes. If you omit the size entirely, the 
 
 **--tls-verify** *bool-value*
 
-Require HTTPS and verify certificates when talking to container registries (defaults to true)
+Require HTTPS and verify certificates when talking to container registries (defaults to true).
 
 **--ulimit** *type*=*soft-limit*[:*hard-limit*]
 

--- a/docs/buildah-login.md
+++ b/docs/buildah-login.md
@@ -47,7 +47,7 @@ Return the logged-in user for the registry.  Return error if no login is found.
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+The default certificates directory is _/etc/containers/certs.d_.
 
 **--tls-verify**
 

--- a/docs/buildah-manifest-add.md
+++ b/docs/buildah-manifest-add.md
@@ -44,7 +44,7 @@ If the authorization state is not found there, $HOME/.docker/config.json is chec
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+The default certificates directory is _/etc/containers/certs.d_.
 
 **--creds** *creds*
 
@@ -76,7 +76,7 @@ image.  This option is rarely used.
 
 **--tls-verify** *bool-value*
 
-Require HTTPS and verify certificates when talking to container registries (defaults to true)
+Require HTTPS and verify certificates when talking to container registries (defaults to true).
 
 **--variant**
 
@@ -102,4 +102,4 @@ buildah manifest add --arch arm64 --variant v8 mylist:v1.11 docker://fedora@sha2
 ```
 
 ## SEE ALSO
-buildah(1), buildah-manifest(1), buildah-manifest-create(1), buildah-manifest-remove(1), buildah-manifest-annotate(1), buildah-manifest-inspect(1), buildah-manifest-push(1), buildah-rmi(1)
+buildah(1), buildah-login(1), buildah-manifest(1), buildah-manifest-create(1), buildah-manifest-remove(1), buildah-manifest-annotate(1), buildah-manifest-inspect(1), buildah-manifest-push(1), buildah-rmi(1), docker-login(1)

--- a/docs/buildah-manifest-add.md
+++ b/docs/buildah-manifest-add.md
@@ -36,6 +36,22 @@ the image.  If *imageName* refers to a manifest list or image index, the
 architecture information will be retrieved from it.  Otherwise, it will be
 retrieved from the image's configuration information.
 
+**--authfile** *path*
+
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+
+**--cert-dir** *path*
+
+Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
+Default certificates directory is _/etc/containers/certs.d_.
+
+**--creds** *creds*
+
+The [username[:password]] to use to authenticate with the registry if required.
+If one or both values are not supplied, a command line prompt will appear and the
+value can be entered.  The password is entered without echo.
+
 **--features**
 
 Specify the features list which the list or index records as requirements for
@@ -57,6 +73,10 @@ for the image.  This option is rarely used.
 
 Specify the OS version which the list or index records as a requirement for the
 image.  This option is rarely used.
+
+**--tls-verify** *bool-value*
+
+Require HTTPS and verify certificates when talking to container registries (defaults to true)
 
 **--variant**
 

--- a/docs/buildah-manifest-push.md
+++ b/docs/buildah-manifest-push.md
@@ -31,7 +31,7 @@ If the authorization state is not found there, $HOME/.docker/config.json is chec
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+The default certificates directory is _/etc/containers/certs.d_.
 
 **--creds** *creds*
 
@@ -61,7 +61,7 @@ Sign the pushed images using the GPG key that matches the specified fingerprint.
 
 **--tls-verify** *bool-value*
 
-Require HTTPS and verify certificates when talking to container registries (defaults to true)
+Require HTTPS and verify certificates when talking to container registries (defaults to true).
 
 ## EXAMPLE
 
@@ -70,4 +70,4 @@ buildah manifest push mylist:v1.11 docker://registry.example.org/mylist:v1.11
 ```
 
 ## SEE ALSO
-buildah(1), buildah-manifest(1), buildah-manifest-create(1), buildah-manifest-add(1), buildah-manifest-remove(1), buildah-manifest-annotate(1), buildah-manifest-inspect(1), buildah-rmi(1)
+buildah(1), buildah-login(1), buildah-manifest(1), buildah-manifest-create(1), buildah-manifest-add(1), buildah-manifest-remove(1), buildah-manifest-annotate(1), buildah-manifest-inspect(1), buildah-rmi(1), docker-login(1)

--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -82,7 +82,7 @@ If you omit the unit, the system uses bytes. If you omit the size entirely, the 
 
 **--tls-verify** *bool-value*
 
-Require HTTPS and verify certificates when talking to container registries (defaults to true)
+Require HTTPS and verify certificates when talking to container registries (defaults to true).
 
 
 ## EXAMPLE

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -50,7 +50,7 @@ If the authorization state is not found there, $HOME/.docker/config.json is chec
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+The default certificates directory is _/etc/containers/certs.d_.
 
 **--creds** *creds*
 
@@ -88,7 +88,7 @@ Sign the pushed image using the GPG key that matches the specified fingerprint.
 
 **--tls-verify** *bool-value*
 
-Require HTTPS and verify certificates when talking to container registries (defaults to true)
+Require HTTPS and verify certificates when talking to container registries (defaults to true).
 
 ## EXAMPLE
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

This PR extends the flags of `buildah manifest add` to include also:

  * cert-dir
  * auth-file
  * creds
  * tls-verify

These options are useful when adding to a manifest an image that is not part of the local image store. The image resides on a remote registry that falls into one of these cases: it's not using tls termination, it requires authentication or it's secured with an unknown tls certificate.

Consider the following scenario: a multi architecture manifest is created as part of a multi-step CI pipeline running in a containerized way.
All the images referenced by the manifest live inside of a registry secured with a self-signed tls certificate.

Without this patch the manifest creation step would have to pull all the multi-architecture images locally via `buildah pull`.

With this patch the usage of `buildah pull` would not be needed because the images' digests can be requested straight to the registry. That means the execution of manifest creation step would be faster and result in less disk space and network bandwidth being used.

#### How to verify it

Prepare the following environments:

* Insecure container registry: `insecure-reg.local.lan`
* Container registry secured by self-signed ceriticate: `self-signed-reg.local.lan`
* Container registry with authentication enforced, even for pull options: `auth-reg.local.lan`

Ensure each repository has at least an image inside of it: 
  * `<registry>/busybox:latest-amd64`
  * `<registry>/busybox:latest-arm64`

On a machine where no container images are defined execute the following steps:

* Create a manifest for the insecure registry:

```
buildah manifest create insecure-reg.local.lan/busybox:latest
buildah manifest add --tls-verify=false insecure-reg.local.lan/busybox:latest docker://insecure-reg.local.lan/busybox:latest-amd64 docker://insecure-reg.local.lan/busybox:latest-arm64
buildah manifest push --tls-verify=false insecure-reg.local.lan/busybox:latest
```

* Create a manifest for the registry secured by a self-signed certificate not known by the host:

```
mkdir ~/certs
cp self-signed-reg.local.lan.crt ~/certs
buildah manifest create self-signed-reg.local.lan/busybox:latest
buildah manifest add --cert-dir=~/certs self-signed-reg.local.lan/busybox:latest docker://self-signed-reg.local.lan/busybox:latest-amd64 docker://self-signed-reg.local.lan/busybox:latest-arm64
buildah manifest push --cert-dir=~/certs self-signed-reg.local.lan/busybox:latest
```

* Create a manifest for the registry secured by a self-signed certificate and using authentication:

```
mkdir ~/certs
cp auth-reg.local.lan.crt ~/certs
buildah manifest create auth-reg.local.lan/busybox:latest
buildah manifest add --cert-dir=~/certs --creds alice:secret auth-reg.local.lan/busybox:latest docker://auth-reg.local.lan/busybox:latest-amd64 docker://auth-reg.local.lan/busybox:latest-arm64
buildah manifest push --cert-dir=~/certs  --creds alice:secret auth-reg.local.lan/busybox:latest
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Nothing special to report.

#### Does this PR introduce a user-facing change?

```release-note
* Extend the `manifest add` command to support also `cert-dir`, `auth-file`, `creds` and `tls-verify` flags like other buildah command already do.
```

