### PR TITLE
Handle cases where other tools mount/unmount containers

### DIFF
--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -97,10 +97,13 @@ func mountCmd(c *cobra.Command, args []string) error {
 			return errors.Wrapf(err, "error reading build containers")
 		}
 		for _, builder := range builders {
-			if builder.MountPoint == "" {
-				continue
+			mounted, err := builder.Mounted()
+			if err != nil {
+				return err
 			}
-			fmt.Printf("%s %s\n", builder.Container, builder.MountPoint)
+			if mounted {
+				fmt.Printf("%s %s\n", builder.Container, builder.MountPoint)
+			}
 		}
 	}
 	return lastError

--- a/mount.go
+++ b/mount.go
@@ -19,3 +19,35 @@ func (b *Builder) Mount(label string) (string, error) {
 	}
 	return mountpoint, nil
 }
+
+func (b *Builder) setMountPoint(mountPoint string) error {
+	b.MountPoint = mountPoint
+	if err := b.Save(); err != nil {
+		return errors.Wrapf(err, "error saving updated state for build container %q", b.ContainerID)
+	}
+	return nil
+}
+
+// Mounted returns whether the container is mounted or not
+func (b *Builder) Mounted() (bool, error) {
+	mountCnt, err := b.store.Mounted(b.ContainerID)
+	if err != nil {
+		return false, errors.Wrapf(err, "error determining if mounting build container %q is mounted", b.ContainerID)
+	}
+	mounted := mountCnt > 0
+	if mounted && b.MountPoint == "" {
+		ctr, err := b.store.Container(b.ContainerID)
+		if err != nil {
+			return mountCnt > 0, errors.Wrapf(err, "error determining if mounting build container %q is mounted", b.ContainerID)
+		}
+		layer, err := b.store.Layer(ctr.LayerID)
+		if err != nil {
+			return mountCnt > 0, errors.Wrapf(err, "error determining if mounting build container %q is mounted", b.ContainerID)
+		}
+		return mounted, b.setMountPoint(layer.MountPoint)
+	}
+	if !mounted && b.MountPoint != "" {
+		return mounted, b.setMountPoint("")
+	}
+	return mounted, nil
+}


### PR DESCRIPTION
Podman is growing the support to mount and umount storage containers.
This patch will help maintain buildahs internel state and will return
the correct information to the user if they check if buildah containers
are mounted.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

