### PR TITLE
Fix crash on invalid filter commands

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -171,7 +171,7 @@ func imagesCmd(c *cobra.Command, args []string, iopts *imageResults) error {
 	if iopts.filter != "" {
 		params, err = parseFilter(ctx, store, images, iopts.filter)
 		if err != nil {
-			return errors.Wrapf(err, "error parsing filter")
+			return err
 		}
 	}
 
@@ -183,6 +183,9 @@ func parseFilter(ctx context.Context, store storage.Store, images []storage.Imag
 	filterStrings := strings.Split(filter, ",")
 	for _, param := range filterStrings {
 		pair := strings.SplitN(param, "=", 2)
+		if len(pair) < 2 {
+			return nil, errors.Errorf("invalid filter: %q requires value", filter)
+		}
 		switch strings.TrimSpace(pair[0]) {
 		case "dangling":
 			if pair[1] == "true" || pair[1] == "false" {
@@ -195,14 +198,14 @@ func parseFilter(ctx context.Context, store storage.Store, images []storage.Imag
 		case "before":
 			beforeDate, err := setFilterDate(ctx, store, images, pair[1])
 			if err != nil {
-				return nil, errors.Errorf("no such id: %s", pair[0])
+				return nil, errors.Wrapf(err, "invalid filter: '%s=[%s]'", pair[0], pair[1])
 			}
 			params.beforeDate = beforeDate
 			params.beforeImage = pair[1]
 		case "since":
 			sinceDate, err := setFilterDate(ctx, store, images, pair[1])
 			if err != nil {
-				return nil, errors.Errorf("no such id: %s", pair[0])
+				return nil, errors.Wrapf(err, "invalid filter: '%s=[%s]'", pair[0], pair[1])
 			}
 			params.sinceDate = sinceDate
 			params.sinceImage = pair[1]

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -275,7 +275,7 @@ func TestParseFilterInvalidBefore(t *testing.T) {
 
 	label := "dangling=false,label=a=b,before=:,since=busybox:latest,reference=abcdef"
 	_, err = parseFilter(getContext(), store, images, label)
-	if err == nil || !strings.Contains(err.Error(), "no such id") {
+	if err == nil || !strings.Contains(err.Error(), "invalid filter") {
 		t.Fatalf("expected error parsing filter")
 	}
 }
@@ -299,7 +299,7 @@ func TestParseFilterInvalidSince(t *testing.T) {
 
 	label := "dangling=false,label=a=b,before=busybox:latest,since=:,reference=abcdef"
 	_, err = parseFilter(getContext(), store, images, label)
-	if err == nil || !strings.Contains(err.Error(), "no such id") {
+	if err == nil || !strings.Contains(err.Error(), "invalid filter") {
 		t.Fatalf("expected error parsing filter")
 	}
 }

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -46,6 +46,11 @@ load helpers
   cid1=$output
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
   cid2=$output
+
+  run_buildah 125 images --noheading --filter since k8s.gcr.io/pause
+  expect_output 'invalid filter: "since" requires value'
+
+
   run_buildah images --noheading --filter since=k8s.gcr.io/pause
   expect_line_count 1
 }


### PR DESCRIPTION
If users forget to use "=" sign when doing image filters
buildah was crashing.

Fixes: https://github.com/containers/buildah/issues/2763

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

