### PR TITLE
Move away from using docker.io

### DIFF
--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -57,8 +57,9 @@ load helpers
 }
 
 @test "commit-alternate-storage" {
+  _prefetch alpine
   echo FROM
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json openshift/hello-openshift
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
   echo COMMIT
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid "containers-storage:[vfs@${TESTDIR}/root2+${TESTDIR}/runroot2]newimage"

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -60,6 +60,10 @@ function teardown() {
 }
 
 function _prefetch() {
+	# Tell podman to use the same mirror registries as buildah, to
+	# avoid docker.io
+	export REGISTRIES_CONFIG_PATH=${TESTSDIR}/registries.conf
+
 	if [ -z "${_BUILDAH_IMAGE_CACHEDIR}" ]; then
             _pgid=$(sed -ne 's/^NSpgid:\s*//p' /proc/$$/status)
             export _BUILDAH_IMAGE_CACHEDIR=${BATS_TMPDIR}/buildah-image-cache.$_pgid

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -36,7 +36,7 @@ load helpers
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine_nginx:latest"
 
-  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json alpine@sha256:1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe
+  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json alpine@sha256:e9a2035f9d0d7cee1cdd445f5bfa0c5c646455ee26f14565dce23cf2d2de7570
   run_buildah 125 pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json fakeimage/fortest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   [[ ! "$output" =~ "fakeimage/fortest" ]]

--- a/tests/registries.bats
+++ b/tests/registries.bats
@@ -26,7 +26,7 @@ load helpers
     run_buildah rmi -a
   }
   # Test with pairs of short and fully-qualified names that should be the same image.
-  registrypair busybox        docker.io/busybox
-  registrypair busybox        docker.io/library/busybox
-  registrypair fedora-minimal registry.fedoraproject.org/fedora-minimal
+  registrypair busybox           docker.io/busybox
+  registrypair busybox           docker.io/library/busybox
+  registrypair fedora-minimal:32 registry.fedoraproject.org/fedora-minimal:32
 }

--- a/tests/registries.conf
+++ b/tests/registries.conf
@@ -1,25 +1,17 @@
-# This is a system-wide configuration file used to
-# keep track of registries for various container backends.
-# It adheres to TOML format and does not support recursive
-# lists of registries.
+# Note that changing the order here may break tests.
+unqualified-search-registries = ['docker.io', 'quay.io', 'registry.fedoraproject.org']
 
-# The default location for this configuration file is /etc/containers/registries.conf.
+[[registry]]
+# In Nov. 2020, Docker rate-limits image pulling.  To avoid hitting these
+# limits while testing, always use the google mirror for qualified and
+# unqualified `docker.io` images.
+# Ref: https://cloud.google.com/container-registry/docs/pulling-cached-images
+prefix="docker.io"
+location="mirror.gcr.io"
 
-# The only valid categories are: 'registries.search', 'registries.insecure', 
-# and 'registries.block'.
-
-[registries.search]
-registries = ['docker.io', 'quay.io', 'registry.fedoraproject.org']
-
-# If you need to access insecure registries, add the registry's fully-qualified name.
-# An insecure registry is one that does not have a valid SSL certificate or only does HTTP.
-[registries.insecure]
-registries = []
-
-
-# If you need to block pull access from a registry, uncomment the section below
-# and add the registries fully-qualified name.
-#
-# Docker only
-[registries.block]
-registries = []
+# 2020-10-27 a number of images are not present in gcr.io, and podman
+# barfs spectacularly when trying to fetch them. We've hand-copied
+# those to quay, using skopeo copy --all ...
+[[registry]]
+prefix="docker.io/library"
+location="quay.io/libpod"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -348,7 +348,7 @@ function configure_and_check_user() {
 @test "run-builtin-volume-omitted" {
 	# This image is known to include a volume, but not include the mountpoint
 	# in the image.
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json docker.io/library/registry@sha256:a25e4660ed5226bdb59a5e555083e08ded157b1218282840e55d25add0223390
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/registry:volume_omitted
 	cid=$output
 	run_buildah mount $cid
 	mnt=$output


### PR DESCRIPTION
November 2020, docker.io started restricting unauthenticated
image pulls. Try to work around this by using a custom
registries.conf file.

For the most part this means copying images from docker.io
to quay.io, via:

   $ skopeo copy --all docker://docker.io/library/img:tag \
                       docker://quay.io/libpod/img:tag

...for the following values of 'img:tag':

   busybox:musl
   centos:7  centos:8  centos:latest
   composer:latest
   debian:latest       ubuntu:latest
   docker:latest
   php:7.2

For each of those, it was necessary to go into the quay.io
GUI, click the image name, click the settings (gear) icon
at bottom left, click 'Make public', and confirm.

This process did not work in four instances, which required
special-casing:

   commit.bats : openshift/hello-openshift did not match the
                 mirroring rules; I switched to alpine instead.
                 Nalin confirmed on IRC that there was no magic
                 reason for requiring hello-openshift.

   pull.bats   : change a SHA. AFAICT there was nothing magic
                 about the SHA being used, it was just a
                 convenient one for purposes of testing
                 pull-by-sha. I simply switched to the SHA
                 of an image present on quay.

   registries.bats : was assuming that fedora-minimal shortname
                     would be pulled from fedora registry.
                     Unfortunately, we have a copy on quay
                     (for podman tests), so that's what we
                     pull by shortname, and it does not match
                     the SHA of the fedoraproject.org one.
                     Solution: pull by tag (fedora-minimal:32)
                     and hope that nobody ever mirrors that one
                     on quay.

   run.bats    : another pull-by-SHA, but this time I changed
                 the SHA to a named tag, and skopeo copy'd
                 that image from docker.io to the given name
                 on quay. This time there _is_ something
                 magic about that particular SHA (it's an
                 image with a specific volume quirk) but
                 there's no actual reason to reference it
                 by SHA - we simply did so because we have
                 no control over tag names on docker.io.
                 Since we control tag names on quay.io,
                 it's easy and more maintainable to give
                 this image a descriptive tag.

Signed-off-by: Ed Santiago <santiago@redhat.com>
