### PR TITLE
overlay: fix umount

### DIFF
--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -101,18 +102,19 @@ func Mount(contentDir, source, dest string, rootUID, rootGID int, graphOptions [
 // RemoveTemp removes temporary mountpoint and all content from its parent
 // directory
 func RemoveTemp(contentDir string) error {
-	if unshare.IsRootless() {
-		if err := Unmount(contentDir); err != nil {
-			return err
-		}
+	if err := Unmount(contentDir); err != nil {
+		return err
 	}
+
 	return os.RemoveAll(contentDir)
 }
 
 // Unmount the overlay mountpoint
-func Unmount(contentDir string) (Err error) {
+func Unmount(contentDir string) error {
 	mergeDir := filepath.Join(contentDir, "merge")
-	if err := unix.Unmount(mergeDir, 0); err != nil && !os.IsNotExist(err) {
+
+	// Ignore EINVAL as the specified merge dir is not a mount point
+	if err := unix.Unmount(mergeDir, 0); err != nil && !os.IsNotExist(err) && err != unix.EINVAL {
 		return errors.Wrapf(err, "unmount overlay %s", mergeDir)
 	}
 	return nil
@@ -153,14 +155,20 @@ func CleanupMount(contentDir string) (Err error) {
 func CleanupContent(containerDir string) (Err error) {
 	contentDir := filepath.Join(containerDir, "overlay")
 
-	if unshare.IsRootless() {
-		mergeDir := filepath.Join(contentDir, "merge")
-		if err := unix.Unmount(mergeDir, 0); err != nil {
-			if !os.IsNotExist(err) {
-				return errors.Wrapf(err, "unmount overlay %s", mergeDir)
-			}
+	files, err := ioutil.ReadDir(contentDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "read directory")
+	}
+	for _, f := range files {
+		dir := filepath.Join(contentDir, f.Name())
+		if err := Unmount(dir); err != nil {
+			return err
 		}
 	}
+
 	if err := os.RemoveAll(contentDir); err != nil && !os.IsNotExist(err) {
 		return errors.Wrapf(err, "failed to cleanup overlay %s directory", contentDir)
 	}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

fix unmounting overlay when running as rootless.

#### How to verify it

`mkdir /tmp/foo && podman run --rm -v /tmp/foo:/tmp/foo:O fedora true` works

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
NONE
```

