### PR TITLE
Cirrus: Track libseccomp and golang version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -196,6 +196,7 @@ gce_instance:
         buildah_version_script: '$GOSRC/$SCRIPT_BASE/logcollector.sh buildah_version'
         buildah_info_script: '$GOSRC/$SCRIPT_BASE/logcollector.sh buildah_info'
         package_versions_script: '$GOSRC/$SCRIPT_BASE/logcollector.sh packages'
+        golang_version_script: '$GOSRC/$SCRIPT_BASE/logcollector.sh golang'
 
 
 'cirrus-ci/required/in_podman_task':

--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -19,6 +19,7 @@ case $1 in
     podman) showrun podman system info ;;
     buildah_version) showrun $GOSRC/bin/buildah version;;
     buildah_info) showrun $GOSRC/bin/buildah info;;
+    golang) showrun go version;;
     packages)
         # These names are common to Fedora and Ubuntu
         PKG_NAMES=(\
@@ -28,7 +29,8 @@ case $1 in
                     containernetworking-plugins
                     containers-common
                     crun
-                    golang
+                    libseccomp
+                    libseccomp2
                     podman
                     runc
                     skopeo


### PR DESCRIPTION
The versions of these packages on Fedora/Ubuntu are important/relevant for testing, make them easy to observe.