### PR TITLE
Remove a "storage mountopt" workaround

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -178,22 +178,6 @@ showrun() {
     "$@"
 }
 
-# workaround issue 1945 (remove when resolved)
-remove_storage_mountopt() {
-    local FILEPATH=/etc/containers/storage.conf
-    warn "remove_storage_mountopt() is overwriting $FILEPATH"
-    # This file normally comes from containers-common package
-    cat <<EOF> $FILEPATH
-[storage]
-driver = "overlay"
-runroot = "/var/run/containers/storage"
-graphroot = "/var/lib/containers/storage"
-[storage.options]
-mountopt = ""
-EOF
-    cat $FILEPATH
-}
-
 # Remove all files provided by the distro version of buildah.
 # All VM cache-images used for testing include the distro buildah because it
 # simplifies installing necessary dependencies which can change over time.

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -67,10 +67,14 @@ echo -e "[registries.search]\nregistries = ['docker.io', 'registry.fedoraproject
 
 show_env_vars
 
+echo "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"
+echo "/etc/containers/storage.conf :"
+ls -l /etc/containers/storage.conf
+cat   /etc/containers/storage.conf
+echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+
 if [[ -z "$CROSS_TARGET" ]]
 then
-    remove_storage_mountopt  # workaround issue 1945 (remove when resolved)
-
     execute_local_registry  # checks for existing port 5000 listener
 
     if [[ "$IN_PODMAN" == "true" ]]


### PR DESCRIPTION
PR #2115 (Kill Travis and Enable Bors, merged 2020-02-07) added
code that completely clobbered /etc/containers/storage.conf,
as a workaround for issue #1945. That closed 2020-04-29, and
the workaround is now a liability that has wasted developer
time. Remove it.

Signed-off-by: Ed Santiago <santiago@redhat.com>
