### PR TITLE
Upper directory should match mode of destination directory

### DIFF
--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -77,6 +77,13 @@ func mountHelper(contentDir, source, dest string, _, _ int, graphOptions []strin
 		// Read-write overlay mounts want a lower, upper and a work layer.
 		workDir := filepath.Join(contentDir, "work")
 		upperDir := filepath.Join(contentDir, "upper")
+		st, err := os.Stat(dest)
+		if err != nil {
+			return mount, err
+		}
+		if err := os.Chmod(upperDir, st.Mode()); err != nil {
+			return mount, err
+		}
 		overlayOptions = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,private", source, upperDir, workDir)
 	}
 

--- a/tests/overlay.bats
+++ b/tests/overlay.bats
@@ -29,3 +29,36 @@ load helpers
   run ls ${TESTDIR}/lower/bar
   [ "$status" -ne 0 ]
 }
+
+@test "overlay dest permissions" {
+  if test \! -e /usr/bin/fuse-overlayfs -a "$BUILDAH_ISOLATION" = "rootless"; then
+    skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION" and no /usr/bin/fuse-overlayfs present
+  elif test "$STORAGE_DRIVER" = "vfs"; then
+    skip "skipping overlay test because \$STORAGE_DRIVER = $STORAGE_DRIVER"
+  fi
+  image=alpine
+  mkdir ${TESTDIR}/lower
+  run_buildah from --quiet --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  cid=$output
+  run_buildah run $cid sh -c 'ls -ld /tmp | cut -f1 -d" "'
+  permission=$output
+  run_buildah rm $cid
+
+  run_buildah from --quiet -v ${TESTDIR}/lower:/tmp:O --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  cid=$output
+
+  # This should succeed
+  run_buildah run $cid sh -c 'ls -ld /tmp | cut -f1 -d" "'
+  expect_output $permission
+
+  # Create and remove content in the overlay directory, should succeed
+  run_buildah run $cid touch /lower/bar
+  run_buildah run $cid rm /lower/foo
+
+  # This should fail, second runs of containers go back to original
+  run_buildah 125 run $cid ls /lower/bar
+
+  # This should fail
+  run ls ${TESTDIR}/lower/bar
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
When we mount over a destination directory inside of the container
we need to preserve the mode of the destination.

Needed to fix: https://github.com/containers/podman/issues/8801

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

