### PR TITLE
[release-1.16] Set directory ownership when copied with ID mapping

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -1271,6 +1271,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			return errorResponse("copier: put: error mapping container filesystem owner %d:%d to host filesystem owners: %v", dirUID, dirGID, err)
 		}
 		dirUID, dirGID = hostDirPair.UID, hostDirPair.GID
+		defaultDirUID, defaultDirGID = hostDirPair.UID, hostDirPair.GID
 		if req.PutOptions.ChownFiles != nil {
 			containerFilePair := idtools.IDPair{UID: *fileUID, GID: *fileGID}
 			hostFilePair, err := idMappings.ToHost(containerFilePair)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
When a directory is copied by `buildah copy` to a container with ID mapping, the directory owner is not set correctly after #2659 was merged. This PR sets the ownership correctly.

This also fixes `idmapping` test to verify this fix. It seems that this test has not been working since the variable `maps` was renamed.

#### How to verify it
Run `bats tests/namespaces.bats`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Cherry-picked from #2647.

#### Does this PR introduce a user-facing change?

```
None
```