### PR TITLE
[release-1.16] Add(): fix handling of relative paths with no ContextDir

### DIFF
--- a/add.go
+++ b/add.go
@@ -151,18 +151,26 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	}()
 
 	contextDir := options.ContextDir
-	if contextDir == "" {
+	currentDir := options.ContextDir
+	if options.ContextDir == "" {
 		contextDir = string(os.PathSeparator)
+		currentDir, err = os.Getwd()
+		if err != nil {
+			return errors.Wrapf(err, "error determining current working directory")
+		}
 	}
 
 	// Figure out what sorts of sources we have.
 	var localSources, remoteSources []string
-	for _, src := range sources {
+	for i, src := range sources {
 		if sourceIsRemote(src) {
 			remoteSources = append(remoteSources, src)
 			continue
 		}
-		localSources = append(localSources, src)
+		if !filepath.IsAbs(src) && options.ContextDir == "" {
+			sources[i] = filepath.Join(currentDir, src)
+		}
+		localSources = append(localSources, sources[i])
 	}
 
 	// Check how many items our local source specs matched.  Each spec

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -172,3 +172,19 @@ load helpers
   run_buildah add $cid https://github.com/containers/buildah/raw/master/README.md /home
   run_buildah run $cid ls /home/README.md
 }
+
+@test "add relative" {
+  # make sure we don't get thrown by relative source locations
+  _prefetch busybox
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  cid=$output
+
+  run_buildah add $cid deny.json /
+  run_buildah run $cid ls /deny.json
+
+  run_buildah add $cid ./docker.json /
+  run_buildah run $cid ls /docker.json
+
+  run_buildah add $cid tools/Makefile /
+  run_buildah run $cid ls /Makefile
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`Add()` is supposed to handle relative paths when the `ContextDir` value passed to it is not set, but it hasn't been doing that correctly since it was overhauled.  Correct it to recognize relative paths at the function start, when `ContextDir` is not set, and combining them with the current directory to convert them to absolute paths.

#### How to verify it

Added an integration test which should cover the reported cases.

#### Which issue(s) this PR fixes:

Fixes #2619.

#### Special notes for your reviewer:

Cherry picked from #2630.

#### Does this PR introduce a user-facing change?

```
The regression in `buildah add` which caused it to not properly handle source locations specified using relative paths should be fixed.
```