### PR TITLE
run: fix check for host pid namespace

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -2210,7 +2210,7 @@ func checkAndOverrideIsolationOptions(isolation Isolation, options *RunOptions) 
 	case IsolationOCI:
 		pidns := options.NamespaceOptions.Find(string(specs.PIDNamespace))
 		userns := options.NamespaceOptions.Find(string(specs.UserNamespace))
-		if (pidns == nil || pidns.Host) && (userns != nil && !userns.Host) {
+		if (pidns != nil && pidns.Host) && (userns != nil && !userns.Host) {
 			return errors.Errorf("not allowed to mix host PID namespace with container user namespace")
 		}
 	}


### PR DESCRIPTION
check the pidns is shared with the host only when the pidns mode is
specified.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

fix running with --userns-uid-map-user and --userns-gid-map-user

#### How to verify it

on my system, all builds created with --userns-uid-map-user failed with:

"not allowed to mix host PID namespace with container user namespace"

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

