### PR TITLE
imagebuildah: disable pseudo-terminals for RUN

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -368,6 +368,7 @@ func (s *StageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 		Stderr:           s.executor.err,
 		Quiet:            s.executor.quiet,
 		NamespaceOptions: s.executor.namespaceOptions,
+		Terminal:         buildah.WithoutTerminal,
 	}
 	if config.NetworkDisabled {
 		options.ConfigureNetwork = buildah.NetworkDisabled

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2384,3 +2384,7 @@ EOF
   run cmp tar1 url1
   [[ "$status" -ne 0 ]]
 }
+
+@test "bud-terminal" {
+  run_buildah bud ${TESTSDIR}/bud/terminal
+}

--- a/tests/bud/terminal/Dockerfile
+++ b/tests/bud/terminal/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+RUN ! tty


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Always handle RUN instructions with no pseudo terminal, which matches what I see with docker build 19.03.  Interactive `buildah run` will still have the same default behavior.

#### How to verify it

Tests should continue to pass, and the issue described in https://github.com/containers/podman/issues/8342 should no longer occur.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
RUN instructions in builds will no longer be run attached to a pseudo-terminal.
```