### PR TITLE
DO NOT MERGE: Write output to stdout and not stderr

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -210,7 +210,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 	var stdout, stderr, reporter *os.File
 	stdout = os.Stdout
 	stderr = os.Stderr
-	reporter = os.Stderr
+	reporter = os.Stdout
 	if c.Flag("logfile").Changed {
 		f, err := os.OpenFile(iopts.Logfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 		if err != nil {

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -215,7 +215,7 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 	}
 
 	if !iopts.quiet {
-		options.ReportWriter = os.Stderr
+		options.ReportWriter = os.Stdout
 	}
 	id, ref, _, err := builder.Commit(ctx, dest, options)
 	if err != nil {

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -298,7 +298,7 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 	}
 
 	if !iopts.quiet {
-		options.ReportWriter = os.Stderr
+		options.ReportWriter = os.Stdout
 	}
 
 	builder, err := buildah.NewBuilder(getContext(), store, options)

--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -708,7 +708,7 @@ func manifestPush(systemContext *types.SystemContext, store storage.Store, listI
 		options.ImageListSelection = cp.CopyAllImages
 	}
 	if !opts.quiet {
-		options.ReportWriter = os.Stderr
+		options.ReportWriter = os.Stdout
 	}
 
 	_, digest, err := list.Push(getContext(), dest, options)

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -115,7 +115,7 @@ func pullCmd(c *cobra.Command, args []string, iopts pullOptions) error {
 		SystemContext:       systemContext,
 		BlobDirectory:       iopts.blobCache,
 		AllTags:             iopts.allTags,
-		ReportWriter:        os.Stderr,
+		ReportWriter:        os.Stdout,
 		RemoveSignatures:    iopts.removeSignatures,
 		MaxRetries:          maxPullPushRetries,
 		RetryDelay:          pullPushRetryDelay,

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -195,7 +195,7 @@ func pushCmd(c *cobra.Command, args []string, iopts pushOptions) error {
 		OciEncryptLayers:    encLayers,
 	}
 	if !iopts.quiet {
-		options.ReportWriter = os.Stderr
+		options.ReportWriter = os.Stdout
 	}
 
 	ref, digest, err := buildah.Push(getContext(), src, dest, options)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1687,6 +1687,15 @@ _EOF
   test -s "${root}"/subdir/file2.txt
 }
 
+@test "bud should write to stdout and not stderr" {
+  _prefetch alpine
+  target=testimage
+  mkdir ${TESTDIR}/tmp
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1 ${TESTSDIR}/bud/dockerfile > ${TESTDIR}/tmp/stdout.txt 2> ${TESTDIR}/tmp/stderr.txt
+  run cat ${TESTDIR}/tmp/stderr.txt
+  expect_output ""
+}
+
 @test "bud-build-arg-cache" {
   _prefetch busybox alpine
   target=derived-image

--- a/tests/bud/dockerfile/Dockerfile1
+++ b/tests/bud/dockerfile/Dockerfile1
@@ -1,0 +1,3 @@
+FROM alpine
+RUN echo "hello"
+ENV foo=bar

--- a/tests/containers_conf.bats
+++ b/tests/containers_conf.bats
@@ -11,14 +11,14 @@ load helpers
 
 
     export CONTAINERS_CONF=${TESTSDIR}/containers.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    cid=$(buildah from -q --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
     run_buildah --log-level=error run $cid sh -c "cat /proc/self/attr/current | grep container_t"
 
     buildah rm $cid
 
     export CONTAINERS_CONF=${TESTSDIR}/containers1.conf
     sed "s/^label = true/label = false/g" ${TESTSDIR}/containers.conf > ${TESTSDIR}/containers1.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    cid=$(buildah from -q --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
     run_buildah 1 --log-level=error run $cid sh -c "cat /proc/self/attr/current | grep container_t"
     rm ${TESTSDIR}/containers1.conf
 }
@@ -29,11 +29,11 @@ load helpers
   fi
 
     export CONTAINERS_CONF=${TESTSDIR}/containers.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    cid=$(buildah from -q --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
     run_buildah --log-level=error run $cid  awk '/open files/{print $4}' /proc/self/limits
 	expect_output "500" "limits: open files (w/file limit)"
 
-    cid=$(buildah from --pull --ulimit nofile=300:400 --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    cid=$(buildah from -q --pull --ulimit nofile=300:400 --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
 	run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output "300" "limits: open files (w/file limit)"
 }
@@ -43,14 +43,14 @@ load helpers
 	skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION"
     fi
     export CONTAINERS_CONF=${TESTSDIR}/containers.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    cid=$(buildah from -q --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
     run_buildah 1 --log-level=error run $cid ls /dev/foo1
     buildah rm $cid
 
     sed '/^devices.*/a "/dev/foo:\/dev\/foo1:rmw",' ${TESTSDIR}/containers.conf > ${TESTSDIR}/containers1.conf
     rm -f /dev/foo; mknod /dev/foo c 1 1
     export CONTAINERS_CONF=${TESTSDIR}/containers1.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    cid=$(buildah from -q --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
     run_buildah  --log-level=error run $cid ls /dev/foo1
     rm -f /dev/foo
     rm ${TESTSDIR}/containers1.conf
@@ -58,7 +58,7 @@ load helpers
 
 @test "containers.conf capabilities test" {
     export CONTAINERS_CONF=${TESTSDIR}/containers.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    cid=$(buildah from -q --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
     run_buildah --log-level=error run $cid sh -c 'grep  CapEff /proc/self/status | cut -f2'
     CapEff=$output
     expect_output "00000000a80425fb"
@@ -66,7 +66,7 @@ load helpers
 
     sed "/AUDIT_WRITE/d" ${TESTSDIR}/containers.conf > ${TESTSDIR}/containers1.conf
     export CONTAINERS_CONF=${TESTSDIR}/containers1.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    cid=$(buildah from -q --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
 
     run_buildah --log-level=error run $cid sh -c 'grep  CapEff /proc/self/status | cut -f2'
     buildah rm $cid
@@ -81,7 +81,7 @@ load helpers
   fi
 
     export CONTAINERS_CONF=${TESTSDIR}/containers.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    cid=$(buildah from -q --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
     run_buildah --log-level=error run $cid sh -c 'df /dev/shm | awk '\''/shm/{print $4}'\'''
     expect_output "200"
 }


### PR DESCRIPTION
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

We had set the report writer to stderr so some info during
builds were being written to stderr. Move everything over
to stdout.

#### How to verify it

#### Which issue(s) this PR fixes:
Fixes https://github.com/containers/buildah/issues/2423

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

