### PR TITLE
[release-1.16] copier.Get(): hard link targets shouldn't be relative paths

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1829,6 +1829,11 @@ _EOF
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --squash ${TESTSDIR}/bud/layers-squash
 }
 
+@test "bud-squash-hardlinks" {
+  _prefetch busybox
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --squash ${TESTSDIR}/bud/layers-squash/Dockerfile.hardlinks
+}
+
 @test "bud with additional directory of devices" {
   skip_if_chroot
   skip_if_rootless

--- a/tests/bud/layers-squash/Dockerfile.hardlinks
+++ b/tests/bud/layers-squash/Dockerfile.hardlinks
@@ -1,0 +1,3 @@
+FROM busybox
+COPY artifact /subdir/artifact
+RUN ln -f /subdir/artifact /subdir/artifact-hardlink


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When adding a hard link entry to an archive, don't try to make the path of the link's target name be relative to the link's location in the filesystem if they're in the same directory, since receivers don't interpret it that way.

Flagged by one of podman's e2e tests.  h/t @rhatdan

#### How to verify it

Added an integration test, but using squashing (our `--squash`, or podman's `--squash-all`) to trigger the right code path, and then having a file with two or more links, all in the same subdirectory below the root directory, should trigger the error path.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Cherry-picked from #2598.

#### Does this PR introduce a user-facing change?

```
Fixes a regression in 1.16.0 where attempting to "squash" an image while committing it could fail.
```