### PR TITLE
Rebuild layer if a change in ARG is detected

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -834,7 +834,11 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		// Check if there's already an image based on our parent that
 		// has the same change that we're about to make, so far as we
 		// can tell.
-		if checkForLayers {
+		// Only do this if there were no build args given by the user,
+		// we need to call ib.Run() to correctly put the args together before
+		// determining if a cached layer with the same build args already exists
+		// and that is done in the if block below.
+		if checkForLayers && s.builder.Args == nil {
 			cacheID, err = s.intermediateImageExists(ctx, node, addedContentSummary, s.stepRequiresLayer(step))
 			if err != nil {
 				return "", nil, errors.Wrap(err, "error checking if cached image exists from a previous build")
@@ -1022,6 +1026,9 @@ func (s *StageExecutor) getCreatedBy(node *parser.Node, addedContentSummary stri
 		return "/bin/sh"
 	}
 	switch strings.ToUpper(node.Value) {
+	case "ARG":
+		buildArgs := s.getBuildArgs()
+		return "/bin/sh -c #(nop) ARG " + buildArgs
 	case "RUN":
 		buildArgs := s.getBuildArgs()
 		if buildArgs != "" {

--- a/tests/bud/build-arg/Dockerfile4
+++ b/tests/bud/build-arg/Dockerfile4
@@ -1,0 +1,3 @@
+FROM alpine
+ARG TEST
+ENV NAME=$TEST


### PR DESCRIPTION
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

Check whether the ARG in the containerfile is changed by
either the --build-arg flag or local environment and use
the cached layer or rebuild the layer accordingly.
Add tests for this use case as well.

#### How to verify it

#### Which issue(s) this PR fixes:

Fixes https://github.com/containers/buildah/issues/2848
Fixes https://github.com/containers/buildah/issues/2837

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

