### PR TITLE
Buildah inspect should be able to inspect manifests

### DIFF
--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -18,6 +18,7 @@ import (
 const (
 	inspectTypeContainer = "container"
 	inspectTypeImage     = "image"
+	inspectTypeManifest  = "manifest"
 )
 
 type inspectResults struct {
@@ -88,6 +89,9 @@ func inspectCmd(c *cobra.Command, args []string, iopts inspectResults) error {
 			}
 			builder, err = openImage(ctx, systemContext, store, name)
 			if err != nil {
+				if manifestErr := manifestInspect(ctx, store, systemContext, name); manifestErr == nil {
+					return nil
+				}
 				return err
 			}
 		}
@@ -96,6 +100,8 @@ func inspectCmd(c *cobra.Command, args []string, iopts inspectResults) error {
 		if err != nil {
 			return err
 		}
+	case inspectTypeManifest:
+		return manifestInspect(ctx, store, systemContext, name)
 	default:
 		return errors.Errorf("the only recognized types are %q and %q", inspectTypeContainer, inspectTypeImage)
 	}

--- a/docs/buildah-inspect.md
+++ b/docs/buildah-inspect.md
@@ -1,14 +1,14 @@
 # buildah-inspect "1" "May 2017" "buildah"
 
 ## NAME
-buildah\-inspect - Display information about working containers or images.
+buildah\-inspect - Display information about working containers or images or manifest lists.
 
 ## SYNOPSIS
 **buildah inspect** [*options*] [**--**] *object*
 
 ## DESCRIPTION
-Prints the low-level information on Buildah object(s) (e.g. container, images) identified by name or ID. By default, this will render all results in a
-JSON array. If the container and image have the same name, this will return container JSON for unspecified type. If a format is specified,
+Prints the low-level information on Buildah object(s) (e.g. container, images, manifest lists) identified by name or ID. By default, this will render all results in a
+JSON array. If the container, image, or manifest lists have the same name, this will return container JSON for an unspecified type. If a format is specified,
 the given template will be executed for each result.
 
 ## OPTIONS
@@ -21,9 +21,9 @@ Users of this option should be familiar with the [*text/template*
 package](https://golang.org/pkg/text/template/) in the Go standard library, and
 of internals of Buildah's implementation.
 
-**--type**, **-t** **container** | **image**
+**--type**, **-t** **container** | **image** | **manifest**
 
-Specify whether *object* is a container or an image.
+Specify whether *object* is a container, image or a manifest list.
 
 ## EXAMPLE
 

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -29,9 +29,11 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 @test "manifest-add-one" {
     run_buildah manifest create foo
     run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST_INSTANCE}
-    run_buildah 125 inspect foo
-    expect_output --substring "no image found"
     run_buildah manifest inspect foo
+    expect_output --substring ${IMAGE_LIST_ARM64_INSTANCE_DIGEST}
+    run_buildah 125 inspect --type image foo
+    expect_output --substring "no image found"
+    run_buildah inspect foo
     expect_output --substring ${IMAGE_LIST_ARM64_INSTANCE_DIGEST}
 }
 

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -275,7 +275,7 @@ load helpers
   #  If image does not exist the never will fail
   run_buildah 125 pull -q --signature-policy ${TESTSDIR}/policy.json --policy never alpine
   expect_output --substring "could not be found locally"
-  run_buildah 125 inspect alpine
+  run_buildah 125 inspect --type image alpine
   expect_output --substring "image not known"
 
   # create bogus alpine image


### PR DESCRIPTION
When you create a manifest or pull a manifest, it shows up
inside of the buildah images list.  When you go to inspect it
the inspect code blows up with a cryptic error message.

This patch fixes this problem and just uses the buildah manifest inspect
code.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

