### PR TITLE
contrib/cirrus/lib.sh: don't use CN for the hostname

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -304,7 +304,8 @@ execute_local_registry() {
     mkdir -p $authdirpath
     openssl req \
         -newkey rsa:4096 -nodes -sha256 -x509 -days 2 \
-        -subj "/C=US/ST=Foo/L=Bar/O=Red Hat, Inc./CN=localhost" \
+        -subj "/C=US/ST=Foo/L=Bar/O=Red Hat, Inc./CN=registry host certificate" \
+        -addext subjectAltName=DNS:localhost \
         -keyout $authdirpath/domain.key \
         -out $authdirpath/domain.crt
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

When generating a certificate to be used by a registry server that we're bringing up, instead of setting a CN value in the subject name to "localhost" to pass the name check that a client makes, use a subject alternative name extension.

The "compare the hostname we're given with a CN from the subject name field" method stops working if the client is built with Go 1.15.

#### How to verify it

Tests which passed before should continue to pass, even when run using a binary built with Go 1.15.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```