### PR TITLE
Switch references of /var/run -> /run

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -186,7 +186,7 @@ remove_storage_mountopt() {
     cat <<EOF> $FILEPATH
 [storage]
 driver = "overlay"
-runroot = "/var/run/containers/storage"
+runroot = "/run/containers/storage"
 graphroot = "/var/lib/containers/storage"
 [storage.options]
 mountopt = ""

--- a/docs/buildah-info.md
+++ b/docs/buildah-info.md
@@ -56,7 +56,7 @@ $ buildah info
         "ImageStore": {
             "number": 1
         },
-        "RunRoot": "/var/run/containers/storage"
+        "RunRoot": "/run/containers/storage"
     }
 }
 ```
@@ -64,7 +64,7 @@ $ buildah info
 Run buildah info and retrieve only the store information:
 ```
 $ buildah info --format={{".store"}}
-map[GraphOptions:[overlay.override_kernel_check=true] GraphStatus:map[Backing Filesystem:extfs Supports d_type:true Native Overlay Diff:true] ImageStore:map[number:1] ContainerStore:map[number:2] GraphRoot:/var/lib/containers/storage RunRoot:/var/run/containers/storage GraphDriverName:overlay]
+map[GraphOptions:[overlay.override_kernel_check=true] GraphStatus:map[Backing Filesystem:extfs Supports d_type:true Native Overlay Diff:true] ImageStore:map[number:1] ContainerStore:map[number:2] GraphRoot:/var/lib/containers/storage RunRoot:/run/containers/storage GraphDriverName:overlay]
 ```
 
 ## SEE ALSO

--- a/docs/buildah-unshare.md
+++ b/docs/buildah-unshare.md
@@ -35,7 +35,7 @@ buildah unshare pwd
 
 buildah unshare cat /proc/self/uid\_map /proc/self/gid\_map
 
-buildah unshare rm -fr $HOME/.local/share/containers/storage /var/run/user/\`id -u\`/run
+buildah unshare rm -fr $HOME/.local/share/containers/storage /run/user/\`id -u\`/run
 
 buildah unshare --mount containerID sh -c 'cat ${containerID}/etc/os-release'
 

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -51,7 +51,7 @@ Default root dir is configured in /etc/containers/storage.conf
 
 **--runroot** **value**
 
-Storage state dir (default: "/var/run/containers/storage" for UID 0, "/var/run/user/$UID" for other users)
+Storage state dir (default: "/run/containers/storage" for UID 0, "/run/user/$UID" for other users)
 Default state dir is configured in /etc/containers/storage.conf
 
 **--storage-driver** **value**

--- a/docs/tutorials/03-on-build.md
+++ b/docs/tutorials/03-on-build.md
@@ -69,7 +69,7 @@ The second container is now created and the `/bar` file will be created within i
 STEP 1: FROM onbuild-image
 STEP 2: RUN touch /bar    # Note /bar created here based on the ONBUILD in Dockerfile
 STEP 3: RUN touch /baz
-STEP 4: COMMIT containers-storage:[overlay@/var/lib/containers/storage+/var/run/containers/storage:overlay.override_kernel_check=true]localhost/result-image:latest
+STEP 4: COMMIT containers-storage:[overlay@/var/lib/containers/storage+/run/containers/storage:overlay.override_kernel_check=true]localhost/result-image:latest
 {output edited for brevity}
 $ container=$(sudo buildah from result-image:latest)
 # buildah run $container ls /bar /foo /baz
@@ -98,7 +98,7 @@ The onbuild-image has been created, so now create a container from it using the 
 STEP 1: FROM onbuild-image
 STEP 2: RUN touch /bar    # Note /bar created here based on the ONBUILD in Dockerfile
 STEP 3: RUN touch /baz
-STEP 4: COMMIT containers-storage:[overlay@/var/lib/containers/storage+/var/run/containers/storage:overlay.override_kernel_check=true]localhost/result-image:latest
+STEP 4: COMMIT containers-storage:[overlay@/var/lib/containers/storage+/run/containers/storage:overlay.override_kernel_check=true]localhost/result-image:latest
 {output edited for brevity}
 $ container=$(sudo buildah from result-image:latest)
 # buildah run $container ls /bar /foo /baz


### PR DESCRIPTION
Systemd is now complaining or mentioning /var/run as a legacy directory.
It has been many years where /var/run is a symlink to /run on all
most distributions, make the change to the default.

Partial fix for https://github.com/containers/podman/issues/8369

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

