### PR TITLE
Not use local image create/add manifest

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -237,10 +237,13 @@ func manifestCreateCmd(c *cobra.Command, args []string, opts manifestCreateOpts)
 	}
 
 	for _, imageSpec := range imageSpecs {
-		ref, _, err := util.FindImage(store, "", systemContext, imageSpec)
+		ref, err := alltransports.ParseImageName(imageSpec)
 		if err != nil {
-			if ref, err = alltransports.ParseImageName(imageSpec); err != nil {
-				return err
+			if ref, err = alltransports.ParseImageName(util.DefaultTransport + imageSpec); err != nil {
+				// check if the local image exists
+				if ref, _, err = util.FindImage(store, "", systemContext, imageSpec); err != nil {
+					return err
+				}
 			}
 		}
 		if _, err = list.Add(getContext(), systemContext, ref, opts.all); err != nil {
@@ -293,10 +296,13 @@ func manifestAddCmd(c *cobra.Command, args []string, opts manifestAddOpts) error
 		return err
 	}
 
-	ref, _, err := util.FindImage(store, "", systemContext, imageSpec)
+	ref, err := alltransports.ParseImageName(imageSpec)
 	if err != nil {
-		if ref, err = alltransports.ParseImageName(imageSpec); err != nil {
-			return err
+		if ref, err = alltransports.ParseImageName(util.DefaultTransport + imageSpec); err != nil {
+			// check if the local image exists
+			if ref, _, err = util.FindImage(store, "", systemContext, imageSpec); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Avoid first checking the image from local storage for `manifest create` and `manifest add`
since the local image does not include other entries of the list from the registry.
`--all` flag of `manifest create` and `manifest add` can not add all of the lists as expected.
So first attempt to get manifest from the registry and if not successful, fall back to use local images.

Signed-off-by: Qi Wang <qiwan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

