### PR TITLE
SELinux no longer requires a tag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 export GOPROXY=https://proxy.golang.org
 
-SELINUXTAG := $(shell ./selinux_tag.sh)
 APPARMORTAG := $(shell hack/apparmor_tag.sh)
 STORAGETAGS := $(shell ./btrfs_tag.sh) $(shell ./btrfs_installed_tag.sh) $(shell ./libdm_tag.sh)
-SECURITYTAGS ?= seccomp $(SELINUXTAG) $(APPARMORTAG)
+SECURITYTAGS ?= seccomp $(APPARMORTAG)
 TAGS ?= $(SECURITYTAGS) $(STORAGETAGS)
 BUILDTAGS += $(TAGS)
 PREFIX := /usr/local

--- a/chroot/selinux.go
+++ b/chroot/selinux.go
@@ -1,4 +1,4 @@
-// +build linux,selinux
+// +build linux
 
 package chroot
 

--- a/chroot/selinux_unsupported.go
+++ b/chroot/selinux_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux !selinux
+// +build !linux
 
 package chroot
 

--- a/selinux.go
+++ b/selinux.go
@@ -1,4 +1,4 @@
-// +build selinux,linux
+// +build linux
 
 package buildah
 

--- a/selinux_unsupported.go
+++ b/selinux_unsupported.go
@@ -1,4 +1,4 @@
-// +build !selinux !linux
+// +build !linux
 
 package buildah
 


### PR DESCRIPTION
It should work fine on linux and not linux boxes. Since there
is no glibc added, we can safely compile and run this code
on non SELinux boxes.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

