### PR TITLE
bud.bats: use absolute paths in newly-added tests

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2182,7 +2182,7 @@ EOM
 
 @test "bud timestamp" {
   _prefetch alpine
-  run_buildah bud --timestamp=0 --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 bud/cache-stages
+  run_buildah bud --timestamp=0 --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
   cid=$output
   run_buildah inspect --format '{{ .Docker.Created }}' timestamp
   expect_output --substring "1970-01-01"
@@ -2200,10 +2200,10 @@ EOM
 @test "bud timestamp compare" {
   _prefetch alpine
   TIMESTAMP=$(date '+%s')
-  run_buildah bud --timestamp=${TIMESTAMP} --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 bud/cache-stages
+  run_buildah bud --timestamp=${TIMESTAMP} --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
   cid=$output
 
-  run_buildah bud --timestamp=${TIMESTAMP} --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 bud/cache-stages
+  run_buildah bud --timestamp=${TIMESTAMP} --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
   expect_output "$cid"
 
   rm -rf ${TESTDIR}/tmp
@@ -2211,7 +2211,7 @@ EOM
 
 @test "bud with-rusage" {
   _prefetch alpine
-  run_buildah bud --log-rusage --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json bud/shell
+  run_buildah bud --log-rusage --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/shell
   cid=$output
   # expect something that looks like it was formatted using pkg/rusage.FormatDiff()
   expect_output --substring ".*\(system\).*\(user\).*\(elapsed\).*input.*output"
@@ -2220,17 +2220,17 @@ EOM
 @test "bud-caching-from-scratch" {
   _prefetch alpine
   # run the build once
-  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json bud/cache-scratch
+  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/cache-scratch
   iid="$output"
   # now run it again - the cache should give us the same final image ID
-  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json bud/cache-scratch
+  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/cache-scratch
   iid2="$output"
   expect_output --substring "$iid"
   # now run it *again*, except with more content added at an intermediate step, which should invalidate the cache
-  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.different1 bud/cache-scratch
+  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.different1 ${TESTSDIR}/bud/cache-scratch
   test "$output" != "$iid"
   # now run it *again* again, except with more content added at an intermediate step, which should invalidate the cache
-  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.different2 bud/cache-scratch
+  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.different2 ${TESTSDIR}/bud/cache-scratch
   test "$output" != "$iid"
   test "$output" != "$iid2"
 }
@@ -2238,17 +2238,17 @@ EOM
 @test "bud-caching-from-scratch-config" {
   _prefetch alpine
   # run the build once
-  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.config bud/cache-scratch
+  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.config ${TESTSDIR}/bud/cache-scratch
   iid="$output"
   # now run it again - the cache should give us the same final image ID
-  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.config bud/cache-scratch
+  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.config ${TESTSDIR}/bud/cache-scratch
   iid2="$output"
   expect_output --substring "$iid"
   # now run it *again*, except with more content added at an intermediate step, which should invalidate the cache
-  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.different1 bud/cache-scratch
+  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.different1 ${TESTSDIR}/bud/cache-scratch
   test "$output" != "$iid"
   # now run it *again* again, except with more content added at an intermediate step, which should invalidate the cache
-  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.different2 bud/cache-scratch
+  run_buildah bud --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.different2 ${TESTSDIR}/bud/cache-scratch
   test "$output" != "$iid"
   test "$output" != "$iid2"
 }


### PR DESCRIPTION
Gating tests run in a temp directory; relative paths (bud/foo/bar)
will pass in CI but cause gating-test failures.

Solution is trivial: always use `${TESTSDIR}/bud/etc`

Signed-off-by: Ed Santiago <santiago@redhat.com>

#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Fedora gating tests are failing on rawhide with errors like:
```
$ /usr/bin/buildah bud --timestamp=0 --quiet --pull=false --signature-policy /usr/share/buildah/test/system/policy.json -t timestamp -f Dockerfile.1 bud/cache-stages
error evaluating symlinks in build context path: lstat /var/str/bud: no such file or directory
[ rc=125 (** EXPECTED 0 **) ]
```

#### How to verify it

Run `bats /path/to/bud.bats` while cd'ed to a directory other than the git checkout

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None