### PR TITLE
[release-1.16] add: preserve ownerships and permissions on ADDed archives

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,38 +7,26 @@ run:
   # Don't exceed number of threads available when running under CI
   concurrency: 4
 linters:
-  disable-all: true
-  enable:
-    - bodyclose
+  enable-all: true
+  disable:
+    # All these break for one reason or another
     - deadcode
     - depguard
     - dupl
     - errcheck
-    - gofmt
-    - goimports
+    - gochecknoglobals
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
     - golint
-    # Broken? Unpredictably dies w/o any error well before deadline/timeout expires
-    # - gosimple
-    - govet
-    - ineffassign
-    - interfacer
-    - misspell
-    - nakedret
-    - staticcheck
+    - gosec
+    - gosimple
+    - lll
+    - maligned
+    - prealloc
+    - scopelint
     - structcheck
-    - stylecheck
     - typecheck
     - unconvert
-    - unparam
-    - unused
     - varcheck
-    # - gochecknoglobals
-    # - gochecknoinits
-    # - goconst
-    # - gocritic
-    # - gocyclo
-    # - gosec
-    # - lll
-    # - maligned
-    # - prealloc
-    # - scopelint

--- a/add.go
+++ b/add.go
@@ -33,7 +33,8 @@ type AddAndCopyOptions struct {
 	Chown string
 	// PreserveOwnership, if Chown is not set, tells us to avoid setting
 	// ownership of copied items to 0:0, instead using whatever ownership
-	// information is already set.  Not meaningful for remote sources.
+	// information is already set.  Not meaningful for remote sources or
+	// local archives that we extract.
 	PreserveOwnership bool
 	// All of the data being copied will pass through Hasher, if set.
 	// If the sources are URLs or files, their contents will be passed to
@@ -210,7 +211,6 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 
 	// Find out which user (and group) the destination should belong to.
 	var chownDirs, chownFiles *idtools.IDPair
-	var chmodDirs, chmodFiles *os.FileMode
 	var user specs.User
 	if options.Chown != "" {
 		user, _, err = b.user(mountPoint, options.Chown)
@@ -319,9 +319,9 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 						UIDMap:     destUIDMap,
 						GIDMap:     destGIDMap,
 						ChownDirs:  chownDirs,
-						ChmodDirs:  chmodDirs,
+						ChmodDirs:  nil,
 						ChownFiles: chownFiles,
-						ChmodFiles: chmodFiles,
+						ChmodFiles: nil,
 					}
 					putErr = copier.Put(mountPoint, extractDirectory, putOptions, io.TeeReader(pipeReader, hasher))
 				}
@@ -396,6 +396,10 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 					GIDMap:         srcGIDMap,
 					Excludes:       options.Excludes,
 					ExpandArchives: extract,
+					ChownDirs:      chownDirs,
+					ChmodDirs:      nil,
+					ChownFiles:     chownFiles,
+					ChmodFiles:     nil,
 					StripSetuidBit: options.StripSetuidBit,
 					StripSetgidBit: options.StripSetgidBit,
 					StripStickyBit: options.StripStickyBit,
@@ -423,12 +427,14 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 					_, putErr = io.Copy(hasher, pipeReader)
 				} else {
 					putOptions := copier.PutOptions{
-						UIDMap:     destUIDMap,
-						GIDMap:     destGIDMap,
-						ChownDirs:  chownDirs,
-						ChmodDirs:  chmodDirs,
-						ChownFiles: chownFiles,
-						ChmodFiles: chmodFiles,
+						UIDMap:          destUIDMap,
+						GIDMap:          destGIDMap,
+						DefaultDirOwner: chownDirs,
+						DefaultDirMode:  nil,
+						ChownDirs:       nil,
+						ChmodDirs:       nil,
+						ChownFiles:      nil,
+						ChmodFiles:      nil,
 					}
 					putErr = copier.Put(mountPoint, extractDirectory, putOptions, io.TeeReader(pipeReader, hasher))
 				}

