### PR TITLE
[release-1.16] bump(github.com/openshift/imagebuilder) to v1.1.8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -90,11 +90,13 @@ gce_instance:
 
 
 'cirrus-ci/only_prs/gate_task':
+    gce_instance:
+        memory: "12Gb"
 
     # see bors.toml
     skip: $CIRRUS_BRANCH =~ ".*\.tmp"
 
-    timeout_in: 30m
+    timeout_in: 10m
 
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
     build_script: '${SCRIPT_BASE}/build.sh |& ${_TIMESTAMP}'

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200710190001-3e4195d92445
 	github.com/opencontainers/runtime-tools v0.9.0
 	github.com/opencontainers/selinux v1.6.0
-	github.com/openshift/imagebuilder v1.1.6
+	github.com/openshift/imagebuilder v1.1.8
 	github.com/pkg/errors v0.9.1
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20200616122406-847368b35ebf
 	github.com/sirupsen/logrus v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ github.com/opencontainers/selinux v1.5.2 h1:F6DgIsjgBIcDksLW4D5RG9bXok6oqZ3nvMwj
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/opencontainers/selinux v1.6.0 h1:+bIAS/Za3q5FTwWym4fTB0vObnfCf3G/NC7K6Jx62mY=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
-github.com/openshift/imagebuilder v1.1.6 h1:1+YzRxIIefY4QqtCImx6rg+75QrKNfBoPAKxgMo/khM=
-github.com/openshift/imagebuilder v1.1.6/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
+github.com/openshift/imagebuilder v1.1.8 h1:gjiIl8pbNj0eC4XWvFJHATdDvYm64p9/pLDLQWoLZPA=
+github.com/openshift/imagebuilder v1.1.8/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913 h1:TnbXhKzrTOyuvWrjI8W6pcoI9XPbLHFXCdN2dtUw7Rw=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/run_linux.go
+++ b/run_linux.go
@@ -91,11 +91,8 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		return err
 	}
 
