### PR TITLE
bump(github.com/openshift/imagebuilder) to v1.1.8 and require conformance

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -120,9 +120,6 @@ gce_instance:
     gce_instance:  # Only need to specify differences from defaults (above)
         image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
 
-    # don't fail the PR when we fail until #2480 is merged
-    allow_failures: true
-
     timeout_in: 20m
 
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200710190001-3e4195d92445
 	github.com/opencontainers/runtime-tools v0.9.0
 	github.com/opencontainers/selinux v1.6.0
-	github.com/openshift/imagebuilder v1.1.7
+	github.com/openshift/imagebuilder v1.1.8
 	github.com/pkg/errors v0.9.1
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20200616122406-847368b35ebf
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pK
 github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/opencontainers/selinux v1.6.0 h1:+bIAS/Za3q5FTwWym4fTB0vObnfCf3G/NC7K6Jx62mY=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
-github.com/openshift/imagebuilder v1.1.7 h1:nabi5f9Y2rZr68tiLA9kgZOUyhrHJsrkzk5mgZPb7mA=
-github.com/openshift/imagebuilder v1.1.7/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
+github.com/openshift/imagebuilder v1.1.8 h1:gjiIl8pbNj0eC4XWvFJHATdDvYm64p9/pLDLQWoLZPA=
+github.com/openshift/imagebuilder v1.1.8/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913 h1:TnbXhKzrTOyuvWrjI8W6pcoI9XPbLHFXCdN2dtUw7Rw=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/imagebuilder/builder.go
+++ b/vendor/github.com/openshift/imagebuilder/builder.go
@@ -563,14 +563,21 @@ var builtinAllowedBuildArgs = map[string]bool{
 }
 
 // ParseDockerIgnore returns a list of the excludes in the .dockerignore file.
-// extracted from fsouza/go-dockerclient.
+// extracted from fsouza/go-dockerclient and modified to drop comments and
+// empty lines.
 func ParseDockerignore(root string) ([]string, error) {
 	var excludes []string
 	ignore, err := ioutil.ReadFile(filepath.Join(root, ".dockerignore"))
 	if err != nil && !os.IsNotExist(err) {
 		return excludes, fmt.Errorf("error reading .dockerignore: '%s'", err)
 	}
-	return strings.Split(string(ignore), "\n"), nil
+	for _, e := range strings.Split(string(ignore), "\n") {
+		if len(e) == 0 || e[0] == '#' {
+			continue
+		}
+		excludes = append(excludes, e)
+	}
+	return excludes, nil
 }
 
 // ExportEnv creates an export statement for a shell that contains all of the

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/archive.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/archive.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/klog"
 )
 
+var isArchivePath = archive.IsArchivePath
+
 // TransformFileFunc is given a chance to transform an arbitrary input file.
 type TransformFileFunc func(h *tar.Header, r io.Reader) (data []byte, update bool, skip bool, err error)
 

--- a/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
+++ b/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
@@ -12,7 +12,7 @@
 #
 
 %global golang_version 1.8.1
-%{!?version: %global version 1.1.7}
+%{!?version: %global version 1.1.8}
 %{!?release: %global release 1}
 %global package_name imagebuilder
 %global product_name Container Image Builder

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -347,7 +347,7 @@ github.com/opencontainers/runtime-tools/validate
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
-# github.com/openshift/imagebuilder v1.1.7
+# github.com/openshift/imagebuilder v1.1.8
 github.com/openshift/imagebuilder
 github.com/openshift/imagebuilder/dockerclient
 github.com/openshift/imagebuilder/dockerfile/command


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

This updates our vendored copy of imagebuilder to v1.1.8, which includes https://github.com/openshift/imagebuilder/pull/170, which fixes the last of our failing conformance tests, so at last, we can take the "allow_failures: true" tag off of them in our CI configuration.

#### How to verify it

Our tests should continue to pass.

#### Which issue(s) this PR fixes:

Also fixes #2686.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
Commented lines in .dockerignore files which are not valid regular expressions should no longer cause errors.
```