### PR TITLE
imagebuildah: cache should take image format into account

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/buildah/util"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/manifest"
 	is "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -335,22 +336,29 @@ func (b *Executor) waitForStage(ctx context.Context, name string, stages imagebu
 	}
 }
 
-// getImageHistoryAndDiffIDs returns the history and diff IDs list of imageID.
-func (b *Executor) getImageHistoryAndDiffIDs(ctx context.Context, imageID string) ([]v1.History, []digest.Digest, error) {
+// getImageTypeAndHistoryAndDiffIDs returns the manifest type, history, and diff IDs list of imageID.
+func (b *Executor) getImageTypeAndHistoryAndDiffIDs(ctx context.Context, imageID string) (string, []v1.History, []digest.Digest, error) {
 	imageRef, err := is.Transport.ParseStoreReference(b.store, "@"+imageID)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error getting image reference %q", imageID)
+		return "", nil, nil, errors.Wrapf(err, "error getting image reference %q", imageID)
 	}
 	ref, err := imageRef.NewImage(ctx, nil)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error creating new image from reference to image %q", imageID)
+		return "", nil, nil, errors.Wrapf(err, "error creating new image from reference to image %q", imageID)
 	}
 	defer ref.Close()
 	oci, err := ref.OCIConfig(ctx)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error getting possibly-converted OCI config of image %q", imageID)
+		return "", nil, nil, errors.Wrapf(err, "error getting possibly-converted OCI config of image %q", imageID)
 	}
-	return oci.History, oci.RootFS.DiffIDs, nil
+	manifestBytes, manifestFormat, err := ref.Manifest(ctx)
+	if err != nil {
+		return "", nil, nil, errors.Wrapf(err, "error getting manifest of image %q", imageID)
+	}
+	if manifestFormat == "" && len(manifestBytes) > 0 {
+		manifestFormat = manifest.GuessMIMEType(manifestBytes)
+	}
+	return manifestFormat, oci.History, oci.RootFS.DiffIDs, nil
 }
 
 func (b *Executor) buildStage(ctx context.Context, cleanupStages map[int]*StageExecutor, stages imagebuilder.Stages, stageIndex int) (imageID string, ref reference.Canonical, err error) {

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1110,7 +1110,7 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 	var baseHistory []v1.History
 	var baseDiffIDs []digest.Digest
 	if s.builder.FromImageID != "" {
-		baseHistory, baseDiffIDs, err = s.executor.getImageHistoryAndDiffIDs(ctx, s.builder.FromImageID)
+		_, baseHistory, baseDiffIDs, err = s.executor.getImageTypeAndHistoryAndDiffIDs(ctx, s.builder.FromImageID)
 		if err != nil {
 			return "", errors.Wrapf(err, "error getting history of base image %q", s.builder.FromImageID)
 		}
@@ -1142,9 +1142,14 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 		}
 		// Next we double check that the history of this image is equivalent to the previous
 		// lines in the Dockerfile up till the point we are at in the build.
-		history, diffIDs, err := s.executor.getImageHistoryAndDiffIDs(ctx, image.ID)
+		manifestType, history, diffIDs, err := s.executor.getImageTypeAndHistoryAndDiffIDs(ctx, image.ID)
 		if err != nil {
 			return "", errors.Wrapf(err, "error getting history of %q", image.ID)
+		}
+		// If this candidate isn't of the type that we're building, then it may have lost
+		// some format-specific information that a building-without-cache run wouldn't lose.
+		if manifestType != s.executor.outputFormat {
+			continue
 		}
 		// children + currNode is the point of the Dockerfile we are currently at.
 		if s.historyAndDiffIDsMatch(baseHistory, baseDiffIDs, currNode, history, diffIDs, addedContentDigest, buildAddsLayer) {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2295,3 +2295,20 @@ EOF
 
   expect_output --from="$passthru" "$random_msg" "stdin was passed through"
 }
+
+@test "bud cache by format" {
+  # Build first in Docker format.  Whether we do OCI or Docker first shouldn't matter, so we picked one.
+  run_buildah bud --iidfile first-docker  --format docker --layers --quiet --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/cache-format
+  # Build in OCI format.  Cache should not re-use the same images, so we should get a different image ID.
+  run_buildah bud --iidfile first-oci     --format oci    --layers --quiet --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/cache-format
+  # Build in Docker format again.  Cache traversal should 100% hit the Docker image, so we should get its image ID.
+  run_buildah bud --iidfile second-docker --format docker --layers --quiet --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/cache-format
+  # Build in OCI format again.  Cache traversal should 100% hit the OCI image, so we should get its image ID.
+  run_buildah bud --iidfile second-oci    --format oci    --layers --quiet --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/cache-format
+  # Compare them.  The two images we built in Docker format should be the same, the two we built in OCI format
+  # should be the same, but the OCI and Docker format images should be different.
+  cmp first-docker second-docker
+  cmp first-oci    second-oci
+  run cmp first-docker first-oci
+  [[ "$status" -ne 0 ]]
+}

--- a/tests/bud/cache-format/Dockerfile
+++ b/tests/bud/cache-format/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+COPY . .
+RUN pwd


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When evaluating cache candidates during a build, only consider an image if it's in the same format that we're attempting to build.  That way, we won't mistakenly try to use an OCI format image as a cache when we're attempting to build an image in Docker format because we're using configuration features specific to that format, but we forgot to specify the format during a previous attempt.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes #2389.

#### Special notes for your reviewer:

An alternative to #2731.

#### Does this PR introduce a user-facing change?

```
None
```