### PR TITLE
Add U volume flag to chown source volumes

### DIFF
--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -581,6 +581,7 @@ process.
    container. The `OPTIONS` are a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
 
    * [rw|ro]
+   * [U]
    * [z|Z|O]
    * [`[r]shared`|`[r]slave`|`[r]private`]
 
@@ -593,9 +594,17 @@ and bind mounts that into the container.
 You can specify multiple  **-v** options to mount one or more mounts to a
 container.
 
+  `Write Protected Volume Mounts`
+
 You can add the `:ro` or `:rw` suffix to a volume to mount it read-only or
 read-write mode, respectively. By default, the volumes are mounted read-write.
 See examples.
+
+  `Chowning Volume Mounts`
+
+By default, Buildah does not change the owner and group of source volume directories mounted into containers. If a container is created in a new user namespace, the UID and GID in the container may correspond to another UID and GID on the host.
+
+The `:U` suffix tells Buildah to use the correct host UID and GID based on the UID and GID within the container, to change the owner and group of the source volume.
 
   `Labeling Volume Mounts`
 
@@ -688,6 +697,8 @@ buildah bud --memory 40m --cpu-period 10000 --cpu-quota 50000 --ulimit nofile=10
 buildah bud --security-opt label=level:s0:c100,c200 --cgroup-parent /path/to/cgroup/parent -t imageName .
 
 buildah bud --volume /home/test:/myvol:ro,Z -t imageName .
+
+buildah bud -v /home/test:/myvol:z,U -t imageName .
 
 buildah bud -v /var/lib/dnf:/var/lib/dnf:O -t imageName .
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -449,6 +449,7 @@ process.
    container. The `OPTIONS` are a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
 
    * [rw|ro]
+   * [U]
    * [z|Z|O]
    * [`[r]shared`|`[r]slave`|`[r]private`|`[r]unbindable`]
 
@@ -461,9 +462,17 @@ and bind mounts that into the container.
 You can specify multiple  **-v** options to mount one or more mounts to a
 container.
 
+  `Write Protected Volume Mounts`
+
 You can add the `:ro` or `:rw` suffix to a volume to mount it read-only or
 read-write mode, respectively. By default, the volumes are mounted read-write.
 See examples.
+
+  `Chowning Volume Mounts`
+
+By default, Buildah does not change the owner and group of source volume directories mounted into containers. If a container is created in a new user namespace, the UID and GID in the container may correspond to another UID and GID on the host.
+
+The `:U` suffix tells Buildah to use the correct host UID and GID based on the UID and GID within the container, to change the owner and group of the source volume.
 
   `Labeling Volume Mounts`
 
@@ -552,6 +561,8 @@ buildah from --memory 40m --cpu-shares 2 --cpuset-cpus 0,2 --security-opt label=
 buildah from --ulimit nofile=1024:1028 --cgroup-parent /path/to/cgroup/parent myregistry/myrepository/imagename:imagetag
 
 buildah from --volume /home/test:/myvol:ro,Z myregistry/myrepository/imagename:imagetag
+
+buildah from -v /home/test:/myvol:z,U myregistry/myrepository/imagename:imagetag
 
 buildah from -v /var/lib/yum:/var/lib/yum:O myregistry/myrepository/imagename:imagetag
 

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -188,6 +188,7 @@ bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the Buildah
 container. The `OPTIONS` are a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
 
    * [rw|ro]
+   * [U]
    * [z|Z]
    * [`[r]shared`|`[r]slave`|`[r]private`]
 
@@ -200,9 +201,19 @@ and bind mounts that into the container.
 You can specify multiple  **-v** options to mount one or more mounts to a
 container.
 
+  `Write Protected Volume Mounts`
+
 You can add the `:ro` or `:rw` suffix to a volume to mount it read-only or
 read-write mode, respectively. By default, the volumes are mounted read-write.
 See examples.
