### PR TITLE
Verify userns-uid-map and userns-gid-map input

### DIFF
--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -120,8 +120,8 @@ type FromAndBudResults struct {
 func GetUserNSFlags(flags *UserNSResults) pflag.FlagSet {
 	usernsFlags := pflag.FlagSet{}
 	usernsFlags.StringVar(&flags.UserNS, "userns", "", "'container', `path` of user namespace to join, or 'host'")
-	usernsFlags.StringSliceVar(&flags.UserNSUIDMap, "userns-uid-map", []string{}, "`containerID:hostID:length` UID mapping to use in user namespace")
-	usernsFlags.StringSliceVar(&flags.UserNSGIDMap, "userns-gid-map", []string{}, "`containerID:hostID:length` GID mapping to use in user namespace")
+	usernsFlags.StringSliceVar(&flags.UserNSUIDMap, "userns-uid-map", []string{}, "`containerUID:hostUID:length` UID mapping to use in user namespace")
+	usernsFlags.StringSliceVar(&flags.UserNSGIDMap, "userns-gid-map", []string{}, "`containerGID:hostGID:length` GID mapping to use in user namespace")
 	usernsFlags.StringVar(&flags.UserNSUIDMapUser, "userns-uid-map-user", "", "`name` of entries from /etc/subuid to use to set user namespace UID mapping")
 	usernsFlags.StringVar(&flags.UserNSGIDMapGroup, "userns-gid-map-group", "", "`name` of entries from /etc/subgid to use to set user namespace GID mapping")
 	return usernsFlags

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -373,3 +373,11 @@ general_namespace() {
 	[ "$status" -eq 0 ]
         expect_output "1:1"
 }
+
+@test "invalid userns-uid-map userns-gid-map" {
+	run_buildah 125 from --userns-uid-map 16  --userns-gid-map 0:48:16 scratch
+	expect_output "uidmap must be a triple of the form 'containerUID:hostUID:length'"
+
+	run_buildah 125 from --userns-uid-map 0:32:16  --userns-gid-map 16 scratch
+	expect_output "gidmap must be a triple of the form 'containerGID:hostGID:length'"
+}


### PR DESCRIPTION
The format of the userns-uid-map and userns-gid-map fields must be
the form of a triple `ctrUid:hostUid:length` but we were not validating
that, doing a lot of useless processing, and then not even failing.

Also includes a potential fix for the abrupt lint failures in .cirrus.yml.

Addresses: #2676

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>



