### PR TITLE
Change call to Split() to safer SplitN()

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -335,7 +335,7 @@ func GetBindMount(args []string) (specs.Mount, error) {
 	setDest := false
 
 	for _, val := range args {
-		kv := strings.Split(val, "=")
+		kv := strings.SplitN(val, "=", 2)
 		switch kv[0] {
 		case "bind-nonrecursive":
 			newMount.Options = append(newMount.Options, "bind")
@@ -407,7 +407,7 @@ func GetTmpfsMount(args []string) (specs.Mount, error) {
 	setDest := false
 
 	for _, val := range args {
-		kv := strings.Split(val, "=")
+		kv := strings.SplitN(val, "=", 2)
 		switch kv[0] {
 		case "ro", "nosuid", "nodev", "noexec":
 			newMount.Options = append(newMount.Options, kv[0])


### PR DESCRIPTION
Change calls to Split to SplitN when we are splitting on an "=" sign to make sure
we're not over chopping what the caller requested.

I started this search after seeing https://github.com/containers/podman/pull/7759.
I'll do similar for Podman, but initial results on my search is order of
magnitudes bigger there.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>