### PR TITLE
Improve buildah completions

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -73,12 +73,22 @@ __buildah_pos_first_nonflag() {
 __buildah_previous_extglob_setting=$(shopt -p extglob)
 shopt -s extglob
 
+# __buildah_list_mounted
+__buildah_list_mounted() {
+   COMPREPLY=($(compgen -W "$(buildah mount | awk '{print $1}')" -- $cur))
+}
+
 __buildah_list_containers() {
    COMPREPLY=($(compgen -W "$(buildah containers --format '{{.ContainerName}} {{.ContainerID}}' )" -- $cur))
 }
-
 __buildah_list_images() {
    COMPREPLY=($(compgen -W "$(buildah images --format '{{.ID}} {{.Name}}' )" -- $cur))
+}
+__buildah_list_images_scratch() {
+   COMPREPLY=($(compgen -W "$(buildah images --format '{{.ID}} {{.Name}}' ) scratch" -- $cur))
+}
+__buildah_list_containers_images() {
+   COMPREPLY=($(compgen -W "$(buildah containers --format '{{.ContainerName}} {{.ContainerID}}') $(buildah images --format '{{.ID}} {{.Name}}')" -- $cur))
 }
 
 __buildah_pos_first_nonflag() {
@@ -302,6 +312,9 @@ return 1
          -*)
              COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
              ;;
+         *)
+             __buildah_list_containers
+             ;;
      esac
  }
 
@@ -355,6 +368,9 @@ return 1
      case "$cur" in
          -*)
              COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+             ;;
+         *)
+             __buildah_list_containers
              ;;
      esac
  }
@@ -502,6 +518,9 @@ return 1
  case "$cur" in
      -*)
          COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+	 ;;
+      *)
+         __buildah_list_containers
          ;;
  esac
 }
@@ -570,6 +589,9 @@ return 1
      case "$cur" in
          -*)
              COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+             ;;
+         *)
+	     __buildah_list_mounted
              ;;
      esac
  }
@@ -651,6 +673,9 @@ return 1
      case "$cur" in
          -*)
              COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+             ;;
+         *)
+             __buildah_list_images
              ;;
      esac
  }
@@ -884,6 +909,9 @@ return 1
          -*)
              COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
              ;;
+         *)
+             __buildah_list_containers
+             ;;
      esac
  }
 
@@ -990,7 +1018,11 @@ _buildah_containers() {
          -*)
              COMPREPLY=($(compgen -W "$options_with_args" -- "$cur"))
              ;;
-     esac
+         *)
+             __buildah_list_containers_images
+             ;;
+
+esac
  }
 
  _buildah_tag() {
@@ -1002,6 +1034,9 @@ _buildah_containers() {
      case "$cur" in
          -*)
              COMPREPLY=($(compgen -W "$options_with_args" -- "$cur"))
+             ;;
+         *)
+             __buildah_list_images
              ;;
      esac
  }
@@ -1063,7 +1098,7 @@ _buildah_containers() {
              COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
              ;;
          *)
-             __buildah_list_containers
+             __buildah_list_images_scratch
              ;;
      esac
  }


### PR DESCRIPTION
Watching users playing with buildah, they were disappointed in some of
the command completions that were missing. I have added the ones that they
were looking for plus a few more.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