-	defaultContainerConfig, err := config.Default()
-	if err != nil {
-		return errors.Wrapf(err, "failed to get container config")
-	}
-	b.configureEnvironment(g, options, defaultContainerConfig.Containers.Env)
+	// hardwire the environment to match docker build to avoid subtle and hard-to-debug differences due to containers.conf
+	b.configureEnvironment(g, options, []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"})
 
 	if b.CommonBuildOpts == nil {
 		return errors.Errorf("Invalid format on container you must recreate the container")

--- a/tests/containers_conf.bats
+++ b/tests/containers_conf.bats
@@ -2,12 +2,6 @@
 
 load helpers
 
-@test "containers.conf env test" {
-    export CONTAINERS_CONF=${TESTSDIR}/containers.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
-    run_buildah --log-level=error run $cid sh -c 'env | grep "foo=bar"'
-}
-
 @test "containers.conf selinux test" {
     if ! which selinuxenabled > /dev/null 2> /dev/null ; then
 	skip "No selinuxenabled executable"

--- a/vendor/github.com/openshift/imagebuilder/README.md
+++ b/vendor/github.com/openshift/imagebuilder/README.md
@@ -102,5 +102,6 @@ Example of usage from OpenShift's experimental `dockerbuild` [command with mount
 ## Run conformance tests (very slow):
 
 ```
-go test ./dockerclient/conformance_test.go -tags conformance
+chmod -R go-w ./dockerclient/testdata
+go test ./dockerclient/conformance_test.go -tags conformance -timeout 30m
 ```

--- a/vendor/github.com/openshift/imagebuilder/builder.go
+++ b/vendor/github.com/openshift/imagebuilder/builder.go
@@ -332,20 +332,10 @@ func ParseFile(path string) (*parser.Node, error) {
 
 // Step creates a new step from the current state.
 func (b *Builder) Step() *Step {
-	argsMap := make(map[string]string)
-	for _, argsVal := range b.Arguments() {
-		val := strings.SplitN(argsVal, "=", 2)
-		if len(val) > 1 {
-			argsMap[val[0]] = val[1]
-		}
-	}
-
-	userArgs := makeUserArgs(b.Env, argsMap) 
-	dst := make([]string, len(userArgs)+len(b.RunConfig.Env))
-	copy(dst, userArgs)
-	dst = append(dst, b.RunConfig.Env...)
-
-	return &Step{Env: dst}
+	// Include build arguments in the table of variables that we'll use in
+	// Resolve(), but override them with values from the actual
+	// environment in case there's any conflict.
+	return &Step{Env: mergeEnv(b.Arguments(), mergeEnv(b.Env, b.RunConfig.Env))}
 }
 
 // Run executes a step, transforming the current builder and
@@ -473,7 +463,7 @@ func (b *Builder) FromImage(image *docker.Image, node *parser.Node) error {
 	SplitChildren(node, command.From)
 
 	b.RunConfig = *image.Config
-	b.Env = append(b.Env, b.RunConfig.Env...)
+	b.Env = mergeEnv(b.Env, b.RunConfig.Env)
 	b.RunConfig.Env = nil
 
 	// Check to see if we have a default PATH, note that windows won't
@@ -573,14 +563,21 @@ var builtinAllowedBuildArgs = map[string]bool{
 }
 
 // ParseDockerIgnore returns a list of the excludes in the .dockerignore file.
-// extracted from fsouza/go-dockerclient.
+// extracted from fsouza/go-dockerclient and modified to drop comments and
+// empty lines.
 func ParseDockerignore(root string) ([]string, error) {
 	var excludes []string
 	ignore, err := ioutil.ReadFile(filepath.Join(root, ".dockerignore"))
 	if err != nil && !os.IsNotExist(err) {
 		return excludes, fmt.Errorf("error reading .dockerignore: '%s'", err)
 	}
-	return strings.Split(string(ignore), "\n"), nil
+	for _, e := range strings.Split(string(ignore), "\n") {
+		if len(e) == 0 || e[0] == '#' {
+			continue
+		}
+		excludes = append(excludes, e)
+	}
+	return excludes, nil
 }
 
 // ExportEnv creates an export statement for a shell that contains all of the

--- a/vendor/github.com/openshift/imagebuilder/dispatchers.go
+++ b/vendor/github.com/openshift/imagebuilder/dispatchers.go
@@ -83,21 +83,9 @@ func env(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	for j := 0; j < len(args); j++ {
 		// name  ==> args[j]
 		// value ==> args[j+1]
-		newVar := args[j] + "=" + args[j+1] + ""
-		gotOne := false
-		for i, envVar := range b.RunConfig.Env {
-			envParts := strings.SplitN(envVar, "=", 2)
-			if envParts[0] == args[j] {
-				b.RunConfig.Env[i] = newVar
-				b.Env = append([]string{newVar}, b.Env...)
-				gotOne = true
-				break
-			}
-		}
-		if !gotOne {
-			b.RunConfig.Env = append(b.RunConfig.Env, newVar)
-			b.Env = append([]string{newVar}, b.Env...)
-		}
+		newVar := []string{args[j] + "=" + args[j+1]}
+		b.RunConfig.Env = mergeEnv(b.RunConfig.Env, newVar)
+		b.Env = mergeEnv(b.Env, newVar)
 		j++
 	}
 
@@ -153,7 +141,7 @@ func add(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	var chown string
 	last := len(args) - 1
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
-	userArgs := makeUserArgs(b.Env, b.Args)
+	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {
@@ -182,7 +170,7 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, flagArg
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
 	var chown string
 	var from string
-	userArgs := makeUserArgs(b.Env, b.Args)
+	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/archive.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/archive.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/klog"
 )
 
+var isArchivePath = archive.IsArchivePath
+
 // TransformFileFunc is given a chance to transform an arbitrary input file.
 type TransformFileFunc func(h *tar.Header, r io.Reader) (data []byte, update bool, skip bool, err error)
 

--- a/vendor/github.com/openshift/imagebuilder/dockerfile/parser/parser.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerfile/parser/parser.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/openshift/imagebuilder/dockerfile/command"
 	"github.com/docker/docker/pkg/system"
+	"github.com/openshift/imagebuilder/dockerfile/command"
 	"github.com/pkg/errors"
 )
 
@@ -37,7 +37,7 @@ type Node struct {
 	Original   string          // original line used before parsing
 	Flags      []string        // only top Node should have this set
 	StartLine  int             // the line in the original dockerfile where the node begins
-	endLine    int             // the line in the original dockerfile where the node ends
+	EndLine    int             // the line in the original dockerfile where the node ends
 }
 
 // Dump dumps the AST defined by `node` as a list of sexps.
@@ -67,7 +67,7 @@ func (node *Node) Dump() string {
 
 func (node *Node) lines(start, end int) {
 	node.StartLine = start
-	node.endLine = end
+	node.EndLine = end
 }
 
 // AddChild adds a new child node, and updates line information
@@ -76,7 +76,7 @@ func (node *Node) AddChild(child *Node, startLine, endLine int) {
 	if node.StartLine < 0 {
 		node.StartLine = startLine
 	}
-	node.endLine = endLine
+	node.EndLine = endLine
 	node.Children = append(node.Children, child)
 }
 

--- a/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
+++ b/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
@@ -12,7 +12,7 @@
 #
 
 %global golang_version 1.8.1
-%{!?version: %global version 1.1.6}
+%{!?version: %global version 1.1.8}
 %{!?release: %global release 1}
 %global package_name imagebuilder
 %global product_name Container Image Builder

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -347,7 +347,7 @@ github.com/opencontainers/runtime-tools/validate
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
-# github.com/openshift/imagebuilder v1.1.6
+# github.com/openshift/imagebuilder v1.1.8
 github.com/openshift/imagebuilder
 github.com/openshift/imagebuilder/dockerclient
 github.com/openshift/imagebuilder/dockerfile/command


### PR DESCRIPTION
#### What type of PR is this?

/kind bug 

#### What this PR does / why we need it:

This updates our vendored copy of imagebuilder to v1.1.8, which includes https://github.com/openshift/imagebuilder/pull/170, which fixes the last of our failing conformance tests, and https://github.com/openshift/imagebuilder/pull/177, which avoids attempting to compile comment lines in `.dockerignore` files into regular expressions.

#### How to verify it

Our tests should continue to pass.

#### Which issue(s) this PR fixes:

Fixes #2686.

#### Special notes for your reviewer:

Cherry-picked from part of #2693 and the CI configuration part of #2681.

#### Does this PR introduce a user-facing change?

```
Commented lines in .dockerignore files which are not valid regular expressions should no longer cause errors.
```