### PR TITLE
Fix build path wrong https://github.com/containers/podman/issues/7993

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -220,10 +220,14 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options BuildOpt
 			// context directory to it.
 			dinfo, err := os.Stat(dfile)
 			if os.IsNotExist(err) {
-				dfile = filepath.Join(options.ContextDirectory, dfile)
+				// If they are "/workDir/Dockerfile" and "/workDir"
+				// so don't joint it
+				if !strings.HasPrefix(dfile, options.ContextDirectory) {
+					dfile = filepath.Join(options.ContextDirectory, dfile)
+				}
 				dinfo, err = os.Stat(dfile)
 				if err != nil {
-					return "", nil, errors.Wrapf(err, "error reading info about %q", dfile)
+					return "", nil, err
 				}
 			}
 			// If given a directory, add '/Dockerfile' to it.


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/7993
```
mkdir -p /tmp/buildTest
cd /tmp/buildTest
podman build -t testName .
```
will got this error
```
Error: error reading info about "/tmp/buildTest/tmp/buildTest/Dockerfile": stat /tmp/buildTest/tmp/buildTest/Dockerfile: no such file or directory
```


Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>