### PR TITLE
local image lookup by digest

### DIFF
--- a/new.go
+++ b/new.go
@@ -150,10 +150,10 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 		return nil, "", nil, err
 	}
 
-	// If we could resolve the image locally, check if it was referenced by
-	// ID.  In that case, we don't need to bother any further and can
-	// prevent prompting the user.
-	if localImage != nil && strings.HasPrefix(localImage.ID, options.FromImage) {
+	// If we could resolve the image locally, check if it was clearly
+	// referring to a local image, either by ID or digest.  In that case,
+	// we don't need to perform a remote lookup.
+	if localImage != nil && (strings.HasPrefix(localImage.ID, options.FromImage) || strings.HasPrefix(options.FromImage, "sha256:")) {
 		return localImageRef, localImageRef.Transport().Name(), localImage, nil
 	}
 

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -19,6 +19,18 @@ load helpers
   check_options_flag_err "--cred=fake fake"
 }
 
+@test "from-with-digest" {
+  run_buildah pull alpine
+  run_buildah inspect --format "{{.FromImageID}}" alpine
+  digest=$output
+
+  run_buildah from "sha256:$digest"
+  run_buildah rm $output
+
+  run_buildah 125 from sha256:1111111111111111111111111111111111111111111111111111111111111111
+  expect_output --substring "error locating image with ID \"1111111111111111111111111111111111111111111111111111111111111111\""
+}
+
 @test "commit-to-from-elsewhere" {
   elsewhere=${TESTDIR}/elsewhere-img
   mkdir -p ${elsewhere}


### PR DESCRIPTION
Detect local-image lookups by digest.  Those clearly refer to local
images only, so we must not proceed to remote lookups.

Fixes: #2836
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>