### PR TITLE
--iidfile: print hash prefix

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -466,7 +466,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 			dest = dest2
 		}
 		if options.IIDFile != "" {
-			if err = ioutil.WriteFile(options.IIDFile, []byte(img.ID), 0644); err != nil {
+			if err = ioutil.WriteFile(options.IIDFile, []byte("sha256:"+img.ID), 0644); err != nil {
 				return imgID, nil, "", err
 			}
 		}

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -681,7 +681,7 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 	}
 	logrus.Debugf("printing final image id %q", imageID)
 	if b.iidfile != "" {
-		if err = ioutil.WriteFile(b.iidfile, []byte(imageID), 0644); err != nil {
+		if err = ioutil.WriteFile(b.iidfile, []byte("sha256:"+imageID), 0644); err != nil {
 			return imageID, ref, errors.Wrapf(err, "failed to write image ID to file %q", b.iidfile)
 		}
 	} else {

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -69,6 +69,7 @@ load helpers
   run_buildah unmount $cid
   run_buildah commit --iidfile output.iid --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   iid=$(cat output.iid)
+  [[ "$iid" == "sha256:"* ]]
   run_buildah rmi $iid
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   run_buildah rm $cid

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -368,6 +368,7 @@ symlink(subdir)"
   target=scratch-image
   run_buildah bud --iidfile ${TESTDIR}/output.iid --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
   iid=$(cat ${TESTDIR}/output.iid)
+  [[ "$iid" == "sha256:"* ]]
   run_buildah from ${iid}
   expect_output "${target}-working-container"
 }


### PR DESCRIPTION
Prefix the image ID with the hash prefix when using `--iidfile` to be
compatible with Docker.  The absence of the hash can cause
docker-compose to error out.

Reported-in: github.com/containers/podman/issues/9260
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>