### PR TITLE
local image lookup by digest

### DIFF
--- a/new.go
+++ b/new.go
@@ -150,10 +150,10 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 		return nil, "", nil, err
 	}
 
-	// If we could resolve the image locally, check if it was referenced by
-	// ID.  In that case, we don't need to bother any further and can
-	// prevent prompting the user.
-	if localImage != nil && strings.HasPrefix(localImage.ID, options.FromImage) {
+	// If we could resolve the image locally, check if it was clearly
+	// referring to a local image, either by ID or digest.  In that case,
+	// we don't need to perform a remote lookup.
+	if localImage != nil && (strings.HasPrefix(localImage.ID, options.FromImage) || strings.HasPrefix(options.FromImage, "sha256:")) {
 		return localImageRef, localImageRef.Transport().Name(), localImage, nil
 	}
 

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -19,6 +19,18 @@ load helpers
   check_options_flag_err "--cred=fake fake"
 }
 
+@test "from-with-digest" {
+  run_buildah pull alpine
+  run_buildah inspect --format "{{.FromImageID}}" alpine
+  digest=$output
+
+  run_buildah from "sha256:$digest"
+  run_buildah rm $output
+
+  run_buildah 125 from sha256:1111111111111111111111111111111111111111111111111111111111111111
+  expect_output --substring "error locating image with ID \"1111111111111111111111111111111111111111111111111111111111111111\""
+}
+
 @test "commit-to-from-elsewhere" {
   elsewhere=${TESTDIR}/elsewhere-img
   mkdir -p ${elsewhere}


### PR DESCRIPTION
Detect local-image lookups by digest.  Those clearly refer to local
images only, so we must not proceed to remote lookups.

Note that the specifed digest refers to an image ID and not to the
digest of an image's manifest.

Fixes: #2836
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

