### PR TITLE
refactor buildah types and structs from heavy deps

### DIFF
--- a/add.go
+++ b/add.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/containers/buildah/copier"
+	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/pkg/chrootuser"
 	"github.com/containers/storage/pkg/fileutils"
 	"github.com/containers/storage/pkg/idtools"
@@ -24,6 +25,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
+
+type IDMappingOptions = define.IDMappingOptions
 
 // AddAndCopyOptions holds options for add and copy commands.
 type AddAndCopyOptions struct {

--- a/buildah.go
+++ b/buildah.go
@@ -4,16 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
-	"time"
 
+	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/docker"
 	"github.com/containers/image/v5/types"
-	encconfig "github.com/containers/ocicrypt/config"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/ioutils"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -40,74 +38,29 @@ const (
 	stateFile = Package + ".json"
 )
 
-// PullPolicy takes the value PullIfMissing, PullAlways, PullIfNewer, or PullNever.
-type PullPolicy int
+type PullPolicy = define.PullPolicy
 
-const (
-	// PullIfMissing is one of the values that BuilderOptions.PullPolicy
-	// can take, signalling that the source image should be pulled from a
-	// registry if a local copy of it is not already present.
-	PullIfMissing PullPolicy = iota
-	// PullAlways is one of the values that BuilderOptions.PullPolicy can
-	// take, signalling that a fresh, possibly updated, copy of the image
-	// should be pulled from a registry before the build proceeds.
-	PullAlways
-	// PullIfNewer is one of the values that BuilderOptions.PullPolicy
-	// can take, signalling that the source image should only be pulled
-	// from a registry if a local copy is not already present or if a
-	// newer version the image is present on the repository.
-	PullIfNewer
-	// PullNever is one of the values that BuilderOptions.PullPolicy can
-	// take, signalling that the source image should not be pulled from a
-	// registry if a local copy of it is not already present.
-	PullNever
+var (
+	PullIfMissing = define.PullIfMissing
+	PullAlways    = define.PullAlways
+	PullIfNewer   = define.PullIfNewer
+	PullNever     = define.PullNever
 )
 
-// String converts a PullPolicy into a string.
-func (p PullPolicy) String() string {
-	switch p {
-	case PullIfMissing:
-		return "PullIfMissing"
-	case PullAlways:
-		return "PullAlways"
-	case PullIfNewer:
-		return "PullIfNewer"
-	case PullNever:
-		return "PullNever"
-	}
-	return fmt.Sprintf("unrecognized policy %d", p)
-}
+type NetworkConfigurationPolicy = define.NetworkConfigurationPolicy
 
-// NetworkConfigurationPolicy takes the value NetworkDefault, NetworkDisabled,
-// or NetworkEnabled.
-type NetworkConfigurationPolicy int
-
-const (
-	// NetworkDefault is one of the values that BuilderOptions.ConfigureNetwork
-	// can take, signalling that the default behavior should be used.
-	NetworkDefault NetworkConfigurationPolicy = iota
-	// NetworkDisabled is one of the values that BuilderOptions.ConfigureNetwork
-	// can take, signalling that network interfaces should NOT be configured for
-	// newly-created network namespaces.
-	NetworkDisabled
-	// NetworkEnabled is one of the values that BuilderOptions.ConfigureNetwork
-	// can take, signalling that network interfaces should be configured for
-	// newly-created network namespaces.
-	NetworkEnabled
+var (
+	NetworkDefault  = define.NetworkDefault
+	NetworkDisabled = define.NetworkDisabled
+	NetworkEnabled  = define.NetworkEnabled
 )
 
-// String formats a NetworkConfigurationPolicy as a string.
-func (p NetworkConfigurationPolicy) String() string {
-	switch p {
-	case NetworkDefault:
-		return "NetworkDefault"
-	case NetworkDisabled:
-		return "NetworkDisabled"
-	case NetworkEnabled:
-		return "NetworkEnabled"
-	}
-	return fmt.Sprintf("unknown NetworkConfigurationPolicy %d", p)
-}
+type ContainerDevices = define.ContainerDevices
+type Isolation = define.Isolation
+type NamespaceOptions = define.NamespaceOptions
+type CommonBuildOptions = define.CommonBuildOptions
+type BuilderOptions = define.BuilderOptions
+type ImportOptions = define.ImportOptions
 
 // Builder objects are used to represent containers which are being used to
 // build images.  They also carry potential updates which will be applied to
@@ -267,162 +220,6 @@ func GetBuildInfo(b *Builder) BuilderInfo {
 		History:               history,
 		Devices:               b.Devices,
 	}
-}
-
-// CommonBuildOptions are resources that can be defined by flags for both buildah from and build-using-dockerfile
-type CommonBuildOptions struct {
-	// AddHost is the list of hostnames to add to the build container's /etc/hosts.
-	AddHost []string
-	// CgroupParent is the path to cgroups under which the cgroup for the container will be created.
-	CgroupParent string
-	// CPUPeriod limits the CPU CFS (Completely Fair Scheduler) period
-	CPUPeriod uint64
-	// CPUQuota limits the CPU CFS (Completely Fair Scheduler) quota
-	CPUQuota int64
-	// CPUShares (relative weight
-	CPUShares uint64
-	// CPUSetCPUs in which to allow execution (0-3, 0,1)
-	CPUSetCPUs string
-	// CPUSetMems memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
-	CPUSetMems string
-	// HTTPProxy determines whether *_proxy env vars from the build host are passed into the container.
-	HTTPProxy bool
-	// Memory is the upper limit (in bytes) on how much memory running containers can use.
-	Memory int64
-	// DNSSearch is the list of DNS search domains to add to the build container's /etc/resolv.conf
-	DNSSearch []string
-	// DNSServers is the list of DNS servers to add to the build container's /etc/resolv.conf
-	DNSServers []string
-	// DNSOptions is the list of DNS
-	DNSOptions []string
-	// MemorySwap limits the amount of memory and swap together.
-	MemorySwap int64
-	// LabelOpts is the a slice of fields of an SELinux context, given in "field:pair" format, or "disable".
-	// Recognized field names are "role", "type", and "level".
-	LabelOpts []string
-	// OmitTimestamp forces epoch 0 as created timestamp to allow for
-	// deterministic, content-addressable builds.
-	OmitTimestamp bool
-	// SeccompProfilePath is the pathname of a seccomp profile.
-	SeccompProfilePath string
-	// ApparmorProfile is the name of an apparmor profile.
-	ApparmorProfile string
-	// ShmSize is the "size" value to use when mounting an shmfs on the container's /dev/shm directory.
-	ShmSize string
-	// Ulimit specifies resource limit options, in the form type:softlimit[:hardlimit].
-	// These types are recognized:
-	// "core": maximum core dump size (ulimit -c)
-	// "cpu": maximum CPU time (ulimit -t)
-	// "data": maximum size of a process's data segment (ulimit -d)
-	// "fsize": maximum size of new files (ulimit -f)
-	// "locks": maximum number of file locks (ulimit -x)
-	// "memlock": maximum amount of locked memory (ulimit -l)
-	// "msgqueue": maximum amount of data in message queues (ulimit -q)
-	// "nice": niceness adjustment (nice -n, ulimit -e)
-	// "nofile": maximum number of open files (ulimit -n)
-	// "nproc": maximum number of processes (ulimit -u)
-	// "rss": maximum size of a process's (ulimit -m)
-	// "rtprio": maximum real-time scheduling priority (ulimit -r)
-	// "rttime": maximum amount of real-time execution between blocking syscalls
-	// "sigpending": maximum number of pending signals (ulimit -i)
-	// "stack": maximum stack size (ulimit -s)
-	Ulimit []string
-	// Volumes to bind mount into the container
-	Volumes []string
-}
-
-// BuilderOptions are used to initialize a new Builder.
-type BuilderOptions struct {
-	// Args define variables that users can pass at build-time to the builder
-	Args map[string]string
-	// FromImage is the name of the image which should be used as the
-	// starting point for the container.  It can be set to an empty value
-	// or "scratch" to indicate that the container should not be based on
-	// an image.
-	FromImage string
-	// Container is a desired name for the build container.
-	Container string
-	// PullPolicy decides whether or not we should pull the image that
-	// we're using as a base image.  It should be PullIfMissing,
-	// PullAlways, or PullNever.
-	PullPolicy PullPolicy
-	// Registry is a value which is prepended to the image's name, if it
-	// needs to be pulled and the image name alone can not be resolved to a
-	// reference to a source image.  No separator is implicitly added.
-	Registry string
-	// BlobDirectory is the name of a directory in which we'll attempt
-	// to store copies of layer blobs that we pull down, if any.  It should
-	// already exist.
-	BlobDirectory string
-	// Mount signals to NewBuilder() that the container should be mounted
-	// immediately.
-	Mount bool
-	// SignaturePolicyPath specifies an override location for the signature
-	// policy which should be used for verifying the new image as it is
-	// being written.  Except in specific circumstances, no value should be
-	// specified, indicating that the shared, system-wide default policy
-	// should be used.
-	SignaturePolicyPath string
-	// ReportWriter is an io.Writer which will be used to log the reading
-	// of the source image from a registry, if we end up pulling the image.
-	ReportWriter io.Writer
-	// github.com/containers/image/types SystemContext to hold credentials
-	// and other authentication/authorization information.
-	SystemContext *types.SystemContext
-	// DefaultMountsFilePath is the file path holding the mounts to be
-	// mounted in "host-path:container-path" format
-	DefaultMountsFilePath string
-	// Isolation controls how we handle "RUN" statements and the Run()
-	// method.
-	Isolation Isolation
-	// NamespaceOptions controls how we set up namespaces for processes that
-	// we might need to run using the container's root filesystem.
-	NamespaceOptions NamespaceOptions
-	// ConfigureNetwork controls whether or not network interfaces and
-	// routing are configured for a new network namespace (i.e., when not
-	// joining another's namespace and not just using the host's
-	// namespace), effectively deciding whether or not the process has a
-	// usable network.
-	ConfigureNetwork NetworkConfigurationPolicy
-	// CNIPluginPath is the location of CNI plugin helpers, if they should be
-	// run from a location other than the default location.
-	CNIPluginPath string
-	// CNIConfigDir is the location of CNI configuration files, if the files in
-	// the default configuration directory shouldn't be used.
-	CNIConfigDir string
-	// ID mapping options to use if we're setting up our own user namespace.
-	IDMappingOptions *IDMappingOptions
-	// Capabilities is a list of capabilities to use when
-	// running commands in the container.
-	Capabilities    []string
-	CommonBuildOpts *CommonBuildOptions
-	// Format for the container image
-	Format string
-	// Devices are the additional devices to add to the containers
-	Devices ContainerDevices
-	//DefaultEnv for containers
-	DefaultEnv []string
-	// MaxPullRetries is the maximum number of attempts we'll make to pull
-	// any one image from the external registry if the first attempt fails.
-	MaxPullRetries int
-	// PullRetryDelay is how long to wait before retrying a pull attempt.
-	PullRetryDelay time.Duration
-	// OciDecryptConfig contains the config that can be used to decrypt an image if it is
-	// encrypted if non-nil. If nil, it does not attempt to decrypt an image.
-	OciDecryptConfig *encconfig.DecryptConfig
-}
-
-// ImportOptions are used to initialize a Builder from an existing container
-// which was created elsewhere.
-type ImportOptions struct {
-	// Container is the name of the build container.
-	Container string
-	// SignaturePolicyPath specifies an override location for the signature
-	// policy which should be used for verifying the new image as it is
-	// being written.  Except in specific circumstances, no value should be
-	// specified, indicating that the shared, system-wide default policy
-	// should be used.
-	SignaturePolicyPath string
 }
 
 // ImportFromImageOptions are used to initialize a Builder from an image.

--- a/define/buildah.go
+++ b/define/buildah.go
@@ -1,0 +1,239 @@
+package define
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/containers/image/v5/types"
+	"github.com/containers/ocicrypt/config"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+// PullPolicy takes the value PullIfMissing, PullAlways, PullIfNewer, or PullNever.
+type PullPolicy int
+
+const (
+	// PullIfMissing is one of the values that BuilderOptions.PullPolicy
+	// can take, signalling that the source image should be pulled from a
+	// registry if a local copy of it is not already present.
+	PullIfMissing PullPolicy = iota
+	// PullAlways is one of the values that BuilderOptions.PullPolicy can
+	// take, signalling that a fresh, possibly updated, copy of the image
+	// should be pulled from a registry before the build proceeds.
+	PullAlways
+	// PullIfNewer is one of the values that BuilderOptions.PullPolicy
+	// can take, signalling that the source image should only be pulled
+	// from a registry if a local copy is not already present or if a
+	// newer version the image is present on the repository.
+	PullIfNewer
+	// PullNever is one of the values that BuilderOptions.PullPolicy can
+	// take, signalling that the source image should not be pulled from a
+	// registry if a local copy of it is not already present.
+	PullNever
+)
+
+// String converts a PullPolicy into a string.
+func (p PullPolicy) String() string {
+	switch p {
+	case PullIfMissing:
+		return "PullIfMissing"
+	case PullAlways:
+		return "PullAlways"
+	case PullIfNewer:
+		return "PullIfNewer"
+	case PullNever:
+		return "PullNever"
+	}
+	return fmt.Sprintf("unrecognized policy %d", p)
+}
+
+// CommonBuildOptions are resources that can be defined by flags for both buildah from and build-using-dockerfile
+type CommonBuildOptions struct {
+	// AddHost is the list of hostnames to add to the build container's /etc/hosts.
+	AddHost []string
+	// CgroupParent is the path to cgroups under which the cgroup for the container will be created.
+	CgroupParent string
+	// CPUPeriod limits the CPU CFS (Completely Fair Scheduler) period
+	CPUPeriod uint64
+	// CPUQuota limits the CPU CFS (Completely Fair Scheduler) quota
+	CPUQuota int64
+	// CPUShares (relative weight
+	CPUShares uint64
+	// CPUSetCPUs in which to allow execution (0-3, 0,1)
+	CPUSetCPUs string
+	// CPUSetMems memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
+	CPUSetMems string
+	// HTTPProxy determines whether *_proxy env vars from the build host are passed into the container.
+	HTTPProxy bool
+	// Memory is the upper limit (in bytes) on how much memory running containers can use.
+	Memory int64
+	// DNSSearch is the list of DNS search domains to add to the build container's /etc/resolv.conf
+	DNSSearch []string
+	// DNSServers is the list of DNS servers to add to the build container's /etc/resolv.conf
+	DNSServers []string
+	// DNSOptions is the list of DNS
+	DNSOptions []string
+	// MemorySwap limits the amount of memory and swap together.
+	MemorySwap int64
+	// LabelOpts is the a slice of fields of an SELinux context, given in "field:pair" format, or "disable".
+	// Recognized field names are "role", "type", and "level".
+	LabelOpts []string
+	// OmitTimestamp forces epoch 0 as created timestamp to allow for
+	// deterministic, content-addressable builds.
+	OmitTimestamp bool
+	// SeccompProfilePath is the pathname of a seccomp profile.
+	SeccompProfilePath string
+	// ApparmorProfile is the name of an apparmor profile.
+	ApparmorProfile string
+	// ShmSize is the "size" value to use when mounting an shmfs on the container's /dev/shm directory.
+	ShmSize string
+	// Ulimit specifies resource limit options, in the form type:softlimit[:hardlimit].
+	// These types are recognized:
+	// "core": maximum core dump size (ulimit -c)
+	// "cpu": maximum CPU time (ulimit -t)
+	// "data": maximum size of a process's data segment (ulimit -d)
+	// "fsize": maximum size of new files (ulimit -f)
+	// "locks": maximum number of file locks (ulimit -x)
+	// "memlock": maximum amount of locked memory (ulimit -l)
+	// "msgqueue": maximum amount of data in message queues (ulimit -q)
+	// "nice": niceness adjustment (nice -n, ulimit -e)
+	// "nofile": maximum number of open files (ulimit -n)
+	// "nproc": maximum number of processes (ulimit -u)
+	// "rss": maximum size of a process's (ulimit -m)
+	// "rtprio": maximum real-time scheduling priority (ulimit -r)
+	// "rttime": maximum amount of real-time execution between blocking syscalls
+	// "sigpending": maximum number of pending signals (ulimit -i)
+	// "stack": maximum stack size (ulimit -s)
+	Ulimit []string
+	// Volumes to bind mount into the container
+	Volumes []string
+}
+
+// BuilderOptions are used to initialize a new Builder.
+type BuilderOptions struct {
+	// Args define variables that users can pass at build-time to the builder
+	Args map[string]string
+	// FromImage is the name of the image which should be used as the
+	// starting point for the container.  It can be set to an empty value
+	// or "scratch" to indicate that the container should not be based on
+	// an image.
+	FromImage string
+	// Container is a desired name for the build container.
+	Container string
+	// PullPolicy decides whether or not we should pull the image that
+	// we're using as a base image.  It should be PullIfMissing,
+	// PullAlways, or PullNever.
+	PullPolicy PullPolicy
+	// Registry is a value which is prepended to the image's name, if it
+	// needs to be pulled and the image name alone can not be resolved to a
+	// reference to a source image.  No separator is implicitly added.
+	Registry string
+	// BlobDirectory is the name of a directory in which we'll attempt
+	// to store copies of layer blobs that we pull down, if any.  It should
+	// already exist.
+	BlobDirectory string
+	// Mount signals to NewBuilder() that the container should be mounted
+	// immediately.
+	Mount bool
+	// SignaturePolicyPath specifies an override location for the signature
+	// policy which should be used for verifying the new image as it is
+	// being written.  Except in specific circumstances, no value should be
+	// specified, indicating that the shared, system-wide default policy
+	// should be used.
+	SignaturePolicyPath string
+	// ReportWriter is an io.Writer which will be used to log the reading
+	// of the source image from a registry, if we end up pulling the image.
+	ReportWriter io.Writer
+	// github.com/containers/image/types SystemContext to hold credentials
+	// and other authentication/authorization information.
+	SystemContext *types.SystemContext
+	// DefaultMountsFilePath is the file path holding the mounts to be
+	// mounted in "host-path:container-path" format
+	DefaultMountsFilePath string
+	// Isolation controls how we handle "RUN" statements and the Run()
+	// method.
+	Isolation Isolation
+	// NamespaceOptions controls how we set up namespaces for processes that
+	// we might need to run using the container's root filesystem.
+	NamespaceOptions NamespaceOptions
+	// ConfigureNetwork controls whether or not network interfaces and
+	// routing are configured for a new network namespace (i.e., when not
+	// joining another's namespace and not just using the host's
+	// namespace), effectively deciding whether or not the process has a
+	// usable network.
+	ConfigureNetwork NetworkConfigurationPolicy
+	// CNIPluginPath is the location of CNI plugin helpers, if they should be
+	// run from a location other than the default location.
+	CNIPluginPath string
+	// CNIConfigDir is the location of CNI configuration files, if the files in
+	// the default configuration directory shouldn't be used.
+	CNIConfigDir string
+	// ID mapping options to use if we're setting up our own user namespace.
+	IDMappingOptions *IDMappingOptions
+	// Capabilities is a list of capabilities to use when
+	// running commands in the container.
+	Capabilities    []string
+	CommonBuildOpts *CommonBuildOptions
+	// Format for the container image
+	Format string
+	// Devices are the additional devices to add to the containers
+	Devices ContainerDevices
+	//DefaultEnv for containers
+	DefaultEnv []string
+	// MaxPullRetries is the maximum number of attempts we'll make to pull
+	// any one image from the external registry if the first attempt fails.
+	MaxPullRetries int
+	// PullRetryDelay is how long to wait before retrying a pull attempt.
+	PullRetryDelay time.Duration
+	// OciDecryptConfig contains the config that can be used to decrypt an image if it is
+	// encrypted if non-nil. If nil, it does not attempt to decrypt an image.
+	OciDecryptConfig *config.DecryptConfig
+}
+
+// ImportOptions are used to initialize a Builder from an existing container
+// which was created elsewhere.
+type ImportOptions struct {
+	// Container is the name of the build container.
+	Container string
+	// SignaturePolicyPath specifies an override location for the signature
+	// policy which should be used for verifying the new image as it is
+	// being written.  Except in specific circumstances, no value should be
+	// specified, indicating that the shared, system-wide default policy
+	// should be used.
+	SignaturePolicyPath string
+}
+
+// NetworkConfigurationPolicy takes the value NetworkDefault, NetworkDisabled,
+// or NetworkEnabled.
+type NetworkConfigurationPolicy int
+
+const (
+	// NetworkDefault is one of the values that BuilderOptions.ConfigureNetwork
+	// can take, signalling that the default behavior should be used.
+	NetworkDefault NetworkConfigurationPolicy = iota
+	// NetworkDisabled is one of the values that BuilderOptions.ConfigureNetwork
+	// can take, signalling that network interfaces should NOT be configured for
+	// newly-created network namespaces.
+	NetworkDisabled
+	// NetworkEnabled is one of the values that BuilderOptions.ConfigureNetwork
+	// can take, signalling that network interfaces should be configured for
+	// newly-created network namespaces.
+	NetworkEnabled
+)
+
+// String formats a NetworkConfigurationPolicy as a string.
+func (p NetworkConfigurationPolicy) String() string {
+	switch p {
+	case NetworkDefault:
+		return "NetworkDefault"
+	case NetworkDisabled:
+		return "NetworkDisabled"
+	case NetworkEnabled:
+		return "NetworkEnabled"
+	}
+	return fmt.Sprintf("unknown NetworkConfigurationPolicy %d", p)
+}
+
+// ContainerDevices is an alias for a slice of github.com/opencontainers/runc/libcontainer/configs.Device structures.
+type ContainerDevices = []configs.Device

--- a/define/run.go
+++ b/define/run.go
@@ -1,0 +1,98 @@
+package define
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Isolation provides a way to specify whether we're supposed to use a proper
+// OCI runtime, or some other method for running commands.
+type Isolation int
+
+// String converts a Isolation into a string.
+func (i Isolation) String() string {
+	switch i {
+	case IsolationDefault:
+		return "IsolationDefault"
+	case IsolationOCI:
+		return "IsolationOCI"
+	case IsolationChroot:
+		return "IsolationChroot"
+	case IsolationOCIRootless:
+		return "IsolationOCIRootless"
+	}
+	return fmt.Sprintf("unrecognized isolation type %d", i)
+}
+
+const (
+	// IsolationDefault is whatever we think will work best.
+	IsolationDefault Isolation = iota
+	// IsolationOCI is a proper OCI runtime.
+	IsolationOCI
+	// IsolationChroot is a more chroot-like environment: less isolation,
+	// but with fewer requirements.
+	IsolationChroot
+	// IsolationOCIRootless is a proper OCI runtime in rootless mode.
+	IsolationOCIRootless
+)
+
+// NamespaceOption controls how we set up a namespace when launching processes.
+type NamespaceOption struct {
+	// Name specifies the type of namespace, typically matching one of the
+	// ...Namespace constants defined in
+	// github.com/opencontainers/runtime-spec/specs-go.
+	Name string
+	// Host is used to force our processes to use the host's namespace of
+	// this type.
+	Host bool
+	// Path is the path of the namespace to attach our process to, if Host
+	// is not set.  If Host is not set and Path is also empty, a new
+	// namespace will be created for the process that we're starting.
+	// If Name is specs.NetworkNamespace, if Path doesn't look like an
+	// absolute path, it is treated as a comma-separated list of CNI
+	// configuration names which will be selected from among all of the CNI
+	// network configurations which we find.
+	Path string
+}
+
+// NamespaceOptions provides some helper methods for a slice of NamespaceOption
+// structs.
+type NamespaceOptions []NamespaceOption
+
+// Find the configuration for the namespace of the given type.  If there are
+// duplicates, find the _last_ one of the type, since we assume it was appended
+// more recently.
+func (n *NamespaceOptions) Find(namespace string) *NamespaceOption {
+	for i := range *n {
+		j := len(*n) - 1 - i
+		if (*n)[j].Name == namespace {
+			return &((*n)[j])
+		}
+	}
+	return nil
+}
+
+// AddOrReplace either adds or replaces the configuration for a given namespace.
+func (n *NamespaceOptions) AddOrReplace(options ...NamespaceOption) {
+nextOption:
+	for _, option := range options {
+		for i := range *n {
+			j := len(*n) - 1 - i
+			if (*n)[j].Name == option.Name {
+				(*n)[j] = option
+				continue nextOption
+			}
+		}
+		*n = append(*n, option)
+	}
+}
+
+// IDMappingOptions controls how we set up UID/GID mapping when we set up a
+// user namespace.
+type IDMappingOptions struct {
+	HostUIDMapping bool
+	HostGIDMapping bool
+	UIDMap         []specs.LinuxIDMapping
+	GIDMap         []specs.LinuxIDMapping
+}

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -11,13 +11,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
-	"github.com/containers/buildah"
+	"github.com/containers/buildah/define"
+	botypes "github.com/containers/buildah/imagebuildah/define"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/docker/reference"
-	"github.com/containers/image/v5/types"
-	encconfig "github.com/containers/ocicrypt/config"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -28,10 +26,10 @@ import (
 )
 
 const (
-	PullIfMissing = buildah.PullIfMissing
-	PullAlways    = buildah.PullAlways
-	PullIfNewer   = buildah.PullIfNewer
-	PullNever     = buildah.PullNever
+	PullIfMissing = define.PullIfMissing
+	PullAlways    = define.PullAlways
+	PullIfNewer   = define.PullIfNewer
+	PullNever     = define.PullNever
 
 	Gzip         = archive.Gzip
 	Bzip2        = archive.Bzip2
@@ -43,154 +41,12 @@ const (
 // Mount is a mountpoint for the build container.
 type Mount specs.Mount
 
-// BuildOptions can be used to alter how an image is built.
-type BuildOptions struct {
-	// ContextDirectory is the default source location for COPY and ADD
-	// commands.
-	ContextDirectory string
-	// PullPolicy controls whether or not we pull images.  It should be one
-	// of PullIfMissing, PullAlways, PullIfNewer, or PullNever.
-	PullPolicy buildah.PullPolicy
-	// Registry is a value which is prepended to the image's name, if it
-	// needs to be pulled and the image name alone can not be resolved to a
-	// reference to a source image.  No separator is implicitly added.
-	Registry string
-	// IgnoreUnrecognizedInstructions tells us to just log instructions we
-	// don't recognize, and try to keep going.
-	IgnoreUnrecognizedInstructions bool
-	// Quiet tells us whether or not to announce steps as we go through them.
-	Quiet bool
-	// Isolation controls how Run() runs things.
-	Isolation buildah.Isolation
-	// Runtime is the name of the command to run for RUN instructions when
-	// Isolation is either IsolationDefault or IsolationOCI.  It should
-	// accept the same arguments and flags that runc does.
-	Runtime string
-	// RuntimeArgs adds global arguments for the runtime.
-	RuntimeArgs []string
-	// TransientMounts is a list of mounts that won't be kept in the image.
-	TransientMounts []string
-	// Compression specifies the type of compression which is applied to
-	// layer blobs.  The default is to not use compression, but
-	// archive.Gzip is recommended.
-	Compression archive.Compression
-	// Arguments which can be interpolated into Dockerfiles
-	Args map[string]string
-	// Name of the image to write to.
-	Output string
-	// Additional tags to add to the image that we write, if we know of a
-	// way to add them.
-	AdditionalTags []string
-	// Log is a callback that will print a progress message.  If no value
-	// is supplied, the message will be sent to Err (or os.Stderr, if Err
-	// is nil) by default.
-	Log func(format string, args ...interface{})
-	// In is connected to stdin for RUN instructions.
-	In io.Reader
-	// Out is a place where non-error log messages are sent.
-	Out io.Writer
-	// Err is a place where error log messages should be sent.
-	Err io.Writer
-	// SignaturePolicyPath specifies an override location for the signature
-	// policy which should be used for verifying the new image as it is
-	// being written.  Except in specific circumstances, no value should be
-	// specified, indicating that the shared, system-wide default policy
-	// should be used.
-	SignaturePolicyPath string
-	// ReportWriter is an io.Writer which will be used to report the
-	// progress of the (possible) pulling of the source image and the
-	// writing of the new image.
-	ReportWriter io.Writer
-	// OutputFormat is the format of the output image's manifest and
-	// configuration data.
-	// Accepted values are buildah.OCIv1ImageManifest and buildah.Dockerv2ImageManifest.
-	OutputFormat string
-	// SystemContext holds parameters used for authentication.
-	SystemContext *types.SystemContext
-	// NamespaceOptions controls how we set up namespaces processes that we
-	// might need when handling RUN instructions.
-	NamespaceOptions []buildah.NamespaceOption
-	// ConfigureNetwork controls whether or not network interfaces and
-	// routing are configured for a new network namespace (i.e., when not
-	// joining another's namespace and not just using the host's
-	// namespace), effectively deciding whether or not the process has a
-	// usable network.
-	ConfigureNetwork buildah.NetworkConfigurationPolicy
-	// CNIPluginPath is the location of CNI plugin helpers, if they should be
-	// run from a location other than the default location.
-	CNIPluginPath string
-	// CNIConfigDir is the location of CNI configuration files, if the files in
-	// the default configuration directory shouldn't be used.
-	CNIConfigDir string
-	// ID mapping options to use if we're setting up our own user namespace
-	// when handling RUN instructions.
-	IDMappingOptions *buildah.IDMappingOptions
-	// AddCapabilities is a list of capabilities to add to the default set when
-	// handling RUN instructions.
-	AddCapabilities []string
-	// DropCapabilities is a list of capabilities to remove from the default set
-	// when handling RUN instructions. If a capability appears in both lists, it
-	// will be dropped.
-	DropCapabilities []string
-	// CommonBuildOpts is *required*.
-	CommonBuildOpts *buildah.CommonBuildOptions
-	// DefaultMountsFilePath is the file path holding the mounts to be mounted in "host-path:container-path" format
-	DefaultMountsFilePath string
-	// IIDFile tells the builder to write the image ID to the specified file
-	IIDFile string
-	// Squash tells the builder to produce an image with a single layer
-	// instead of with possibly more than one layer.
-	Squash bool
-	// Labels metadata for an image
-	Labels []string
-	// Annotation metadata for an image
-	Annotations []string
-	// OnBuild commands to be run by images based on this image
-	OnBuild []string
-	// Layers tells the builder to create a cache of images for each step in the Dockerfile
-	Layers bool
-	// NoCache tells the builder to build the image from scratch without checking for a cache.
-	// It creates a new set of cached images for the build.
-	NoCache bool
-	// RemoveIntermediateCtrs tells the builder whether to remove intermediate containers used
-	// during the build process. Default is true.
-	RemoveIntermediateCtrs bool
-	// ForceRmIntermediateCtrs tells the builder to remove all intermediate containers even if
-	// the build was unsuccessful.
-	ForceRmIntermediateCtrs bool
-	// BlobDirectory is a directory which we'll use for caching layer blobs.
-	BlobDirectory string
-	// Target the targeted FROM in the Dockerfile to build.
-	Target string
-	// Devices are the additional devices to add to the containers.
-	Devices []string
-	// SignBy is the fingerprint of a GPG key to use for signing images.
-	SignBy string
-	// Architecture specifies the target architecture of the image to be built.
-	Architecture string
-	// Timestamp sets the created timestamp to the specified time, allowing
-	// for deterministic, content-addressable builds.
-	Timestamp *time.Time
-	// OS is the specifies the operating system of the image to be built.
-	OS string
-	// MaxPullPushRetries is the maximum number of attempts we'll make to pull or push any one
-	// image from or to an external registry if the first attempt fails.
-	MaxPullPushRetries int
-	// PullPushRetryDelay is how long to wait before retrying a pull or push attempt.
-	PullPushRetryDelay time.Duration
-	// OciDecryptConfig contains the config that can be used to decrypt an image if it is
-	// encrypted if non-nil. If nil, it does not attempt to decrypt an image.
-	OciDecryptConfig *encconfig.DecryptConfig
-	// Jobs is the number of stages to run in parallel.  If not specified it defaults to 1.
-	Jobs *int
-	// LogRusage logs resource usage for each step.
-	LogRusage bool
-}
+type BuildOptions = botypes.BuildOptions
 
 // BuildDockerfiles parses a set of one or more Dockerfiles (which may be
 // URLs), creates a new Executor, and then runs Prepare/Execute/Commit/Delete
 // over the entire set of instructions.
-func BuildDockerfiles(ctx context.Context, store storage.Store, options BuildOptions, paths ...string) (string, reference.Canonical, error) {
+func BuildDockerfiles(ctx context.Context, store storage.Store, options botypes.BuildOptions, paths ...string) (string, reference.Canonical, error) {
 	if len(paths) == 0 {
 		return "", nil, errors.Errorf("error building: no dockerfiles specified")
 	}

--- a/imagebuildah/define/build.go
+++ b/imagebuildah/define/build.go
@@ -1,0 +1,155 @@
+package define
+
+import (
+	"io"
+	"time"
+
+	"github.com/containers/buildah/define"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/ocicrypt/config"
+	"github.com/containers/storage/pkg/archive"
+)
+
+// BuildOptions can be used to alter how an image is built.
+type BuildOptions struct {
+	// ContextDirectory is the default source location for COPY and ADD
+	// commands.
+	ContextDirectory string
+	// PullPolicy controls whether or not we pull images.  It should be one
+	// of PullIfMissing, PullAlways, PullIfNewer, or PullNever.
+	PullPolicy define.PullPolicy
+	// Registry is a value which is prepended to the image's name, if it
+	// needs to be pulled and the image name alone can not be resolved to a
+	// reference to a source image.  No separator is implicitly added.
+	Registry string
+	// IgnoreUnrecognizedInstructions tells us to just log instructions we
+	// don't recognize, and try to keep going.
+	IgnoreUnrecognizedInstructions bool
+	// Quiet tells us whether or not to announce steps as we go through them.
+	Quiet bool
+	// Isolation controls how Run() runs things.
+	Isolation define.Isolation
+	// Runtime is the name of the command to run for RUN instructions when
+	// Isolation is either IsolationDefault or IsolationOCI.  It should
+	// accept the same arguments and flags that runc does.
+	Runtime string
+	// RuntimeArgs adds global arguments for the runtime.
+	RuntimeArgs []string
+	// TransientMounts is a list of mounts that won't be kept in the image.
+	TransientMounts []string
+	// Compression specifies the type of compression which is applied to
+	// layer blobs.  The default is to not use compression, but
+	// archive.Gzip is recommended.
+	Compression archive.Compression
+	// Arguments which can be interpolated into Dockerfiles
+	Args map[string]string
+	// Name of the image to write to.
+	Output string
+	// Additional tags to add to the image that we write, if we know of a
+	// way to add them.
+	AdditionalTags []string
+	// Log is a callback that will print a progress message.  If no value
+	// is supplied, the message will be sent to Err (or os.Stderr, if Err
+	// is nil) by default.
+	Log func(format string, args ...interface{})
+	// In is connected to stdin for RUN instructions.
+	In io.Reader
+	// Out is a place where non-error log messages are sent.
+	Out io.Writer
+	// Err is a place where error log messages should be sent.
+	Err io.Writer
+	// SignaturePolicyPath specifies an override location for the signature
+	// policy which should be used for verifying the new image as it is
+	// being written.  Except in specific circumstances, no value should be
+	// specified, indicating that the shared, system-wide default policy
+	// should be used.
+	SignaturePolicyPath string
+	// ReportWriter is an io.Writer which will be used to report the
+	// progress of the (possible) pulling of the source image and the
+	// writing of the new image.
+	ReportWriter io.Writer
+	// OutputFormat is the format of the output image's manifest and
+	// configuration data.
+	// Accepted values are buildah.OCIv1ImageManifest and buildah.Dockerv2ImageManifest.
+	OutputFormat string
+	// SystemContext holds parameters used for authentication.
+	SystemContext *types.SystemContext
+	// NamespaceOptions controls how we set up namespaces processes that we
+	// might need when handling RUN instructions.
+	NamespaceOptions []define.NamespaceOption
+	// ConfigureNetwork controls whether or not network interfaces and
+	// routing are configured for a new network namespace (i.e., when not
+	// joining another's namespace and not just using the host's
+	// namespace), effectively deciding whether or not the process has a
+	// usable network.
+	ConfigureNetwork define.NetworkConfigurationPolicy
+	// CNIPluginPath is the location of CNI plugin helpers, if they should be
+	// run from a location other than the default location.
+	CNIPluginPath string
+	// CNIConfigDir is the location of CNI configuration files, if the files in
+	// the default configuration directory shouldn't be used.
+	CNIConfigDir string
+	// ID mapping options to use if we're setting up our own user namespace
+	// when handling RUN instructions.
+	IDMappingOptions *define.IDMappingOptions
+	// AddCapabilities is a list of capabilities to add to the default set when
+	// handling RUN instructions.
+	AddCapabilities []string
+	// DropCapabilities is a list of capabilities to remove from the default set
+	// when handling RUN instructions. If a capability appears in both lists, it
+	// will be dropped.
+	DropCapabilities []string
+	// CommonBuildOpts is *required*.
+	CommonBuildOpts *define.CommonBuildOptions
+	// DefaultMountsFilePath is the file path holding the mounts to be mounted in "host-path:container-path" format
+	DefaultMountsFilePath string
+	// IIDFile tells the builder to write the image ID to the specified file
+	IIDFile string
+	// Squash tells the builder to produce an image with a single layer
+	// instead of with possibly more than one layer.
+	Squash bool
+	// Labels metadata for an image
+	Labels []string
+	// Annotation metadata for an image
+	Annotations []string
+	// OnBuild commands to be run by images based on this image
+	OnBuild []string
+	// Layers tells the builder to create a cache of images for each step in the Dockerfile
+	Layers bool
+	// NoCache tells the builder to build the image from scratch without checking for a cache.
+	// It creates a new set of cached images for the build.
+	NoCache bool
+	// RemoveIntermediateCtrs tells the builder whether to remove intermediate containers used
+	// during the build process. Default is true.
+	RemoveIntermediateCtrs bool
+	// ForceRmIntermediateCtrs tells the builder to remove all intermediate containers even if
+	// the build was unsuccessful.
+	ForceRmIntermediateCtrs bool
+	// BlobDirectory is a directory which we'll use for caching layer blobs.
+	BlobDirectory string
+	// Target the targeted FROM in the Dockerfile to build.
+	Target string
+	// Devices are the additional devices to add to the containers.
+	Devices []string
+	// SignBy is the fingerprint of a GPG key to use for signing images.
+	SignBy string
+	// Architecture specifies the target architecture of the image to be built.
+	Architecture string
+	// Timestamp sets the created timestamp to the specified time, allowing
+	// for deterministic, content-addressable builds.
+	Timestamp *time.Time
+	// OS is the specifies the operating system of the image to be built.
+	OS string
+	// MaxPullPushRetries is the maximum number of attempts we'll make to pull or push any one
+	// image from or to an external registry if the first attempt fails.
+	MaxPullPushRetries int
+	// PullPushRetryDelay is how long to wait before retrying a pull or push attempt.
+	PullPushRetryDelay time.Duration
+	// OciDecryptConfig contains the config that can be used to decrypt an image if it is
+	// encrypted if non-nil. If nil, it does not attempt to decrypt an image.
+	OciDecryptConfig *config.DecryptConfig
+	// Jobs is the number of stages to run in parallel.  If not specified it defaults to 1.
+	Jobs *int
+	// LogRusage logs resource usage for each step.
+	LogRusage bool
+}

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/containers/buildah"
+	"github.com/containers/buildah/define"
+	botypes "github.com/containers/buildah/imagebuildah/define"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
 	"github.com/containers/common/pkg/config"
@@ -55,7 +57,7 @@ type Executor struct {
 	stages                         map[string]*StageExecutor
 	store                          storage.Store
 	contextDir                     string
-	pullPolicy                     buildah.PullPolicy
+	pullPolicy                     define.PullPolicy
 	registry                       string
 	ignoreUnrecognizedInstructions bool
 	quiet                          bool
@@ -73,13 +75,13 @@ type Executor struct {
 	signaturePolicyPath            string
 	systemContext                  *types.SystemContext
 	reportWriter                   io.Writer
-	isolation                      buildah.Isolation
-	namespaceOptions               []buildah.NamespaceOption
-	configureNetwork               buildah.NetworkConfigurationPolicy
+	isolation                      define.Isolation
+	namespaceOptions               []define.NamespaceOption
+	configureNetwork               define.NetworkConfigurationPolicy
 	cniPluginPath                  string
 	cniConfigDir                   string
-	idmappingOptions               *buildah.IDMappingOptions
-	commonBuildOptions             *buildah.CommonBuildOptions
+	idmappingOptions               *define.IDMappingOptions
+	commonBuildOptions             *define.CommonBuildOptions
 	defaultMountsFilePath          string
 	iidfile                        string
 	squash                         bool
@@ -97,7 +99,7 @@ type Executor struct {
 	excludes                       []string
 	unusedArgs                     map[string]struct{}
 	capabilities                   []string
-	devices                        buildah.ContainerDevices
+	devices                        define.ContainerDevices
 	signBy                         string
 	architecture                   string
 	timestamp                      *time.Time
@@ -114,7 +116,7 @@ type Executor struct {
 }
 
 // NewExecutor creates a new instance of the imagebuilder.Executor interface.
-func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Node) (*Executor, error) {
+func NewExecutor(store storage.Store, options botypes.BuildOptions, mainNode *parser.Node) (*Executor, error) {
 	defaultContainerConfig, err := config.Default()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get container config")
@@ -129,7 +131,7 @@ func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Nod
 		return nil, err
 	}
 
-	devices := buildah.ContainerDevices{}
+	devices := define.ContainerDevices{}
 	for _, device := range append(defaultContainerConfig.Containers.Devices, options.Devices...) {
 		dev, err := parse.DeviceFromPath(device)
 		if err != nil {

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/copier"
+	"github.com/containers/buildah/define"
 	buildahdocker "github.com/containers/buildah/docker"
 	"github.com/containers/buildah/pkg/rusage"
 	"github.com/containers/buildah/util"
@@ -275,7 +276,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 		// The From field says to read the content from another
 		// container.  Update the ID mappings and
 		// all-content-comes-from-below-this-directory value.
-		var idMappingOptions *buildah.IDMappingOptions
+		var idMappingOptions *define.IDMappingOptions
 		var copyExcludes []string
 		stripSetuid := false
 		stripSetgid := false
@@ -370,9 +371,9 @@ func (s *StageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 		NamespaceOptions: s.executor.namespaceOptions,
 	}
 	if config.NetworkDisabled {
-		options.ConfigureNetwork = buildah.NetworkDisabled
+		options.ConfigureNetwork = define.NetworkDisabled
 	} else {
-		options.ConfigureNetwork = buildah.NetworkEnabled
+		options.ConfigureNetwork = define.NetworkEnabled
 	}
 
 	args := run.Args
@@ -450,7 +451,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		}
 	}
 
-	builderOptions := buildah.BuilderOptions{
+	builderOptions := define.BuilderOptions{
 		Args:                  ib.Args,
 		FromImage:             from,
 		PullPolicy:            s.executor.pullPolicy,

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -15,6 +15,7 @@ import (
 	"unicode"
 
 	"github.com/containers/buildah"
+	"github.com/containers/buildah/define"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/unshare"
@@ -45,7 +46,7 @@ var (
 )
 
 // CommonBuildOptions parses the build options from the bud cli
-func CommonBuildOptions(c *cobra.Command) (*buildah.CommonBuildOptions, error) {
+func CommonBuildOptions(c *cobra.Command) (*define.CommonBuildOptions, error) {
 	var (
 		memoryLimit int64
 		memorySwap  int64
@@ -125,7 +126,7 @@ func CommonBuildOptions(c *cobra.Command) (*buildah.CommonBuildOptions, error) {
 		ulimit, _ = c.Flags().GetStringSlice("ulimit")
 	}
 
-	commonOpts := &buildah.CommonBuildOptions{
+	commonOpts := &define.CommonBuildOptions{
 		AddHost:      addHost,
 		CPUPeriod:    cpuPeriod,
 		CPUQuota:     cpuQuota,
@@ -150,7 +151,7 @@ func CommonBuildOptions(c *cobra.Command) (*buildah.CommonBuildOptions, error) {
 	return commonOpts, nil
 }
 
-func parseSecurityOpts(securityOpts []string, commonOpts *buildah.CommonBuildOptions) error {
+func parseSecurityOpts(securityOpts []string, commonOpts *define.CommonBuildOptions) error {
 	for _, opt := range securityOpts {
 		if opt == "no-new-privileges" {
 			return errors.Errorf("no-new-privileges is not supported")
@@ -700,7 +701,7 @@ func getDockerAuth(creds string) (*types.DockerAuthConfig, error) {
 }
 
 // IDMappingOptions parses the build options related to user namespaces and ID mapping.
-func IDMappingOptions(c *cobra.Command, isolation buildah.Isolation) (usernsOptions buildah.NamespaceOptions, idmapOptions *buildah.IDMappingOptions, err error) {
+func IDMappingOptions(c *cobra.Command, isolation define.Isolation) (usernsOptions define.NamespaceOptions, idmapOptions *define.IDMappingOptions, err error) {
 	user := c.Flag("userns-uid-map-user").Value.String()
 	group := c.Flag("userns-gid-map-group").Value.String()
 	// If only the user or group was specified, use the same value for the
@@ -775,7 +776,7 @@ func IDMappingOptions(c *cobra.Command, isolation buildah.Isolation) (usernsOpti
 
 	// By default, having mappings configured means we use a user
 	// namespace.  Otherwise, we don't.
-	usernsOption := buildah.NamespaceOption{
+	usernsOption := define.NamespaceOption{
 		Name: string(specs.UserNamespace),
 		Host: len(uidmap) == 0 && len(gidmap) == 0,
 	}
@@ -797,11 +798,11 @@ func IDMappingOptions(c *cobra.Command, isolation buildah.Isolation) (usernsOpti
 			usernsOption.Path = how
 		}
 	}
-	usernsOptions = buildah.NamespaceOptions{usernsOption}
+	usernsOptions = define.NamespaceOptions{usernsOption}
 
 	usernetwork := c.Flags().Lookup("network")
 	if usernetwork != nil && !usernetwork.Changed {
-		usernsOptions = append(usernsOptions, buildah.NamespaceOption{
+		usernsOptions = append(usernsOptions, define.NamespaceOption{
 			Name: string(specs.NetworkNamespace),
 			Host: usernsOption.Host,
 		})
@@ -811,7 +812,7 @@ func IDMappingOptions(c *cobra.Command, isolation buildah.Isolation) (usernsOpti
 	if (len(uidmap) != 0 || len(gidmap) != 0) && usernsOption.Host {
 		return nil, nil, errors.Errorf("can not specify ID mappings while using host's user namespace")
 	}
-	return usernsOptions, &buildah.IDMappingOptions{
+	return usernsOptions, &define.IDMappingOptions{
 		HostUIDMapping: usernsOption.Host,
 		HostGIDMapping: usernsOption.Host,
 		UIDMap:         uidmap,
@@ -846,9 +847,9 @@ func parseIDMap(spec []string) (m [][3]uint32, err error) {
 }
 
 // NamespaceOptions parses the build options for all namespaces except for user namespace.
-func NamespaceOptions(c *cobra.Command) (namespaceOptions buildah.NamespaceOptions, networkPolicy buildah.NetworkConfigurationPolicy, err error) {
-	options := make(buildah.NamespaceOptions, 0, 7)
-	policy := buildah.NetworkDefault
+func NamespaceOptions(c *cobra.Command) (namespaceOptions define.NamespaceOptions, networkPolicy define.NetworkConfigurationPolicy, err error) {
+	options := make(define.NamespaceOptions, 0, 7)
+	policy := define.NetworkDefault
 	for _, what := range []string{string(specs.IPCNamespace), "network", string(specs.PIDNamespace), string(specs.UTSNamespace)} {
 		if c.Flags().Lookup(what) != nil && c.Flag(what).Changed {
 			how := c.Flag(what).Value.String()
@@ -859,41 +860,41 @@ func NamespaceOptions(c *cobra.Command) (namespaceOptions buildah.NamespaceOptio
 			switch how {
 			case "", "container", "private":
 				logrus.Debugf("setting %q namespace to %q", what, "")
-				options.AddOrReplace(buildah.NamespaceOption{
+				options.AddOrReplace(define.NamespaceOption{
 					Name: what,
 				})
 			case "host":
 				logrus.Debugf("setting %q namespace to host", what)
-				options.AddOrReplace(buildah.NamespaceOption{
+				options.AddOrReplace(define.NamespaceOption{
 					Name: what,
 					Host: true,
 				})
 			default:
 				if what == string(specs.NetworkNamespace) {
 					if how == "none" {
-						options.AddOrReplace(buildah.NamespaceOption{
+						options.AddOrReplace(define.NamespaceOption{
 							Name: what,
 						})
-						policy = buildah.NetworkDisabled
+						policy = define.NetworkDisabled
 						logrus.Debugf("setting network to disabled")
 						break
 					}
 					if !filepath.IsAbs(how) {
-						options.AddOrReplace(buildah.NamespaceOption{
+						options.AddOrReplace(define.NamespaceOption{
 							Name: what,
 							Path: how,
 						})
-						policy = buildah.NetworkEnabled
+						policy = define.NetworkEnabled
 						logrus.Debugf("setting network configuration to %q", how)
 						break
 					}
 				}
 				how = strings.TrimPrefix(how, "ns:")
 				if _, err := os.Stat(how); err != nil {
-					return nil, buildah.NetworkDefault, errors.Wrapf(err, "error checking for %s namespace at %q", what, how)
+					return nil, define.NetworkDefault, errors.Wrapf(err, "error checking for %s namespace at %q", what, how)
 				}
 				logrus.Debugf("setting %q namespace to %q", what, how)
-				options.AddOrReplace(buildah.NamespaceOption{
+				options.AddOrReplace(define.NamespaceOption{
 					Name: what,
 					Path: how,
 				})
@@ -903,36 +904,36 @@ func NamespaceOptions(c *cobra.Command) (namespaceOptions buildah.NamespaceOptio
 	return options, policy, nil
 }
 
-func defaultIsolation() (buildah.Isolation, error) {
+func defaultIsolation() (define.Isolation, error) {
 	isolation, isSet := os.LookupEnv("BUILDAH_ISOLATION")
 	if isSet {
 		switch strings.ToLower(isolation) {
 		case "oci":
-			return buildah.IsolationOCI, nil
+			return define.IsolationOCI, nil
 		case "rootless":
-			return buildah.IsolationOCIRootless, nil
+			return define.IsolationOCIRootless, nil
 		case "chroot":
-			return buildah.IsolationChroot, nil
+			return define.IsolationChroot, nil
 		default:
 			return 0, errors.Errorf("unrecognized $BUILDAH_ISOLATION value %q", isolation)
 		}
 	}
 	if unshare.IsRootless() {
-		return buildah.IsolationOCIRootless, nil
+		return define.IsolationOCIRootless, nil
 	}
-	return buildah.IsolationDefault, nil
+	return define.IsolationDefault, nil
 }
 
 // IsolationOption parses the --isolation flag.
-func IsolationOption(isolation string) (buildah.Isolation, error) {
+func IsolationOption(isolation string) (define.Isolation, error) {
 	if isolation != "" {
 		switch strings.ToLower(isolation) {
 		case "oci":
-			return buildah.IsolationOCI, nil
+			return define.IsolationOCI, nil
 		case "rootless":
-			return buildah.IsolationOCIRootless, nil
+			return define.IsolationOCIRootless, nil
 		case "chroot":
-			return buildah.IsolationChroot, nil
+			return define.IsolationChroot, nil
 		default:
 			return 0, errors.Errorf("unrecognized isolation type %q", isolation)
 		}

--- a/pkg/parse/parse_unsupported.go
+++ b/pkg/parse/parse_unsupported.go
@@ -3,7 +3,7 @@
 package parse
 
 import (
-	"github.com/containers/buildah"
+	"github.com/containers/buildah/define"
 	"github.com/pkg/errors"
 )
 
@@ -11,6 +11,6 @@ func getDefaultProcessLimits() []string {
 	return []string{}
 }
 
-func DeviceFromPath(device string) (buildah.ContainerDevices, error) {
-	return buildah.ContainerDevices{}, errors.Errorf("devices not supported")
+func DeviceFromPath(device string) (define.ContainerDevices, error) {
+	return define.ContainerDevices{}, errors.Errorf("devices not supported")
 }

--- a/run.go
+++ b/run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/containers/buildah/define"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -40,75 +41,14 @@ func (t TerminalPolicy) String() string {
 	return fmt.Sprintf("unrecognized terminal setting %d", t)
 }
 
-// NamespaceOption controls how we set up a namespace when launching processes.
-type NamespaceOption struct {
-	// Name specifies the type of namespace, typically matching one of the
-	// ...Namespace constants defined in
-	// github.com/opencontainers/runtime-spec/specs-go.
-	Name string
-	// Host is used to force our processes to use the host's namespace of
-	// this type.
-	Host bool
-	// Path is the path of the namespace to attach our process to, if Host
-	// is not set.  If Host is not set and Path is also empty, a new
-	// namespace will be created for the process that we're starting.
-	// If Name is specs.NetworkNamespace, if Path doesn't look like an
-	// absolute path, it is treated as a comma-separated list of CNI
-	// configuration names which will be selected from among all of the CNI
-	// network configurations which we find.
-	Path string
-}
-
-// NamespaceOptions provides some helper methods for a slice of NamespaceOption
-// structs.
-type NamespaceOptions []NamespaceOption
-
-// IDMappingOptions controls how we set up UID/GID mapping when we set up a
-// user namespace.
-type IDMappingOptions struct {
-	HostUIDMapping bool
-	HostGIDMapping bool
-	UIDMap         []specs.LinuxIDMapping
-	GIDMap         []specs.LinuxIDMapping
-}
-
-// Isolation provides a way to specify whether we're supposed to use a proper
-// OCI runtime, or some other method for running commands.
-type Isolation int
-
-const (
-	// IsolationDefault is whatever we think will work best.
-	IsolationDefault Isolation = iota
-	// IsolationOCI is a proper OCI runtime.
-	IsolationOCI
-	// IsolationChroot is a more chroot-like environment: less isolation,
-	// but with fewer requirements.
-	IsolationChroot
-	// IsolationOCIRootless is a proper OCI runtime in rootless mode.
-	IsolationOCIRootless
-)
-
-// String converts a Isolation into a string.
-func (i Isolation) String() string {
-	switch i {
-	case IsolationDefault:
-		return "IsolationDefault"
-	case IsolationOCI:
-		return "IsolationOCI"
-	case IsolationChroot:
-		return "IsolationChroot"
-	case IsolationOCIRootless:
-		return "IsolationOCIRootless"
-	}
-	return fmt.Sprintf("unrecognized isolation type %d", i)
-}
+type NameSpaceOption = define.NamespaceOption
 
 // RunOptions can be used to alter how a command is run in the container.
 type RunOptions struct {
 	// Hostname is the hostname we set for the running container.
 	Hostname string
 	// Isolation is either IsolationDefault, IsolationOCI, IsolationChroot, or IsolationOCIRootless.
-	Isolation Isolation
+	Isolation define.Isolation
 	// Runtime is the name of the runtime to run.  It should accept the
 	// same arguments that runc does, and produce similar output.
 	Runtime string
@@ -131,13 +71,13 @@ type RunOptions struct {
 	// Entrypoint is an override for the configured entry point.
 	Entrypoint []string
 	// NamespaceOptions controls how we set up the namespaces for the process.
-	NamespaceOptions NamespaceOptions
+	NamespaceOptions define.NamespaceOptions
 	// ConfigureNetwork controls whether or not network interfaces and
 	// routing are configured for a new network namespace (i.e., when not
 	// joining another's namespace and not just using the host's
 	// namespace), effectively deciding whether or not the process has a
 	// usable network.
-	ConfigureNetwork NetworkConfigurationPolicy
+	ConfigureNetwork define.NetworkConfigurationPolicy
 	// CNIPluginPath is the location of CNI plugin helpers, if they should be
 	// run from a location other than the default location.
 	CNIPluginPath string
@@ -168,33 +108,5 @@ type RunOptions struct {
 	// lists, it will be dropped.
 	DropCapabilities []string
 	// Devices are the additional devices to add to the containers
-	Devices ContainerDevices
-}
-
-// Find the configuration for the namespace of the given type.  If there are
-// duplicates, find the _last_ one of the type, since we assume it was appended
-// more recently.
-func (n *NamespaceOptions) Find(namespace string) *NamespaceOption {
-	for i := range *n {
-		j := len(*n) - 1 - i
-		if (*n)[j].Name == namespace {
-			return &((*n)[j])
-		}
-	}
-	return nil
-}
-
-// AddOrReplace either adds or replaces the configuration for a given namespace.
-func (n *NamespaceOptions) AddOrReplace(options ...NamespaceOption) {
-nextOption:
-	for _, option := range options {
-		for i := range *n {
-			j := len(*n) - 1 - i
-			if (*n)[j].Name == option.Name {
-				(*n)[j] = option
-				continue nextOption
-			}
-		}
-		*n = append(*n, option)
-	}
+	Devices define.ContainerDevices
 }

--- a/run_unix.go
+++ b/run_unix.go
@@ -3,6 +3,7 @@
 package buildah
 
 import (
+	"github.com/containers/buildah/define"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/pkg/errors"
 )
@@ -20,5 +21,5 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	return errors.New("function not supported on non-linux systems")
 }
 func DefaultNamespaceOptions() (NamespaceOptions, error) {
-	return NamespaceOptions{}, errors.New("function not supported on non-linux systems")
+	return define.NamespaceOptions{}, errors.New("function not supported on non-linux systems")
 }

--- a/run_unsupported.go
+++ b/run_unsupported.go
@@ -3,6 +3,7 @@
 package buildah
 
 import (
+	"github.com/containers/buildah/define"
 	"github.com/pkg/errors"
 )
 
@@ -19,5 +20,5 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	return errors.New("function not supported on non-linux systems")
 }
 func DefaultNamespaceOptions() (NamespaceOptions, error) {
-	return NamespaceOptions{}, errors.New("function not supported on non-linux systems")
+	return define.NamespaceOptions{}, errors.New("function not supported on non-linux systems")
 }

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/containers/buildah/imagebuildah"
 	"github.com/containers/image/v5/docker/daemon"
 	"github.com/containers/image/v5/image"
+	"github.com/containers/buildah/define"
+	define2 "github.com/containers/buildah/imagebuildah/define"
 	"github.com/containers/image/v5/pkg/compression"
 	istorage "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/transports"
@@ -505,10 +507,10 @@ func buildUsingBuildah(ctx context.Context, t *testing.T, store storage.Store, t
 	}
 	// set up build options
 	output := &bytes.Buffer{}
-	options := imagebuildah.BuildOptions{
+	options := define2.BuildOptions{
 		ContextDirectory: contextDir,
-		CommonBuildOpts:  &buildah.CommonBuildOptions{},
-		NamespaceOptions: []buildah.NamespaceOption{{
+		CommonBuildOpts:  &define.CommonBuildOptions{},
+		NamespaceOptions: []define.NamespaceOption{{
 			Name: string(rspec.NetworkNamespace),
 			Host: true,
 		}},


### PR DESCRIPTION
When other pieces of code, like the go bindings in libpod, import buildah structs and types, they do not want to also have the burden of importing containers image and containers storage.  To avoid this, we put these structs into builld/define/run|build.go.

Signed-off-by: baude <bbaude@redhat.com>

/kind other

```release-note
None
```

