### PR TITLE
pkg, cli: rootless uses correct isolation

### DIFF
--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/common/pkg/auth"
 	commonComp "github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/config"
+	"github.com/containers/storage/pkg/unshare"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -365,6 +366,9 @@ func DefaultIsolation() string {
 	isolation := os.Getenv("BUILDAH_ISOLATION")
 	if isolation != "" {
 		return isolation
+	}
+	if unshare.IsRootless() {
+		return "rootless"
 	}
 	return buildah.OCI
 }


### PR DESCRIPTION
when running as rootless, make sure the cli default isolation is set
to "rootless" instead of "oci".

Closes: https://github.com/containers/buildah/issues/2750

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

use "rootless" isolation by default when running rootless

#### How to verify it
follow the steps in https://github.com/containers/buildah/issues/2750

#### Which issue(s) this PR fixes:
https://github.com/containers/buildah/issues/2750

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

