### PR TITLE
imagebuildah: use overlay for volumes when using overlay

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -149,6 +149,10 @@ unit_task:
     binary_artifacts:
         path: ./bin/*
 
+    env:
+        matrix:
+            STORAGE_DRIVER: 'vfs'
+            STORAGE_DRIVER: 'overlay'
 
 conformance_task:
     name: "Docker Build Conformance"
@@ -165,6 +169,10 @@ conformance_task:
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
     conformance_test_script: '${SCRIPT_BASE}/test.sh conformance |& ${_TIMESTAMP}'
 
+    env:
+        matrix:
+            STORAGE_DRIVER: 'vfs'
+            STORAGE_DRIVER: 'overlay'
 
 # Confirm cross-compile ALL archetectures on a Mac OS-X VM.
 cross_build_task:
@@ -268,6 +276,10 @@ integration_task:
         package_versions_script: '$GOSRC/$SCRIPT_BASE/logcollector.sh packages'
         golang_version_script: '$GOSRC/$SCRIPT_BASE/logcollector.sh golang'
 
+    env:
+        matrix:
+            STORAGE_DRIVER: 'vfs'
+            STORAGE_DRIVER: 'overlay'
 
 in_podman_task:
     name: "Containerized Integration"
@@ -281,7 +293,6 @@ in_podman_task:
         IN_PODMAN: 'true'
         BUILDAH_ISOLATION: 'chroot'
         STORAGE_DRIVER: 'vfs'
-        STORAGE_OPTIONS: ''
 
     # Separate scripts for separate outputs, makes debugging easier.
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -243,6 +243,7 @@ func testConformanceInternal(t *testing.T, dateStamp string, testIndex int) {
 
 	// initialize storage for buildah
 	options := storage.StoreOptions{
+		GraphDriverName:     os.Getenv("STORAGE_DRIVER"),
 		GraphRoot:           rootDir,
 		RunRoot:             runrootDir,
 		RootlessStoragePath: rootDir,

--- a/tests/e2e/buildah_suite_test.go
+++ b/tests/e2e/buildah_suite_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 const (
-	storageOptions = "--storage-driver vfs"
-	artifactDir    = "/tmp/.artifacts"
+	artifactDir = "/tmp/.artifacts"
 )
 
 var (
@@ -99,9 +98,9 @@ func BuildahCreate(tempDir string) BuildAhTest {
 	if os.Getenv("BUILDAH_BINARY") != "" {
 		buildAhBinary = os.Getenv("BUILDAH_BINARY")
 	}
-	storageOpts := storageOptions
-	if os.Getenv("STORAGE_OPTIONS") != "" {
-		storageOpts = os.Getenv("STORAGE_OPTIONS")
+	storageOpts := "--storage-driver vfs"
+	if os.Getenv("STORAGE_DRIVER") != "" {
+		storageOpts = fmt.Sprintf("--storage-driver %s", os.Getenv("STORAGE_DRIVER"))
 	}
 
 	return BuildAhTest{
@@ -237,8 +236,10 @@ func (p *BuildAhTest) CreateArtifact(image string) error {
 // RestoreArtifact puts the cached image into our test store
 func (p *BuildAhTest) RestoreArtifact(image string) error {
 	storeOptions, _ := sstorage.DefaultStoreOptions(false, 0)
-	storeOptions.GraphDriverName = "vfs"
-	//storeOptions.GraphDriverOptions = storageOptions
+	storeOptions.GraphDriverName = os.Getenv("STORAGE_DRIVER")
+	if storeOptions.GraphDriverName == "" {
+		storeOptions.GraphDriverName = "vfs"
+	}
 	storeOptions.GraphRoot = p.Root
 	storeOptions.RunRoot = p.RunRoot
 	store, err := sstorage.GetStore(storeOptions)

--- a/tests/overlay.bats
+++ b/tests/overlay.bats
@@ -38,24 +38,24 @@ load helpers
     skip "skipping overlay test because \$STORAGE_DRIVER = $STORAGE_DRIVER"
   fi
   image=alpine
-  mkdir ${TESTDIR}/lower
-  chmod 770 ${TESTDIR}/lower
-  permissions=`ls -ld ${TESTDIR}/lower | cut -f1 -d" "`
+  mkdir -m 770 ${TESTDIR}/lower
+  permission=`stat -c %a ${TESTDIR}/lower`
   run_buildah from --quiet -v ${TESTDIR}/lower:/tmp/test:O --quiet --signature-policy ${TESTSDIR}/policy.json $image
   cid=$output
 
   # This should succeed
-  run_buildah run $cid sh -c 'ls -ld /tmp/test | cut -f1 -d" "'
+  run_buildah run $cid sh -c 'stat -c %a /tmp/test'
   expect_output $permission
 
   # Create and remove content in the overlay directory, should succeed
-  run_buildah run $cid touch /lower/bar
-  run_buildah run $cid rm /lower/foo
+  touch ${TESTDIR}/lower/foo
+  run_buildah run $cid touch /tmp/test/bar
+  run_buildah run $cid rm /tmp/test/foo
 
   # This should fail, second runs of containers go back to original
-  run_buildah 125 run $cid ls /lower/bar
+  run_buildah 1 run $cid ls /tmp/test/bar
 
-  # This should fail
+  # This should fail since /tmp/test was an overlay, not a bind mount
   run ls ${TESTDIR}/lower/bar
   [ "$status" -ne 0 ]
 }

--- a/tests/overlay.bats
+++ b/tests/overlay.bats
@@ -18,12 +18,13 @@ load helpers
   # This should succeed
   run_buildah run $cid ls /lower/foo
 
-  # Create and remove content in the overlay directory, should succeed
+  # Create and remove content in the overlay directory, should succeed,
+  # resetting the contents between each run.
   run_buildah run $cid touch /lower/bar
   run_buildah run $cid rm /lower/foo
 
   # This should fail, second runs of containers go back to original
-  run_buildah 125 run $cid ls /lower/bar
+  run_buildah 1 run $cid ls /lower/bar
 
   # This should fail
   run ls ${TESTDIR}/lower/bar


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When we're using the overlay driver (which means we know overlay is available), use it to make volumes appear to be writeable during RUN instructions instead of saving/restoring their contents.

This avoids having to copy the contents of the volume directory before each RUN instruction, and having to remove and extract the contents after each RUN instruction, which should be faster, particularly if the amount of content in that volume location is large.

For empty directories, it will at least avoid adding an "opaque" notation for the directory in a layer that might otherwise be empty.

Make conformance tests pay attention to the STORAGE_DRIVER environment variable, so that they use the same driver the integration tests do instead of the hardwired or configured default.

#### How to verify it

We add test passes that use overlay storage.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```