### PR TITLE
Run: correctly call copier.Mkdir

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1281,5 +1281,5 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 }
 
 func (s *StageExecutor) EnsureContainerPath(path string) error {
-	return copier.Mkdir(s.mountPoint, path, copier.MkdirOptions{})
+	return copier.Mkdir(s.mountPoint, filepath.Join(s.mountPoint, path), copier.MkdirOptions{})
 }

--- a/run_linux.go
+++ b/run_linux.go
@@ -185,7 +185,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		ChownNew: rootIDPair,
 		ChmodNew: &mode,
 	}
-	if err := copier.Mkdir(mountPoint, spec.Process.Cwd, coptions); err != nil {
+	if err := copier.Mkdir(mountPoint, filepath.Join(mountPoint, spec.Process.Cwd), coptions); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Make sure we specify the working directory that we're creating using a path that is explicitly below the chroot we want to create it under.

#### How to verify it

Tests should continue to pass.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I missed this when reviewing #2735.

#### Does this PR introduce a user-facing change?

```
None
```