### PR TITLE
Add --policy flag to buildah pull

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -137,7 +137,7 @@ func openBuilder(ctx context.Context, store storage.Store, name string) (builder
 		}
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error reading build container")
+		return nil, err
 	}
 	if builder == nil {
 		return nil, errors.Errorf("error finding build container")
@@ -156,7 +156,7 @@ func openImage(ctx context.Context, sc *types.SystemContext, store storage.Store
 	}
 	builder, err = buildah.ImportBuilderFromImage(ctx, store, options)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error reading image")
+		return nil, err
 	}
 	if builder == nil {
 		return nil, errors.Errorf("error mocking up build configuration")

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -84,17 +84,17 @@ func inspectCmd(c *cobra.Command, args []string, iopts inspectResults) error {
 		builder, err = openBuilder(ctx, store, name)
 		if err != nil {
 			if c.Flag("type").Changed {
-				return errors.Wrapf(err, "error reading build container %q", name)
+				return errors.Wrapf(err, "error reading build container")
 			}
 			builder, err = openImage(ctx, systemContext, store, name)
 			if err != nil {
-				return errors.Wrapf(err, "error reading build object %q", name)
+				return err
 			}
 		}
 	case inspectTypeImage:
 		builder, err = openImage(ctx, systemContext, store, name)
 		if err != nil {
-			return errors.Wrapf(err, "error reading image %q", name)
+			return err
 		}
 	default:
 		return errors.Errorf("the only recognized types are %q and %q", inspectTypeContainer, inspectTypeImage)

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -613,6 +613,7 @@ return 1
      --cert-dir
      --creds
      --decryption-key
+     --policy
   "
 
      local all_options="$options_with_args $boolean_options"

--- a/define/types.go
+++ b/define/types.go
@@ -1,6 +1,8 @@
 package define
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // PullPolicy takes the value PullIfMissing, PullAlways, PullIfNewer, or PullNever.
 type PullPolicy int
@@ -38,4 +40,11 @@ func (p PullPolicy) String() string {
 		return "PullNever"
 	}
 	return fmt.Sprintf("unrecognized policy %d", p)
+}
+
+var PolicyMap = map[string]PullPolicy{
+	"missing": PullIfMissing,
+	"always":  PullAlways,
+	"never":   PullNever,
+	"ifnewer": PullIfNewer,
 }

--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -70,6 +70,14 @@ The [key[:passphrase]] to be used for decryption of images. Key can point to key
 
 If an image needs to be pulled from the registry, suppress progress output.
 
+**--policy**=**always**|**missing**|**never**
+
+Pull image policy. The default is **missing**.
+
+- **missing**: attempt to pull the latest image from the registries listed in registries.conf if a local image does not exist. Raise an error if the image is not in any listed registry and is not present locally.
+- **always**: Pull the image from the first registry it is found in as listed in  registries.conf. Raise an error if not found in the registries, even if the image is present locally.
+- **never**: do not pull the image from the registry, use only the local version. Raise an error if the image is not present locally.
+
 **--remove-signatures**
 
 Don't copy signatures when pulling images.

--- a/import.go
+++ b/import.go
@@ -154,7 +154,7 @@ func importBuilderFromImage(ctx context.Context, store storage.Store, options Im
 
 	_, img, err := util.FindImage(store, "", systemContext, options.Image)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error locating image %q for importing settings", options.Image)
+		return nil, errors.Wrapf(err, "importing settings")
 	}
 
 	builder, err := importBuilderDataFromImage(ctx, store, systemContext, img.ID, "", "")

--- a/pull.go
+++ b/pull.go
@@ -60,6 +60,8 @@ type PullOptions struct {
 	// OciDecryptConfig contains the config that can be used to decrypt an image if it is
 	// encrypted if non-nil. If nil, it does not attempt to decrypt an image.
 	OciDecryptConfig *encconfig.DecryptConfig
+	// PullPolicy takes the value PullIfMissing, PullAlways, PullIfNewer, or PullNever.
+	PullPolicy PullPolicy
 }
 
 func localImageNameForReference(ctx context.Context, store storage.Store, srcRef types.ImageReference) (string, error) {
@@ -169,6 +171,7 @@ func Pull(ctx context.Context, imageName string, options PullOptions) (imageID s
 		MaxPullRetries:      options.MaxRetries,
 		PullRetryDelay:      options.RetryDelay,
 		OciDecryptConfig:    options.OciDecryptConfig,
+		PullPolicy:          options.PullPolicy,
 	}
 
 	storageRef, transport, img, err := resolveImage(ctx, systemContext, options.Store, boptions)

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -53,7 +53,7 @@ load helpers
   cid=$output
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json --rm $cid alpine-image
   run_buildah 125 rm $cid
-  expect_output --substring "error removing container \"alpine-working-container\": error reading build container: container not known"
+  expect_output --substring "error removing container \"alpine-working-container\": container not known"
 }
 
 @test "commit-alternate-storage" {

--- a/tests/rm.bats
+++ b/tests/rm.bats
@@ -12,9 +12,9 @@ load helpers
 
 @test "remove multiple containers errors" {
   run_buildah 125 rm mycontainer1 mycontainer2 mycontainer3
-  expect_output --from="${lines[0]}" "error removing container \"mycontainer1\": error reading build container: container not known" "output line 1"
-  expect_output --from="${lines[1]}" "error removing container \"mycontainer2\": error reading build container: container not known" "output line 2"
-  expect_output --from="${lines[2]}" "error removing container \"mycontainer3\": error reading build container: container not known" "output line 3"
+  expect_output --from="${lines[0]}" "error removing container \"mycontainer1\": container not known" "output line 1"
+  expect_output --from="${lines[1]}" "error removing container \"mycontainer2\": container not known" "output line 2"
+  expect_output --from="${lines[2]}" "error removing container \"mycontainer3\": container not known" "output line 3"
   expect_line_count 3
 }
 


### PR DESCRIPTION
This allows the user to specify the pull policy for pulling images.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

