### PR TITLE
Stop overriding the location of the blob info cache

### DIFF
--- a/common.go
+++ b/common.go
@@ -56,9 +56,6 @@ func getSystemContext(store storage.Store, defaults *types.SystemContext, signat
 		sc.SignaturePolicyPath = signaturePolicyPath
 	}
 	if store != nil {
-		if sc.BlobInfoCacheDir == "" {
-			sc.BlobInfoCacheDir = filepath.Join(store.GraphRoot(), "cache")
-		}
 		if sc.SystemRegistriesConfPath == "" && unshare.IsRootless() {
 			userRegistriesFile := filepath.Join(store.GraphRoot(), "registries.conf")
 			if _, err := os.Stat(userRegistriesFile); err == nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When it was first introduced, the blob info cache's location didn't change from the system-wide default location when we were running in rootless mode, so we started setting its location ourselves to avoid triggering permissions errors when updating it.

The image library has since started taking into account that it was running in rootless mode, but its hardwired default isn't the same as the one we were setting, so we ended up creating a second cache file.

Stop doing that.

#### How to verify it

Pull or push an image to or from a registry using buildah.  The cache file in /var/lib/containers/storage/cache or ~/.local/share/containers/storage/cache should be ignored if it exists, but the cache file in /var/lib/containers/cache or ~/.local/share/containers/cache should be updated.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

General behavior shouldn't change, but we should no longer be creating a /var/lib/containers/storage/cache directory or a ~/.local/share/containers/storage/cache directory, since those aren't the default locations.

#### Does this PR introduce a user-facing change?

```
Buildah no longer uses blob info cache data in /var/lib/containers/storage/cache or ~/.local/share/containers/storage/cache.  It should share the cache files used by skopeo and other tools.
```