### PR TITLE
[ci:docs] Fix tutorial for rootless mode

### DIFF
--- a/docs/tutorials/01-intro.md
+++ b/docs/tutorials/01-intro.md
@@ -100,6 +100,11 @@ Nope. This really is empty. The package installer `dnf` is not even inside this 
 
     # scratchmnt=$(buildah mount $newcontainer)
 
+Note: If attempting to mount in rootless mode, the command fails. Mounting an image needs to be done in a different mount namespace. Enter the mount namespace by executing the `buildah unshare` command. See buildah-mount(1) man page for more information.
+
+    $ buildah unshare
+    # scratchmnt=$(buildah mount $newcontainer)
+
 By echoing `$scratchmnt` we can see the path for the [overlay image](https://wiki.archlinux.org/index.php/Overlay_filesystem), which gives you a link directly to the root file system of the container.
 
     # echo $scratchmnt


### PR DESCRIPTION
Users have gotten confused when attempting the introduction turturial in
rootless mode.  Explain that they have to `buildah unshare` before
mounting the image.

Fixes: https://github.com/containers/buildah/issues/2833

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

