### PR TITLE
Use build-arg ENV val from local environment if set

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -129,7 +129,12 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 			if len(av) > 1 {
 				args[av[0]] = av[1]
 			} else {
-				delete(args, av[0])
+				// check if the env is set in the local environment and use that value if it is
+				if val, present := os.LookupEnv(av[0]); present {
+					args[av[0]] = val
+				} else {
+					delete(args, av[0])
+				}
 			}
 		}
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2154,9 +2154,15 @@ EOM
 }
 
 @test "bud with --build-arg" {
-  _prefetch alpine
-  run_buildah --log-level "warn" bud --signature-policy ${TESTSDIR}/policy.json -t test ${TESTSDIR}/bud/build-arg
+  _prefetch alpine busybox
+  target=busybox-image
+  run_buildah --log-level "warn" bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/build-arg
   expect_output --substring 'missing .+ build argument'
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg foo=bar ${TESTSDIR}/bud/build-arg
+  expect_output --substring "bar"
+  export foo=hello-world
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg foo ${TESTSDIR}/bud/build-arg
+  expect_output --substring "hello-world"
 }
 
 @test "bud arg and env var with same name" {

--- a/tests/bud/build-arg/Dockerfile
+++ b/tests/bud/build-arg/Dockerfile
@@ -1,3 +1,3 @@
 FROM busybox
-
 ARG foo
+RUN echo $foo


### PR DESCRIPTION
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

If a user sets the ENV to be used with the build-arg flag in
the local environment by exporting it, look it up and use the
value set there for that ENV.
Add tests to cover this use case as well.

#### How to verify it

#### Which issue(s) this PR fixes:

Fixes https://github.com/containers/buildah/issues/2888

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

