### PR TITLE
[1.19] buildah manifest add localimage should work

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -307,7 +307,15 @@ func manifestAddCmd(c *cobra.Command, args []string, opts manifestAddOpts) error
 
 	digest, err := list.Add(getContext(), systemContext, ref, opts.all)
 	if err != nil {
-		return err
+		var storeErr error
+		// check if the local image exists
+		if ref, _, storeErr = util.FindImage(store, "", systemContext, imageSpec); storeErr != nil {
+			return err
+		}
+		digest, storeErr = list.Add(getContext(), systemContext, ref, opts.all)
+		if storeErr != nil {
+			return err
+		}
 	}
 
 	if opts.os != "" {

--- a/commit.go
+++ b/commit.go
@@ -224,7 +224,7 @@ func checkRegistrySourcesAllows(forWhat string, dest types.ImageReference) (inse
 	return false, nil
 }
 
-func (b *Builder) addManifest(ctx context.Context, manifestName string, imageSpec string) error {
+func (b *Builder) addManifest(ctx context.Context, manifestName string, imageSpec string) (string, error) {
 	var create bool
 	systemContext := &types.SystemContext{}
 	var list manifests.List
@@ -235,13 +235,13 @@ func (b *Builder) addManifest(ctx context.Context, manifestName string, imageSpe
 	} else {
 		_, list, err = manifests.LoadFromImage(b.store, listImage.ID)
 		if err != nil {
-			return err
+			return "", err
 		}
 	}
 
 	names, err := util.ExpandNames([]string{manifestName}, "", systemContext, b.store)
 	if err != nil {
-		return errors.Wrapf(err, "error encountered while expanding image name %q", manifestName)
+		return "", errors.Wrapf(err, "error encountered while expanding image name %q", manifestName)
 	}
 
 	ref, err := alltransports.ParseImageName(imageSpec)
@@ -249,13 +249,13 @@ func (b *Builder) addManifest(ctx context.Context, manifestName string, imageSpe
 		if ref, err = alltransports.ParseImageName(util.DefaultTransport + imageSpec); err != nil {
 			// check if the local image exists
 			if ref, _, err = util.FindImage(b.store, "", systemContext, imageSpec); err != nil {
-				return err
+				return "", err
 			}
 		}
 	}
 
 	if _, err = list.Add(ctx, systemContext, ref, true); err != nil {
-		return err
+		return "", err
 	}
 	var imageID string
 	if create {
@@ -263,10 +263,7 @@ func (b *Builder) addManifest(ctx context.Context, manifestName string, imageSpe
 	} else {
 		imageID, err = list.SaveToImage(b.store, listImage.ID, nil, "")
 	}
-	if err == nil {
-		fmt.Printf("%s\n", imageID)
-	}
-	return err
+	return imageID, err
 }
 
 // Commit writes the contents of the container, along with its updated
@@ -489,9 +486,12 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 	}
 
 	if options.Manifest != "" {
-		if err := b.addManifest(ctx, options.Manifest, imgID); err != nil {
+		manifestID, err := b.addManifest(ctx, options.Manifest, imgID)
+		if err != nil {
 			return imgID, nil, "", err
 		}
+		logrus.Debugf("added imgID %s to manifestID %s", imgID, manifestID)
+
 	}
 	return imgID, ref, manifestDigest, nil
 }

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -115,6 +115,7 @@ type Executor struct {
 	imageInfoLock                  sync.Mutex
 	imageInfoCache                 map[string]imageTypeAndHistoryAndDiffIDs
 	fromOverride                   string
+	manifest                       string
 }
 
 type imageTypeAndHistoryAndDiffIDs struct {
@@ -231,6 +232,7 @@ func NewExecutor(store storage.Store, options BuildOptions, mainNode *parser.Nod
 		logRusage:                      options.LogRusage,
 		imageInfoCache:                 make(map[string]imageTypeAndHistoryAndDiffIDs),
 		fromOverride:                   options.From,
+		manifest:                       options.Manifest,
 	}
 	if exec.err == nil {
 		exec.err = os.Stderr

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1276,6 +1276,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		MaxRetries:            s.executor.maxPullPushRetries,
 		RetryDelay:            s.executor.retryPullPushDelay,
 		HistoryTimestamp:      s.executor.timestamp,
+		Manifest:              s.executor.manifest,
 	}
 	imgID, _, manifestDigest, err := s.builder.Commit(ctx, imageRef, options)
 	if err != nil {

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -26,6 +26,13 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest add foo ${IMAGE_LIST}
 }
 
+@test "manifest-add local image" {
+    target=scratch-image
+    run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+    run_buildah manifest create foo
+    run_buildah manifest add foo ${target}
+}
+
 @test "manifest-add-one" {
     run_buildah manifest create foo
     run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST_INSTANCE}


### PR DESCRIPTION
Currently if you attempt to build create a manifest
and add a local image, the command blows up.

The current code always looks for a remote image.
This PR fixes the code to use the local image if it
exists.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

