### PR TITLE
Warn when setting healthcheck in OCI format

### DIFF
--- a/config.go
+++ b/config.go
@@ -565,6 +565,9 @@ func (b *Builder) Healthcheck() *docker.HealthConfig {
 func (b *Builder) SetHealthcheck(config *docker.HealthConfig) {
 	b.Docker.Config.Healthcheck = nil
 	if config != nil {
+		if b.Format != Dockerv2ImageManifest {
+			logrus.Warnf("Healthcheck is not supported for OCI image format and will be ignored. Must use `docker` format")
+		}
 		b.Docker.Config.Healthcheck = &docker.HealthConfig{
 			Test:        copyStringSlice(config.Test),
 			Interval:    config.Interval,


### PR DESCRIPTION
Signed-off-by: Ashley Cui <acui@redhat.com>

#### What type of PR is this?
/kind other

#### What this PR does / why we need it:
Healthcheck only works in Docker format, so when healthcheck is set in OCI format, warn user that it will be discarded
#### How to verify it

#### Which issue(s) this PR fixes:
Fixes: https://github.com/containers/buildah/issues/2388


