### PR TITLE
[release-1.15] chroot: fix handling of errno seccomp rules

### DIFF
--- a/chroot/seccomp.go
+++ b/chroot/seccomp.go
@@ -15,18 +15,26 @@ func setSeccomp(spec *specs.Spec) error {
 	if spec.Linux.Seccomp == nil {
 		return nil
 	}
-	mapAction := func(specAction specs.LinuxSeccompAction) libseccomp.ScmpAction {
+	mapAction := func(specAction specs.LinuxSeccompAction, errnoRet *uint) libseccomp.ScmpAction {
 		switch specAction {
 		case specs.ActKill:
 			return libseccomp.ActKill
 		case specs.ActTrap:
 			return libseccomp.ActTrap
 		case specs.ActErrno:
-			return libseccomp.ActErrno
+			action := libseccomp.ActErrno
+			if errnoRet != nil {
+				action = action.SetReturnCode(int16(*errnoRet))
+			}
+			return action
 		case specs.ActTrace:
 			return libseccomp.ActTrace
 		case specs.ActAllow:
 			return libseccomp.ActAllow
+		case specs.ActLog:
+			return libseccomp.ActLog
+		default:
+			logrus.Errorf("unmappable action %v", specAction)
 		}
 		return libseccomp.ActInvalid
 	}
@@ -68,6 +76,8 @@ func setSeccomp(spec *specs.Spec) error {
 			/* fallthrough */ /* for now */
 		case specs.ArchPARISC64:
 			/* fallthrough */ /* for now */
+		default:
+			logrus.Errorf("unmappable arch %v", specArch)
 		}
 		return libseccomp.ArchInvalid
 	}
@@ -87,11 +97,13 @@ func setSeccomp(spec *specs.Spec) error {
 			return libseccomp.CompareGreater
 		case specs.OpMaskedEqual:
 			return libseccomp.CompareMaskedEqual
+		default:
+			logrus.Errorf("unmappable op %v", op)
 		}
 		return libseccomp.CompareInvalid
 	}
 
-	filter, err := libseccomp.NewFilter(mapAction(spec.Linux.Seccomp.DefaultAction))
+	filter, err := libseccomp.NewFilter(mapAction(spec.Linux.Seccomp.DefaultAction, nil))
 	if err != nil {
 		return errors.Wrapf(err, "error creating seccomp filter with default action %q", spec.Linux.Seccomp.DefaultAction)
 	}
@@ -112,7 +124,7 @@ func setSeccomp(spec *specs.Spec) error {
 		}
 		for scnum := range scnames {
 			if len(rule.Args) == 0 {
-				if err = filter.AddRule(scnum, mapAction(rule.Action)); err != nil {
+				if err = filter.AddRule(scnum, mapAction(rule.Action, rule.ErrnoRet)); err != nil {
 					return errors.Wrapf(err, "error adding a rule (%q:%q) to seccomp filter", scnames[scnum], rule.Action)
 				}
 				continue
@@ -129,7 +141,7 @@ func setSeccomp(spec *specs.Spec) error {
 				}
 				conditions = append(conditions, condition)
 			}
-			if err = filter.AddRuleConditional(scnum, mapAction(rule.Action), conditions); err != nil {
+			if err = filter.AddRuleConditional(scnum, mapAction(rule.Action, rule.ErrnoRet), conditions); err != nil {
 				// Okay, if the rules specify multiple equality
 				// checks, assume someone thought that they
 				// were OR'd, when in fact they're ordinarily
@@ -137,7 +149,7 @@ func setSeccomp(spec *specs.Spec) error {
 				// different rules to get that OR effect.
 				if len(rule.Args) > 1 && opsAreAllEquality && err.Error() == "two checks on same syscall argument" {
 					for i := range conditions {
-						if err = filter.AddRuleConditional(scnum, mapAction(rule.Action), conditions[i:i+1]); err != nil {
+						if err = filter.AddRuleConditional(scnum, mapAction(rule.Action, rule.ErrnoRet), conditions[i:i+1]); err != nil {
 							return errors.Wrapf(err, "error adding a conditional rule (%q:%q[%d]) to seccomp filter", scnames[scnum], rule.Action, i)
 						}
 					}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When converting seccomp rules from the runtime spec to the structure that we can feed to libseccomp, combine the prescribed errno value with the action when we're mapping the "return an errno" action from one to the other.

#### How to verify it

Currently, chroot isolation hits an error processing this seccomp rule:
```
                {
                        "names": [
                                "socket"
                        ],
                        "action": "SCMP_ACT_ERRNO",
                        "args": [
                                {
                                        "index": 0,
                                        "value": 16,
                                        "valueTwo": 0,
                                        "op": "SCMP_CMP_EQ"
                                },
                                {
                                        "index": 2,
                                        "value": 9,
                                        "valueTwo": 0,
                                        "op": "SCMP_CMP_EQ"
                                }
                        ],
                        "comment": "",
                        "includes": {},
                        "excludes": {
                                "caps": [
                                        "CAP_AUDIT_WRITE"
                                ]
                        },
                        "errnoRet": 22
                },
```
on Fedora 33.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Cherry picked from #2644.

#### Does this PR introduce a user-facing change?

```
None
```