### PR TITLE
Makefile: tweak the cross-compile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,12 @@ bin/buildah:  $(SOURCES)
 buildah: bin/buildah
 
 .PHONY: cross
-cross: bin/buildah.darwin bin/buildah.darwin.386 bin/buildah.darwin.amd64 bin/buildah.linux.386 bin/buildah.linux.amd64 bin/buildah.linux.arm64 bin/buildah.linux.arm bin/buildah.linux.mips64 bin/buildah.linux.mips64le bin/buildah.linux.mips bin/buildah.linux.mipsle bin/buildah.linux.ppc64 bin/buildah.linux.ppc64le bin/buildah.linux.riscv64 bin/buildah.linux.s390x
+cross: bin/buildah.darwin.amd64 bin/buildah.linux.386 bin/buildah.linux.amd64 bin/buildah.linux.arm64 bin/buildah.linux.arm bin/buildah.linux.mips64 bin/buildah.linux.mips64le bin/buildah.linux.mips bin/buildah.linux.mipsle bin/buildah.linux.ppc64 bin/buildah.linux.ppc64le bin/buildah.linux.riscv64 bin/buildah.linux.s390x bin/buildah.windows.386.exe bin/buildah.windows.amd64.exe
 
 .PHONY: bin/buildah.%
 bin/buildah.%:
 	mkdir -p ./bin
-	GOOS=$(shell echo $@ | awk -F. '{print $$2}') GOARCH=$(shell echo $@ | awk -F. '{ print $$3 }') $(GO_BUILD) $(LDFLAGS) -o $@ -tags "containers_image_openpgp" ./cmd/buildah
+	GOOS=$(word 2,$(subst ., ,$@)) GOARCH=$(word 3,$(subst ., ,$@)) $(GO_BUILD) $(LDFLAGS) -o $@ -tags "containers_image_openpgp" ./cmd/buildah
 
 .PHONY: bin/imgtype
 bin/imgtype: *.go docker/*.go util/*.go tests/imgtype/imgtype.go

--- a/buildah.go
+++ b/buildah.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/ioutils"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -202,7 +201,7 @@ type Builder struct {
 	// ContentDigester counts the digest of all Add()ed content
 	ContentDigester CompositeDigester
 	// Devices are the additional devices to add to the containers
-	Devices []configs.Device
+	Devices ContainerDevices
 }
 
 // BuilderInfo are used as objects to display container information
@@ -231,7 +230,7 @@ type BuilderInfo struct {
 	CNIConfigDir          string
 	IDMappingOptions      IDMappingOptions
 	History               []v1.History
-	Devices               []configs.Device
+	Devices               ContainerDevices
 }
 
 // GetBuildInfo gets a pointer to a Builder object and returns a BuilderInfo object from it.
@@ -400,7 +399,7 @@ type BuilderOptions struct {
 	// Format for the container image
 	Format string
 	// Devices are the additional devices to add to the containers
-	Devices []configs.Device
+	Devices ContainerDevices
 	//DefaultEnv for containers
 	DefaultEnv []string
 	// MaxPullRetries is the maximum number of attempts we'll make to pull

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/config"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -255,7 +254,7 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 	if err != nil {
 		return err
 	}
-	devices := []configs.Device{}
+	devices := buildah.ContainerDevices{}
 	for _, device := range append(defaultContainerConfig.Containers.Devices, iopts.Devices...) {
 		dev, err := parse.DeviceFromPath(device)
 		if err != nil {

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	digest "github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/openshift/imagebuilder"
 	"github.com/openshift/imagebuilder/dockerfile/parser"
 	"github.com/pkg/errors"
@@ -98,7 +97,7 @@ type Executor struct {
 	excludes                       []string
 	unusedArgs                     map[string]struct{}
 	capabilities                   []string
-	devices                        []configs.Device
+	devices                        buildah.ContainerDevices
 	signBy                         string
 	architecture                   string
 	timestamp                      *time.Time
@@ -130,7 +129,7 @@ func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Nod
 		return nil, err
 	}
 
-	devices := []configs.Device{}
+	devices := buildah.ContainerDevices{}
 	for _, device := range append(defaultContainerConfig.Containers.Devices, options.Devices...) {
 		dev, err := parse.DeviceFromPath(device)
 		if err != nil {

--- a/pkg/parse/parse_unsupported.go
+++ b/pkg/parse/parse_unsupported.go
@@ -3,7 +3,7 @@
 package parse
 
 import (
-	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/containers/buildah"
 	"github.com/pkg/errors"
 )
 
@@ -11,6 +11,6 @@ func getDefaultProcessLimits() []string {
 	return []string{}
 }
 
-func DeviceFromPath(device string) ([]configs.Device, error) {
-	return []configs.Device{}, errors.Errorf("devices not supported")
+func DeviceFromPath(device string) (buildah.ContainerDevices, error) {
+	return buildah.ContainerDevices{}, errors.Errorf("devices not supported")
 }

--- a/run.go
+++ b/run.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -169,7 +168,7 @@ type RunOptions struct {
 	// lists, it will be dropped.
 	DropCapabilities []string
 	// Devices are the additional devices to add to the containers
-	Devices []configs.Device
+	Devices ContainerDevices
 }
 
 // Find the configuration for the namespace of the given type.  If there are

--- a/run_linux.go
+++ b/run_linux.go
@@ -37,6 +37,7 @@ import (
 	"github.com/docker/libnetwork/resolvconf"
 	"github.com/docker/libnetwork/types"
 	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -46,6 +47,9 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/sys/unix"
 )
+
+// ContainerDevices is an alias for a slice of github.com/opencontainers/runc/libcontainer/configs.Device structures.
+type ContainerDevices = []configs.Device
 
 func setChildProcess() error {
 	if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, uintptr(1), 0, 0, 0); err != nil {

--- a/run_unix.go
+++ b/run_unix.go
@@ -1,13 +1,14 @@
-// +build !linux,!darwin
+// +build darwin
 
 package buildah
 
 import (
+	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/pkg/errors"
 )
 
-// ContainerDevices is currently not implemented.
-type ContainerDevices = []struct{}
+// ContainerDevices is an alias for a slice of github.com/opencontainers/runc/libcontainer/configs.Device structures.
+type ContainerDevices = []configs.Device
 
 func setChildProcess() error {
 	return errors.New("function not supported on non-linux systems")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

What `go tool dist list` says the toolchain supports changes, so this change removes these attempted cross-compile build targets.
* GOOS=darwin, GOARCH unspecified build
* GOOS=darwin, GOARCH=386 build

Replace our use of slices of github.com/opencontainers/runc/libcontainer/configs.Device structures with a locally-defined type alias so that we can avoid importing the package on non-Unixy systems.  The result is not going to be a very useful binary on non-Linux systems, but it helps ensure that our subpackages won't break compilation for other projects who consume us as a library.

#### How to verify it

CI all the way.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Don't try to actually run the non-Linux binaries.

#### Does this PR introduce a user-facing change?

```
None
```