+
+  `Chowning Volume Mounts`
+
+By default, Buildah does not change the owner and group of source volume directories mounted into containers. If a container is created in a new user namespace, the UID and GID in the container may correspond to another UID and GID on the host.
+
+The `:U` suffix tells Buildah to use the correct host UID and GID based on the UID and GID within the container, to change the owner and group of the source volume.
+
+  `Labeling Volume Mounts`
 
 Labeling systems like SELinux require that proper labels are placed on volume
 content mounted into a container. Without a label, the security system might
@@ -269,6 +280,8 @@ buildah run --tty containerID /bin/bash
 buildah run --tty=false containerID ls /
 
 buildah run --volume /path/on/host:/path/in/container:ro,z containerID sh
+
+buildah run -v /path/on/host:/path/in/container:z,U containerID sh
 
 buildah run --mount type=bind,src=/tmp/on:host,dst=/in:container,ro containerID sh
 

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -486,7 +486,7 @@ func ValidateVolumeCtrDir(ctrDir string) error {
 
 // ValidateVolumeOpts validates a volume's options
 func ValidateVolumeOpts(options []string) ([]string, error) {
-	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid int
+	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid, foundChown int
 	finalOpts := make([]string, 0, len(options))
 	for _, opt := range options {
 		switch opt {
@@ -514,6 +514,11 @@ func ValidateVolumeOpts(options []string) ([]string, error) {
 			foundLabelChange++
 			if foundLabelChange > 1 {
 				return nil, errors.Errorf("invalid options %q, can only specify 1 'z', 'Z', or 'O' option", strings.Join(options, ", "))
+			}
+		case "U":
+			foundChown++
+			if foundChown > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'U' option", strings.Join(options, ", "))
 			}
 		case "private", "rprivate", "shared", "rshared", "slave", "rslave", "unbindable", "runbindable":
 			foundRootPropagation++

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -252,6 +252,25 @@ function configure_and_check_user() {
 	run_buildah run -v ${TESTDIR}/was-empty/testfile:/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
 }
 
+@test "run --volume with U flag" {
+  skip_if_no_runtime
+
+  # Create source volume.
+  mkdir ${TESTDIR}/testdata
+
+  # Create the container.
+  _prefetch alpine
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json alpine
+  ctr="$output"
+
+  # Test user can create file in the mounted volume.
+  run_buildah run --user 888:888 --volume ${TESTDIR}/testdata:/mnt:z,U "$ctr" touch /mnt/testfile1.txt
+
+  # Test created file has correct UID and GID ownership.
+  run_buildah run --user 888:888 --volume ${TESTDIR}/testdata:/mnt:z,U "$ctr" stat -c "%u:%g" /mnt/testfile1.txt
+  expect_output "888:888"
+}
+
 @test "run --mount" {
 	skip_if_no_runtime
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

It adds the U volume flag to chown source volumes based on the uid, gid within the container. 

When a new container is created with a user namespace, we want to get the uid,gid that has been assigned outside the container to chown source volumes. This will isolate the filesystem (source volumes) from other containers (users, groups) since they will be owned by the same user and group within the container.

This is required by podman, so it can parse the U volume flag. 
Podman Issue: [7778](https://github.com/containers/podman/issues/7778)

#### How to verify it

There is an integration test to validate this functionality.
Example:
```
# Create source volume
mkdir -p /var/tmp/foo

# Create container with user namespace and mount volume using U flag
buildah from --userns-uid-map 0:1000:1024 --userns-gid-map 0:1000:1024 --volume /var/tmp/foo:/testdata:z,U --name container-foo alpine

# Ensure owner of the volume is 0:0
buildah run container-foo stat -c "%u:%g" /testdata

# Ensure source volume has been chowned based on user namespace mapping
stat -c "%u:%g" /var/tmp/foo
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None

Signed-off-by: Eduardo Vega <edvegavalerio@gmail.com>

