### PR TITLE
[release-1.17] Update CI configuration for the release-1.17 branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
     #### Global variables used for all tasks
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
-    DEST_BRANCH: "master"
+    DEST_BRANCH: "release-1.17"
     GOPATH: "/var/tmp/go"
     GOSRC: "${GOPATH}/src/github.com/containers/buildah"
     # Overrides default location (/tmp/cirrus) for repo clone

--- a/tests/validate/git-validation.sh
+++ b/tests/validate/git-validation.sh
@@ -11,7 +11,7 @@ if [[ -z "$(type -P git-validation)" ]]; then
 	exit 1
 fi
 
-GITVALIDATE_EPOCH="${GITVALIDATE_EPOCH:-1f8bf4dba27d9a157f966dad3a1e0f58091091d8}"
+GITVALIDATE_EPOCH="${GITVALIDATE_EPOCH:-8891d05dbaffc0b6013a48a68177b4ccec281f8c}"
 
 OUTPUT_OPTIONS="-q"
 if [[ "$CI" == 'true' ]]; then


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Update the default git-validation epoch to point to the v1.17.0 tag,
Update the Cirrus CI configuration to point to this branch.

#### How to verify it

CI should keep rolling.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```
None
```