### PR TITLE
[release-1.18] imagebuildah: disable pseudo-terminals for RUN, allow users to specify stdin into containers

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -197,6 +198,10 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		return errors.Wrapf(err, "error evaluating symlinks in build context path")
 	}
 
+	var stdin io.Reader
+	if iopts.Stdin {
+		stdin = os.Stdin
+	}
 	var stdout, stderr, reporter *os.File
 	stdout = os.Stdout
 	stderr = os.Stderr
@@ -320,6 +325,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		ForceRmIntermediateCtrs: iopts.ForceRm,
 		IDMappingOptions:        idmappingOptions,
 		IIDFile:                 iopts.Iidfile,
+		In:                      stdin,
 		Isolation:               isolation,
 		Labels:                  iopts.Label,
 		Layers:                  layers,

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -478,6 +478,12 @@ Sign the built image using the GPG key that matches the specified fingerprint.
 Squash all of the image's new layers into a single new layer; any preexisting layers
 are not squashed.
 
+**--stdin**
+
+Pass stdin into the RUN containers. Sometime commands being RUN within a Containerfile
+want to request information from the user. For example apt asking for a confirmation for install.
+Use --stdin to be able to interact from the terminal during the build.
+
 **--tag**, **-t** *imageName*
 
 Specifies the name which will be assigned to the resulting image if the build

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -368,6 +368,7 @@ func (s *StageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 		Stderr:           s.executor.err,
 		Quiet:            s.executor.quiet,
 		NamespaceOptions: s.executor.namespaceOptions,
+		Terminal:         buildah.WithoutTerminal,
 	}
 	if config.NetworkDisabled {
 		options.ConfigureNetwork = buildah.NetworkDisabled

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -79,6 +79,7 @@ type BudResults struct {
 	SignaturePolicy     string
 	SignBy              string
 	Squash              bool
+	Stdin               bool
 	Tag                 []string
 	Target              string
 	TLSVerify           bool
@@ -212,6 +213,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 		panic(fmt.Sprintf("error marking the signature-policy flag as hidden: %v", err))
 	}
 	fs.BoolVar(&flags.Squash, "squash", false, "squash newly built layers into a single new layer")
+	fs.BoolVar(&flags.Stdin, "stdin", false, "pass stdin into containers")
 	fs.StringArrayVarP(&flags.Tag, "tag", "t", []string{}, "tagged `name` to apply to the built image")
 	fs.StringVar(&flags.Target, "target", "", "set the target build stage to build")
 	fs.Int64Var(&flags.Timestamp, "timestamp", 0, "set created timestamp to the specified epoch seconds to allow for deterministic builds, defaults to current time")

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2388,3 +2388,20 @@ EOF
 @test "bud-terminal" {
   run_buildah bud ${TESTSDIR}/bud/terminal
 }
+
+@test "bud test no --stdin" {
+  _prefetch alpine
+  mytmpdir=${TESTDIR}/my-dir
+  mkdir -p ${mytmpdir}
+cat > $mytmpdir/Containerfile << _EOF
+FROM alpine
+RUN read -t 1 x && echo test got \<\$x\>
+RUN touch /tmp/done
+_EOF
+
+  # fail without --stdin
+  run_buildah 1 bud -t testbud --signature-policy ${TESTSDIR}/policy.json ${mytmpdir} <<< input
+
+  run_buildah bud --stdin -t testbud --signature-policy ${TESTSDIR}/policy.json ${mytmpdir} <<< input
+  expect_output --substring "test got <input>"
+}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2384,3 +2384,7 @@ EOF
   run cmp tar1 url1
   [[ "$status" -ne 0 ]]
 }
+
+@test "bud-terminal" {
+  run_buildah bud ${TESTSDIR}/bud/terminal
+}

--- a/tests/bud/terminal/Dockerfile
+++ b/tests/bud/terminal/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+RUN ! tty


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Default to handling RUN instructions with no pseudo terminal, which matches what I see with docker build 19.03.  Interactive `buildah run` will still have the same default behavior.

Some commands within a Containerfile might need input from users, for example confirmation commands from `apt`, so add a `--stdin` flag to allows users to interact with commands which are run during a build.

#### How to verify it

Tests should continue to pass, and the issue described in https://github.com/containers/podman/issues/8342 should no longer occur.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Cherry-picked from #2803 and #2847.

#### Does this PR introduce a user-facing change?

```
RUN instructions in builds will no longer be run attached to a pseudo-terminal unless the `--stdin` flag is added.
```