### PR TITLE
CI: re-enable several linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,24 +10,15 @@ linters:
   enable-all: true
   disable:
     # All these break for one reason or another
-    - deadcode
-    - depguard
     - dupl
-    - errcheck
     - funlen
     - gochecknoglobals
     - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
-    - golint
     - gosec
-    - gosimple
     - lll
     - maligned
     - prealloc
     - scopelint
-    - structcheck
-    - typecheck
-    - unconvert
-    - varcheck

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -789,9 +789,7 @@ func IDMappingOptions(c *cobra.Command, isolation buildah.Isolation) (usernsOpti
 		case "host":
 			usernsOption.Host = true
 		default:
-			if strings.HasPrefix(how, "ns:") {
-				how = how[3:]
-			}
+			how = strings.TrimPrefix(how, "ns:")
 			if _, err := os.Stat(how); err != nil {
 				return nil, nil, errors.Wrapf(err, "error checking for %s namespace at %q", string(specs.UserNamespace), how)
 			}
@@ -890,9 +888,7 @@ func NamespaceOptions(c *cobra.Command) (namespaceOptions buildah.NamespaceOptio
 						break
 					}
 				}
-				if strings.HasPrefix(how, "ns:") {
-					how = how[3:]
-				}
+				how = strings.TrimPrefix(how, "ns:")
 				if _, err := os.Stat(how); err != nil {
 					return nil, buildah.NetworkDefault, errors.Wrapf(err, "error checking for %s namespace at %q", what, how)
 				}

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1124,12 +1124,9 @@ func compareJSON(a, b map[string]interface{}, skip []string) (missKeys, leftKeys
 	}
 
 	replace := func(slice []string) []string {
-		r := make([]string, 0, len(slice))
-		for _, s := range slice {
-			r = append(r, s)
-		}
-		return r
+		return append([]string{}, slice...)
 	}
+
 	return replace(missKeys), replace(leftKeys), replace(diffKeys), isSame
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

When we carried over the linting configuration from podman, we carried over the list of checkers that were disabled for podman's sake, even ones that don't complain about the code in this repository.  Re-enable some of them.

Make a few trivial changes to make gosimple happy.

#### How to verify it

Verify the code changes, and that CI continues to pass.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

``
None
```