### PR TITLE
intermediateImageExists: ignore images whose history we can't read

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -126,7 +126,7 @@ func init() {
 	flags.StringVar(&manifestAddOpts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	flags.StringVar(&manifestAddOpts.os, "os", "", "override the `OS` of the specified image")
 	flags.StringVar(&manifestAddOpts.arch, "arch", "", "override the `architecture` of the specified image")
-	flags.StringVar(&manifestAddOpts.variant, "variant", "", "override the `Variant` of the specified image")
+	flags.StringVar(&manifestAddOpts.variant, "variant", "", "override the `variant` of the specified image")
 	flags.StringVar(&manifestAddOpts.osVersion, "os-version", "", "override the OS `version` of the specified image")
 	flags.StringSliceVar(&manifestAddOpts.features, "features", nil, "override the `features` of the specified image")
 	flags.StringSliceVar(&manifestAddOpts.osFeatures, "os-features", nil, "override the OS `features` of the specified image")

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1144,7 +1144,11 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 		// lines in the Dockerfile up till the point we are at in the build.
 		manifestType, history, diffIDs, err := s.executor.getImageTypeAndHistoryAndDiffIDs(ctx, image.ID)
 		if err != nil {
-			return "", errors.Wrapf(err, "error getting history of %q", image.ID)
+			// It's possible that this image is for another architecture, which results
+			// in a custom-crafted error message that we'd have to use substring matching
+			// to recognize.  Instead, ignore the image.
+			logrus.Debugf("error getting history of %q (%v), ignoring it", image.ID, err)
+			continue
 		}
 		// If this candidate isn't of the type that we're building, then it may have lost
 		// some format-specific information that a building-without-cache run wouldn't lose.

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -134,3 +134,25 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah inspect --format ''{{.OCIv1.Architecture}}' test-container
     expect_output --substring arm64
 }
+
+@test "manifest-no-matching-instance" {
+    # Check that local images which we can't load the config and history for
+    # don't just break multi-layer builds.
+    #
+    # Create a test list with some stuff in it.
+    run_buildah manifest create test-list
+    run_buildah manifest add --all test-list ${IMAGE_LIST}
+    # Remove the entry for the current arch from the list.
+    arch=$(go env GOARCH)
+    run_buildah manifest inspect test-list
+    archinstance=$(jq -r '.manifests|map(select(.platform.architecture=="'$arch'"))[].digest' <<< "$output")
+    run_buildah manifest remove test-list $archinstance
+    # Try to build using the build cache.
+    mkdir ${TESTDIR}/build
+    echo 'much content, wow.' > ${TESTDIR}/build/content.txt
+    echo 'FROM scratch' > ${TESTDIR}/build/Dockerfile
+    echo 'ADD content.txt /' >> ${TESTDIR}/build/Dockerfile
+    run_buildah bud --layers --iidfile image-id.txt ${TESTDIR}/build
+    # Make sure we can add the new image to the list.
+    run_buildah manifest add test-list $(cat image-id.txt)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When attempting to read the history of an image in order to try to check if it's suitable as a cache entry for an image we're building, if we fail to read its history, ignore the image instead of failing.

If the image was pulled into local storage for a different architecture, or it's a list with no entry in it for the local architecture, or if
it's a list which references an image for the local architecture that we haven't pulled down, we'll get an error back from the image library, and we don't want to fail because of that.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Stumbled onto this when looking at a podman mailing list thread about manifest lists.

#### Does this PR introduce a user-facing change?

```
None
```