### PR TITLE
Run: don't forcibly disable UTS namespaces in rootless mode

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -1986,7 +1986,6 @@ func (b *Builder) configureEnvironment(g *generate.Generator, options RunOptions
 }
 
 func setupRootlessSpecChanges(spec *specs.Spec, bundleDir string, shmSize string) error {
-	spec.Hostname = ""
 	spec.Process.User.AdditionalGids = nil
 	spec.Linux.Resources = nil
 
@@ -2142,10 +2141,6 @@ func checkAndOverrideIsolationOptions(isolation Isolation, options *RunOptions) 
 			logrus.Debugf("Forcing use of a user namespace.")
 		}
 		options.NamespaceOptions.AddOrReplace(NamespaceOption{Name: string(specs.UserNamespace)})
-		if ns := options.NamespaceOptions.Find(string(specs.UTSNamespace)); ns != nil && !ns.Host {
-			logrus.Debugf("Disabling UTS namespace.")
-		}
-		options.NamespaceOptions.AddOrReplace(NamespaceOption{Name: string(specs.UTSNamespace), Host: true})
 	case IsolationOCI:
 		pidns := options.NamespaceOptions.Find(string(specs.PIDNamespace))
 		userns := options.NamespaceOptions.Find(string(specs.UserNamespace))

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -214,7 +214,6 @@ function configure_and_check_user() {
 }
 
 @test "run --hostname" {
-	skip_if_rootless
 	skip_if_no_runtime
 
 	_prefetch alpine


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

I can't remember why we disabled UTS namespaces for rootless isolation, but it doesn't look necessary.

#### How to verify it

`buildah run --hostname foo $container uname -n` should print "foo" when run as an unprivileged user, which forces use of rootless mode.

#### Which issue(s) this PR fixes:

Report came in via IRC.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
The "--hostname" option for "buildah run" should work as expected for unprivileged users.
```