### PR TITLE
shebang fixes for rpm compilation

### DIFF
--- a/tests/digest/make-v2sN
+++ b/tests/digest/make-v2sN
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 #
 # make-v2sN - create a v2sN image, possibly with dups
 #

--- a/tests/test_buildah_authentication.sh
+++ b/tests/test_buildah_authentication.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 # test_buildah_authentication
 # A script to be run at the command line with Buildah installed.
 # This currently needs to be run as root and Docker must be

--- a/tests/test_buildah_baseline.sh
+++ b/tests/test_buildah_baseline.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 # test_buildah_baseline.sh 
 # A script to be run at the command line with Buildah installed.
 # This should be run against a new kit to provide base level testing

--- a/tests/test_buildah_build_rpm.sh
+++ b/tests/test_buildah_build_rpm.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 #
 # test_buildah_build_rpm.sh
 #

--- a/tests/test_runner.sh
+++ b/tests/test_runner.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 set -e
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"

--- a/tests/validate/git-validation.sh
+++ b/tests/validate/git-validation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 set -e
 

--- a/tests/validate/whitespace.sh
+++ b/tests/validate/whitespace.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 #  Check for one or more whitespace characters at the end of a line in a markdown or text file.
 #  gofmt is already going to be doing the same for source code.


### PR DESCRIPTION
Jindrich sent me an email with a number of soft errors from the rpm
building process that he does.  I've change things to make the errors go
away.

They are:
```
mangling shebang in /usr/share/buildah/test/system/digest/make-v2sN from /bin/bash to #!/usr/bin/bash
mangling shebang in /usr/share/buildah/test/system/test_buildah_authentication.sh from /usr/bin/env bash to #!/usr/bin/bash
mangling shebang in /usr/share/buildah/test/system/test_buildah_baseline.sh from /usr/bin/env bash to #!/usr/bin/bash
mangling shebang in /usr/share/buildah/test/system/test_buildah_build_rpm.sh from /usr/bin/env bash to #!/usr/bin/bash
mangling shebang in /usr/share/buildah/test/system/test_runner.sh from /usr/bin/env bash to #!/usr/bin/bash
mangling shebang in /usr/share/buildah/test/system/validate/git-validation.sh from /bin/bash to #!/usr/bin/bash
mangling shebang in /usr/share/buildah/test/system/validate/whitespace.sh from /bin/sh to #!/usr/bin/sh
```

I seem to recall that we purposefully add `/usr/bin/env bash` in a few of these prior, IDK if this change will upset the apple cart or not.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>


