### PR TITLE
Allow users to specify stdin into containers

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -197,6 +198,10 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		return errors.Wrapf(err, "error evaluating symlinks in build context path")
 	}
 
+	var stdin io.Reader
+	if iopts.Stdin {
+		stdin = os.Stdin
+	}
 	var stdout, stderr, reporter *os.File
 	stdout = os.Stdout
 	stderr = os.Stderr
@@ -321,6 +326,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		From:                    iopts.From,
 		IDMappingOptions:        idmappingOptions,
 		IIDFile:                 iopts.Iidfile,
+		In:                      stdin,
 		Isolation:               isolation,
 		Labels:                  iopts.Label,
 		Layers:                  layers,

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -492,6 +492,12 @@ Sign the built image using the GPG key that matches the specified fingerprint.
 Squash all of the image's new layers into a single new layer; any preexisting layers
 are not squashed.
 
+**--stdin**
+
+Pass stdin into the RUN containers. Sometime commands being RUN within a Containerfile
+want to request information from the user. For example apt asking for a confirmation for install.
+Use --stdin to be able to interact from the terminal during the build.
+
 **--tag**, **-t** *imageName*
 
 Specifies the name which will be assigned to the resulting image if the build

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -82,6 +82,7 @@ type BudResults struct {
 	SignaturePolicy     string
 	SignBy              string
 	Squash              bool
+	Stdin               bool
 	Tag                 []string
 	Target              string
 	TLSVerify           bool
@@ -217,6 +218,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 		panic(fmt.Sprintf("error marking the signature-policy flag as hidden: %v", err))
 	}
 	fs.BoolVar(&flags.Squash, "squash", false, "squash newly built layers into a single new layer")
+	fs.BoolVar(&flags.Stdin, "stdin", false, "pass stdin into containers")
 	fs.StringArrayVarP(&flags.Tag, "tag", "t", []string{}, "tagged `name` to apply to the built image")
 	fs.StringVar(&flags.Target, "target", "", "set the target build stage to build")
 	fs.Int64Var(&flags.Timestamp, "timestamp", 0, "set created timestamp to the specified epoch seconds to allow for deterministic builds, defaults to current time")


### PR DESCRIPTION
Some commands within a Containerfile, might need input from users.
For example confirmation commands from Apt.

Adding a --stdin flag will allows users to interact with containers
while running inside of buildah bud.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

