### PR TITLE
New CI check: xref --help vs man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ codespell:
 validate: install.tools
 	@./tests/validate/whitespace.sh
 	@./tests/validate/git-validation.sh
+	@./hack/xref-helpmsgs-manpages
 
 .PHONY: install.tools
 install.tools:

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -40,8 +40,8 @@ func init() {
 	namespaceResults := buildahcli.NameSpaceResults{}
 
 	budCommand := &cobra.Command{
-		Use:     "build-using-dockerfile",
-		Aliases: []string{"bud"},
+		Use:     "bud",
+		Aliases: []string{"build-using-dockerfile"},
 		Short:   "Build an image using instructions in a Dockerfile",
 		Long:    budDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -14,18 +14,17 @@ import (
 )
 
 type runInputOptions struct {
-	addHistory     bool
-	capAdd         []string
-	capDrop        []string
-	hostname       string
-	isolation      string
-	runtime        string
-	runtimeFlag    []string
-	noPivot        bool
-	securityOption []string
-	terminal       bool
-	volumes        []string
-	mounts         []string
+	addHistory  bool
+	capAdd      []string
+	capDrop     []string
+	hostname    string
+	isolation   string
+	mounts      []string
+	runtime     string
+	runtimeFlag []string
+	noPivot     bool
+	terminal    bool
+	volumes     []string
 	*buildahcli.NameSpaceResults
 }
 
@@ -63,7 +62,6 @@ func init() {
 	flags.StringVar(&opts.runtime, "runtime", "", "`path` to an alternate OCI runtime")
 	flags.StringSliceVar(&opts.runtimeFlag, "runtime-flag", []string{}, "add global flags for the container runtime")
 	flags.BoolVar(&opts.noPivot, "no-pivot", false, "do not use pivot root to jail process inside rootfs")
-	flags.StringArrayVar(&opts.securityOption, "security-opt", []string{}, "security options (default [])")
 	// TODO add-third alias for tty
 	flags.BoolVarP(&opts.terminal, "terminal", "t", false, "allocate a pseudo-TTY in the container")
 	flags.BoolVar(&opts.terminal, "tty", false, "allocate a pseudo-TTY in the container")

--- a/docs/buildah-add.md
+++ b/docs/buildah-add.md
@@ -27,7 +27,7 @@ BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
 
 Sets the user and group ownership of the destination content.
 
-**--quiet**
+**--quiet**, **-q**
 
 Refrain from printing a digest of the added content.
 

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -123,7 +123,7 @@ Limit the container's CPU usage. By default, containers run with the full
 CPU resource. This flag tell the kernel to restrict the container's CPU usage
 to the quota you specify.
 
-**--cpu-shares, -c**=*0*
+**--cpu-shares**, **-c**=*0*
 
 CPU shares (relative weight)
 
@@ -186,7 +186,7 @@ The [key[:passphrase]] to be used for decryption of images. Key can point to key
 
 Add a host device or devices under a directory to the container. The format is `<device-on-host>[:<device-on-container>][:<permissions>]` (e.g. --device=/dev/sdc:/dev/xvdc:rwm)
 
-**--disable-compression, -D**
+**--disable-compression**, **-D**
 Don't compress filesystem layers when building the image unless it is required
 by the location where the image is being written.  This is the default setting,
 because image layers are compressed automatically when they are pushed to
@@ -216,7 +216,7 @@ Set custom DNS options
 
 Set custom DNS search domains
 
-**--file, -f** *Containerfile*
+**--file**, **-f** *Containerfile*
 
 Specifies a Containerfile which contains instructions for building the image,
 either a local file or an **http** or **https** URL.  If more than one
@@ -306,7 +306,7 @@ environment variable. `export BUILDAH_LAYERS=true`
 Log output which would be sent to standard output and standard error to the
 specified file instead of to standard output and standard error.
 
-**--memory, -m**=""
+**--memory**, **-m**=""
 
 Memory limit (format: <number>[<unit>], where unit = b, k, m or g)
 
@@ -392,7 +392,7 @@ Raise an error if not found in the registries, even if the image is present loca
 Do not pull the image from the registry, use only the local version. Raise an error
 if the image is not present locally.
 
-**--quiet, -q**
+**--quiet**, **-q**
 
 Suppress output messages which indicate which instruction is being processed,
 and of progress when pulling images from a registry, and when writing the
@@ -441,6 +441,10 @@ Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater tha
 Unit is optional and can be `b` (bytes), `k` (kilobytes), `m`(megabytes), or `g` (gigabytes).
 If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
 
+**--signature-policy** *path*
+
+Path to alternate signature policy file (intended for testing; not typically used).
+
 **--sign-by** *fingerprint*
 
 Sign the built image using the GPG key that matches the specified fingerprint.
@@ -449,7 +453,7 @@ Sign the built image using the GPG key that matches the specified fingerprint.
 
 Squash all of the new image's layers (including those inherited from a base image) into a single new layer.
 
-**--tag, -t** *imageName*
+**--tag**, **-t** *imageName*
 
 Specifies the name which will be assigned to the resulting image if the build
 process completes successfully.
@@ -532,7 +536,7 @@ that the UTS namespace in which `buildah` itself is being run should be reused,
 or it can be the path to a UTS namespace which is already in use by another
 process.
 
-**--volume, -v**[=*[HOST-DIR:CONTAINER-DIR[:OPTIONS]]*]
+**--volume**, **-v**[=*[HOST-DIR:CONTAINER-DIR[:OPTIONS]]*]
 
    Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Buildah
    bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the Buildah

--- a/docs/buildah-commit.md
+++ b/docs/buildah-commit.md
@@ -35,7 +35,7 @@ The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
 
-**--disable-compression, -D**
+**--disable-compression**, **-D**
 
 Don't compress filesystem layers when building the image unless it is required
 by the location where the image is being written.  This is the default setting,
@@ -44,7 +44,15 @@ registries, and images being written to local storage would only need to be
 decompressed again to be stored.  Compression can be forced in all cases by
 specifying **--disable-compression=false**.
 
-**--format**
+**--encryption-key** *key*
+
+The [protocol:keyfile] specifies the encryption protocol, which can be JWE (RFC7516), PGP (RFC4880), and PKCS7 (RFC2315) and the key material required for image encryption. For instance, jwe:/path/to/key.pem or pgp:admin@example.com or pkcs7:/path/to/x509-file.
+
+**--encrypt-layer** *layer(s)*
+
+Layer(s) to encrypt: 0-indexed layer indices with support for negative indexing (e.g. 0 is the first layer, -1 is the last layer). If not defined, will encrypt all layers if encryption-key flag is specified.
+
+**--format**, **-f** *[oci | docker]*
 
 Control the format for the image manifest and configuration data.  Recognized
 formats include *oci* (OCI image-spec v1.0, the default) and *docker* (version
@@ -57,7 +65,7 @@ environment variable.  `export BUILDAH\_FORMAT=docker`
 
 Write the image ID to the file.
 
-**--quiet**
+**--quiet**, **-q**
 
 When writing the output image, suppress progress output.
 

--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -22,7 +22,7 @@ Defaults to false.
 Note: You can also override the default value of --add-history by setting the
 BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
 
-**--annotation** *annotation*=*annotation*
+**--annotation**, **-a** *annotation*=*annotation*
 
 Add an image *annotation* (e.g. annotation=*annotation*) to the image manifest
 of any images which will be built using the specified container. Can be used multiple times.
@@ -76,7 +76,7 @@ ignore the `cmd` value of the container image.  However if you use the array
 form, then the cmd will be appended onto the end of the entrypoint cmd and be
 executed together.
 
-**--env** *env=value*
+**--env**, **-e** *env=value*
 
 Add a value (e.g. env=*value*) to the environment for containers based on any
 images which will be built using the specified container. Can be used multiple times.
@@ -138,7 +138,7 @@ the specified container.
 
 Note: this setting is not present in the OCIv1 image format, so it is discarded when writing images using OCIv1 formats.
 
-**--label** *label*=*value*
+**--label**, **-l** *label*=*value*
 
 Add an image *label* (e.g. label=*value*) to the image configuration of any
 images which will be built using the specified container. Can be used multiple times.
@@ -157,7 +157,7 @@ Set the target *operating system* for any images which will be built using
 the specified container.  By default, if the container was based on an image,
 its OS is kept, otherwise the host's OS's name is recorded.
 
-**--port** *port*
+**--port**, **-p** *port*
 
 Add a *port* to expose when running containers based on any images which
 will be built using the specified container. Can be used multiple times.
@@ -173,7 +173,7 @@ Note: this setting is not present in the OCIv1 image format, so it is discarded 
 
 Set default *stop signal* for container. This signal will be sent when container is stopped, default is SIGINT.
 
-**--user** *user*[:*group*]
+**--user**, **-u** *user*[:*group*]
 
 Set the default *user* to be used when running containers based on this image.
 The user can be specified as a user name
@@ -181,7 +181,7 @@ or UID, optionally followed by a group name or GID, separated by a colon (':').
 If names are used, the container should include entries for those names in its
 */etc/passwd* and */etc/group* files.
 
-**--volume** *volume*
+**--volume**, **-v** *volume*
 
 Add a location in the directory tree which should be marked as a *volume* in any images which will be built using the specified container. Can be used multiple times. If *volume* has a trailing `-`, and is already set, then the *volume* is removed from the config.
 

--- a/docs/buildah-containers.md
+++ b/docs/buildah-containers.md
@@ -12,13 +12,13 @@ IDs, and the names and IDs of the images from which they were initialized.
 
 ## OPTIONS
 
-**--all, -a**
+**--all**, **-a**
 
 List information about all containers, including those which were not created
 by and are not being used by Buildah.  Containers created by Buildah are
 denoted with an '*' in the 'BUILDER' column.
 
-**--filter, -f**
+**--filter**, **-f**
 
 Filter output based on conditions provided.
 
@@ -48,7 +48,7 @@ Valid placeholders for the Go template are listed below:
 
 Output in JSON format.
 
-**--noheading, -n**
+**--noheading**, **-n**
 
 Omit the table headings from the listing of containers.
 
@@ -56,7 +56,7 @@ Omit the table headings from the listing of containers.
 
 Do not truncate IDs and image names in the output.
 
-**--quiet, -q**
+**--quiet**, **-q**
 
 Displays only the container IDs.
 
@@ -121,4 +121,3 @@ fbfd3505376e     *     0ff04b2e7b63 docker.io/library/ubuntu:latest  ubuntu-work
 
 ## SEE ALSO
 buildah(1)
-

--- a/docs/buildah-copy.md
+++ b/docs/buildah-copy.md
@@ -25,7 +25,7 @@ BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
 
 Sets the user and group ownership of the destination content.
 
-**--quiet**
+**--quiet**, **-q**
 
 Refrain from printing a digest of the copied content.
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -113,7 +113,7 @@ Limit the container's CPU usage. By default, containers run with the full
 CPU resource. This flag tell the kernel to restrict the container's CPU usage
 to the quota you specify.
 
-**--cpu-shares, -c**=*0*
+**--cpu-shares**, **-c**=*0*
 
 CPU shares (relative weight)
 
@@ -192,7 +192,7 @@ Set custom DNS options
 
 Set custom DNS search domains
 
-**--format**
+**--format**, **-f** *oci* | *docker*
 
 Control the format for the built image's manifest and configuration data.
 Recognized formats include *oci* (OCI image-spec v1.0, the default) and
@@ -235,7 +235,7 @@ container technology).
 Note: You can also override the default isolation type by setting the
 BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`
 
-**--memory, -m**=""
+**--memory**, **-m**=""
 
 Memory limit (format: <number>[<unit>], where unit = b, k, m or g)
 
@@ -304,7 +304,7 @@ Raise an error if not found in the registries, even if the image is present loca
 Do not pull the image from the registry, use only the local version. Raise an error
 if the image is not present locally.
 
-**--quiet, -q**
+**--quiet**, **-q**
 
 If an image needs to be pulled from the registry, suppress progress output.
 
@@ -368,7 +368,7 @@ the user namespace in which `Buildah` itself is being run should be reused, or
 it can be the path to an user namespace which is already in use by another
 process.
 
-**--userns-uid-map** *mapping*
+**--userns-uid-map-user** *mapping*
 
 Directly specifies a UID mapping which should be used to set ownership, at the
 filesystem level, on the container's contents.
@@ -389,7 +389,7 @@ If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-uid-map
 are specified, but --userns-gid-map is specified, the UID map will be set to
 use the same numeric values as the GID map.
 
-**--userns-gid-map** *mapping*
+**--userns-gid-map-group** *mapping*
 
 Directly specifies a GID mapping which should be used to set ownership, at the
 filesystem level, on the container's contents.
@@ -442,7 +442,7 @@ that the UTS namespace in which `Buildah` itself is being run should be reused,
 or it can be the path to a UTS namespace which is already in use by another
 process.
 
-**--volume, -v**[=*[HOST-DIR:CONTAINER-DIR[:OPTIONS]]*]
+**--volume**, **-v**[=*[HOST-DIR:CONTAINER-DIR[:OPTIONS]]*]
 
    Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Buildah
    bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the Buildah

--- a/docs/buildah-images.md
+++ b/docs/buildah-images.md
@@ -12,7 +12,7 @@ The created date is displayed in the time locale of the local machine.
 
 ## OPTIONS
 
-**--all, -a**
+**--all**, **-a**
 
 Show all images, including intermediate images from a build.
 
@@ -20,7 +20,7 @@ Show all images, including intermediate images from a build.
 
 Show the image digests.
 
-**--filter, -f=[]**
+**--filter**, **-f**=[]
 
 Filter output based on conditions provided (default []).  Valid
 keywords are 'before', 'dangling', 'label', 'readonly' and 'since' .
@@ -42,7 +42,7 @@ keywords are 'before', 'dangling', 'label', 'readonly' and 'since' .
   **since==TIMESTRING**
     Filter on images created since the given time.Time.
 
-**--format="TEMPLATE"**
+**--format**="TEMPLATE"
 
 Pretty-print images using a Go template.
 
@@ -66,15 +66,15 @@ Display the image name history.
 
 Display the output in JSON format.
 
-**--noheading, -n**
+**--noheading**, **-n**
 
 Omit the table headings from the listing of images.
 
-**--no-trunc, --notruncate**
+**--no-trunc**
 
 Do not truncate output.
 
-**--quiet, -q**
+**--quiet**, **-q**
 
 Displays only the image IDs.
 
@@ -88,7 +88,7 @@ buildah images --json
 
 buildah images --quiet
 
-buildah images -q --noheading --notruncate
+buildah images -q --noheading --no-trunc
 
 buildah images --quiet fedora:latest
 

--- a/docs/buildah-inspect.md
+++ b/docs/buildah-inspect.md
@@ -13,7 +13,7 @@ the given template will be executed for each result.
 
 ## OPTIONS
 
-**--format** *template*
+**--format**, **-f** *template*
 
 Use *template* as a Go template when formatting the output.
 
@@ -21,7 +21,7 @@ Users of this option should be familiar with the [*text/template*
 package](https://golang.org/pkg/text/template/) in the Go standard library, and
 of internals of Buildah's implementation.
 
-**--type** **container** | **image**
+**--type**, **-t** **container** | **image**
 
 Specify whether *object* is a container or an image.
 

--- a/docs/buildah-login.md
+++ b/docs/buildah-login.md
@@ -21,7 +21,7 @@ flag. The default path used is **${XDG\_RUNTIME_DIR}/containers/auth.json**.
 
 ## OPTIONS
 
-**--password, -p**
+**--password**, **-p**
 
 Password for registry
 
@@ -29,7 +29,7 @@ Password for registry
 
 Take the password from stdin
 
-**--username, -u**
+**--username**, **-u**
 
 Username for registry
 

--- a/docs/buildah-logout.md
+++ b/docs/buildah-logout.md
@@ -27,7 +27,7 @@ Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
 
-**--all, -a**
+**--all**, **-a**
 
 Remove the cached credentials for all registries in the auth file
 

--- a/docs/buildah-manifest-push.md
+++ b/docs/buildah-manifest-push.md
@@ -43,13 +43,17 @@ value can be entered.  The password is entered without echo.
 
 After copying the image, write the digest of the resulting image to the file.
 
-**--format, -f**
+**--format**, **-f**
 
 Manifest list type (oci or v2s2) to use when pushing the list (default is oci).
 
 **--purge**
 
 Delete the manifest list or image index from local storage if pushing succeeds.
+
+**--quiet**, **-q**
+
+Don't output progress information when pushing lists.
 
 **--remove-signatures**
 

--- a/docs/buildah-manifest.md
+++ b/docs/buildah-manifest.md
@@ -19,9 +19,9 @@ The `buildah manifest` command provides subcommands which can be used to:
 
 | Command  | Man Page                                                     | Description                                                                 |
 | -------  | ------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| create   | [buildah-manifest-create(1)](buildah-manifest-create.md)     | Create a manifest list or image index.                                      |
 | add      | [buildah-manifest-add(1)](buildah-manifest-add.md)           | Add an image to a manifest list or image index.                             |
 | annotate | [buildah-manifest-annotate(1)](buildah-manifest-annotate.md) | Add or update information about an image in a manifest list or image index. |
+| create   | [buildah-manifest-create(1)](buildah-manifest-create.md)     | Create a manifest list or image index.                                      |
 | inspect  | [buildah-manifest-inspect(1)](buildah-manifest-inspect.md)   | Display the contents of a manifest list or image index.                     |
 | push     | [buildah-manifest-push(1)](buildah-manifest-push.md)         | Push a manifest list or image index to a registry or other location.        |
 | remove   | [buildah-manifest-remove(1)](buildah-manifest-remove.md)     | Remove an image from a manifest list or image index.                        |

--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -42,7 +42,7 @@ The image ID of the image that was pulled.  On error 1 is returned.
 
 ## OPTIONS
 
-**--all-tags, a**
+**--all-tags**, **-a**
 
 All tagged images in the repository will be pulled.
 
@@ -66,19 +66,13 @@ value can be entered.  The password is entered without echo.
 
 The [key[:passphrase]] to be used for decryption of images. Key can point to keys and/or certificates. Decryption will be tried with all keys. If the key is protected by a passphrase, it is required to be passed in the argument and omitted otherwise.
 
-**--quiet, -q**
+**--quiet**, **-q**
 
 If an image needs to be pulled from the registry, suppress progress output.
 
 **--remove-signatures**
 
 Don't copy signatures when pulling images.
-
-**--shm-size**=""
-
-Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater than `0`.
-Unit is optional and can be `b` (bytes), `k` (kilobytes), `m`(megabytes), or `g` (gigabytes).
-If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
 
 **--tls-verify** *bool-value*
 

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -62,7 +62,7 @@ value can be entered.  The password is entered without echo.
 
 After copying the image, write the digest of the resulting image to the file.
 
-**--disable-compression, -D**
+**--disable-compression**, **-D**
 
 Don't compress copies of filesystem layers which will be pushed.
 
@@ -70,11 +70,15 @@ Don't compress copies of filesystem layers which will be pushed.
 
 The [protocol:keyfile] specifies the encryption protocol, which can be JWE (RFC7516), PGP (RFC4880), and PKCS7 (RFC2315) and the key material required for image encryption. For instance, jwe:/path/to/key.pem or pgp:admin@example.com or pkcs7:/path/to/x509-file.
 
-**--format, -f**
+**--encrypt-layer** *layer(s)*
+
+Layer(s) to encrypt: 0-indexed layer indices with support for negative indexing (e.g. 0 is the first layer, -1 is the last layer). If not defined, will encrypt all layers if encryption-key flag is specified.
+
+**--format**, **-f**
 
 Manifest Type (oci, v2s1, or v2s2) to use when saving image to directory using the 'dir:' transport (default is manifest type of source)
 
-**--quiet, -q**
+**--quiet**, **-q**
 
 When writing the output image, suppress progress output.
 

--- a/docs/buildah-rm.md
+++ b/docs/buildah-rm.md
@@ -11,7 +11,7 @@ Removes one or more working containers, unmounting them if necessary.
 
 ## OPTIONS
 
-**--all, -a**
+**--all**, **-a**
 
 All Buildah containers will be removed.  Buildah containers are denoted with an '*' in the 'BUILDER' column listed by the command 'buildah containers'.A container name or id cannot be provided when this option is used.
 

--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -17,17 +17,17 @@ If _imageID_ is a name, but does not include a registry name, buildah will attem
 
 ## OPTIONS
 
-**--all, -a**
+**--all**, **-a**
 
 All local images will be removed from the system that do not have containers using the image as a reference image.
 An image name or id cannot be provided when this option is used.  Read/Only images configured by modifying the  "additionalimagestores" in the /etc/containers/storage.conf file, can not be removed.
 
-**--prune, -p**
+**--prune**, **-p**
 
 All local images will be removed from the system that do not have a tag and do not have a child image pointing to them.
 An image name or id cannot be provided when this option is used.
 
-**--force, -f**
+**--force**, **-f**
 
 This option will cause Buildah to remove all containers that are using the image before removing the image from the system.
 

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -181,7 +181,7 @@ that the UTS namespace in which `buildah` itself is being run should be reused,
 or it can be the path to a UTS namespace which is already in use by another
 process.
 
-**--volume, -v** *source*:*destination*:*options*
+**--volume**, **-v** *source*:*destination*:*options*
 
 Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Buildah
 bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the Buildah

--- a/docs/buildah-umount.md
+++ b/docs/buildah-umount.md
@@ -10,7 +10,7 @@ buildah\-umount - Unmount the root file system on the specified working containe
 Unmounts the root file system on the specified working containers.
 
 ## OPTIONS
-**--all, -a**
+**--all**, **-a**
 
 All of the currently mounted containers will be unmounted.
 

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -109,7 +109,7 @@ If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-gid-map
 are specified, but --userns-uid-map is specified, the GID map will be set to
 use the same numeric values as the UID map.
 
-**--version, -v**
+**--version**, **-v**
 
 Print the version
 
@@ -131,9 +131,10 @@ Buildah can set up environment variables from the env entry in the [engine] tabl
 | buildah-images(1)     | List images in local storage.                                                                        |
 | buildah-info(1)       | Display Buildah system information.                                                                  |
 | buildah-inspect(1)    | Inspects the configuration of a container or image                                                   |
-| buildah-mount(1)      | Mount the working container's root filesystem.                                                       |
 | buildah-login(1)      | Login to a container registry.                                                                       |
 | buildah-logout(1)     | Logout of a container registry                                                                       |
+| buildah-manifest(1)   | Create and manipulate manifest lists and image indexes. |
+| buildah-mount(1)      | Mount the working container's root filesystem.                                                       |
 | buildah-pull(1)       | Pull an image from the specified location.                                                           |
 | buildah-push(1)       | Push an image from local storage to elsewhere.                                                       |
 | buildah-rename(1)     | Rename a local container.                                                                            |

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -1,0 +1,310 @@
+#!/usr/bin/perl
+#
+# xref-helpmsgs-manpages - cross-reference --help options against man pages
+#
+package LibPod::CI::XrefHelpmsgsManpages;
+
+use v5.14;
+use utf8;
+
+use strict;
+use warnings;
+
+(our $ME = $0) =~ s|.*/||;
+our $VERSION = '0.1';
+
+# For debugging, show data structures using DumpTree($var)
+#use Data::TreeDumper; $Data::TreeDumper::Displayaddress = 0;
+
+# unbuffer output
+$| = 1;
+
+###############################################################################
+# BEGIN user-customizable section
+
+# Path to desired executable
+my $Default_Tool = './bin/buildah';
+my $TOOL = $ENV{BUILDAH} || $Default_Tool;
+
+# Path to all doc files, including .rst and (down one level) markdown
+my $Docs_Path = 'docs';
+
+# Path to markdown source files (of the form <toolname>-*.1.md)
+my $Markdown_Path = "$Docs_Path";
+
+# Global error count
+my $Errs = 0;
+
+# END   user-customizable section
+###############################################################################
+
+use FindBin;
+
+###############################################################################
+# BEGIN boilerplate args checking, usage messages
+
+sub usage {
+    print  <<"END_USAGE";
+Usage: $ME [OPTIONS]
+
+$ME recursively runs '<tool> --help' against
+all subcommands; and recursively reads <tool>-*.1.md files
+in $Markdown_Path, then cross-references that each --help
+option is listed in the appropriate man page and vice-versa.
+
+$ME invokes '\$BUILDAH' (default: $Default_Tool).
+
+Exit status is zero if no inconsistencies found, one otherwise
+
+OPTIONS:
+
+  -v, --verbose  show verbose progress indicators
+  -n, --dry-run  make no actual changes
+
+  --help         display this message
+  --version      display program name and version
+END_USAGE
+
+    exit;
+}
+
+# Command-line options.  Note that this operates directly on @ARGV !
+our $debug   = 0;
+our $verbose = 0;
+sub handle_opts {
+    use Getopt::Long;
+    GetOptions(
+        'debug!'     => \$debug,
+        'verbose|v'  => \$verbose,
+
+        help         => \&usage,
+        version      => sub { print "$ME version $VERSION\n"; exit 0 },
+    ) or die "Try `$ME --help' for help\n";
+}
+
+# END   boilerplate args checking, usage messages
+###############################################################################
+
+############################## CODE BEGINS HERE ###############################
+
+# The term is "modulino".
+__PACKAGE__->main()                                     unless caller();
+
+# Main code.
+sub main {
+    # Note that we operate directly on @ARGV, not on function parameters.
+    # This is deliberate: it's because Getopt::Long only operates on @ARGV
+    # and there's no clean way to make it use @_.
+    handle_opts();                      # will set package globals
+
+    # Fetch command-line arguments.  Barf if too many.
+    die "$ME: Too many arguments; try $ME --help\n"                 if @ARGV;
+
+    my $help = tool_help();
+    my $man  = tool_man('buildah');
+
+    xref_by_help($help, $man);
+    xref_by_man($help, $man);
+
+#    xref_rst($help, $rst);
+
+    exit !!$Errs;
+}
+
+###############################################################################
+# BEGIN cross-referencing
+
+##################
+#  xref_by_help  #  Find keys in '--help' but not in man
+##################
+sub xref_by_help {
+    my ($help, $man, @subcommand) = @_;
+
+    for my $k (sort keys %$help) {
+        if (exists $man->{$k}) {
+            if (ref $help->{$k}) {
+                xref_by_help($help->{$k}, $man->{$k}, @subcommand, $k);
+            }
+            # Otherwise, non-ref is leaf node such as a --option
+        }
+        else {
+            my $man = $man->{_path} || 'man';
+            warn "$ME: buildah @subcommand --help lists $k, but $k not in $man\n";
+            ++$Errs;
+        }
+    }
+}
+
+#################
+#  xref_by_man  #  Find keys in man pages but not in --help
+#################
+#
+# In an ideal world we could share the functionality in one function; but
+# there are just too many special cases in man pages.
+#
+sub xref_by_man {
+    my ($help, $man, @subcommand) = @_;
+
+    # FIXME: this generates way too much output
+    for my $k (grep { $_ ne '_path' } sort keys %$man) {
+        if (exists $help->{$k}) {
+            if (ref $man->{$k}) {
+                xref_by_man($help->{$k}, $man->{$k}, @subcommand, $k);
+            }
+        }
+        elsif ($k ne '--help' && $k ne '-h') {
+            my $man = $man->{_path} || 'man';
+
+            # Special case: 'buildah run --tty' is an invisible alias for -t
+            next if $k eq '--tty' && $help->{'--terminal'};
+
+            # Special case: '--net' is an undocumented shortcut in from,run
+            next if $k eq '--net' && $help->{'--network'};
+
+            # Special case: global options, re-documented in buildah-bud.md
+#            next if "@subcommand" eq "bud" && $k =~ /^--userns-.id-map$/;
+
+            warn "$ME: buildah @subcommand: $k in $man, but not --help\n";
+            ++$Errs;
+        }
+    }
+}
+
+# END   cross-referencing
+###############################################################################
+# BEGIN data gathering
+
+###############
+#  tool_help  #  Parse output of '<tool> [subcommand] --help'
+###############
+sub tool_help {
+    my %help;
+    open my $fh, '-|', $TOOL, @_, '--help'
+        or die "$ME: Cannot fork: $!\n";
+    my $section = '';
+    while (my $line = <$fh>) {
+        # Cobra is blessedly consistent in its output:
+        #    Usage: ...
+        #    Available Commands:
+        #       ....
+        #    Flags:
+        #       ....
+        #
+        # Start by identifying the section we're in...
+        if ($line =~ /^Available\s+(Commands):/) {
+            $section = lc $1;
+        }
+        elsif ($line =~ /^(Flags):/) {
+            $section = lc $1;
+        }
+
+        # ...then track commands and options. For subcommands, recurse.
+        elsif ($section eq 'commands') {
+            if ($line =~ /^\s{1,4}(\S+)\s/) {
+                my $subcommand = $1;
+                print "> buildah @_ $subcommand\n"               if $debug;
+                $help{$subcommand} = tool_help(@_, $subcommand)
+                    unless $subcommand eq 'help';       # 'help' not in man
+            }
+        }
+        elsif ($section eq 'flags') {
+            next if $line =~ /^\s+-h,\s+--help/;        # Ignore --help
+
+            # Handle '--foo' or '-f, --foo'
+            if ($line =~ /^\s{1,10}(--\S+)\s/) {
+                print "> buildah @_ $1\n"                        if $debug;
+                $help{$1} = 1;
+            }
+            elsif ($line =~ /^\s{1,10}(-\S),\s+(--\S+)\s/) {
+                print "> buildah @_ $1, $2\n"                    if $debug;
+                $help{$1} = $help{$2} = 1;
+            }
+        }
+    }
+    close $fh
+        or die "$ME: Error running 'buildah @_ --help'\n";
+
+    return \%help;
+}
+
+
+##############
+#  tool_man  #  Parse contents of <tool>-*.md
+##############
+sub tool_man {
+    my $command = shift;
+    my $subpath = "$Markdown_Path/$command.md";
+    my $manpath = "$FindBin::Bin/../$subpath";
+    print "** $subpath \n"                              if $debug;
+
+    my %man = (_path => $subpath);
+    open my $fh, '<', $manpath
+        or die "$ME: Cannot read $manpath: $!\n";
+    my $section = '';
+    my @most_recent_flags;
+    my $previous_subcmd = '';
+    while (my $line = <$fh>) {
+        chomp $line;
+        next unless $line;		# skip empty lines
+
+        # .md files designate sections with leading double hash
+        if ($line =~ /^##\s*(GLOBAL\s+)?OPTIONS/) {
+            $section = 'flags';
+        }
+        elsif ($line =~ /^\#\#\s+(SUB)?COMMANDS/) {
+            $section = 'commands';
+        }
+        elsif ($line =~ /^\#\#/) {
+            $section = '';
+        }
+
+        # This will be a table containing subcommand names, links to man pages.
+        # The format is slightly different between buildah.md and subcommands.
+        elsif ($section eq 'commands') {
+            # In tool.1.md
+            if ($line =~ /^\|\s*buildah-(\S+?)\(\d\)/) {
+                # $1 will be changed by recursion _*BEFORE*_ left-hand assignment
+                my $subcmd = $1;
+                $man{$subcmd} = tool_man("buildah-$1");
+            }
+
+            # In tool-<subcommand>.1.md
+            elsif ($line =~ /^\|\s+(\S+)\s+\|\s+\[\S+\]\((\S+)\.md\)/) {
+                # $1 will be changed by recursion _*BEFORE*_ left-hand assignment
+                my $subcmd = $1;
+                if ($previous_subcmd gt $subcmd) {
+                    warn "$ME: $subpath: '$previous_subcmd' and '$subcmd' are out of order\n";
+                    ++$Errs;
+                }
+                $previous_subcmd = $subcmd;
+                $man{$subcmd} = tool_man($2);
+            }
+        }
+
+        # Flags should always be of the form '**-f**' or '**--flag**',
+        # possibly separated by comma-space.
+        elsif ($section eq 'flags') {
+            # e.g. 'podman run --ip6', documented in man page, but nonexistent
+            if ($line =~ /^not\s+implemented/i) {
+                delete $man{$_} for @most_recent_flags;
+            }
+
+            @most_recent_flags = ();
+            # Handle any variation of '**--foo**, **-f**'
+            while ($line =~ s/^\*\*((--[a-z0-9-]+)|(-.))\*\*(,\s+)?//g) {
+                $man{$1} = 1;
+
+                # Keep track of them, in case we see 'Not implemented' below
+                push @most_recent_flags, $1;
+            }
+        }
+    }
+    close $fh;
+
+    return \%man;
+}
+
+# END   data gathering
+###############################################################################
+
+1;


### PR DESCRIPTION
Run 'buildah --help', recursively against all subcommands,
then cross-reference the results against docs/buildah*.md.
Report differences in subcommands and/or flags.

The majority of the changes in this PR are trivial (see
below) but a handful may be controversial and require
careful review:

  * Making 'bud' the default output of 'buildah help',
    with 'build-using-dockerfile' as an alias. This is
    the inverse of the situation until now: buildah
    would list build-using-dockerfile as the primary
    name. The man page, OTOH, lists 'bud'. The source
    file name is 'bud'. I suspect that most people
    type 'bud'. So, for consistency, I choose to make
    'bud' the default visible command.

  * add --encryption-key and --encrypt-layer documentation
    to buildah-commit.md, and --encrypt-layer to -push.md.
    Please double-check the wording here.

  * remove --notruncate from buildah-images.md. The option
    does not exist (although there is a TODO comment in
    the code). If it should exist, it is left to the
    reader to implement. I would humbly suggest that this
    is a good idea, for consistency with buildah containers.

  * remove --shm-size from buildah-pull.md. The option
    does not exist, and I suspect this was a copy-paste error.

  * add --security-opt stub to buildah-run.md. This is
    flagged with FIXME, and I would appreciate someone
    offering suggested wording here.

There is one other decision that needs to be made before this
PR merges (I will update commit message accordingly once done):
buildah-bud.md documents --userns-[gu]id-map which are not
actual buildah-bud option (they are global). I believe they
are documented well enough in buildah.bud, and would like to
remove them. May I? The alternative is to add special-case
code in the script to ignore those entries in bud.md.

Trivial (IMO) changes:

  * split options in man pages, from '**--foo, -f**'
    to '**--foo**, **-f**'. This conforms with the style
    used in podman man pages.

  * add missing one-letter aliases (usually "-q", "-a")

  * add missing man page entries for some easy options

  * sort out-of-order subcommand listings in man pages

Finally, do note that this is a copy-and-alter duplicate of the
original script in podman, and that is horrible. In an ideal
world I would've been able to refactor the podman version into
something usable on both repos (and then more). It turns out the
differences in man page format and in special-case handling are
too broad to let me do a clean refactor.

Signed-off-by: Ed Santiago <santiago@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

