### PR TITLE
integration tests: make sure tests run in ${topdir}/tests

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -16,6 +16,8 @@ BUILDAH_TIMEOUT=${BUILDAH_TIMEOUT:-300}
 export GPG_TTY=/dev/null
 
 function setup() {
+	pushd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
 	suffix=$(dd if=/dev/urandom bs=12 count=1 status=none | od -An -tx1 | sed -e 's, ,,g')
 	TESTDIR=${BATS_TMPDIR}/tmp${suffix}
 	rm -fr ${TESTDIR}
@@ -53,6 +55,8 @@ function teardown() {
             xargs --no-run-if-empty --max-lines=1 umount
 
 	rm -fr ${TESTDIR}
+
+	popd
 }
 
 function _prefetch() {


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Add a pushd/popd to setup()/teardown() to ensure that tests run in our tests directory, even if they're not invoked by test_runner.sh, so that we can reliably use relative paths in tests without having to ensure our location on a per-test or per-test-file basis.

#### How to verify it

If you run `bats` directly and point it to either the `tests` directory, or the `add.bats` file within it, the test shouldn't fail for attempting to access a path relative to the current directory which should actually be relative to the `tests` directory.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```