### PR TITLE
copier.PutOptions: add an "IgnoreDevices" flag

### DIFF
--- a/add.go
+++ b/add.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/storage/pkg/fileutils"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/hashicorp/go-multierror"
+	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -347,12 +348,13 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 					_, putErr = io.Copy(hasher, pipeReader)
 				} else {
 					putOptions := copier.PutOptions{
-						UIDMap:     destUIDMap,
-						GIDMap:     destGIDMap,
-						ChownDirs:  nil,
-						ChmodDirs:  nil,
-						ChownFiles: nil,
-						ChmodFiles: nil,
+						UIDMap:        destUIDMap,
+						GIDMap:        destGIDMap,
+						ChownDirs:     nil,
+						ChmodDirs:     nil,
+						ChownFiles:    nil,
+						ChmodFiles:    nil,
+						IgnoreDevices: rsystem.RunningInUserNS(),
 					}
 					putErr = copier.Put(mountPoint, extractDirectory, putOptions, io.TeeReader(pipeReader, hasher))
 				}
@@ -482,6 +484,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 						ChmodDirs:       nil,
 						ChownFiles:      nil,
 						ChmodFiles:      nil,
+						IgnoreDevices:   rsystem.RunningInUserNS(),
 					}
 					putErr = copier.Put(mountPoint, extractDirectory, putOptions, io.TeeReader(pipeReader, hasher))
 				}

--- a/copier/copier.go
+++ b/copier/copier.go
@@ -289,6 +289,7 @@ type PutOptions struct {
 	ChmodFiles           *os.FileMode      // set permissions on newly-created files
 	StripXattrs          bool              // don't bother trying to set extended attributes of items being copied
 	IgnoreXattrErrors    bool              // ignore any errors encountered when attempting to set extended attributes
+	IgnoreDevices        bool              // ignore items which are character or block devices
 	NoOverwriteDirNonDir bool              // instead of quietly overwriting directories with non-directories, return an error
 	Rename               map[string]string // rename items with the specified names, or under the specified names
 }
@@ -1402,11 +1403,14 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				}
 			}
 		}()
+		ignoredItems := make(map[string]struct{})
 		tr := tar.NewReader(bulkReader)
 		hdr, err := tr.Next()
 		for err == nil {
+			nameBeforeRenaming := hdr.Name
 			if len(hdr.Name) == 0 {
 				// no name -> ignore the entry
+				ignoredItems[nameBeforeRenaming] = struct{}{}
 				hdr, err = tr.Next()
 				continue
 			}
@@ -1465,6 +1469,11 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				}
 			case tar.TypeLink:
 				var linkTarget string
+				if _, ignoredTarget := ignoredItems[hdr.Linkname]; ignoredTarget {
+					// hard link to an ignored item: skip this, too
+					ignoredItems[nameBeforeRenaming] = struct{}{}
+					goto nextHeader
+				}
 				if req.PutOptions.Rename != nil {
 					hdr.Linkname = handleRename(req.PutOptions.Rename, hdr.Linkname)
 				}
@@ -1497,6 +1506,10 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 					}
 				}
 			case tar.TypeChar:
+				if req.PutOptions.IgnoreDevices {
+					ignoredItems[nameBeforeRenaming] = struct{}{}
+					goto nextHeader
+				}
 				if err = mknod(path, chrMode(0600), int(mkdev(devMajor, devMinor))); err != nil && os.IsExist(err) {
 					if req.PutOptions.NoOverwriteDirNonDir {
 						if st, err := os.Lstat(path); err == nil && st.IsDir() {
@@ -1508,6 +1521,10 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 					}
 				}
 			case tar.TypeBlock:
+				if req.PutOptions.IgnoreDevices {
+					ignoredItems[nameBeforeRenaming] = struct{}{}
+					goto nextHeader
+				}
 				if err = mknod(path, blkMode(0600), int(mkdev(devMajor, devMinor))); err != nil && os.IsExist(err) {
 					if req.PutOptions.NoOverwriteDirNonDir {
 						if st, err := os.Lstat(path); err == nil && st.IsDir() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Prior to 1.16, when ADDing contents to a working container, if we were being run by an unprivileged user using a user namespace, content that was a device node would be ignored.

Add a flag in copier.PutOptions that tells copier.Put() to ignore entries that are either a device, or a hard link to a device.
Make buildah.Add() set the IgnoreDevices flag in PutOptions when libcontainer says we're running in a user namespace.

Together, these two changes should restore the earlier behavior.

#### How to verify it

New unit tests!  Also, manually running "buildah add" and specifying as the source either device nodes, or a tarball containing device nodes, should quietly ignore the device nodes and keep on chugging.

#### Which issue(s) this PR fixes:

Fixes https://github.com/containers/buildah/issues/2876.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
Attempting to ADD device nodes to a working container when running as an unprivileged user in rootless mode will now quietly ignore the device nodes and appear to succeed again, matching the behavior of versions before 1.16, instead of triggering an error.
```