### PR TITLE
Fix NPE when Dockerfile path contains non-directory entries

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -216,20 +216,19 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options BuildOpt
 			}
 			data = resp.Body
 		} else {
-			// If the Dockerfile isn't found try prepending the
-			// context directory to it.
 			dinfo, err := os.Stat(dfile)
-			if os.IsNotExist(err) {
-				// If they are "/workDir/Dockerfile" and "/workDir"
-				// so don't joint it
+			if err != nil {
+				// If the Dockerfile isn't available, try again with
+				// context directory prepended (if not prepended yet).
 				if !strings.HasPrefix(dfile, options.ContextDirectory) {
 					dfile = filepath.Join(options.ContextDirectory, dfile)
-				}
-				dinfo, err = os.Stat(dfile)
-				if err != nil {
-					return "", nil, err
+					dinfo, err = os.Stat(dfile)
 				}
 			}
+			if err != nil {
+				return "", nil, err
+			}
+
 			// If given a directory, add '/Dockerfile' to it.
 			if dinfo.Mode().IsDir() {
 				dfile = filepath.Join(dfile, "Dockerfile")

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2,6 +2,11 @@
 
 load helpers
 
+@test "bud with a path to a Dockerfile (-f) containing a non-directory entry" {
+  run_buildah 125 bud -f ${TESTSDIR}/bud/non-directory-in-path/non-directory/Dockerfile
+  expect_output --substring "non-directory/Dockerfile: not a directory"
+}
+
 @test "bud with --dns* flags" {
   _prefetch alpine
   run_buildah bud --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc  --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/dns/Dockerfile  ${TESTSDIR}/bud/dns

--- a/tests/bud/non-directory-in-path/non-directory
+++ b/tests/bud/non-directory-in-path/non-directory
@@ -1,0 +1,1 @@
+A dummy file that is not a directory.


### PR DESCRIPTION
When building `nondir/Dockerfile` and `nondir` exists in `os.Getwd()` and is not a directory, `os.Stat()` will return an error which needs to be handled, otherwise `dinfo` will be `nil` and `dinfo.Mode()` will cause panic.