### PR TITLE
copier: try to force loading of nsswitch modules before chroot()

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,7 @@ github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b/go.mod h1:9rfv
 github.com/containers/ocicrypt v1.0.3 h1:vYgl+RZ9Q3DPMuTfxmN+qp0X2Bj52uuY2vnt6GzVe1c=
 github.com/containers/ocicrypt v1.0.3/go.mod h1:CUBa+8MRNL/VkpxYIpaMtgn1WgXGyvPQj8jcy0EVG6g=
 github.com/containers/storage v1.23.6/go.mod h1:haFs0HRowKwyzvWEx9EgI3WsL8XCSnBDb5f8P5CAxJY=
+github.com/containers/storage v1.23.7/go.mod h1:cUT2zHjtx+WlVri30obWmM2gpqpi8jfPsmIzP1TVpEI=
 github.com/containers/storage v1.23.8 h1:Z3KKE9BkbW6CGOjIeTtvX+Dl9pFX8QgvSD2j/tS+r5E=
 github.com/containers/storage v1.23.8/go.mod h1:3b2ktpB6pw53SEeIoFfO0sQfP9+IoJJKPq5iJk74gxE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Attempt to address CVE-2019-14271 by having the copier module attempt to trigger loading of dynamic nsswitch modules, that it'll end up using while chrooted, before it chroots into a target rootfs.

#### How to verify it

Hard to write an automated test for this one.

#### Which issue(s) this PR fixes:

Fixes #2740.

#### Special notes for your reviewer:

Based on a similar [PR for containers/storage](https://github.com/containers/storage/pull/768), in turn based on a [fix in moby/moby](https://github.com/moby/moby/pull/39612).

#### Does this PR introduce a user-facing change?

```
None
```