### PR TITLE
Use CPP, CC and flags in dep check scripts

### DIFF
--- a/btrfs_installed_tag.sh
+++ b/btrfs_installed_tag.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-cc -E - > /dev/null 2> /dev/null << EOF
+${CPP:-${CC:-cc} -E} ${CPPFLAGS} - > /dev/null 2> /dev/null << EOF
 #include <btrfs/ioctl.h>
 EOF
 if test $? -ne 0 ; then

--- a/btrfs_tag.sh
+++ b/btrfs_tag.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-cc -E - > /dev/null 2> /dev/null << EOF
+${CPP:-${CC:-cc} -E} ${CPPFLAGS} - > /dev/null 2> /dev/null << EOF
 #include <btrfs/version.h>
 EOF
 if test $? -ne 0 ; then

--- a/libdm_tag.sh
+++ b/libdm_tag.sh
@@ -2,7 +2,7 @@
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT
-cc -o "$tmpdir"/libdm_tag -ldevmapper -x c - > /dev/null 2> /dev/null << EOF
+${CC:-cc} ${CFLAGS} ${CPPFLAGS} ${LDFLAGS} -o "$tmpdir"/libdm_tag -x c - -ldevmapper > /dev/null 2> /dev/null << EOF
 #include <libdevmapper.h>
 int main() {
 	struct dm_task *task;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake

/kind other

#### What this PR does / why we need it:

Allow build system without standard `cc` to successfully run the dependency checking helper scripts from the Makefile.
This supports custom compilers specified by the common `CC` environment variable, preprocessors given as `CPP` and additional preprocessor flags from `CPPFLAGS`.
Additionally, additional flags from `CFLAGS` and `LDFLAGS` are considered for compiling/linking.
Overall, this facilitates cross-compilation and similar setups (e.g., for building Conda packages at https://gitub.com/conda-forge).

#### How to verify it

Temporarily remove `cc` from `PATH` and point `CC`/`CPP` to a different compiler.
Install header files, e.g., `btrfs/ioctl.h`, in a custom location and set `CPPFLAGS=-I/custom/location`.
Add `-Wl,--as-needed` to `LDFLAGS` (which makes library order important (again) while linking) to confirm the order of the inputs `-` and `-ldevmapper` is correct in `libdm_tag.sh`.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

