### PR TITLE
1.19.2

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -28,7 +28,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.19.0"
+	Version = "1.19.2"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in buildah.go too
-Version:        1.19.0
+Version:        1.19.2
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,6 +100,12 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Fri Jan 15, 2021 Dan Walsh <dwalsh@redhat.com> 1.19.2-1
+- If overlay destination does not exists, do not throw error
+
+* Thu Jan 14, 2021 Dan Walsh <dwalsh@redhat.com> 1.19.1-1
+- use local image name for pull policy checks
+
 * Fri Jan 8, 2021 Tom Sweeney <tsweeney@redhat.com> 1.19.0-1
 - Update vendor of containers/storage and containers/common
 - Buildah inspect should be able to inspect manifests

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/containerd/containerd v1.4.1 // indirect
 	github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784
-	github.com/containers/common v0.33.0
+	github.com/containers/common v0.33.1
 	github.com/containers/image/v5 v5.9.0
 	github.com/containers/ocicrypt v1.0.3
 	github.com/containers/storage v1.24.5

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDG
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784 h1:rqUVLD8I859xRgUx/WMC3v7QAFqbLKZbs+0kqYboRJc=
 github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
-github.com/containers/common v0.33.0 h1:7Z6aAQ2s2iniEXd/IoGgc0ukmgmzAE8Oa929t6huVB8=
-github.com/containers/common v0.33.0/go.mod h1:mjDo/NKeweL/onaspLhZ38WnHXaYmrELHclIdvSnYpY=
+github.com/containers/common v0.33.1 h1:XpDiq8Cta8+u1s4kpYSEWdB140ZmqgyIXfWkLqKx3z0=
+github.com/containers/common v0.33.1/go.mod h1:mjDo/NKeweL/onaspLhZ38WnHXaYmrELHclIdvSnYpY=
 github.com/containers/image/v5 v5.9.0 h1:dRmUtcluQcmasNo3DpnRoZjfU0rOu1qZeL6wlDJr10Q=
 github.com/containers/image/v5 v5.9.0/go.mod h1:blOEFd/iFdeyh891ByhCVUc+xAcaI3gBegXECwz9UbQ=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=

--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -78,10 +78,12 @@ func mountHelper(contentDir, source, dest string, _, _ int, graphOptions []strin
 		workDir := filepath.Join(contentDir, "work")
 		upperDir := filepath.Join(contentDir, "upper")
 		st, err := os.Stat(dest)
-		if err != nil {
-			return mount, err
+		if err == nil {
+			if err := os.Chmod(upperDir, st.Mode()); err != nil {
+				return mount, err
+			}
 		}
-		if err := os.Chmod(upperDir, st.Mode()); err != nil {
+		if !os.IsNotExist(err) {
 			return mount, err
 		}
 		overlayOptions = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,private", source, upperDir, workDir)

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -318,7 +318,7 @@ type EngineConfig struct {
 
 	// RuntimeSupportsNoCgroups is a list of OCI runtimes that support
 	// running containers without CGroups.
-	RuntimeSupportsNoCgroups []string `toml:"runtime_supports_nocgroupv2,omitempty"`
+	RuntimeSupportsNoCgroups []string `toml:"runtime_supports_nocgroup,omitempty"`
 
 	// RuntimeSupportsKVM is a list of OCI runtimes that support
 	// KVM separation for containers.

--- a/vendor/github.com/containers/common/pkg/retry/retry.go
+++ b/vendor/github.com/containers/common/pkg/retry/retry.go
@@ -69,7 +69,7 @@ func isRetryable(err error) bool {
 		}
 		return isRetryable(e.Err)
 	case syscall.Errno:
-		return shouldRestart(e)
+		return isErrnoRetryable(e)
 	case errcode.Errors:
 		// if this error is a group of errors, process them all in turn
 		for i := range e {
@@ -94,10 +94,10 @@ func isRetryable(err error) bool {
 	return false
 }
 
-func shouldRestart(e error) bool {
+func isErrnoRetryable(e error) bool {
 	switch e {
 	case syscall.ECONNREFUSED, syscall.EINTR, syscall.EAGAIN, syscall.EBUSY, syscall.ENETDOWN, syscall.ENETUNREACH, syscall.ENETRESET, syscall.ECONNABORTED, syscall.ECONNRESET, syscall.ETIMEDOUT, syscall.EHOSTDOWN, syscall.EHOSTUNREACH:
 		return true
 	}
-	return shouldRestartPlatform(e)
+	return isErrnoERESTART(e)
 }

--- a/vendor/github.com/containers/common/pkg/retry/retry_linux.go
+++ b/vendor/github.com/containers/common/pkg/retry/retry_linux.go
@@ -4,6 +4,6 @@ import (
 	"syscall"
 )
 
-func shouldRestartPlatform(e error) bool {
+func isErrnoERESTART(e error) bool {
 	return e == syscall.ERESTART
 }

--- a/vendor/github.com/containers/common/pkg/retry/retry_unsupported.go
+++ b/vendor/github.com/containers/common/pkg/retry/retry_unsupported.go
@@ -2,6 +2,6 @@
 
 package retry
 
-func shouldRestartPlatform(e error) bool {
+func isErrnoERESTART(e error) bool {
 	return false
 }

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.33.0"
+const Version = "0.33.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
-# github.com/containers/common v0.33.0
+# github.com/containers/common v0.33.1
 github.com/containers/common/pkg/apparmor
 github.com/containers/common/pkg/apparmor/internal/supported
 github.com/containers/common/pkg/auth


### PR DESCRIPTION
Cherry pick updating containers/common and fixing overlay mount points to not throw errors on missing
destination.

Generate a new release of v1.19.2