### PR TITLE
WIP: Add local name to short names list

### DIFF
--- a/vendor/github.com/containers/image/v5/pkg/shortnames/shortnames.go
+++ b/vendor/github.com/containers/image/v5/pkg/shortnames/shortnames.go
@@ -235,9 +235,15 @@ func (c *PullCandidate) Record() error {
 // Furthermore, before attempting to pull callers *should* call
 // `(Resolved).Description` and afterwards use
 // `(Resolved).FormatPullErrors` in case of pull errors.
-func Resolve(ctx *types.SystemContext, name string) (*Resolved, error) {
+func Resolve(ctx *types.SystemContext, name string, localImageName string) (*Resolved, error) {
 	resolved := &Resolved{}
-
+	if localImageName != "" {
+		_, localRef, err := parseUnnormalizedShortName(name)
+		if err != nil {
+			return nil, err
+		}
+		resolved.addCandidate(reference.TagNameOnly(localRef))
+	}
 	// Create a copy of the system context to make it usable beyond this
 	// function call.
 	var sys *types.SystemContext
@@ -454,6 +460,5 @@ func ResolveLocally(ctx *types.SystemContext, name string) ([]reference.Named, e
 
 		candidates = append(candidates, named)
 	}
-
 	return candidates, nil
 }


### PR DESCRIPTION
This is very much a WIP.  Part of this needs to go in c/image, the
rest in Buildah.  But I wanted to put this up for a POC review.

In short, when we're building an image, we see if the image is
known locally.  If it is, and the user gives us the ID for it,
we accept it and continue on with the build.

However, if the user gave us the name, especially in a
`FROM` statement in a Containerfile, we first find that it
was local, then resolve the image name using all of
the registries that we know, but neglect to add the local
image to that list that we build.

Now if we find the image locally, this code will pass that
name down to be added to the top of the list that we present
to the user.

Once this approach is OK'd, I'll put a PR together
in c/image and vendor into Buildah, that is unless
@vrothberg beats me to the punch.

Resolves: #2904

Test run:

```
STEP 1: FROM alpine
STEP 2: RUN touch /foo
STEP 3: ONBUILD RUN touch /bar
STEP 4: COMMIT onbuild-image
Getting image source signatures
Copying blob 777b2c648970 skipped: already exists
Copying blob c440ad84933e done
Copying config 0f963b3733 done
Writing manifest to image destination
Storing signatures
--> 0f963b37335
0f963b373356dc17643f3b073a77cc8be37b401837bdf9390d196a4915196f98
STEP 1: FROM onbuild-image
? Please select an image:
  ▸ onbuild-image:latest
    docker.io/library/onbuild-image:latest
    registry.fedoraproject.org/onbuild-image:latest
    registry.access.redhat.com/onbuild-image:latest
↓   registry.centos.org/onbuild-image:latest
# After selecting onbuild-image:latest
STEP 2: RUN touch /bar
STEP 3: RUN touch /baz
STEP 4: COMMIT result-image
Getting image source signatures
Copying blob 777b2c648970 skipped: already exists  
Copying blob c440ad84933e skipped: already exists  
Copying blob 0c8c8672fc70 done  
Copying config 0daca97cc4 done  
Writing manifest to image destination
Storing signatures
--> 0daca97cc43
0daca97cc438ab3a6016ddb8c668ea6a263050aa104cf6477bf03dce03be287c
-rw-r--r--    1 root     root             0 Jan 14 02:54 /bar
-rw-r--r--    1 root     root             0 Jan 14 02:54 /baz
-rw-r--r--    1 root     root             0 Jan 14 02:50 /foo

```

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

