### PR TITLE
Shell Completion for podman build flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784
-	github.com/containers/common v0.23.0
+	github.com/containers/common v0.24.0
 	github.com/containers/image/v5 v5.6.0
 	github.com/containers/ocicrypt v1.0.3
 	github.com/containers/storage v1.23.5
@@ -27,7 +27,7 @@ require (
 	github.com/openshift/imagebuilder v1.1.7
 	github.com/pkg/errors v0.9.1
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20200616122406-847368b35ebf
-	github.com/sirupsen/logrus v1.6.0
+	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDG
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784 h1:rqUVLD8I859xRgUx/WMC3v7QAFqbLKZbs+0kqYboRJc=
 github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
-github.com/containers/common v0.23.0 h1:+g4mI3wUYSzOtoWU9TNVoV4K52/aN6JEz0qs1YdPEe8=
-github.com/containers/common v0.23.0/go.mod h1:E56/N0beWGf+lrrJX32atuo2hkjzHwSC8n1vCG+TAR0=
+github.com/containers/common v0.24.0 h1:5C03ROzmRvZCyooNJVkZ4Q8T2d04g+VVyPMQ428XC4Y=
+github.com/containers/common v0.24.0/go.mod h1:BFRo6uRh1TbkZgR2oYTILxc2BNZTBtBffa9xtu881QI=
 github.com/containers/image/v5 v5.6.0 h1:r4AqIX4NO/X7OJkqX574zITV3fq0ZPn0pSlLsxWF6ww=
 github.com/containers/image/v5 v5.6.0/go.mod h1:iUSWo3SOLqJo0CkZkKrHxqR6YWqrT98mkXFpE0MceE8=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -188,11 +188,15 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringSliceVarP(&flags.File, "file", "f", []string{}, "`pathname or URL` of a Dockerfile")
 	fs.StringVar(&flags.Format, "format", DefaultFormat(), "`format` of the built image's manifest and metadata. Use BUILDAH_FORMAT environment variable to override.")
 	fs.StringVar(&flags.Iidfile, "iidfile", "", "`file` to write the image ID to")
+	fs.IntVar(&flags.Jobs, "jobs", 1, "how many stages to run in parallel")
 	fs.StringArrayVar(&flags.Label, "label", []string{}, "Set metadata for an image (default [])")
-	fs.BoolVar(&flags.NoCache, "no-cache", false, "Do not use existing cached images for the container build. Build from the start with a new set of cached layers.")
 	fs.StringVar(&flags.Logfile, "logfile", "", "log to `file` instead of stdout/stderr")
 	fs.IntVar(&flags.Loglevel, "loglevel", 0, "adjust logging level (range from -2 to 3)")
-	fs.Int64Var(&flags.Timestamp, "timestamp", 0, "set created timestamp to the specified epoch seconds to allow for deterministic builds, defaults to current time")
+	fs.BoolVar(&flags.LogRusage, "log-rusage", false, "log resource usage at each build step")
+	if err := fs.MarkHidden("log-rusage"); err != nil {
+		panic(fmt.Sprintf("error marking the log-rusage flag as hidden: %v", err))
+	}
+	fs.BoolVar(&flags.NoCache, "no-cache", false, "Do not use existing cached images for the container build. Build from the start with a new set of cached layers.")
 	fs.StringVar(&flags.OS, "os", runtime.GOOS, "set the OS to the provided value instead of the current operating system of the host")
 	fs.StringVar(&flags.Platform, "platform", parse.DefaultPlatform(), "set the OS/ARCH to the provided value instead of the current operating system and architecture of the host (for example `linux/arm`)")
 	fs.BoolVar(&flags.Pull, "pull", true, "pull the image from the registry if newer or not present in store, if false, only pull the image if not present")
@@ -207,12 +211,8 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.BoolVar(&flags.Squash, "squash", false, "squash newly built layers into a single new layer")
 	fs.StringArrayVarP(&flags.Tag, "tag", "t", []string{}, "tagged `name` to apply to the built image")
 	fs.StringVar(&flags.Target, "target", "", "set the target build stage to build")
+	fs.Int64Var(&flags.Timestamp, "timestamp", 0, "set created timestamp to the specified epoch seconds to allow for deterministic builds, defaults to current time")
 	fs.BoolVar(&flags.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
-	fs.IntVar(&flags.Jobs, "jobs", 1, "how many stages to run in parallel")
-	fs.BoolVar(&flags.LogRusage, "log-rusage", false, "log resource usage at each build step")
-	if err := fs.MarkHidden("log-rusage"); err != nil {
-		panic(fmt.Sprintf("error marking the log-rusage flag as hidden: %v", err))
-	}
 	return fs
 }
 
@@ -229,10 +229,10 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["file"] = commonComp.AutocompleteDefault
 	flagCompletion["format"] = commonComp.AutocompleteNone
 	flagCompletion["iidfile"] = commonComp.AutocompleteDefault
+	flagCompletion["jobs"] = commonComp.AutocompleteNone
 	flagCompletion["label"] = commonComp.AutocompleteNone
 	flagCompletion["logfile"] = commonComp.AutocompleteDefault
 	flagCompletion["loglevel"] = commonComp.AutocompleteDefault
-	flagCompletion["timestamp"] = commonComp.AutocompleteNone
 	flagCompletion["os"] = commonComp.AutocompleteNone
 	flagCompletion["platform"] = commonComp.AutocompleteNone
 	flagCompletion["runtime-flag"] = commonComp.AutocompleteNone
@@ -240,7 +240,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["signature-policy"] = commonComp.AutocompleteNone
 	flagCompletion["tag"] = commonComp.AutocompleteNone
 	flagCompletion["target"] = commonComp.AutocompleteNone
-	flagCompletion["jobs"] = commonComp.AutocompleteNone
+	flagCompletion["timestamp"] = commonComp.AutocompleteNone
 	return flagCompletion
 }
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -11,9 +11,11 @@ import (
 	"strings"
 
 	"github.com/containers/buildah"
+	"github.com/containers/buildah/pkg/completion"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
 	"github.com/containers/common/pkg/auth"
+	commonComp "github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/config"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -125,6 +127,17 @@ func GetUserNSFlags(flags *UserNSResults) pflag.FlagSet {
 	return usernsFlags
 }
 
+// GetUserNSFlagsCompletions returns the FlagCompletions for the userns flags
+func GetUserNSFlagsCompletions() commonComp.FlagCompletions {
+	flagCompletion := commonComp.FlagCompletions{}
+	flagCompletion["userns"] = completion.AutocompleteNamespaceFlag
+	flagCompletion["userns-uid-map"] = commonComp.AutocompleteNone
+	flagCompletion["userns-gid-map"] = commonComp.AutocompleteNone
+	flagCompletion["userns-uid-map-user"] = commonComp.AutocompleteSubuidName
+	flagCompletion["userns-gid-map-group"] = commonComp.AutocompleteSubgidName
+	return flagCompletion
+}
+
 // GetNameSpaceFlags returns the common flags for a namespace menu
 func GetNameSpaceFlags(flags *NameSpaceResults) pflag.FlagSet {
 	fs := pflag.FlagSet{}
@@ -137,6 +150,18 @@ func GetNameSpaceFlags(flags *NameSpaceResults) pflag.FlagSet {
 	return fs
 }
 
+// GetNameSpaceFlagsCompletions returns the FlagCompletions for the namespace flags
+func GetNameSpaceFlagsCompletions() commonComp.FlagCompletions {
+	flagCompletion := commonComp.FlagCompletions{}
+	flagCompletion[string(specs.IPCNamespace)] = completion.AutocompleteNamespaceFlag
+	flagCompletion[string(specs.NetworkNamespace)] = completion.AutocompleteNamespaceFlag
+	flagCompletion["cni-config-dir"] = commonComp.AutocompleteDefault
+	flagCompletion["cni-plugin-path"] = commonComp.AutocompleteDefault
+	flagCompletion[string(specs.PIDNamespace)] = completion.AutocompleteNamespaceFlag
+	flagCompletion[string(specs.UTSNamespace)] = completion.AutocompleteNamespaceFlag
+	return flagCompletion
+}
+
 // GetLayerFlags returns the common flags for layers
 func GetLayerFlags(flags *LayerResults) pflag.FlagSet {
 	fs := pflag.FlagSet{}
@@ -144,6 +169,8 @@ func GetLayerFlags(flags *LayerResults) pflag.FlagSet {
 	fs.BoolVar(&flags.Layers, "layers", UseLayers(), fmt.Sprintf("cache intermediate layers during build. Use BUILDAH_LAYERS environment variable to override."))
 	return fs
 }
+
+// Note: GetLayerFlagsCompletion is not needed since GetLayerFlags only contains bool flags
 
 // GetBudFlags returns common bud flags
 func GetBudFlags(flags *BudResults) pflag.FlagSet {
@@ -189,6 +216,35 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	return fs
 }
 
+// GetBudFlagsCompletions returns the FlagCompletions for the common bud flags
+func GetBudFlagsCompletions() commonComp.FlagCompletions {
+	flagCompletion := commonComp.FlagCompletions{}
+	flagCompletion["arch"] = commonComp.AutocompleteNone
+	flagCompletion["annotation"] = commonComp.AutocompleteNone
+	flagCompletion["authfile"] = commonComp.AutocompleteDefault
+	flagCompletion["build-arg"] = commonComp.AutocompleteNone
+	flagCompletion["cache-from"] = commonComp.AutocompleteNone
+	flagCompletion["cert-dir"] = commonComp.AutocompleteDefault
+	flagCompletion["creds"] = commonComp.AutocompleteNone
+	flagCompletion["file"] = commonComp.AutocompleteDefault
+	flagCompletion["format"] = commonComp.AutocompleteNone
+	flagCompletion["iidfile"] = commonComp.AutocompleteDefault
+	flagCompletion["label"] = commonComp.AutocompleteNone
+	flagCompletion["logfile"] = commonComp.AutocompleteDefault
+	flagCompletion["loglevel"] = commonComp.AutocompleteDefault
+	flagCompletion["timestamp"] = commonComp.AutocompleteNone
+	flagCompletion["os"] = commonComp.AutocompleteNone
+	flagCompletion["platform"] = commonComp.AutocompleteNone
+	flagCompletion["runtime-flag"] = commonComp.AutocompleteNone
+	flagCompletion["sign-by"] = commonComp.AutocompleteNone
+	flagCompletion["signature-policy"] = commonComp.AutocompleteNone
+	flagCompletion["tag"] = commonComp.AutocompleteNone
+	flagCompletion["target"] = commonComp.AutocompleteNone
+	flagCompletion["jobs"] = commonComp.AutocompleteNone
+	return flagCompletion
+}
+
+// GetFromAndBudFlags returns from and bud flags
 func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, namespaceResults *NameSpaceResults) (pflag.FlagSet, error) {
 	fs := pflag.FlagSet{}
 	defaultContainerConfig, err := config.Default()
@@ -237,6 +293,44 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 	fs.AddFlagSet(&namespaceFlags)
 
 	return fs, nil
+}
+
+// GetFromAndBudFlagsCompletions returns the FlagCompletions for the from and bud flags
+func GetFromAndBudFlagsCompletions() commonComp.FlagCompletions {
+	flagCompletion := commonComp.FlagCompletions{}
+	flagCompletion["add-host"] = commonComp.AutocompleteNone
+	flagCompletion["blob-cache"] = commonComp.AutocompleteNone
+	flagCompletion["cap-add"] = commonComp.AutocompleteCapabilities
+	flagCompletion["cap-drop"] = commonComp.AutocompleteCapabilities
+	flagCompletion["cgroup-parent"] = commonComp.AutocompleteDefault // FIXME: This would be a path right?!
+	flagCompletion["cpu-period"] = commonComp.AutocompleteNone
+	flagCompletion["cpu-quota"] = commonComp.AutocompleteNone
+	flagCompletion["cpu-shares"] = commonComp.AutocompleteNone
+	flagCompletion["cpuset-cpus"] = commonComp.AutocompleteNone
+	flagCompletion["cpuset-mems"] = commonComp.AutocompleteNone
+	flagCompletion["device"] = commonComp.AutocompleteDefault
+	flagCompletion["dns-search"] = commonComp.AutocompleteNone
+	flagCompletion["dns"] = commonComp.AutocompleteNone
+	flagCompletion["dns-option"] = commonComp.AutocompleteNone
+	flagCompletion["isolation"] = commonComp.AutocompleteNone
+	flagCompletion["memory"] = commonComp.AutocompleteNone
+	flagCompletion["memory-swap"] = commonComp.AutocompleteNone
+	flagCompletion["security-opt"] = commonComp.AutocompleteNone
+	flagCompletion["shm-size"] = commonComp.AutocompleteNone
+	flagCompletion["ulimit"] = commonComp.AutocompleteNone
+	flagCompletion["volume"] = commonComp.AutocompleteDefault
+
+	// Add in the usernamespace and namespace flag completions
+	userNsComp := GetUserNSFlagsCompletions()
+	for name, comp := range userNsComp {
+		flagCompletion[name] = comp
+	}
+	namespaceComp := GetNameSpaceFlagsCompletions()
+	for name, comp := range namespaceComp {
+		flagCompletion[name] = comp
+	}
+
+	return flagCompletion
 }
 
 // UseLayers returns true if BUILDAH_LAYERS is set to "1" or "true"

--- a/pkg/cli/common_test.go
+++ b/pkg/cli/common_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/containers/common/pkg/completion"
+	"github.com/spf13/pflag"
+)
+
+func testFlagCompletion(t *testing.T, flags pflag.FlagSet, flagCompletions completion.FlagCompletions) {
+	// lookup if for each flag a flag completion function exists
+	flags.VisitAll(func(f *pflag.Flag) {
+		// skip hidden, deprecated and boolean flags
+		if f.Hidden || len(f.Deprecated) > 0 || f.Value.Type() == "bool" {
+			return
+		}
+		if _, ok := flagCompletions[f.Name]; !ok {
+			t.Errorf("Flag %q has no shell completion function set.", f.Name)
+		}
+	})
+
+	// make sure no unnecessary flag completion functions are defined
+	for name := range flagCompletions {
+		if flag := flags.Lookup(name); flag == nil {
+			t.Errorf("Flag %q does not exists but has a shell completion function set.", name)
+		}
+	}
+}
+
+func TestUserNsFlagsCompletion(t *testing.T) {
+	flags := GetUserNSFlags(&UserNSResults{})
+	flagCompletions := GetUserNSFlagsCompletions()
+	testFlagCompletion(t, flags, flagCompletions)
+}
+
+func TestNameSpaceFlagsCompletion(t *testing.T) {
+	flags := GetNameSpaceFlags(&NameSpaceResults{})
+	flagCompletions := GetNameSpaceFlagsCompletions()
+	testFlagCompletion(t, flags, flagCompletions)
+}
+
+func TestBudFlagsCompletion(t *testing.T) {
+	flags := GetBudFlags(&BudResults{})
+	flagCompletions := GetBudFlagsCompletions()
+	testFlagCompletion(t, flags, flagCompletions)
+}
+
+func TestFromAndBudFlagsCompletions(t *testing.T) {
+	flags, err := GetFromAndBudFlags(&FromAndBudResults{}, &UserNSResults{}, &NameSpaceResults{})
+	if err != nil {
+		t.Error("Could load the from and bud flags.")
+	}
+	flagCompletions := GetFromAndBudFlagsCompletions()
+	testFlagCompletion(t, flags, flagCompletions)
+}

--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -1,0 +1,23 @@
+package completion
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+/* Autocomplete Functions for cobra ValidArgsFunction */
+
+// AutocompleteNamespaceFlag - Autocomplete the userns flag.
+// -> host, private, container, ns:[path], [path]
+func AutocompleteNamespaceFlag(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var completions []string
+	// If we don't filter on "toComplete", zsh and fish will not do file completion
+	// even if the prefix typed by the user does not match the returned completions
+	for _, comp := range []string{"host", "private", "container", "ns:"} {
+		if strings.HasPrefix(comp, toComplete) {
+			completions = append(completions, comp)
+		}
+	}
+	return completions, cobra.ShellCompDirectiveDefault
+}

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.23.0"
+const Version = "0.24.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -54,7 +54,7 @@ github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
-# github.com/containers/common v0.23.0
+# github.com/containers/common v0.24.0
 github.com/containers/common/pkg/apparmor
 github.com/containers/common/pkg/apparmor/internal/supported
 github.com/containers/common/pkg/auth
@@ -383,7 +383,7 @@ github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/seccomp/libseccomp-golang v0.9.2-0.20200616122406-847368b35ebf
 github.com/seccomp/libseccomp-golang
-# github.com/sirupsen/logrus v1.6.0 => github.com/sirupsen/logrus v1.4.2
+# github.com/sirupsen/logrus v1.7.0 => github.com/sirupsen/logrus v1.4.2
 github.com/sirupsen/logrus
 # github.com/spf13/cobra v1.0.0
 github.com/spf13/cobra


### PR DESCRIPTION
#### What type of PR is this?

/kind feature (podman)

#### What this PR does / why we need it:

The PR containers/podman#6442 enables a new way to create
shell completions scripts. The shell completion is handled
by cobra and since the build flags are defined here
the completion functions for this should be defined here
as well. For Reference see:
https://github.com/spf13/cobra/blob/master/shell_completions.md

I added a unit test to ensure that the flags have a
completion function set.


#### Special notes for your reviewer:

This PR is specifically for containers/podman#6442 but could also be
used by buildah if someone wants to implement such completions here.

#### Does this PR introduce a user-facing change?


```release-note
None
```

