### PR TITLE
Add container information to .containerenv

### DIFF
--- a/tests/run.bats
+++ b/tests/run.bats
@@ -391,6 +391,23 @@ function configure_and_check_user() {
 	# test a standard mount to /run/.containerenv
 	run_buildah run $cid ls -1 /run/.containerenv
 	expect_output --substring "/run/.containerenv"
+
+	run_buildah run $cid sh -c '. /run/.containerenv; echo $engine'
+	expect_output --substring "buildah"
+
+	run_buildah run $cid sh -c '. /run/.containerenv; echo $name'
+	expect_output "alpine-working-container"
+
+	run_buildah run $cid sh -c '. /run/.containerenv; echo $image'
+	expect_output --substring "alpine:latest"
+
+	rootless=0
+	if ["$(id -u)" -ne 0 ]; then
+		rootless=1
+	fi
+
+	run_buildah run $cid sh -c '. /run/.containerenv; echo $rootless'
+	expect_output ${rootless}
 }
 
 @test "run-device" {


### PR DESCRIPTION
We have been asked to leak some container information
and image information into the container to be used
by certain tools. (Toolbox and others)

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

