### PR TITLE
copier.Get(): ignore ENOTSUP/ENOSYS when listing xattrs

### DIFF
--- a/copier/xattrs.go
+++ b/copier/xattrs.go
@@ -45,6 +45,11 @@ func Lgetxattrs(path string) (map[string]string, error) {
 				listSize *= 2
 				continue
 			}
+			if (unwrapError(err) == syscall.ENOTSUP) || (unwrapError(err) == syscall.ENOSYS) {
+				// treat these errors listing xattrs as equivalent to "no xattrs"
+				list = list[:0]
+				break
+			}
 			return nil, errors.Wrapf(err, "error listing extended attributes of %q", path)
 		}
 		list = list[:size]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When trying to read the list of extended attributes on content that we're reading, if we get an ENOTSUP or ENOSYS error while attempting to list the attributes, treat it as if we succeeded and got an empty list of attributes.

#### How to verify it

Build using COPY from a build context on a volume where the filesystem doesn't support extended attributes.

#### Which issue(s) this PR fixes:

Should fix #2774.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```