### PR TITLE
Workaround for RHEL gating test failure

### DIFF
--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -33,7 +33,12 @@ load helpers
   expect_output --substring "Writing manifest to image destination"
 
   # With tls-verify=true, should fail due to self-signed cert
-  run_buildah 125 push  --signature-policy ${TESTSDIR}/policy.json --tls-verify=true alpine localhost:5000/my-alpine
+  # The magic GODEBUG is needed for RHEL on 2021-01-20. Without it,
+  # we get the following error instead of 'unknown authority':
+  #   x509: certificate relies on legacy Common Name field, use SANs or [...]
+  # It is possible that this is a temporary workaround, and Go
+  # may remove it without notice. We'll deal with that then.
+  GODEBUG=x509ignoreCN=0 run_buildah 125 push  --signature-policy ${TESTSDIR}/policy.json --tls-verify=true alpine localhost:5000/my-alpine
   expect_output --substring " x509: certificate signed by unknown authority" \
                 "push with --tls-verify=true"
 


### PR DESCRIPTION
One of the auth tests is failing on RHEL8.4:
```
   # buildah push --tls-verify=true ...
   Get "https://localhost:5000/v2/": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
```
(Expected output: ' x509: certificate signed by unknown authority')

Cause: who knows? Some internal Go change.

Solution: set magic GODEBUG envariable in the buildah invocation.
This makes that message go away, and gives us the expected one.

Indicate that this may be a temporary workaround. I vaguely
recall reading that a future version of Go would remove it.
We'll deal with that then.

Signed-off-by: Ed Santiago <santiago@redhat.com>
