### PR TITLE
Run(): ignore containers.conf's environment configuration

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -91,11 +91,8 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		return err
 	}
 
-	defaultContainerConfig, err := config.Default()
-	if err != nil {
-		return errors.Wrapf(err, "failed to get container config")
-	}
-	b.configureEnvironment(g, options, defaultContainerConfig.Containers.Env)
+	// hardwire the environment to match docker build to avoid subtle and hard-to-debug differences due to containers.conf
+	b.configureEnvironment(g, options, []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"})
 
 	if b.CommonBuildOpts == nil {
 		return errors.Errorf("Invalid format on container you must recreate the container")

--- a/tests/containers_conf.bats
+++ b/tests/containers_conf.bats
@@ -2,12 +2,6 @@
 
 load helpers
 
-@test "containers.conf env test" {
-    export CONTAINERS_CONF=${TESTSDIR}/containers.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
-    run_buildah --log-level=error run $cid sh -c 'env | grep "foo=bar"'
-}
-
 @test "containers.conf selinux test" {
     if ! which selinuxenabled > /dev/null 2> /dev/null ; then
 	skip "No selinuxenabled executable"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The hardwired default for containers.conf now includes a TERM variable, and passing it through to commands that we "RUN" during a build can subtly cause the resulting image to be different from one that `docker build` would create, so stop using it there.

When a runtime runs the image we eventually produce, it'll consult the configuration file, so the variable will still be set, even when it isn't set in the image.

#### How to verify it

This change prevents a failure in the `TestConformance/ci-pipeline-modified` conformance test, which checks which variables are set during RUN.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This creates an exception to the "environment variables in containers.conf are used everywhere" rule, but while the conformance test is a pretty harmless example of differences in builds that can result from environment variables being set or not, I wouldn't want to have to debug a build problem that was triggered based on whether or not a variable was set in the configuration.

#### Does this PR introduce a user-facing change?

```
Environment variables set in containers.conf will no longer be set for commands run using `buildah run` or by RUN instructions during `buildah build-using-dockerfile`.
```