### PR TITLE
Add a source debug build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,14 @@ SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go cmd/buildah/*.go copier/*.g
 
 LINTFLAGS ?=
 
+ifeq ($(DEBUG), 1)
+  override GOGCFLAGS += -N -l
+endif
+
+#   make all DEBUG=1
+#     Note: Uses the -N -l go compiler options to disable compiler optimizations
+#           and inlining. Using these build options allows you to subsequently
+#           use source debugging tools like delve.
 all: bin/buildah bin/imgtype docs
 
 # Update nix/nixpkgs.json its latest stable commit
@@ -56,7 +64,7 @@ static:
 
 .PHONY: bin/buildah
 bin/buildah:  $(SOURCES)
-	$(GO_BUILD) $(BUILDAH_LDFLAGS) -o $@ $(BUILDFLAGS) ./cmd/buildah
+	$(GO_BUILD) $(BUILDAH_LDFLAGS) -gcflags "$(GOGCFLAGS)" -o $@ $(BUILDFLAGS) ./cmd/buildah
 
 .PHONY: buildah
 buildah: bin/buildah

--- a/install.md
+++ b/install.md
@@ -473,6 +473,13 @@ cat /etc/containers/policy.json
 }
 ```
 
+## Debug with Delve and the like
+
+To make a source debug build without optimizations use `DEBUG=1`, like:
+```
+make all DEBUG=1
+```
+
 ## Vendoring
 
 Buildah uses Go Modules for vendoring purposes.  If you need to update or add a vendored package into Buildah, please follow this procedure:


### PR DESCRIPTION
Add target: make all DEBUG=1.
Uses the -N -l go compiler options to disable compiler optimizations
and inlining. Using these build options allows you to subsequently
use source debugging tools like delve.

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 

/kind feature

> /kind flake
> /kind other

#### What this PR does / why we need it:

Allows making source debug builds of buildah to use it with tools like Delve or [gdlv](https://github.com/aarzilli/gdlv)

#### How to verify it

```
make _something_ DEBUG=1
```
then use ``(g)dlv exec``, like
```
sudo gdlv exec /usr/local/bin/buildah --log-level=debug  bud _anything_
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

