### PR TITLE
Cirrus: Use images from automation_images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,11 +33,13 @@ env:
     UBUNTU_NAME: "ubuntu-20"
     PRIOR_UBUNTU_NAME: "ubuntu-19"
 
-    _BUILT_IMAGE_SUFFIX: "podman-6530021898584064"
-    FEDORA_CACHE_IMAGE_NAME: "${FEDORA_NAME}-${_BUILT_IMAGE_SUFFIX}"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "${PRIOR_FEDORA_NAME}-${_BUILT_IMAGE_SUFFIX}"
-    UBUNTU_CACHE_IMAGE_NAME: "${UBUNTU_NAME}-${_BUILT_IMAGE_SUFFIX}"
-    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "${PRIOR_UBUNTU_NAME}-${_BUILT_IMAGE_SUFFIX}"
+    IMAGE_SUFFIX: "podman-6530021898584064"
+    FEDORA_CACHE_IMAGE_NAME: "${FEDORA_NAME}-${IMAGE_SUFFIX}"
+    PRIOR_FEDORA_CACHE_IMAGE_NAME: "${PRIOR_FEDORA_NAME}-${IMAGE_SUFFIX}"
+    UBUNTU_CACHE_IMAGE_NAME: "${UBUNTU_NAME}-${IMAGE_SUFFIX}"
+    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "${PRIOR_UBUNTU_NAME}-${IMAGE_SUFFIX}"
+
+    IN_PODMAN_IMAGE: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
 
     ####
     #### Command variables to help avoid duplication
@@ -62,10 +64,12 @@ gce_instance:
 
 
 # Update metadata on VM images referenced by this repository state
-'cirrus-ci/only_prs/meta_task':
+meta_task:
+    name: "VM img. keepalive"
+    alias: meta
 
     container:
-        image: "quay.io/libpod/imgts:latest"  # see contrib/imgts
+        image: "quay.io/libpod/imgts:${IMAGE_SUFFIX}"  # see contrib/imgts
         cpu: 1
         memory: 1
 
@@ -86,7 +90,10 @@ gce_instance:
     script: '/usr/local/bin/entrypoint.sh |& ${_TIMESTAMP}'
 
 
-'cirrus-ci/only_prs/gate_task':
+smoke_task:
+    alias: 'smoke'
+    name: "Smoke Test"
+
     gce_instance:
         memory: "12Gb"
 
