### PR TITLE
Make buildah push support pushing manifests lists and digests

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -632,12 +632,14 @@ return 1
 
  _buildah_push() {
      local boolean_options="
+          --all
           --help
           -h
           --disable-compression
           -D
           --quiet
           -q
+          --rm
           --tls-verify
           --remove-signatures
   "
@@ -868,7 +870,7 @@ return 1
      --digestfile
      --format
      -f
-     --purge
+     --rm
      --sign-by
   "
 

--- a/docs/buildah-manifest-push.md
+++ b/docs/buildah-manifest-push.md
@@ -47,10 +47,6 @@ After copying the image, write the digest of the resulting image to the file.
 
 Manifest list type (oci or v2s2) to use when pushing the list (default is oci).
 
-**--purge**
-
-Delete the manifest list or image index from local storage if pushing succeeds.
-
 **--quiet**, **-q**
 
 Don't output progress information when pushing lists.
@@ -58,6 +54,10 @@ Don't output progress information when pushing lists.
 **--remove-signatures**
 
 Don't copy signatures when pushing images.
+
+**--rm**
+
+Delete the manifest list or image index from local storage if pushing succeeds.
 
 **--sign-by** *fingerprint*
 

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -1,7 +1,7 @@
 # buildah-push "1" "June 2017" "buildah"
 
 ## NAME
-buildah\-push - Push an image from local storage to elsewhere.
+buildah\-push - Push an image, manifest list or image index from local storage to elsewhere.
 
 ## SYNOPSIS
 **buildah push** [*options*] *image* [*destination*]
@@ -41,6 +41,11 @@ Image stored in local container/storage
 If the transport part of DESTINATION is omitted, "docker://" is assumed.
 
 ## OPTIONS
+
+**--all**
+
+If specified image is a manifest list or image index, push the images in addition to
+the list or index itself.
 
 **--authfile** *path*
 
@@ -85,6 +90,10 @@ When writing the output image, suppress progress output.
 **--remove-signatures**
 
 Don't copy signatures when pushing images.
+
+**--rm**
+
+When pushing a the manifest list or image index, delete them from local storage if pushing succeeds.
 
 **--sign-by** *fingerprint*
 
@@ -164,4 +173,4 @@ registries.conf is the configuration file which specifies which container regist
 Signature policy file.  This defines the trust policy for container images.  Controls which container registries can be used for image, and whether or not the tool should trust the images.
 
 ## SEE ALSO
-buildah(1), buildah-login(1), containers-policy.json(5), docker-login(1), containers-registries.conf(5)
+buildah(1), buildah-login(1), containers-policy.json(5), docker-login(1), containers-registries.conf(5), buildah-manifest(1)

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -400,6 +400,8 @@ func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "arch"
 	case "override-os":
 		name = "os"
+	case "purge":
+		name = "rm"
 	}
 	return pflag.NormalizedName(name)
 }

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -103,6 +103,14 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah 125 manifest inspect foo
 }
 
+@test "manifest-push-rm" {
+    run_buildah manifest create foo
+    run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST}
+    run_buildah manifest inspect foo
+    run_buildah manifest push --signature-policy ${TESTSDIR}/policy.json --rm foo dir:${TESTDIR}/pushed
+    run_buildah 125 manifest inspect foo
+}
+
 @test "manifest-push should fail with nonexistent authfile" {
     run_buildah manifest create foo
     run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST}


### PR DESCRIPTION
Currently manifests just look like images in container storage.
It is surprising to the user when they go to push the images
that they end up failing, and have to use the buildah manifest push.

This patch causes buildah push to failover to buildah manifest push
if the image is a manifest.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

