### PR TITLE
[release-1.16] chroot: create bind mount targets 0755 instead of 0700

### DIFF
--- a/chroot/run.go
+++ b/chroot/run.go
@@ -1047,7 +1047,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	subDev := filepath.Join(spec.Root.Path, "/dev")
 	if err := unix.Mount("/dev", subDev, "bind", devFlags, ""); err != nil {
 		if os.IsNotExist(err) {
-			err = os.Mkdir(subDev, 0700)
+			err = os.Mkdir(subDev, 0755)
 			if err == nil {
 				err = unix.Mount("/dev", subDev, "bind", devFlags, "")
 			}
@@ -1071,7 +1071,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	subProc := filepath.Join(spec.Root.Path, "/proc")
 	if err := unix.Mount("/proc", subProc, "bind", procFlags, ""); err != nil {
 		if os.IsNotExist(err) {
-			err = os.Mkdir(subProc, 0700)
+			err = os.Mkdir(subProc, 0755)
 			if err == nil {
 				err = unix.Mount("/proc", subProc, "bind", procFlags, "")
 			}
@@ -1086,7 +1086,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	subSys := filepath.Join(spec.Root.Path, "/sys")
 	if err := unix.Mount("/sys", subSys, "bind", sysFlags, ""); err != nil {
 		if os.IsNotExist(err) {
-			err = os.Mkdir(subSys, 0700)
+			err = os.Mkdir(subSys, 0755)
 			if err == nil {
 				err = unix.Mount("/sys", subSys, "bind", sysFlags, "")
 			}
@@ -1163,15 +1163,15 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			}
 			// The target isn't there yet, so create it.
 			if srcinfo.IsDir() {
-				if err = os.MkdirAll(target, 0111); err != nil {
+				if err = os.MkdirAll(target, 0755); err != nil {
 					return undoBinds, errors.Wrapf(err, "error creating mountpoint %q in mount namespace", target)
 				}
 			} else {
-				if err = os.MkdirAll(filepath.Dir(target), 0111); err != nil {
+				if err = os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 					return undoBinds, errors.Wrapf(err, "error ensuring parent of mountpoint %q (%q) is present in mount namespace", target, filepath.Dir(target))
 				}
 				var file *os.File
-				if file, err = os.OpenFile(target, os.O_WRONLY|os.O_CREATE, 0); err != nil {
+				if file, err = os.OpenFile(target, os.O_WRONLY|os.O_CREATE, 0755); err != nil {
 					return undoBinds, errors.Wrapf(err, "error creating mountpoint %q in mount namespace", target)
 				}
 				file.Close()

--- a/tests/validate/git-validation.sh
+++ b/tests/validate/git-validation.sh
@@ -13,7 +13,7 @@ fi
 
 if [[ "$TRAVIS" != 'true' ]]; then
 	#GITVALIDATE_EPOCH=":/git-validation epoch"
-	GITVALIDATE_EPOCH="a8ac807dbb3463943855c1d0d55f6e87b69149f3"
+	GITVALIDATE_EPOCH="v1.16.0"
 fi
 
 OUTPUT_OPTIONS="-q"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When running using chroot isolation, create the target mountpoints for bind mounts, when they don't already exist, with 0755 permissions, for better consistency with runc.

#### How to verify it

Build an image derived from an image that doesn't include a `/dev`, for example `registry.suse.co/suse/sles12sp4@sha256:7504649ba71f61492c309ccada877a47ea11272b8658a9ad52923e8d17204628`, using chroot isolation, and examine the layers in the image we produce, comparing the permissions on `/dev`, `/proc`, and `/sys` for inconsistencies.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Cherry picked from #2646.

#### Does this PR introduce a user-facing change?

```
None
```