@@ -104,7 +111,13 @@ gce_instance:
         path: ./bin/*
 
 
-'cirrus-ci/only_prs/unit_task':
+unit_task:
+    name: "Unit tests"
+    alias: unit
+
+    depends_on:
+      - smoke
+      - vendor
 
     timeout_in: 45m
 
@@ -116,7 +129,13 @@ gce_instance:
         path: ./bin/*
 
 
-'cirrus-ci/only_prs/conformance_task':
+conformance_task:
+    name: "Docker Build Conformance"
+    alias: conformance
+
+    depends_on:
+      - unit
+
     gce_instance:  # Only need to specify differences from defaults (above)
         image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
 
@@ -126,11 +145,11 @@ gce_instance:
     conformance_test_script: '${SCRIPT_BASE}/test.sh conformance |& ${_TIMESTAMP}'
 
 
-# This task runs `make vendor` followed by ./hack/tree_status.sh to check
-# whether the git tree is clean.  The reasoning for that is to make sure
-# that the vendor.conf, the code and the vendored packages in ./vendor are
-# in sync at all times.
-'cirrus-ci/only_prs/vendor_task':
+# Check that all included go modules from other sources match
+# # what is expected in `vendor/modules.txt` vs `go.mod`.
+vendor_task:
+    name: "Test Vendoring"
+    alias: vendor
 
     env:
         CIRRUS_WORKING_DIR: "/var/tmp/go/src/github.com/containers/buildah"
@@ -150,11 +169,13 @@ gce_instance:
         - './hack/tree_status.sh'
 
 
-'cirrus-ci/only_prs/cross_task':
+# Confirm cross-compile ALL archetectures on a Mac OS-X VM.
+cross_build_task:
+    name: "Cross Compile"
+    alias: cross_build
 
     depends_on:
-        - 'cirrus-ci/only_prs/gate'
-        - 'cirrus-ci/only_prs/vendor'
+      - unit
 
     env:
         matrix:
@@ -167,18 +188,29 @@ gce_instance:
         path: ./bin/*
 
 
-'cirrus-ci/required/testing_task':
+integration_task:
+    name: "Integration $DISTRO_NV"
+    alias: integration
 
     depends_on:
-        - 'cirrus-ci/only_prs/gate'
-        - 'cirrus-ci/only_prs/vendor'
+      - unit
 
-    gce_instance:  # Only need to specify differences from defaults (above)
-        matrix:  # Duplicate this task for each matrix product.
-            image_name: "${FEDORA_CACHE_IMAGE_NAME}"
-            image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
-            image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
-#            image_name: "${PRIOR_UBUNTU_CACHE_IMAGE_NAME}"
+    matrix:
+        - env:
+            DISTRO_NV: "${FEDORA_NAME}"
+            IMAGE_NAME: "${FEDORA_CACHE_IMAGE_NAME}"
+        - env:
+            DISTRO_NV: "${PRIOR_FEDORA_NAME}"
+            IMAGE_NAME: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
+        - env:
+            DISTRO_NV: "${UBUNTU_NAME}"
+            IMAGE_NAME: "${UBUNTU_CACHE_IMAGE_NAME}"
+        - env:
+            DISTRO_NV: "${PRIOR_UBUNTU_NAME}"
+            IMAGE_NAME: "${PRIOR_UBUNTU_CACHE_IMAGE_NAME}"
+
+    gce_instance:
+        image_name: "$IMAGE_NAME"
 
     # Separate scripts for separate outputs, makes debugging easier.
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
@@ -199,14 +231,15 @@ gce_instance:
         golang_version_script: '$GOSRC/$SCRIPT_BASE/logcollector.sh golang'
 
 
-'cirrus-ci/required/in_podman_task':
+in_podman_task:
+    name: "Containerized Integration"
+    alias: in_podman
 
     depends_on:
-        - 'cirrus-ci/only_prs/gate'
-        - 'cirrus-ci/only_prs/vendor'
+        - unit
 
     env:
-        # This is key, it causes the scripts to re-execute themselves inside a container.
+        # This is key, cause the scripts to re-execute themselves inside a container.
         IN_PODMAN: 'true'
         BUILDAH_ISOLATION: 'chroot'
         STORAGE_DRIVER: 'vfs'
@@ -223,31 +256,40 @@ gce_instance:
     always:
         <<: *standardlogs
 
-# TODO: Bors-ng has trouble interpreting multiple status-checks as being required
-#       when their names contain wild-cards (like `testing%`).  Until that issue
-#       can be fixed, use a single "test" to represent pass/fail status of all
-#       required checks.
-'cirrus-ci/success_task':
+
+# Status aggregator for all tests.  This task simply ensures a defined
+# set of tasks all passed, and allows confirming that based on the status
+# of this task.
+success_task:
+    name: "Total Success"
+    alias: success
 
     depends_on:
-        - "cirrus-ci/required/testing"
-        - "cirrus-ci/required/in_podman"
-
-    env:
-        CIRRUS_WORKING_DIR: /tmp
-        CIRRUS_CLONE_DEPTH: 1  # no code is being used by this task
+      - meta
+      - smoke
+      - unit
+      - conformance
+      - vendor
+      - cross_build
+      - integration
+      - in_podman
+      - static_build
 
     container:
         image: "quay.io/libpod/fedora-minimal:latest"
         cpu: 1
         memory: 1
 
+    clone_script: mkdir -p $CIRRUS_WORKING_DIR
     script: /bin/true
 
-# Build the static binary
-'cirrus-ci/only_prs/static_binary_task':
+
+static_build_task:
+    name: "Static Build"
+    alias: static_build
+
     depends_on:
-        - "cirrus-ci/only_prs/gate"
+      - unit
 
     gce_instance:
         image_name: "${FEDORA_CACHE_IMAGE_NAME}"
@@ -264,8 +306,7 @@ gce_instance:
 
     nix_cache:
       folder: '.cache'
-      fingerprint_script: |
-        echo "nix-v1-$(sha1sum nix/nixpkgs.json | head -c 40)"
+      fingerprint_script: cat nix/*
 
     build_script: |
         set -ex

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,16 +28,16 @@ env:
     # GCE project where images live
     IMAGE_PROJECT: "libpod-218412"
     # See https://github.com/containers/podman/blob/master/contrib/cirrus/README.md#test_build_cache_images_task-task
-    FEDORA_NAME: "fedora-32"
-    PRIOR_FEDORA_NAME: "fedora-31"
-    UBUNTU_NAME: "ubuntu-20"
-    PRIOR_UBUNTU_NAME: "ubuntu-19"
+    FEDORA_NAME: "fedora-33"
+    PRIOR_FEDORA_NAME: "fedora-32"
+    UBUNTU_NAME: "ubuntu-2010"
+    PRIOR_UBUNTU_NAME: "ubuntu-2004"
 
-    IMAGE_SUFFIX: "podman-6530021898584064"
-    FEDORA_CACHE_IMAGE_NAME: "${FEDORA_NAME}-${IMAGE_SUFFIX}"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "${PRIOR_FEDORA_NAME}-${IMAGE_SUFFIX}"
-    UBUNTU_CACHE_IMAGE_NAME: "${UBUNTU_NAME}-${IMAGE_SUFFIX}"
-    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "${PRIOR_UBUNTU_NAME}-${IMAGE_SUFFIX}"
+    IMAGE_SUFFIX: "c6102133168668672"
+    FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
+    PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
+    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
+    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "prior-ubuntu-${IMAGE_SUFFIX}"
 
     IN_PODMAN_IMAGE: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
 
@@ -110,6 +110,29 @@ smoke_task:
     binary_artifacts:
         path: ./bin/*
 
+# Check that all included go modules from other sources match
+# # what is expected in `vendor/modules.txt` vs `go.mod`.
+vendor_task:
+    name: "Test Vendoring"
+    alias: vendor
+
+    env:
+        CIRRUS_WORKING_DIR: "/var/tmp/go/src/github.com/containers/buildah"
+        GOPATH: "/var/tmp/go"
+        GOSRC: "/var/tmp/go/src/github.com/containers/buildah"
+
+    # Runs within Cirrus's "community cluster"
+    container:
+        image: docker.io/library/golang:1.13
+        cpu: 1
+        memory: 1
+
+    timeout_in: 5m
+
+    vendor_script:
+        - 'make vendor'
+        - './hack/tree_status.sh'
+
 
 unit_task:
     name: "Unit tests"
@@ -145,30 +168,6 @@ conformance_task:
     conformance_test_script: '${SCRIPT_BASE}/test.sh conformance |& ${_TIMESTAMP}'
 
 
-# Check that all included go modules from other sources match
-# # what is expected in `vendor/modules.txt` vs `go.mod`.
-vendor_task:
-    name: "Test Vendoring"
-    alias: vendor
-
-    env:
-        CIRRUS_WORKING_DIR: "/var/tmp/go/src/github.com/containers/buildah"
-        GOPATH: "/var/tmp/go"
-        GOSRC: "/var/tmp/go/src/github.com/containers/buildah"
-
-    # Runs within Cirrus's "community cluster"
-    container:
-        image: docker.io/library/golang:1.13
-        cpu: 1
-        memory: 1
-
-    timeout_in: 5m
-
-    vendor_script:
-        - 'make vendor'
-        - './hack/tree_status.sh'
-
-
 # Confirm cross-compile ALL archetectures on a Mac OS-X VM.
 cross_build_task:
     name: "Cross Compile"
@@ -186,6 +185,45 @@ cross_build_task:
 
     binary_artifacts:
         path: ./bin/*
+
+
+static_build_task:
+    name: "Static Build"
+    alias: static_build
+
+    depends_on:
+      - unit
+
+    gce_instance:
+        image_name: "${FEDORA_CACHE_IMAGE_NAME}"
+        cpu: 8
+        memory: 12
+        disk: 200
+
+    init_script: |
+        set -ex
+        setenforce 0
+        growpart /dev/sda 1 || true
+        resize2fs /dev/sda1 || true
+        yum -y install podman
+
+    nix_cache:
+      folder: '.cache'
+      fingerprint_script: cat nix/*
+
+    build_script: |
+        set -ex
+        mkdir -p .cache
+        mv .cache /nix
+        if [[ -z $(ls -A /nix) ]]; then podman run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
+        podman run --rm --privileged -ti -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/
+
+    binaries_artifacts:
+        path: "result/bin/buildah"
+
+    save_cache_script: |
+        mv /nix .cache
+        chown -Rf $(whoami) .cache
 
 
 integration_task:
@@ -282,42 +320,3 @@ success_task:
 
     clone_script: mkdir -p $CIRRUS_WORKING_DIR
     script: /bin/true
-
-
-static_build_task:
-    name: "Static Build"
-    alias: static_build
-
-    depends_on:
-      - unit
-
-    gce_instance:
-        image_name: "${FEDORA_CACHE_IMAGE_NAME}"
-        cpu: 8
-        memory: 12
-        disk: 200
-
-    init_script: |
-        set -ex
-        setenforce 0
-        growpart /dev/sda 1 || true
-        resize2fs /dev/sda1 || true
-        yum -y install podman
-
-    nix_cache:
-      folder: '.cache'
-      fingerprint_script: cat nix/*
-
-    build_script: |
-        set -ex
-        mkdir -p .cache
-        mv .cache /nix
-        if [[ -z $(ls -A /nix) ]]; then podman run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
-        podman run --rm --privileged -ti -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/
-
-    binaries_artifacts:
-        path: "result/bin/buildah"
-
-    save_cache_script: |
-        mv /nix .cache
-        chown -Rf $(whoami) .cache

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -159,7 +159,7 @@ conformance_task:
     depends_on:
       - unit
 
-    gce_instance:  # Only need to specify differences from defaults (above)
+    gce_instance:
         image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
 
     timeout_in: 20m

--- a/contrib/cirrus/add_second_partition.sh
+++ b/contrib/cirrus/add_second_partition.sh
@@ -24,10 +24,10 @@ then
 fi
 
 [[ -x "$(type -P parted)" ]] || \
-    die 2 "The parted command is required."
+    die "The parted command is required."
 
 [[ ! -b ${SLASH_DEVICE}2 ]] || \
-    die 5 "Found unexpected block device ${SLASH_DEVICE}2"
+    die "Found unexpected block device ${SLASH_DEVICE}2"
 
 PPRINTCMD="parted --script ${SLASH_DEVICE} print"
 FINDMNTCMD="findmnt --source=${SLASH_DEVICE}1 --mountpoint=/ --canonicalize --evaluate --first-only --noheadings"
@@ -39,7 +39,7 @@ then
     echo "Repartitioning original partition table:"
     $PPRINTCMD
 else
-    die 6 "Unexpected output from '$FINDMNTCMD': $(<$TMPF)"
+    die "Unexpected output from '$FINDMNTCMD': $(<$TMPF)"
 fi
 
 echo "Adding partition offset within unpartitioned space."
@@ -55,7 +55,7 @@ FSTYPE=$(findmnt --first-only --noheadings --output FSTYPE ${SLASH_DEVICE}1)
 echo "Expanding $FSTYPE filesystem on ${SLASH_DEVICE}1"
 case $FSTYPE in
     ext*) resize2fs ${SLASH_DEVICE}1 ;;
-    *) die 11 "Script $(basename $0) doesn't know how to resize a $FSTYPE filesystem." ;;
+    *) die "Script $(basename $0) doesn't know how to resize a $FSTYPE filesystem." ;;
 esac
 
 # Must happen last - signals completion to other tooling

--- a/contrib/cirrus/build.sh
+++ b/contrib/cirrus/build.sh
@@ -4,7 +4,7 @@ set -e
 
 source $(dirname $0)/lib.sh
 
-req_env_var IN_PODMAN IN_PODMAN_NAME GOSRC
+req_env_vars IN_PODMAN IN_PODMAN_NAME GOSRC
 
 remove_packaged_buildah_files
 
@@ -16,7 +16,7 @@ then
     in_podman --rm $IN_PODMAN_NAME $0
 else
     echo "Compiling buildah (\$GOSRC=$GOSRC)"
-    showrun make clean ${CROSS_TARGET:-all} ${CROSS_TARGET:+CGO_ENABLED=0}
+    showrun make clean ${CROSS_TARGET:-all} ${CROSS_TARGET:+CGO_ENABLED=0 cross}
 
     echo "Installing buildah"
     mkdir -p bin

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -3,38 +3,59 @@
 # Library of common, shared utility functions.  This file is intended
 # to be sourced by other scripts, not called directly.
 
-# Global details persist here
-source /etc/environment  # not always loaded under all circumstances
+# Due to differences across platforms and runtime execution environments,
+# handling of the (otherwise) default shell setup is non-uniform.  Rather
+# than attempt to workaround differences, simply force-load/set required
+# items every time this library is utilized.
+_waserrexit=0
+if [[ "$SHELLOPTS" =~ errexit ]]; then _waserrexit=1; fi
+set +e  # Assumed in F33 for setting global vars
+source /etc/profile
+source /etc/environment
+set -a
+USER="$(whoami)"
+HOME="$(getent passwd $USER | cut -d : -f 6)"
+# Some platforms set and make this read-only
+[[ -n "$UID" ]] || \
+    UID=$(getent passwd $USER | cut -d : -f 3)
+if ((_waserrexit)); then set -e; fi
 
-# Automation environment doesn't automatically load for Ubuntu 18
-if [[ -r '/usr/share/automation/environment' ]]; then
-    source '/usr/share/automation/environment'
+# During VM Image build, the 'containers/automation' installation
+# was performed.  The final step of that installation sets the
+# installation location in $AUTOMATION_LIB_PATH in /etc/environment
+# or in the default shell profile.
+# shellcheck disable=SC2154
+if [[ -n "$AUTOMATION_LIB_PATH" ]]; then
+    for libname in defaults anchors console_output utils; do
+        # There's no way shellcheck can process this location
+        # shellcheck disable=SC1090
+        source $AUTOMATION_LIB_PATH/${libname}.sh
+    done
+else
+    (
+    echo "WARNING: It does not appear that containers/automation was installed."
+    echo "         Functionality of most of this library will be negatively impacted"
+    echo "         This ${BASH_SOURCE[0]} was loaded by ${BASH_SOURCE[1]}"
+    ) > /dev/stderr
 fi
 
-# Under some contexts these values are not set, make sure they are.
-export USER="$(whoami)"
-export HOME="$(getent passwd $USER | cut -d : -f 6)"
-[[ -n "$UID" ]] || export UID=$(getent passwd $USER | cut -d : -f 3)
-export GID=$(getent passwd $USER | cut -d : -f 4)
 # Not cross-compiling by default
 CROSS_TARGET="${CROSS_TARGET:-}"
 
 # Essential default paths, many are overridden when executing under Cirrus-CI
 # others are duplicated here, to assist in debugging.
-export GOPATH="${GOPATH:-/var/tmp/go}"
+GOPATH="${GOPATH:-/var/tmp/go}"
 if type -P go &> /dev/null
 then
     # required for go 1.12+
-    export GOCACHE="${GOCACHE:-$HOME/.cache/go-build}"
+    GOCACHE="${GOCACHE:-$HOME/.cache/go-build}"
     eval "$(go env)"
-    # required by make and other tools
-    export $(go env | cut -d '=' -f 1)
     # Ensure compiled tooling is reachable
-    export PATH="$PATH:$GOPATH/bin"
+    PATH="$PATH:$GOPATH/bin"
 fi
-export CIRRUS_WORKING_DIR="${CIRRUS_WORKING_DIR:-$GOPATH/src/github.com/containers/buildah}"
-export GOSRC="${GOSRC:-$CIRRUS_WORKING_DIR}"
-export PATH="$GOSRC/tests/tools/build:$HOME/bin:$GOPATH/bin:/usr/local/bin:$PATH"
+CIRRUS_WORKING_DIR="${CIRRUS_WORKING_DIR:-$GOPATH/src/github.com/containers/buildah}"
+GOSRC="${GOSRC:-$CIRRUS_WORKING_DIR}"
+PATH="$GOSRC/tests/tools/build:$HOME/bin:$GOPATH/bin:/usr/local/bin:/usr/lib/cri-o-runc/sbin:$PATH"
 SCRIPT_BASE=${SCRIPT_BASE:-./contrib/cirrus}
 
 cd $GOSRC
@@ -60,7 +81,7 @@ SECRET_ENV_RE='(IRCID)|(ACCOUNT)|(^GC[EP]..+)|(SSH)'
 # GCE image-name compatible string representation of distribution name
 OS_RELEASE_ID="$(source /etc/os-release; echo $ID)"
 # GCE image-name compatible string representation of distribution _major_ version
-OS_RELEASE_VER="$(source /etc/os-release; echo $VERSION_ID | cut -d '.' -f 1)"
+OS_RELEASE_VER="$(source /etc/os-release; echo $VERSION_ID | tr -d '.')"
 # Combined to ease soe usage
 OS_REL_VER="${OS_RELEASE_ID}-${OS_RELEASE_VER}"
 
@@ -69,10 +90,11 @@ REGISTRY_FQIN=${REGISTRY_FQIN:-docker.io/library/registry}
 ALPINE_FQIN=${ALPINE_FQIN:-docker.io/library/alpine}
 
 # for in-container testing
-# TODO: Use $DEST_BRANCH as image tag after automated-builds working
-IN_PODMAN_IMAGE="quay.io/libpod/in_podman:master"
 IN_PODMAN_NAME="in_podman_$CIRRUS_TASK_ID"
 IN_PODMAN="${IN_PODMAN:-false}"
+
+lilto() { err_retry 8 1000 "" "$@"; }  # just over 4 minutes max
+bigto() { err_retry 7 5670 "" "$@"; }  # 12 minutes max
 
 # Working with apt under Debian/Ubuntu automation is a PITA, make it easy
 # Avoid some ways of getting stuck waiting for user input
@@ -80,95 +102,19 @@ export DEBIAN_FRONTEND=noninteractive
 # Short-cut for frequently used base command
 export APTGET='apt-get -qq --yes'
 # Short timeout for quick-running packaging command
-SHORT_APTGET="timeout_attempt_delay_command 24s 5 30s $APTGET"
-SHORT_DNFY="timeout_attempt_delay_command 60s 2 5s dnf -y"
+SHORT_APTGET="lilto $APTGET"
+SHORT_DNFY="lilto dnf -y"
 # Longer timeout for long-running packaging command
-LONG_APTGET="timeout_attempt_delay_command 300s 5 30s $APTGET"
-LONG_DNFY="timeout_attempt_delay_command 300s 3 60s dnf -y"
+LONG_APTGET="bigto $APTGET"
+LONG_DNFY="bigto dnf -y"
 
 # Allow easy substitution for debugging if needed
 CONTAINER_RUNTIME="showrun ${CONTAINER_RUNTIME:-podman}"
 
-# Pass in a list of one or more envariable names; exit non-zero with
-# helpful error message if any value is empty
-req_env_var() {
-    # Provide context. If invoked from function use its name; else script name
-    local caller=${FUNCNAME[1]}
-    if [[ -n "$caller" ]]; then
-        # Indicate that it's a function name
-        caller="$caller()"
-    else
-        # Not called from a function: use script name
-        caller=$(basename $0)
-    fi
-
-    # Usage check
-    [[ -n "$1" ]] || die 1 "FATAL: req_env_var: invoked without arguments"
-
-    # Each input arg is an envariable name, e.g. HOME PATH etc. Expand each.
-    # If any is empty, bail out and explain why.
-    for i; do
-        if [[ -z "${!i}" ]]; then
-            die 9 "FATAL: $caller requires \$$i to be non-empty"
-        fi
-    done
-}
-
-show_env_vars() {
-    echo "Showing selection of environment variable definitions:"
-    _ENV_VAR_NAMES=$(awk 'BEGIN{for(v in ENVIRON) print v}' | \
-        egrep -v "(^PATH$)|(^BASH_FUNC)|(^[[:punct:][:space:]]+)|$SECRET_ENV_RE" | \
-        sort -u)
-    for _env_var_name in $_ENV_VAR_NAMES
-    do
-        # Supports older BASH versions
-        printf "    ${_env_var_name}=%q\n" "$(printenv $_env_var_name)"
-    done
-}
-
-die() {
-    echo "************************************************"
-    echo ">>>>> ${2:-FATAL ERROR (but no message given!) in ${FUNCNAME[1]}()}"
-    echo "************************************************"
-    exit ${1:-1}
-}
-
-warn() {
-    echo ">>>>> WARNING: ${1:-WARNING (but no message given!) in ${FUNCNAME[1]}()}" > /dev/stderr
-}
+set +a
 
 bad_os_id_ver() {
-    echo "Unknown/Unsupported distro. $OS_RELEASE_ID and/or version $OS_RELEASE_VER for $(basename $0)"
-    exit 42
-}
-
-timeout_attempt_delay_command() {
-    TIMEOUT=$1
-    ATTEMPTS=$2
-    DELAY=$3
-    shift 3
-    STDOUTERR=$(mktemp -p '' $(basename $0)_XXXXX)
-    req_env_var ATTEMPTS DELAY
-    echo "Retrying $ATTEMPTS times with a $DELAY delay, and $TIMEOUT timeout for command: $@"
-    for (( COUNT=1 ; COUNT <= $ATTEMPTS ; COUNT++ ))
-    do
-        echo "##### (attempt #$COUNT)" &>> "$STDOUTERR"
-        if timeout --foreground $TIMEOUT "$@" &>> "$STDOUTERR"
-        then
-            echo "##### (success after #$COUNT attempts)" &>> "$STDOUTERR"
-            break
-        else
-            echo "##### (failed with exit: $?)" &>> "$STDOUTERR"
-            sleep $DELAY
-        fi
-    done
-    cat "$STDOUTERR"
-    rm -f "$STDOUTERR"
-    if (( COUNT > $ATTEMPTS ))
-    then
-        echo "##### (exceeded $ATTEMPTS attempts)"
-        exit 125
-    fi
+    die "Unknown/Unsupported distro. $OS_RELEASE_ID and/or version $OS_RELEASE_VER for $(basename $0)"
 }
 
 showrun() {
@@ -178,22 +124,6 @@ showrun() {
     "$@"
 }
 
-# workaround issue 1945 (remove when resolved)
-remove_storage_mountopt() {
-    local FILEPATH=/etc/containers/storage.conf
-    warn "remove_storage_mountopt() is overwriting $FILEPATH"
-    # This file normally comes from containers-common package
-    cat <<EOF> $FILEPATH
-[storage]
-driver = "overlay"
-runroot = "/run/containers/storage"
-graphroot = "/var/lib/containers/storage"
-[storage.options]
-mountopt = ""
-EOF
-    cat $FILEPATH
-}
-
 # Remove all files provided by the distro version of buildah.
 # All VM cache-images used for testing include the distro buildah because it
 # simplifies installing necessary dependencies which can change over time.
@@ -201,7 +131,7 @@ EOF
 # can only run the compiled source version.
 remove_packaged_buildah_files() {
     warn "Removing packaged buildah files to prevent conflicts with source build and testing."
-    req_env_var OS_RELEASE_ID
+    req_env_vars OS_RELEASE_ID
 
     if [[ "$OS_RELEASE_ID" =~ "ubuntu" ]]
     then
@@ -215,6 +145,14 @@ remove_packaged_buildah_files() {
     do
         # Sub-directories may contain unrelated/valuable stuff
         if [[ -d "$fullpath" ]]; then continue; fi
+        # As of Ubuntu 2010, policy.json in buildah, not containers-common package
+        if [[ "$OS_RELEASE_ID" == "ubuntu" ]] && \
+            grep -q '/etc/containers'<<<"$fullpath"; then
+
+            warn "Not removing $fullpath (from buildah package)"
+            continue
+        fi
+
         rm -vf "$fullpath"
     done
 
@@ -225,34 +163,35 @@ remove_packaged_buildah_files() {
 }
 
 in_podman() {
-    req_env_var IN_PODMAN_NAME GOSRC GOPATH SECRET_ENV_RE HOME
+    req_env_vars IN_PODMAN_NAME GOSRC GOPATH SECRET_ENV_RE HOME
     [[ -n "$@" ]] || \
-        die 7 "Must specify FQIN and command with arguments to execute"
+        die "Must specify FQIN and command with arguments to execute"
     local envargs
+    local envarg
     local envname
-    local envvalue
-    local envrx='(^CIRRUS_.+)|(^BUILDAH_+)|(^STORAGE_)|(^CI$)|(^CROSS_TARGET$)|(^IN_PODMAN_.+)'
-    for envname in $(awk 'BEGIN{for(v in ENVIRON) print v}' | \
-                     egrep "$envrx" | \
-                     egrep -v "CIRRUS_.+_MESSAGE" | \
-                     egrep -v "CIRRUS_.+_TITLE" | \
-                     egrep -v "$SECRET_ENV_RE")
+    local envval
+    local xchars='[:punct:][:cntrl:][:space:]'
+    local envrx='(^CI.*)|(^CIRRUS)|(^GOPATH)|(^GOCACHE)|(^GOSRC)|(^SCRIPT_BASE)|(.*_NAME)|(.*_FQIN)|(^IN_PODMAN_)|(^DISTRO)|(^BUILDAH)|(^STORAGE_)'
+    local envfile=$(mktemp -p '' in_podman_env_tmp_XXXXXXXX)
+    trap "rm -f $envfile" EXIT
+
+    msg "Gathering env. vars. to pass-through into container."
+    for envname in $(awk 'BEGIN{for(v in ENVIRON) print v}' | sort | \
+                     egrep "$envrx" | egrep -v "$SECRET_ENV_RE" | \
+                     egrep -v "^CIRRUS_.+(MESSAGE|TITLE)")
     do
-        envvalue="${!envname}"
-        [[ -z "$envname" ]] || [[ -z "$envvalue" ]] || \
-            envargs="${envargs:+$envargs }-e $envname=$envvalue"
+        envval="${!envname}"
+        [[ -n $(tr -d "$xchars" <<<"$envval") ]] || continue
+        envarg=$(printf -- "$envname=%q" "$envval")
+        echo "$envarg" | tee -a $envfile | indent
     done
-    # Back in the days of testing under PAPR, containers were run with super-privileges.
-    # That behavior is preserved here with a few updates for modern podman behaviors.
-    # The only other additions/changes are passthrough of CI-related env. vars ($envargs),
-    # some path related updates, and mounting cgroups RW instead of the RO default.
-    showrun podman run -i --name $IN_PODMAN_NAME \
-                   $envargs \
+    showrun podman run -i --name="$IN_PODMAN_NAME" \
                    --net=host \
                    --net="container:registry" \
-                   --security-opt label=disable \
-                   --security-opt seccomp=unconfined \
+                   --security-opt=label=disable \
+                   --security-opt=seccomp=unconfined \
                    --cap-add=all \
+                   --env-file=$envfile \
                    -e "GOPATH=$GOPATH" \
                    -e "GOSRC=$GOSRC" \
                    -e "IN_PODMAN=false" \
@@ -297,7 +236,7 @@ execute_local_registry() {
         verify_local_registry
         return 0
     fi
-    req_env_var CONTAINER_RUNTIME GOSRC
+    req_env_vars CONTAINER_RUNTIME GOSRC
     local authdirpath=$HOME/auth
     cd $GOSRC
 

--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -4,7 +4,7 @@ set -e
 
 source $(dirname $0)/lib.sh
 
-req_env_var CI GOSRC OS_RELEASE_ID
+req_env_vars CI GOSRC OS_RELEASE_ID
 
 case $1 in
     audit)

--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -29,6 +29,7 @@ case $1 in
                     containernetworking-plugins
                     containers-common
                     crun
+                    cri-o-runc
                     libseccomp
                     libseccomp2
                     podman

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -52,6 +52,16 @@ echo -e "[registries.search]\nregistries = ['docker.io', 'registry.fedoraproject
 
 show_env_vars
 
+if [[ -z "$CONTAINER" ]]; then
+    # Discovered reemergence of BFQ scheduler bug in kernel 5.8.12-200
+    # which causes a kernel panic when system is under heavy I/O load.
+    # Previously discovered in F32beta and confirmed fixed. It's been
+    # observed in F31 kernels as well.  Deploy workaround for all VMs
+    # to ensure a more stable I/O scheduler (elevator).
+    echo "mq-deadline" > /sys/block/sda/queue/scheduler
+    warn "I/O scheduler: $(cat /sys/block/sda/queue/scheduler)"
+fi
+
 if [[ -z "$CROSS_TARGET" ]]
 then
     execute_local_registry  # checks for existing port 5000 listener

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -8,28 +8,16 @@ set -e
 # expectation mismatch.
 source $(dirname $0)/lib.sh
 
-req_env_var OS_RELEASE_ID OS_RELEASE_VER GOSRC IN_PODMAN_IMAGE
+req_env_vars OS_RELEASE_ID OS_RELEASE_VER GOSRC IN_PODMAN_IMAGE
 
 echo "Setting up $OS_RELEASE_ID $OS_RELEASE_VER"
 cd $GOSRC
 case "$OS_RELEASE_ID" in
     fedora)
-        # This can be removed when the kernel bug fix is included in Fedora
-        if [[ $OS_RELEASE_VER -le 32 ]] && [[ -z "$CONTAINER" ]]; then
-            warn "Switching io scheduler to 'deadline' to avoid RHBZ 1767539"
-            warn "aka https://bugzilla.kernel.org/show_bug.cgi?id=205447"
-            echo "mq-deadline" | sudo tee /sys/block/sda/queue/scheduler > /dev/null
-            echo -n "IO Scheduler set to: "
-            $SUDO cat /sys/block/sda/queue/scheduler
-        fi
-
         # Not executing IN_PODMAN container
         if [[ -z "$CONTAINER" ]]; then
             warn "Adding secondary testing partition & growing root filesystem"
             bash $SCRIPT_BASE/add_second_partition.sh
-
-            warn "TODO: Add (for htpasswd) to VM images (in libpod repo)"
-            dnf install -y httpd-tools
         fi
 
         warn "Hard-coding podman to use crun"
@@ -45,9 +33,6 @@ EOF
         fi
         ;;
     ubuntu)
-        warn "TODO: Add to VM images (in libpod repo)"
-        $SHORT_APTGET update
-        $SHORT_APTGET install apache2-utils
         ;;
     *)
         bad_os_id_ver
@@ -69,13 +54,11 @@ show_env_vars
 
 if [[ -z "$CROSS_TARGET" ]]
 then
-    remove_storage_mountopt  # workaround issue 1945 (remove when resolved)
-
     execute_local_registry  # checks for existing port 5000 listener
 
     if [[ "$IN_PODMAN" == "true" ]]
     then
-        req_env_var IN_PODMAN_IMAGE IN_PODMAN_NAME
+        req_env_vars IN_PODMAN_IMAGE IN_PODMAN_NAME
         echo "Setting up image to use for \$IN_PODMAN=true testing"
         cd $GOSRC
         in_podman $IN_PODMAN_IMAGE $0

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -1,50 +1,77 @@
 #!/usr/bin/env bash
 
+#
+# For help and usage information, simply execute the script w/o any arguments.
+#
+# This script is intended to be run by developers who need to debug
+# problems specifically related to Cirrus-CI automated testing.  However,
+# because it's only loosely coupled to the `.cirrus.yml` configuration, it must
+# orchestrate VMs in GCP directly.  This means users need to have
+# pre-authorization (access) to manipulate google-cloud resources.  Additionally,
+# there are no guarantees it will remain in-sync with other automation-related
+# scripts.  Therefore it may not always function for everybody in every
+# future scenario without updates/modifications/tweaks.
+
 set -e
 
-RED="\e[1;36;41m"
-YEL="\e[1;33;44m"
+RED="\e[1;31m"
+YEL="\e[1;32m"
 NOR="\e[0m"
 USAGE_WARNING="
-${YEL}WARNING: This will not work without local sudo access to run podman,${NOR}
-         ${YEL}and prior authorization to use the buildah GCP project. Also,${NOR}
-         ${YEL}possession of the proper ssh private key is required.${NOR}
+${YEL}WARNING: This will not work without podman,${NOR}
+         ${YEL}and prior authorization to use the libpod GCP project.${NOR}
 "
-# TODO: Many/most of these values should come from .cirrus.yml
-ZONE="us-central1-c"
+# These values come from .cirrus.yml gce_instance clause
+ZONE="${ZONE:-us-central1-c}"
 CPUS="2"
 MEMORY="4Gb"
 DISK="200"
 PROJECT="buildah"
+IMGPROJECT="libpod-218412"
+GCFGNAME="buildah"
 GOSRC="/var/tmp/go/src/github.com/containers/buildah"
-GCLOUD_IMAGE=${GCLOUD_IMAGE:-quay.io/cevich/gcloud_centos:latest}
-GCLOUD_SUDO=${GCLOUD_SUDO-sudo}
-SSHUSER="root"
+GIT_REPO="https://github.com/containers/buildah.git"
+
+# Container image with necessary runtime elements
+GCLOUD_IMAGE="${GCLOUD_IMAGE:-docker.io/google/cloud-sdk:alpine}"
+GCLOUD_CFGDIR=".config/gcloud"
+
+SCRIPT_FILENAME=$(basename ${BASH_SOURCE[0]})
+HOOK_FILENAME="${GCFGNAME}_hook_${SCRIPT_FILENAME}"
 
 # Shared tmp directory between container and us
-TMPDIR=$(mktemp -d --tmpdir $(basename $0)_tmpdir_XXXXXX)
+TMPDIR=$(mktemp -d --tmpdir ${SCRIPT_FILENAME}_tmpdir_XXXXXX)
 
-BUILDAHROOT=$(realpath "$(dirname $0)/../")
-# else: Assume $PWD is the root of the buildah repository
-[[ "$BUILDAHROOT" != "/" ]] || BUILDAHROOT=$PWD
+show_usage() {
+    echo -e "\n${RED}ERROR: $1${NOR}"
+    echo -e "${YEL}Usage: $SCRIPT_FILENAME <image_name>${NOR}"
+    echo ""
+    if [[ -r ".cirrus.yml" ]]
+    then
+        echo -e "${YEL}Some possible image_name values (from .cirrus.yml):${NOR}"
+        image_hints
+        echo ""
+        echo -e "${YEL}Optional:${NOR} If a $HOME/$GCLOUD_CFGDIR/$HOOK_FILENAME executable exists during"
+        echo "VM creation, it will be executed remotely after cloning"
+        echo "$GIT_REPO. The"
+        echo "current local working branch name and commit ID, will be provided as"
+        echo "it's arguments."
+    fi
+    exit 1
+}
 
-# Command shortcuts save some typing (assumes $BUILDAHROOT is subdir of $HOME)
-PGCLOUD="$GCLOUD_SUDO podman run -it --rm -e AS_ID=$UID -e AS_USER=$USER --security-opt label=disable -v $TMPDIR:$HOME -v $HOME/.config/gcloud:$HOME/.config/gcloud -v $HOME/.config/gcloud/ssh:$HOME/.ssh -v $BUILDAHROOT:$BUILDAHROOT $GCLOUD_IMAGE --configuration=buildah --project=$PROJECT"
-SCP_CMD="$PGCLOUD compute scp"
+[[ "$UID" -ne 0 ]] || \
+    show_usage "Must execute script as a regular (non-root) user."
+
+
+# Disable SELinux labeling to allow read-only mounting of repository files
+PGCLOUD="podman run -it --rm --security-opt label=disable -v $TMPDIR:$TMPDIR -v $HOME/.config/gcloud:/root/.config/gcloud -v $HOME/.config/gcloud/ssh:/root/.ssh $GCLOUD_IMAGE gcloud --configuration=$GCFGNAME --project=$PROJECT"
 
 
 showrun() {
-    if [[ "$1" == "--background" ]]
-    then
-        shift
-        # Properly escape any nested spaces, so command can be copy-pasted
-        echo '+ '$(printf " %q" "$@")' &' > /dev/stderr
-        "$@" &
-        echo -e "${RED}<backgrounded>${NOR}"
-    else
-        echo '+ '$(printf " %q" "$@") > /dev/stderr
-        "$@"
-    fi
+    echo '+ '$(printf " %q" "$@") > /dev/stderr
+    echo ""
+    "$@"
 }
 
 cleanup() {
@@ -53,6 +80,7 @@ cleanup() {
     wait
 
     # set GCLOUD_DEBUG to leave tmpdir behind for postmortem
+    # shellcheck disable=SC2154
     test -z "$GCLOUD_DEBUG" && rm -rf $TMPDIR
 
     # Not always called from an exit handler, but should always exit when called
@@ -62,37 +90,48 @@ trap cleanup EXIT
 
 delvm() {
     echo -e "\n"
-    echo -e "\n${YEL}Offering to Delete $VMNAME ${RED}(Might take a minute or two)${NOR}"
-    echo -e "\n${YEL}Note: It's safe to answer N, then re-run script again later.${NOR}"
+    echo -e "\n${YEL}Offering to Delete $VMNAME${NOR}"
+    echo -e "${RED}(Deletion might take a minute or two)${NOR}"
+    echo -e "${YEL}Note: It's safe to answer N, then re-run script again later.${NOR}"
     showrun $CLEANUP_CMD  # prompts for Yes/No
     cleanup
 }
 
+get_env_vars() {
+    # Deal with both YAML and embedded shell-like substitutions in values
+    # if substitution fails, fall back to printing naked env. var as-is.
+    python3 -c '
+import sys,yaml,re
+env=yaml.load(open(".cirrus.yml"), Loader=yaml.SafeLoader)["env"]
+dollar_env_var=re.compile(r"\$(\w+)")
+dollarcurly_env_var=re.compile(r"\$\{(\w+)\}")
+class ReIterKey(dict):
+    def __missing__(self, key):
+        # Cirrus-CI provides some runtime-only env. vars.  Avoid
+        # breaking this hack-script if/when any are present in YAML
+        return "${0}".format(key)
+rep=r"{\1}"  # Convert env vars markup to -> str.format_map(re_iter_key) markup
+out=ReIterKey()
+for k,v in env.items():
+    if "ENCRYPTED" not in str(v) and not str(k).startswith("_") and bool(v):
+        out[k]=dollar_env_var.sub(rep, dollarcurly_env_var.sub(rep, str(v)))
+for k,v in out.items():
+    sys.stdout.write("{0}=\"{1}\"\n".format(k, str(v).format_map(out)))
+    '
+}
+
 image_hints() {
-    _BIS=$(egrep -m 1 '_BUILT_IMAGE_SUFFIX:[[:space:]+"[[:print:]]+"' "$BUILDAHROOT/.cirrus.yml" | cut -d: -f 2 | tr -d '"[:blank:]')
-    if test -z "${_BIS}"; then
-        echo "Error: Could not find a _BUILT_IMAGE_SUFFIX definition in .cirrus.yml" > /dev/stderr
-        exit 1
-    fi
-    egrep '[[:space:]]+[[:alnum:]].+_CACHE_IMAGE_NAME:[[:space:]+"[[:print:]]+"' \
-        "$BUILDAHROOT/.cirrus.yml" | cut -d: -f 2 | tr -d '"[:blank:]' | \
-        sed -r -e "s/\\\$[{]_BUILT_IMAGE_SUFFIX[}]/$_BIS/" | sort -u
+    get_env_vars | fgrep '_CACHE_IMAGE_NAME' | awk -F "=" '{print $2}'
 }
 
-show_usage() {
-    echo -e "\n${RED}ERROR: $1${NOR}"
-    echo -e "${YEL}Usage: $(basename $0) <image_name>${NOR}"
-    echo ""
-    if [[ -r ".cirrus.yml" ]]
-    then
-        echo -e "${YEL}Some possible image_name values (from .cirrus.yml):${NOR}"
-        image_hints
-        echo ""
-    fi
-    exit 1
-}
-
+unset VM_IMAGE_NAME
+unset VMNAME
+unset CREATE_CMD
+unset SSH_CMD
+unset CLEANUP_CMD
+declare -xa ENVS
 parse_args(){
+    local arg
     echo -e "$USAGE_WARNING"
 
     if [[ "$USER" =~ "root" ]]
@@ -100,108 +139,118 @@ parse_args(){
         show_usage "This script must be run as a regular user."
     fi
 
-    ENVS='GOPATH="/var/tmp/go" IN_PODMAN="false" CROSS_TARGET=""'
-    IMAGE_NAME="$1"
-    if [[ -z "$IMAGE_NAME" ]]
-    then
-        show_usage "No image-name specified."
+    [[ "$#" -eq 1 ]] || \
+        show_usage "Must specify a VM Image name to use, and the test flavor."
+
+    VM_IMAGE_NAME="$1"
+
+    # Word-splitting is desirable in this case
+    # shellcheck disable=SC2207
+    ENVS=(
+        $(get_env_vars)
+        "VM_IMAGE_NAME=$VM_IMAGE_NAME"
+    )
+
+    VMNAME="${VMNAME:-${USER}-${VM_IMAGE_NAME}}"
+
+    CREATE_CMD="$PGCLOUD compute instances create --zone=$ZONE --image-project=$IMGPROJECT --image=${VM_IMAGE_NAME} --custom-cpu=$CPUS --custom-memory=$MEMORY --boot-disk-size=$DISK --labels=in-use-by=$USER $VMNAME"
+
+    SSH_CMD="$PGCLOUD compute ssh --zone=$ZONE root@$VMNAME"
+
+    CLEANUP_CMD="$PGCLOUD compute instances delete --zone=$ZONE --delete-disks=all $VMNAME"
+}
+
+# Returns true if user has run an 'init' and has a valid token for
+# the specific project-id and named-configuration arguments in $PGCLOUD.
+function has_valid_credentials() {
+    if $PGCLOUD info |& grep -Eq 'Account:.*None'; then
+        return 1
     fi
 
-    SETUP_CMD="env $ENVS $GOSRC/contrib/cirrus/setup.sh"
-    VMNAME="${VMNAME:-${USER}-${IMAGE_NAME}}"
-    CREATE_CMD="$PGCLOUD compute instances create --zone=$ZONE --image-project=libpod-218412 --image=${IMAGE_NAME} --custom-cpu=$CPUS --custom-memory=$MEMORY --boot-disk-size=$DISK --labels=in-use-by=$USER $VMNAME"
-    SSH_CMD="$PGCLOUD compute ssh $SSHUSER@$VMNAME"
-    CLEANUP_CMD="$PGCLOUD compute instances delete --zone $ZONE --delete-disks=all $VMNAME"
+    # It's possible for 'gcloud info' to list expired credentials,
+    # e.g. 'ERROR:  ... invalid grant: Bad Request'
+    if $PGCLOUD auth --configuration=$GCFGNAME print-access-token |& grep -q 'ERROR'; then
+        return 1
+    fi
+
+    return 0
 }
 
 ##### main
 
-[[ "${BUILDAHROOT%%${BUILDAHROOT##$HOME}}" == "$HOME" ]] || \
-    show_usage "Repo clone must be sub-dir of $HOME"
-
-cd "$BUILDAHROOT"
+cd $(realpath "$(dirname ${BASH_SOURCE[0]})/../")
 
 parse_args "$@"
-
-# Ensure mount-points and data directories exist on host as $USER.  Also prevents
-# permission-denied errors during cleanup() b/c `sudo podman` created mount-points
-# owned by root.
-mkdir -p $TMPDIR/${BUILDAHROOT##$HOME}
 mkdir -p $TMPDIR/.ssh
 mkdir -p {$HOME,$TMPDIR}/.config/gcloud/ssh
 chmod 700 {$HOME,$TMPDIR}/.config/gcloud/ssh $TMPDIR/.ssh
 
-cd $BUILDAHROOT
+echo -e "\n${YEL}Pulling gcloud image...${NOR}"
+podman pull $GCLOUD_IMAGE
 
-# Attempt to determine if named 'buildah' gcloud configuration exists
-showrun $PGCLOUD info > $TMPDIR/gcloud-info
-if egrep -q "Account:.*None" $TMPDIR/gcloud-info
+if ! has_valid_credentials
 then
-    echo -e "\n${YEL}WARNING: Can't find gcloud configuration for 'buildah', running init.${NOR}"
-    echo -e "         ${RED}Please choose '#1: Re-initialize' and 'login' if asked.${NOR}"
-    echo -e "         ${RED}Please set Compute Region and Zone (if asked) to 'us-central1-b'.${NOR}"
-    echo -e "         ${RED}DO NOT set any password for the generated ssh key.${NOR}"
-    showrun $PGCLOUD init --project=$PROJECT --console-only --skip-diagnostics
+    echo -e "\n${YEL}WARNING: Can't find gcloud configuration for buildah, running init.${NOR}"
+    echo -e "         ${RED}Please choose \"#1: Re-initialize\" and \"login\" if asked.${NOR}"
+    showrun $PGCLOUD --configuration=$GCFGNAME init --project=$PROJECT --console-only --skip-diagnostics
 
     # Verify it worked (account name == someone@example.com)
     $PGCLOUD info > $TMPDIR/gcloud-info-after-init
     if egrep -q "Account:.*None" $TMPDIR/gcloud-info-after-init
     then
-        echo -e "${RED}ERROR: Could not initialize 'buildah' configuration in gcloud.${NOR}"
+        echo -e "${RED}ERROR: Could not initialize buildah configuration in gcloud.${NOR}"
         exit 5
     fi
 
-    # If this is the only config, make it the default to avoid persistent warnings from gcloud
+    # If this is the only config, make it the default to avoid
+    # persistent warnings from gcloud about there being no default.
     [[ -r "$HOME/.config/gcloud/configurations/config_default" ]] || \
-        ln "$HOME/.config/gcloud/configurations/config_buildah" \
-           "$HOME/.config/gcloud/configurations/config_default"
+       ln "$HOME/.config/gcloud/configurations/config_libpod" \
+          "$HOME/.config/gcloud/configurations/config_default"
 fi
 
-# Couldn't make rsync work with gcloud's ssh wrapper: ssh-keys generated on the fly
-TARBALL=$VMNAME.tar.bz2
-echo -e "\n${YEL}Packing up local repository into a tarball.${NOR}"
-showrun --background tar cjf $TMPDIR/$TARBALL --warning=no-file-changed --exclude-vcs-ignores -C $BUILDAHROOT .
+trap delvm EXIT # Allow deleting VM if CTRL-C during create
+echo -e "\n${YEL}Trying to creating a VM named $VMNAME${NOR}\n${YEL}in GCE region/zone $ZONE${NOR}"
+echo -e "For faster terminal access, export ZONE='<something-closer>'"
+echo -e 'Zone-list at: https://cloud.google.com/compute/docs/regions-zones/\n'
+if showrun $CREATE_CMD; then  # Freshly created VM needs initial setup
 
-trap delvm INT  # Allow deleting VM if CTRL-C during create
-# This fails if VM already exists: permit this usage to re-init
-echo -e "\n${YEL}Trying to create a VM named $VMNAME\n${RED}(might take a minute/two.  Errors ignored).${NOR}"
-showrun $CREATE_CMD || true # allow re-running commands below when "delete: N"
+    echo -e "\n${YEL}Waiting up to 30s for ssh port to open${NOR}"
+    ATTEMPTS=10
+    trap "exit 1" INT
+    while ((ATTEMPTS)) && ! $SSH_CMD --command "true"; do
+        let "ATTEMPTS--"
+        echo -e "${RED}Nope, not yet.${NOR}"
+        sleep 3s
+    done
+    trap - INT
+    if ! ((ATTEMPTS)); then
+        echo -e "\n${RED}Failed${NOR}"
+        exit 7
+    fi
+    echo -e "${YEL}Got it.  Cloning upstream repository as a starting point.${NOR}"
 
-# Any subsequent failure should prompt for VM deletion
-trap delvm EXIT
+    showrun $SSH_CMD -- "mkdir -p $GOSRC"
+    showrun $SSH_CMD -- "git clone --progress $GIT_REPO $GOSRC"
 
-echo -e "\n${YEL}Retrying for 30s for ssh port to open (may give some errors)${NOR}"
-trap 'COUNT=9999' INT
-ATTEMPTS=10
-for (( COUNT=1 ; COUNT <= $ATTEMPTS ; COUNT++ ))
-do
-    if $SSH_CMD --command "true"; then break; else sleep 3s; fi
-done
-if (( COUNT > $ATTEMPTS ))
-then
-    echo -e "\n${RED}Failed${NOR}"
-    exit 7
+    if [[ -x "$HOME/$GCLOUD_CFGDIR/$HOOK_FILENAME" ]]; then
+        echo -e "\n${YEL}Copying hook to VM and executing (ignoring errors).${NOR}"
+        $PGCLOUD compute scp "/root/$GCLOUD_CFGDIR/$HOOK_FILENAME" root@$VMNAME:.
+        if ! showrun $SSH_CMD -- "cd $GOSRC && bash /root/$HOOK_FILENAME $(git branch --show-current) $(git rev-parse HEAD)"; then
+            echo "-e ${RED}Hook exited: $?${NOR}"
+        fi
+    else
+        echo -e "${YEL}Hook script not found, remote source will be a simple clone${NOR}"
+    fi
+
 fi
-echo -e "${YEL}Got it${NOR}"
 
-echo -e "\n${YEL}Removing and re-creating $GOSRC on $VMNAME.${NOR}"
-showrun $SSH_CMD --command "rm -rf $GOSRC"
-showrun $SSH_CMD --command "mkdir -p $GOSRC"
+echo -e "\n${YEL}Generating connection script for $VMNAME.${NOR}"
+echo -e "Note: Script can be re-used in another terminal if needed."
+echo -e "${RED}(option to delete VM presented upon exiting).${NOR}"
+# TODO: This is fairly fragile, specifically the quoting for the remote command.
+echo '#!/bin/bash' > $TMPDIR/ssh
+echo "$SSH_CMD -- -t 'cd $GOSRC && exec env ${ENVS[@]} bash -il'" >> $TMPDIR/ssh
+chmod +x $TMPDIR/ssh
 
-echo -e "\n${YEL}Transferring tarball to $VMNAME.${NOR}"
-wait
-showrun $SCP_CMD $HOME/$TARBALL $SSHUSER@$VMNAME:/tmp/$TARBALL
-
-echo -e "\n${YEL}Unpacking tarball into $GOSRC on $VMNAME.${NOR}"
-showrun $SSH_CMD --command "tar xjf /tmp/$TARBALL -C $GOSRC"
-
-echo -e "\n${YEL}Removing tarball on $VMNAME.${NOR}"
-showrun $SSH_CMD --command "rm -f /tmp/$TARBALL"
-
-echo -e "\n${YEL}Executing environment setup${NOR}"
-showrun $SSH_CMD --command "$SETUP_CMD"
-
-VMIP=$($PGCLOUD compute instances describe $VMNAME --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
-
-echo -e "\n${YEL}Connecting to $VMNAME${NOR}\nPublic IP Address: $VMIP\n${RED}(option to delete VM upon logout).${NOR}\n"
-showrun $SSH_CMD -- -t "cd $GOSRC && exec env $ENVS bash -il"
+showrun $TMPDIR/ssh

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2274,7 +2274,9 @@ EOM
 
 @test "bud capabilities test" {
   _prefetch busybox
-  run_buildah bud -t testcap --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/capabilities/Dockerfile
+  # --cap-add necessary b/c https://github.com/containers/common/pull/319
+  # removed cap_net_raw, cap_mknod, and cap_audit_write
+  run_buildah bud --cap-add cap_net_raw,cap_mknod,cap_audit_write -t testcap --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/capabilities/Dockerfile
   expect_output --substring "uid=3267"
   expect_output --substring "CapBnd:	00000000a80425fb"
   expect_output --substring "CapEff:	0000000000000000"

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -29,7 +29,7 @@ load helpers
   expect_output --substring 'error parsing --healthcheck "AB \"CD": invalid command line string'
 
   run_buildah 125 config --healthcheck-interval ABCD $cid
-  expect_output --substring 'error parsing --healthcheck-interval "ABCD": time: invalid duration ABCD'
+  expect_output --substring 'error parsing --healthcheck-interval "ABCD": time: invalid duration "?ABCD"?'
 
   run_buildah 125 config --cmd 'AB "CD' $cid
   expect_output --substring 'error parsing --cmd "AB \"CD": invalid command line string'

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1928,7 +1928,7 @@ var internalTestCases = []testCase{
 		name:         "copy-integration1",
 		contextDir:   "dockerignore/integration1",
 		shouldFailAt: 3,
-		failureRegex: "no such file or directory",
+		failureRegex: "(no such file or directory)|(file not found)",
 	},
 
 	{
@@ -1940,7 +1940,7 @@ var internalTestCases = []testCase{
 		name:         "copy-integration3",
 		contextDir:   "dockerignore/integration3",
 		shouldFailAt: 4,
-		failureRegex: "no such file or directory",
+		failureRegex: "(no such file or directory)|(file not found)",
 	},
 
 	{
@@ -2664,14 +2664,14 @@ var internalTestCases = []testCase{
 		name:         "dockerignore-allowlist-subdir-nofile-dir",
 		contextDir:   "dockerignore/allowlist/subdir-nofile",
 		shouldFailAt: 2,
-		failureRegex: "no such file or directory",
+		failureRegex: "(no such file or directory)|(file not found)",
 	},
 
 	{
 		name:         "dockerignore-allowlist-subdir-nofile-file",
 		contextDir:   "dockerignore/allowlist/subdir-nofile",
 		shouldFailAt: 2,
-		failureRegex: "no such file or directory",
+		failureRegex: "(no such file or directory)|(file not found)",
 	},
 
 	{
@@ -2740,14 +2740,14 @@ var internalTestCases = []testCase{
 		name:         "dockerignore-allowlist-alternating-nothing",
 		contextDir:   "dockerignore/allowlist/alternating-nothing",
 		shouldFailAt: 7,
-		failureRegex: "no such file or directory",
+		failureRegex: "(no such file or directory)|(file not found)",
 	},
 
 	{
 		name:         "dockerignore-allowlist-alternating-other",
 		contextDir:   "dockerignore/allowlist/alternating-other",
 		shouldFailAt: 7,
-		failureRegex: "no such file or directory",
+		failureRegex: "(no such file or directory)|(file not found)",
 	},
 
 	{


### PR DESCRIPTION
***Depends on:*** #2885

#### What type of PR is this?

> /kind deprecation

#### What this PR does / why we need it:

Previously, VM Images were built from a side-band process tacked onto `containers/podman` automation.  This has recently been split off into it's own repository `containers/automation_images`.  This PR makes use of freshly built images produced using the new workflow.  Additionally, to support testing of a `runc -> crun` transition, both packages are installed in the newly referenced images.

#### How to verify it

Automated tests will pass

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

None