### PR TITLE
util: digging UID/GID out of os.FileInfo should work on Unix

### DIFF
--- a/util/util_linux.go
+++ b/util/util_linux.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"os"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -18,12 +17,4 @@ func IsCgroup2UnifiedMode() (bool, error) {
 		}
 	})
 	return isUnified, isUnifiedErr
-}
-
-func UID(st os.FileInfo) int {
-	return int(st.Sys().(*syscall.Stat_t).Uid)
-}
-
-func GID(st os.FileInfo) int {
-	return int(st.Sys().(*syscall.Stat_t).Gid)
 }

--- a/util/util_unix.go
+++ b/util/util_unix.go
@@ -29,3 +29,11 @@ func (h *HardlinkChecker) Add(fi os.FileInfo, name string) {
 		h.hardlinks.Store(makeHardlinkDeviceAndInode(st), name)
 	}
 }
+
+func UID(st os.FileInfo) int {
+	return int(st.Sys().(*syscall.Stat_t).Uid)
+}
+
+func GID(st os.FileInfo) int {
+	return int(st.Sys().(*syscall.Stat_t).Gid)
+}

--- a/util/util_unsupported.go
+++ b/util/util_unsupported.go
@@ -2,19 +2,7 @@
 
 package util
 
-import (
-	"os"
-)
-
 // IsCgroup2UnifiedMode returns whether we are running in cgroup 2 cgroup2 mode.
 func IsCgroup2UnifiedMode() (bool, error) {
 	return false, nil
-}
-
-func UID(st os.FileInfo) int {
-	return 0
-}
-
-func GID(st os.FileInfo) int {
-	return 0
 }

--- a/util/util_windows.go
+++ b/util/util_windows.go
@@ -14,3 +14,11 @@ func (h *HardlinkChecker) Check(fi os.FileInfo) string {
 }
 func (h *HardlinkChecker) Add(fi os.FileInfo, name string) {
 }
+
+func UID(st os.FileInfo) int {
+	return 0
+}
+
+func GID(st os.FileInfo) int {
+	return 0
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Digging the UID and GID out of an os.FileInfo should work on all Unixy systems, so move it from Linux-specific implementation file to a file that we also build for Darwin.

#### How to verify it

This is heavily exercised on Linux, and cross-compile checks should handle the rest.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```