### PR TITLE
Use --arch and --os options to select architecture and os

### DIFF
--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -20,8 +20,6 @@ type pullOptions struct {
 	blobCache        string
 	certDir          string
 	creds            string
-	overrideArch     string
-	overrideOS       string
 	signaturePolicy  string
 	quiet            bool
 	removeSignatures bool
@@ -67,14 +65,9 @@ func init() {
 		panic(fmt.Sprintf("error marking signature-policy as hidden: %v", err))
 	}
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "don't output progress information when pulling images")
-	flags.StringVar(&opts.overrideOS, "override-os", runtime.GOOS, "prefer `OS` instead of the running OS for choosing images")
-	if err := flags.MarkHidden("override-os"); err != nil {
-		panic(fmt.Sprintf("error marking override-os as hidden: %v", err))
-	}
-	flags.StringVar(&opts.overrideArch, "override-arch", runtime.GOARCH, "prefer `ARCH` instead of the architecture of the machine for choosing images")
-	if err := flags.MarkHidden("override-arch"); err != nil {
-		panic(fmt.Sprintf("error marking override-arch as hidden: %v", err))
-	}
+	flags.String("os", runtime.GOOS, "prefer `OS` instead of the running OS for choosing images")
+	flags.String("arch", runtime.GOARCH, "prefer `ARCH` instead of the architecture of the machine for choosing images")
+	flags.String("variant", "", "override the `variant` of the specified image")
 	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
 	if err := flags.MarkHidden("blob-cache"); err != nil {
 		panic(fmt.Sprintf("error marking blob-cache as hidden: %v", err))

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -44,7 +44,7 @@ Note: this information is not present in Docker image formats, so it is discarde
 
 **--arch**="ARCH"
 
-Set the ARCH of the image to the provided value instead of using the architecture of the host.
+Set the ARCH of the image to be pulled to the provided value instead of using the architecture of the host. (Examples: aarch64, arm, i686, ppc64le, s390x, x86_64)
 
 **--authfile** *path*
 
@@ -393,7 +393,7 @@ Do not use existing cached images for the container build. Build from the start 
 
 **--os**="OS"
 
-Set the OS of the image to the provided value instead of using the current operating system of the host.
+Set the OS of the image to be pulled instead of using the current operating system of the host.
 
 **--pid** *how*
 
@@ -588,6 +588,10 @@ that the UTS namespace in which `buildah` itself is being run should be reused,
 or it can be the path to a UTS namespace which is already in use by another
 process.
 
+**--variant**=""
+
+Set the architecture variant of the image to be pulled.
+
 **--volume**, **-v**[=*[HOST-DIR:CONTAINER-DIR[:OPTIONS]]*]
 
    Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Buildah
@@ -726,6 +730,8 @@ buildah bud --authfile /tmp/auths/myauths.json --cert-dir ~/auth --tls-verify=tr
 buildah bud --memory 40m --cpu-period 10000 --cpu-quota 50000 --ulimit nofile=1024:1028 -t imageName .
 
 buildah bud --security-opt label=level:s0:c100,c200 --cgroup-parent /path/to/cgroup/parent -t imageName .
+
+buildah bud --arch=arm --variant v7 -t imageName .
 
 buildah bud --volume /home/test:/myvol:ro,Z -t imageName .
 

--- a/docs/buildah-from.md
+++ b/docs/buildah-from.md
@@ -49,6 +49,10 @@ Add a custom host-to-IP mapping (host:ip)
 
 Add a line to /etc/hosts. The format is hostname:ip. The **--add-host** option can be set multiple times.
 
+**--arch**="ARCH"
+
+Set the ARCH of the image to be pulled to the provided value instead of using the architecture of the host. (Examples: aarch64, arm, i686, ppc64le, s390x, x86_64)
+
 **--authfile** *path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
@@ -271,6 +275,10 @@ that the network namespace in which `Buildah` itself is being run should be
 reused, or it can be the path to a network namespace which is already in use by
 another process.
 
+**--os**="OS"
+
+Set the OS of the image to be pulled instead of using the current operating system of the host.
+
 **--pid** *how*
 
 Sets the configuration for PID namespaces when the container is subsequently
@@ -442,6 +450,10 @@ that the UTS namespace in which `Buildah` itself is being run should be reused,
 or it can be the path to a UTS namespace which is already in use by another
 process.
 
+**--variant**=""
+
+Set the architecture variant of the image to be pulled.
+
 **--volume**, **-v**[=*[HOST-DIR:CONTAINER-DIR[:OPTIONS]]*]
 
    Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Buildah
@@ -565,6 +577,8 @@ buildah from --volume /home/test:/myvol:ro,Z myregistry/myrepository/imagename:i
 buildah from -v /home/test:/myvol:z,U myregistry/myrepository/imagename:imagetag
 
 buildah from -v /var/lib/yum:/var/lib/yum:O myregistry/myrepository/imagename:imagetag
+
+buildah from --arch=arm --variant v7 myregistry/myrepository/imagename:imagetag
 
 ## ENVIRONMENT
 

--- a/docs/buildah-pull.md
+++ b/docs/buildah-pull.md
@@ -46,6 +46,10 @@ The image ID of the image that was pulled.  On error 1 is returned.
 
 All tagged images in the repository will be pulled.
 
+**--arch**="ARCH"
+
+Set the ARCH of the image to be pulled to the provided value instead of using the architecture of the host. (Examples: aarch64, arm, i686, ppc64le, s390x, x86_64)
+
 **--authfile** *path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `buildah login`.
@@ -70,6 +74,10 @@ The [key[:passphrase]] to be used for decryption of images. Key can point to key
 
 If an image needs to be pulled from the registry, suppress progress output.
 
+**--os**="OS"
+
+Set the OS of the image to be pulled instead of using the current operating system of the host.
+
 **--policy**=**always**|**missing**|**never**
 
 Pull image policy. The default is **missing**.
@@ -86,6 +94,9 @@ Don't copy signatures when pulling images.
 
 Require HTTPS and verify certificates when talking to container registries (defaults to true).  TLS verification cannot be used when talking to an insecure registry.
 
+**--variant**=""
+
+Set the architecture variant of the image to be pulled.
 
 ## EXAMPLE
 
@@ -106,6 +117,10 @@ buildah pull --tls-verify=false myregistry/myrepository/imagename:imagetag
 buildah pull --creds=myusername:mypassword --cert-dir ~/auth myregistry/myrepository/imagename:imagetag
 
 buildah pull --authfile=/tmp/auths/myauths.json myregistry/myrepository/imagename:imagetag
+
+buildah pull --arch=aarch64 myregistry/myrepository/imagename:imagetag
+
+buildah pull --arch=arm --variant=v7 myregistry/myrepository/imagename:imagetag
 
 ## ENVIRONMENT
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -51,7 +51,6 @@ type NameSpaceResults struct {
 // BudResults represents the results for Bud flags
 type BudResults struct {
 	Annotation          []string
-	Arch                string
 	Authfile            string
 	BuildArg            []string
 	CacheFrom           string
@@ -70,8 +69,6 @@ type BudResults struct {
 	Loglevel            int
 	NoCache             bool
 	Timestamp           int64
-	OS                  string
-	Platform            string
 	Pull                bool
 	PullAlways          bool
 	PullNever           bool
@@ -112,8 +109,6 @@ type FromAndBudResults struct {
 	Isolation      string
 	Memory         string
 	MemorySwap     string
-	OverrideArch   string
-	OverrideOS     string
 	SecurityOpt    []string
 	ShmSize        string
 	Ulimit         []string
@@ -179,7 +174,7 @@ func GetLayerFlags(flags *LayerResults) pflag.FlagSet {
 // GetBudFlags returns common bud flags
 func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs := pflag.FlagSet{}
-	fs.StringVar(&flags.Arch, "arch", runtime.GOARCH, "set the ARCH of the image to the provided value instead of the architecture of the host")
+	fs.String("arch", runtime.GOARCH, "set the ARCH of the image to the provided value instead of the architecture of the host")
 	fs.StringArrayVar(&flags.Annotation, "annotation", []string{}, "Set metadata for an image (default [])")
 	fs.StringVar(&flags.Authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file.")
 	fs.StringArrayVar(&flags.BuildArg, "build-arg", []string{}, "`argument=value` to supply to the builder")
@@ -203,8 +198,8 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 		panic(fmt.Sprintf("error marking the log-rusage flag as hidden: %v", err))
 	}
 	fs.BoolVar(&flags.NoCache, "no-cache", false, "Do not use existing cached images for the container build. Build from the start with a new set of cached layers.")
-	fs.StringVar(&flags.OS, "os", runtime.GOOS, "set the OS to the provided value instead of the current operating system of the host")
-	fs.StringVar(&flags.Platform, "platform", parse.DefaultPlatform(), "set the OS/ARCH to the provided value instead of the current operating system and architecture of the host (for example `linux/arm`)")
+	fs.String("os", runtime.GOOS, "set the OS to the provided value instead of the current operating system of the host")
+	fs.String("platform", parse.DefaultPlatform(), "set the OS/ARCH to the provided value instead of the current operating system and architecture of the host (for example `linux/arm`)")
 	fs.BoolVar(&flags.Pull, "pull", true, "pull the image from the registry if newer or not present in store, if false, only pull the image if not present")
 	fs.BoolVar(&flags.PullAlways, "pull-always", false, "pull the image even if the named image is present in store")
 	fs.BoolVar(&flags.PullNever, "pull-never", false, "do not pull the image, use the image present in store if available")
@@ -223,6 +218,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.Target, "target", "", "set the target build stage to build")
 	fs.Int64Var(&flags.Timestamp, "timestamp", 0, "set created timestamp to the specified epoch seconds to allow for deterministic builds, defaults to current time")
 	fs.BoolVar(&flags.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
+	fs.String("variant", "", "override the `variant` of the specified image")
 	return fs
 }
 
@@ -253,6 +249,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["tag"] = commonComp.AutocompleteNone
 	flagCompletion["target"] = commonComp.AutocompleteNone
 	flagCompletion["timestamp"] = commonComp.AutocompleteNone
+	flagCompletion["variant"] = commonComp.AutocompleteNone
 	return flagCompletion
 }
 
@@ -286,14 +283,9 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 	fs.StringVar(&flags.Isolation, "isolation", DefaultIsolation(), "`type` of process isolation to use. Use BUILDAH_ISOLATION environment variable to override.")
 	fs.StringVarP(&flags.Memory, "memory", "m", "", "memory limit (format: <number>[<unit>], where unit = b, k, m or g)")
 	fs.StringVar(&flags.MemorySwap, "memory-swap", "", "swap limit equal to memory plus swap: '-1' to enable unlimited swap")
-	fs.StringVar(&flags.OverrideOS, "override-os", runtime.GOOS, "prefer `OS` instead of the running OS when pulling images")
-	if err := fs.MarkHidden("override-os"); err != nil {
-		panic(fmt.Sprintf("error marking override-os as hidden: %v", err))
-	}
-	fs.StringVar(&flags.OverrideArch, "override-arch", runtime.GOARCH, "prefer `ARCH` instead of the architecture of the machine when pulling images")
-	if err := fs.MarkHidden("override-arch"); err != nil {
-		panic(fmt.Sprintf("error marking override-arch as hidden: %v", err))
-	}
+	fs.String("arch", runtime.GOARCH, "set the ARCH of the image to the provided value instead of the architecture of the host")
+	fs.String("os", runtime.GOOS, "prefer `OS` instead of the running OS when pulling images")
+	fs.String("variant", "", "override the `variant` of the specified image")
 	fs.StringArrayVar(&flags.SecurityOpt, "security-opt", []string{}, "security options (default [])")
 	fs.StringVar(&flags.ShmSize, "shm-size", defaultContainerConfig.Containers.ShmSize, "size of '/dev/shm'. The format is `<number><unit>`.")
 	fs.StringSliceVar(&flags.Ulimit, "ulimit", defaultContainerConfig.Containers.DefaultUlimits, "ulimit options")
@@ -311,6 +303,7 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 // GetFromAndBudFlagsCompletions returns the FlagCompletions for the from and bud flags
 func GetFromAndBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion := commonComp.FlagCompletions{}
+	flagCompletion["arch"] = commonComp.AutocompleteNone
 	flagCompletion["add-host"] = commonComp.AutocompleteNone
 	flagCompletion["blob-cache"] = commonComp.AutocompleteNone
 	flagCompletion["cap-add"] = commonComp.AutocompleteCapabilities
@@ -329,10 +322,12 @@ func GetFromAndBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["isolation"] = commonComp.AutocompleteNone
 	flagCompletion["memory"] = commonComp.AutocompleteNone
 	flagCompletion["memory-swap"] = commonComp.AutocompleteNone
+	flagCompletion["os"] = commonComp.AutocompleteNone
 	flagCompletion["security-opt"] = commonComp.AutocompleteNone
 	flagCompletion["shm-size"] = commonComp.AutocompleteNone
 	flagCompletion["ulimit"] = commonComp.AutocompleteNone
 	flagCompletion["volume"] = commonComp.AutocompleteDefault
+	flagCompletion["variant"] = commonComp.AutocompleteNone
 
 	// Add in the usernamespace and namespace flag completions
 	userNsComp := GetUserNSFlagsCompletions()
@@ -401,6 +396,10 @@ func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 	switch name {
 	case "net":
 		name = "network"
+	case "override-arch":
+		name = "arch"
+	case "override-os":
+		name = "os"
 	}
 	return pflag.NormalizedName(name)
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2458,3 +2458,21 @@ _EOF
   run_buildah bud --stdin -t testbud --signature-policy ${TESTSDIR}/policy.json ${mytmpdir} <<< input
   expect_output --substring "test got <input>"
 }
+
+@test "bud with --arch flag" {
+  _prefetch alpine
+  mytmpdir=${TESTDIR}/my-dir
+  mkdir -p ${mytmpdir}
+cat > $mytmpdir/Containerfile << _EOF
+FROM alpine
+#RUN arch
+_EOF
+
+  run_buildah bud --arch=arm64 -t arch-test --signature-policy ${TESTSDIR}/policy.json ${mytmpdir} <<< input
+# expect_output --substring "aarch64"
+
+#  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json arch-test
+#  cid=$output
+#  run_buildah run $cid arch
+#  expect_output --substring "aarch64"
+}

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -413,3 +413,17 @@ load helpers
   podman rm -f busyboxc-podman
   run_buildah rm busyboxc
 }
+
+@test "from --arch test" {
+  skip_if_no_runtime
+
+  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json --arch=arm64 alpine
+  cid=$output
+#  run_buildah run $cid arch
+#  expect_output "aarch64"
+
+  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json --arch=s390x alpine
+  cid=$output
+#  run_buildah run $cid arch
+#  expect_output "s390x"
+}

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -28,9 +28,9 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 
 @test "manifest-add-one" {
     run_buildah manifest create foo
-    run_buildah manifest add --override-arch=arm64 foo ${IMAGE_LIST_INSTANCE}
+    run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST_INSTANCE}
     run_buildah 125 inspect foo
-    expect_output --substring "does not exist"
+    expect_output --substring "no image found"
     run_buildah manifest inspect foo
     expect_output --substring ${IMAGE_LIST_ARM64_INSTANCE_DIGEST}
 }
@@ -97,7 +97,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 
 @test "manifest-push-purge" {
     run_buildah manifest create foo
-    run_buildah manifest add --override-arch=arm64 foo ${IMAGE_LIST}
+    run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST}
     run_buildah manifest inspect foo
     run_buildah manifest push --signature-policy ${TESTSDIR}/policy.json --purge foo dir:${TESTDIR}/pushed
     run_buildah 125 manifest inspect foo
@@ -105,7 +105,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 
 @test "manifest-push should fail with nonexistent authfile" {
     run_buildah manifest create foo
-    run_buildah manifest add --override-arch=arm64 foo ${IMAGE_LIST}
+    run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST}
     run_buildah manifest inspect foo
     run_buildah 125 manifest push --authfile /tmp/nonexistent --signature-policy ${TESTSDIR}/policy.json --purge foo dir:${TESTDIR}/pushed
 

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -312,3 +312,20 @@ load helpers
 
   run_buildah rmi alpine
 }
+
+@test "pull --arch" {
+  mkdir ${TESTDIR}/buildahtest
+  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --arch bogus alpine
+  expect_output --substring "no image found in manifest list"
+
+  # Make sure missing image works
+  run_buildah pull -q --signature-policy ${TESTSDIR}/policy.json --arch arm64 alpine
+
+  run_buildah inspect --format "{{ .Docker.Architecture }}" alpine
+  expect_output arm64
+
+  run_buildah inspect --format "{{ .OCIv1.Architecture }}" alpine
+  expect_output arm64
+
+  run_buildah rmi alpine
+}


### PR DESCRIPTION
Remove --override-os and --override-arch flags.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

