### PR TITLE
If build format != oci do not use OCI layers

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -140,8 +140,10 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		return err
 	}
 	layers := buildahcli.UseLayers()
-	if c.Flag("layers").Changed {
-		layers = iopts.Layers
+	if strings.Contains(format, "oci") {
+		if c.Flag("layers").Changed {
+			layers = iopts.Layers
+		}
 	}
 	contextDir := ""
 	cliArgs := inputArgs


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

In case of setting `--layers` flag to `true`, buildah uses the same caching layers for OCI and Docker image format which is incorrect behavior.  

**How to verify it**

```bash
# Dockerfile in nooci instruction
FROM alpine
HEALTHCHECK CMD curl --fail http://localhost:7070 || exit 1  
COPY ./main.go 
FROM alpine
```
then
```bash
buildah bud --layers=true -f Dockerfile.nonoci --format oci -t oci-app . 
# and 
buildah bud --layers=true -f Dockerfile.nonoci --format docker -t docker-app .
```
Docker format should not use cache.

**Which issue(s) this PR fixes:**

Fixes #2389

**Special notes for your reviewer:**

Maybe we should use different cache set for OCI and Docker format, but IMO  it's wasting of disc space. 
  
**Does this PR introduce a user-facing change?**
No