### PR TITLE
If destination does not exists, do not throw error

### DIFF
--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -78,10 +78,12 @@ func mountHelper(contentDir, source, dest string, _, _ int, graphOptions []strin
 		workDir := filepath.Join(contentDir, "work")
 		upperDir := filepath.Join(contentDir, "upper")
 		st, err := os.Stat(dest)
-		if err != nil {
-			return mount, err
+		if err == nil {
+			if err := os.Chmod(upperDir, st.Mode()); err != nil {
+				return mount, err
+			}
 		}
-		if err := os.Chmod(upperDir, st.Mode()); err != nil {
+		if !os.IsNotExist(err) {
 			return mount, err
 		}
 		overlayOptions = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,private", source, upperDir, workDir)


### PR DESCRIPTION
When using volume mounts, the destination directory will get
created if it does not exists. The current code blows up when
the destination directory did not exists.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

