### PR TITLE
RFC: manifest.list.Add: default to assuming variant=v8 for arm64 images

### DIFF
--- a/manifests/manifests.go
+++ b/manifests/manifests.go
@@ -266,6 +266,18 @@ func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.Imag
 	var instanceInfos []instanceInfo
 	var manifestDigest digest.Digest
 
+	fixupInstanceInfo := func(i instanceInfo) instanceInfo {
+		switch i.Architecture {
+		case "arm":
+			// should we have a default of v6/v7/v8 here, too?
+		case "arm64":
+			if i.Variant == "" {
+				i.Variant = "v8"
+			}
+		}
+		return i
+	}
+
 	primaryManifestBytes, primaryManifestType, err := src.GetManifest(ctx, nil)
 	if err != nil {
 		return "", errors.Wrapf(err, "error reading manifest from %q", transports.ImageName(ref))
@@ -361,6 +373,7 @@ func (l *list) Add(ctx context.Context, sys *types.SystemContext, ref types.Imag
 		if err != nil {
 			return "", errors.Wrapf(err, "error reading manifest from %q, instance %q", transports.ImageName(ref), instanceInfo.instanceDigest)
 		}
+		instanceInfo = fixupInstanceInfo(instanceInfo)
 		if instanceInfo.instanceDigest == nil {
 			manifestDigest, err = manifest.Digest(manifestBytes)
 			if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

When adding images with Architecture="arm64" to a manifest list, default to adding Variant="v8" to the description of the image's target platform, since it can be overwritten later, and it's the only valid value listed in the OCI image index spec.

#### How to verify it

This shouldn't impact testing.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Is this the correct thing?  If so, should we set a variant by default for 32-bit ARM ("arm") as well?

#### Does this PR introduce a user-facing change?

```
Adding an arm64 image to a manifest list will default to marking it for "Variant" = "v8".
```