### PR TITLE
Pick default OCI Runtime from containers.conf

### DIFF
--- a/util/types.go
+++ b/util/types.go
@@ -1,7 +1,7 @@
 package util
 
 const (
-	// DefaultRuntime is the default command to use to run the container.
+	// Deprecated: Default runtime should come from containers.conf
 	DefaultRuntime = "runc"
 	// DefaultCNIPluginPath is the default location of CNI plugin helpers.
 	DefaultCNIPluginPath = "/usr/libexec/cni:/opt/cni/bin"

--- a/util/util.go
+++ b/util/util.go
@@ -263,7 +263,12 @@ func Runtime() string {
 		return "crun"
 	}
 
-	return DefaultRuntime
+	conf, err := config.Default()
+	if err != nil {
+		logrus.Warnf("Error loading container config when searching for local runtime: %v", err)
+		return DefaultRuntime
+	}
+	return conf.Engine.OCIRuntime
 }
 
 // StringInSlice returns a boolean indicating if the exact value s is present

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -2,7 +2,10 @@ package util
 
 import (
 	"fmt"
+	"os"
 	"testing"
+
+	"github.com/containers/common/pkg/config"
 )
 
 func TestMergeEnv(t *testing.T) {
@@ -35,5 +38,20 @@ func TestMergeEnv(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+func TestRuntime(t *testing.T) {
+	os.Setenv("CONTAINERS_CONF", "/dev/null")
+	conf, _ := config.Default()
+	defaultRuntime := conf.Engine.OCIRuntime
+	runtime := Runtime()
+	if runtime != defaultRuntime {
+		t.Fatalf("expected %v, got %v", runtime, defaultRuntime)
+	}
+	defaultRuntime = "myoci"
+	os.Setenv("BUILDAH_RUNTIME", defaultRuntime)
+	runtime = Runtime()
+	if runtime != defaultRuntime {
+		t.Fatalf("expected %v, got %v", runtime, defaultRuntime)
 	}
 }


### PR DESCRIPTION
Currently we have a weird situation where the user sets the default
runtime in his containers.conf for podman but Buildah is still falling
back to use runc because it was hard coded as the default for Buildah.

I would like to remove this default, but that would theoretically break
the API promise of Buildah.

This should fix https://github.com/containers/podman/issues/8893

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