--- a/copier/copier.go
+++ b/copier/copier.go
@@ -222,6 +222,10 @@ type GetOptions struct {
 	UIDMap, GIDMap     []idtools.IDMap // map from hostIDs to containerIDs in the output archive
 	Excludes           []string        // contents to pretend don't exist, using the OS-specific path separator
 	ExpandArchives     bool            // extract the contents of named items that are archives
+	ChownDirs          *idtools.IDPair // set ownership on directories. no effect on archives being extracted
+	ChmodDirs          *os.FileMode    // set permissions on directories. no effect on archives being extracted
+	ChownFiles         *idtools.IDPair // set ownership of files. no effect on archives being extracted
+	ChmodFiles         *os.FileMode    // set permissions on files. no effect on archives being extracted
 	StripSetuidBit     bool            // strip the setuid bit off of items being copied. no effect on archives being extracted
 	StripSetgidBit     bool            // strip the setgid bit off of items being copied. no effect on archives being extracted
 	StripStickyBit     bool            // strip the sticky bit off of items being copied. no effect on archives being extracted
@@ -265,6 +269,8 @@ func Get(root string, directory string, options GetOptions, globs []string, bulk
 // PutOptions controls parts of Put()'s behavior.
 type PutOptions struct {
 	UIDMap, GIDMap    []idtools.IDMap // map from containerIDs to hostIDs when writing contents to disk
+	DefaultDirOwner   *idtools.IDPair // set ownership of implicitly-created directories, default is ChownDirs, or 0:0 if ChownDirs not set
+	DefaultDirMode    *os.FileMode    // set permissions on implicitly-created directories, default is ChmodDirs, or 0755 if ChmodDirs not set
 	ChownDirs         *idtools.IDPair // set ownership of newly-created directories
 	ChmodDirs         *os.FileMode    // set permissions on newly-created directories
 	ChownFiles        *idtools.IDPair // set ownership of newly-created files
@@ -1193,6 +1199,22 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 			return errors.Wrapf(err, "error mapping host filesystem owners %#v to container filesystem owners", hostPair)
 		}
 	}
+	// force ownership and/or permissions, if requested
+	if hdr.Typeflag == tar.TypeDir {
+		if options.ChownDirs != nil {
+			hdr.Uid, hdr.Gid = options.ChownDirs.UID, options.ChownDirs.GID
+		}
+		if options.ChmodDirs != nil {
+			hdr.Mode = int64(*options.ChmodDirs)
+		}
+	} else {
+		if options.ChownFiles != nil {
+			hdr.Uid, hdr.Gid = options.ChownFiles.UID, options.ChownFiles.GID
+		}
+		if options.ChmodFiles != nil {
+			hdr.Mode = int64(*options.ChmodFiles)
+		}
+	}
 	// output the header
 	if err = tw.WriteHeader(hdr); err != nil {
 		return errors.Wrapf(err, "error writing header for %s (%s)", contentPath, hdr.Name)
@@ -1220,13 +1242,20 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 	errorResponse := func(fmtspec string, args ...interface{}) (*response, func() error, error) {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Put: putResponse{}}, nil, nil
 	}
-	dirUID, dirGID := 0, 0
+	dirUID, dirGID, defaultDirUID, defaultDirGID := 0, 0, 0, 0
 	if req.PutOptions.ChownDirs != nil {
 		dirUID, dirGID = req.PutOptions.ChownDirs.UID, req.PutOptions.ChownDirs.GID
+		defaultDirUID, defaultDirGID = dirUID, dirGID
 	}
-	dirMode := os.FileMode(0755)
+	defaultDirMode := os.FileMode(0755)
 	if req.PutOptions.ChmodDirs != nil {
-		dirMode = *req.PutOptions.ChmodDirs
+		defaultDirMode = *req.PutOptions.ChmodDirs
+	}
+	if req.PutOptions.DefaultDirOwner != nil {
+		defaultDirUID, defaultDirGID = req.PutOptions.DefaultDirOwner.UID, req.PutOptions.DefaultDirOwner.GID
+	}
+	if req.PutOptions.DefaultDirMode != nil {
+		defaultDirMode = *req.PutOptions.DefaultDirMode
 	}
 	var fileUID, fileGID *int
 	if req.PutOptions.ChownFiles != nil {
@@ -1258,11 +1287,11 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			subdir = filepath.Join(subdir, component)
 			path := filepath.Join(req.Root, subdir)
 			if err := os.Mkdir(path, 0700); err == nil {
-				if err = lchown(path, dirUID, dirGID); err != nil {
-					return errors.Wrapf(err, "copier: put: error setting owner of %q to %d:%d", path, dirUID, dirGID)
+				if err = lchown(path, defaultDirUID, defaultDirGID); err != nil {
+					return errors.Wrapf(err, "copier: put: error setting owner of %q to %d:%d", path, defaultDirUID, defaultDirGID)
 				}
-				if err = os.Chmod(path, dirMode); err != nil {
-					return errors.Wrapf(err, "copier: put: error setting permissions on %q to 0%o", path, dirMode)
+				if err = os.Chmod(path, defaultDirMode); err != nil {
+					return errors.Wrapf(err, "copier: put: error setting permissions on %q to 0%o", path, defaultDirMode)
 				}
 			} else {
 				if !os.IsExist(err) {

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -179,12 +179,17 @@ load helpers
       expect_output "nobody:root" "stat UG /subdir/$i"
   done
 
+  # subdir will have been implicitly created, and the --chown should have had an effect
+  run_buildah run $cid stat -c "%U:%G" /subdir
+  expect_output "nobody:root" "stat UG /subdir"
+
   run_buildah copy --chown root:root $cid ${TESTDIR}/other-subdir /subdir
   for i in randomfile other-randomfile ; do
       run_buildah run $cid stat -c "%U:%G" /subdir/$i
       expect_output "root:root" "stat UG /subdir/$i (after chown)"
   done
 
+  # subdir itself will have not been copied (the destination directory was created implicitly), so its permissions should not have changed
   run_buildah run $cid stat -c "%U:%G" /subdir
   expect_output "nobody:root" "stat UG /subdir"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When extracting archives that are added using ADD, don't override permissions and ownership information.  We regressed on this when we switched to using the copier package to handle them.

#### How to verify it

Added a new conformance test for it.

#### Which issue(s) this PR fixes:

Fixes #2657.

#### Special notes for your reviewer:

Cherry-picked from #2625 and #2659.

#### Does this PR introduce a user-facing change?

```
Permissions and ownership information on the contents of archives added using the ADD instruction or "buildah add" on the command line should be preserved again.
```