### PR TITLE
copier.copierHandlerPut: don't check length when there are errors

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -1393,7 +1393,9 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			case tar.TypeReg, tar.TypeRegA:
 				var written int64
 				written, err = createFile(path, tr)
-				if written != hdr.Size {
+				// only check the length if there wasn't an error, which we'll
+				// check along with errors for other types of entries
+				if err == nil && written != hdr.Size {
 					return errors.Errorf("copier: put: error creating %q: incorrect length (%d != %d)", path, written, hdr.Size)
 				}
 			case tar.TypeLink:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When attempting to create a file as part of extracting a tar stream, don't check if the number of bytes written that our helper function reports back to us matches our expectations if it also reported an error, in which case the byte count is irrelevant.

#### How to verify it

#### Which issue(s) this PR fixes:

Related to https://github.com/containers/buildah/issues/2701, though this only fixes the error reporting for that issue.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
Improves error reporting in cases where ADD or COPY (or "buildah add" or "buildah copy") encounter an error while attempting to create a file in a working container.
```