### PR TITLE
Move --userns-uid-map/--userns-gid-map  description into buildah man page

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -44,7 +44,6 @@ func init() {
 		Aliases: []string{"bud"},
 		Short:   "Build an image using instructions in a Dockerfile",
 		Long:    budDescription,
-		//Flags:                  sortFlags(append(append(buildahcli.BudFlags, buildahcli.LayerFlags...), buildahcli.FromAndBudFlags...)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			br := budOptions{
 				&layerFlagsResults,

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -497,48 +497,6 @@ the user namespace in which `buildah` itself is being run should be reused, or
 it can be the path to an user namespace which is already in use by another
 process.
 
-**--userns-uid-map** *mapping*
-
-Directly specifies a UID mapping which should be used to set ownership, at the
-filesystem level, on the working container's contents.
-Commands run when handling `RUN` instructions will default to being run in
-their own user namespaces, configured using the UID and GID maps.
-
-Entries in this map take the form of one or more colon-separated triples of a starting
-in-container UID, a corresponding starting host-level UID, and the number of
-consecutive IDs which the map entry represents.
-
-This option overrides the *remap-uids* setting in the *options* section of
-/etc/containers/storage.conf.
-
-If this option is not specified, but a global --userns-uid-map setting is
-supplied, settings from the global option will be used.
-
-If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-uid-map
-are specified, but --userns-gid-map is specified, the UID map will be set to
-use the same numeric values as the GID map.
-
-**--userns-gid-map** *mapping*
-
-Directly specifies a GID mapping which should be used to set ownership, at the
-filesystem level, on the working container's contents.
-Commands run when handling `RUN` instructions will default to being run in
-their own user namespaces, configured using the UID and GID maps.
-
-Entries in this map take the form of one or more colon-separated triples of a starting
-in-container GID, a corresponding starting host-level GID, and the number of
-consecutive IDs which the map entry represents.
-
-This option overrides the *remap-gids* setting in the *options* section of
-/etc/containers/storage.conf.
-
-If this option is not specified, but a global --userns-gid-map setting is
-supplied, settings from the global option will be used.
-
-If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-gid-map
-are specified, but --userns-uid-map is specified, the GID map will be set to
-use the same numeric values as the UID map.
-
 **--userns-uid-map-user** *user*
 
 Specifies that a UID mapping which should be used to set ownership, at the
@@ -550,6 +508,8 @@ If --userns-gid-map-group is specified, but --userns-uid-map-user is not
 specified, `buildah` will assume that the specified group name is also a
 suitable user name to use as the default setting for this option.
 
+Users can specify the maps directly using `--userns-uid-map` described in the buildah(1) man page.
+
 **--userns-gid-map-group** *group*
 
 Specifies that a GID mapping which should be used to set ownership, at the
@@ -560,6 +520,8 @@ their own user namespaces, configured using the UID and GID maps.
 If --userns-uid-map-user is specified, but --userns-gid-map-group is not
 specified, `buildah` will assume that the specified user name is also a
 suitable group name to use as the default setting for this option.
+
+Users can specify the maps directly using `--userns-gid-map` described in the buildah(1) man page.
 
 **--uts** *how*
 

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -69,23 +69,45 @@ Storage driver option, Default storage driver options are configured in /etc/con
 
 **--userns-uid-map** *mapping*
 
-Specifies UID mappings which should be used to set ownership, at the
-filesystem level, on the contents of images and containers.
-Entries in this map take the form of one or more triples of a starting
+Directly specifies a UID mapping which should be used to set ownership, at the
+filesystem level, on the working container's contents.
+Commands run when handling `RUN` instructions will default to being run in
+their own user namespaces, configured using the UID and GID maps.
+
+Entries in this map take the form of one or more colon-separated triples of a starting
 in-container UID, a corresponding starting host-level UID, and the number of
 consecutive IDs which the map entry represents.
+
 This option overrides the *remap-uids* setting in the *options* section of
 /etc/containers/storage.conf.
 
+If this option is not specified, but a global --userns-uid-map setting is
+supplied, settings from the global option will be used.
+
+If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-uid-map
+are specified, but --userns-gid-map is specified, the UID map will be set to
+use the same numeric values as the GID map.
+
 **--userns-gid-map** *mapping*
 
-Specifies GID mappings which should be used to set ownership, at the
-filesystem level, on the contents of images and containers.
-Entries in this map take the form of one or more triples of a starting
+Directly specifies a GID mapping which should be used to set ownership, at the
+filesystem level, on the working container's contents.
+Commands run when handling `RUN` instructions will default to being run in
+their own user namespaces, configured using the UID and GID maps.
+
+Entries in this map take the form of one or more colon-separated triples of a starting
 in-container GID, a corresponding starting host-level GID, and the number of
 consecutive IDs which the map entry represents.
+
 This option overrides the *remap-gids* setting in the *options* section of
 /etc/containers/storage.conf.
+
+If this option is not specified, but a global --userns-gid-map setting is
+supplied, settings from the global option will be used.
+
+If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-gid-map
+are specified, but --userns-uid-map is specified, the GID map will be set to
+use the same numeric values as the UID map.
 
 **--version, -v**
 


### PR DESCRIPTION
Currently we are describing a root global option --userns-uid-map and --userns-gid-map
options in the buildah-bud man page, These global flags can be used in lots of buildah
commands, and should have complete description in the buildah man page.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

