### PR TITLE
Compute diffID for mapped-layer at creating image source

### DIFF
--- a/image.go
+++ b/image.go
@@ -321,10 +321,7 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, sc *types.System
 		}
 		// If we're not re-exporting the data, and we're reusing layers individually, reuse
 		// the blobsum and diff IDs.
-		if !i.exporting && !i.squash && layerID != i.layerID {
-			if layer.UncompressedDigest == "" {
-				return nil, errors.Errorf("unable to look up size of layer %q", layerID)
-			}
+		if !i.exporting && !i.squash && layerID != i.layerID && layer.UncompressedDigest != "" {
 			layerBlobSum := layer.UncompressedDigest
 			layerBlobSize := layer.UncompressedSize
 			diffID := layer.UncompressedDigest

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -203,6 +203,9 @@ load helpers
     expect_output "$rootuid:$rootgid 4700"
     run_buildah run $RUNOPTS "$ctr" stat -c '%u:%g %a' /somedir/someotherfile
     expect_output "0:0 4700"
+
+    # Check that a container with mapped-layer can be committed.
+    run_buildah commit "$ctr" localhost/alpine-working:$i
   done
 }
 


### PR DESCRIPTION
Signed-off-by: Hironori Shiina <shiina.hironori@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
If UID and GID mappings are specified, the container has a
mapped-layer, whose diffID is not computed when created.
Committing the image fails due to lack of diffID. This fix
computes diffID at creating an image source if a layer
doesn't have a diffID (UncompressedDigest).

This fix also tests if a container with UID and GID mappings
can be committed.

#### How to verify it

This PR adds a test to verify if a container with UID and GID
mappings can be committed to `idmapping` in `namespaces.bats`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

Fixes #2800 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

