### PR TITLE
Add more support for removing config

### DIFF
--- a/docs/buildah-config.md
+++ b/docs/buildah-config.md
@@ -27,6 +27,7 @@ BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
 Add an image *annotation* (e.g. annotation=*annotation*) to the image manifest
 of any images which will be built using the specified container. Can be used multiple times.
 If *annotation* has a trailing `-`, then the *annotation* is removed from the config.
+If the *annotation* is set to "-" then all annotations are removed from the config.
 
 **--arch** *architecture*
 
@@ -81,6 +82,7 @@ executed together.
 Add a value (e.g. env=*value*) to the environment for containers based on any
 images which will be built using the specified container. Can be used multiple times.
 If *env* has a trailing `-`, then the *env* is removed from the config.
+If the *env* is set to "-" then all environment variables are removed from the config.
 
 **--healthcheck** *command*
 
@@ -143,6 +145,7 @@ Note: this setting is not present in the OCIv1 image format, so it is discarded 
 Add an image *label* (e.g. label=*value*) to the image configuration of any
 images which will be built using the specified container. Can be used multiple times.
 If *label* has a trailing `-`, then the *label* is removed from the config.
+If the *label* is set to "-" then all labels are removed from the config.
 
 **--onbuild** *onbuild command*
 
@@ -161,6 +164,8 @@ its OS is kept, otherwise the host's OS's name is recorded.
 
 Add a *port* to expose when running containers based on any images which
 will be built using the specified container. Can be used multiple times.
+If *port* has a trailing `-`, and is already set, then the *port* is removed from the config.
+If the port is set to "-" then all exposed ports settings are removed from the config.
 
 **--shell** *shell*
 
@@ -184,6 +189,7 @@ If names are used, the container should include entries for those names in its
 **--volume**, **-v** *volume*
 
 Add a location in the directory tree which should be marked as a *volume* in any images which will be built using the specified container. Can be used multiple times. If *volume* has a trailing `-`, and is already set, then the *volume* is removed from the config.
+If the *volume* is set to "-" then all volumes are removed from the config.
 
 **--workingdir** *directory*
 
@@ -214,6 +220,9 @@ buildah config --volume /usr/myvol containerID
 
 buildah config --volume /usr/myvol- containerID
 
+buildah config --port 1234 --port 8080 containerID
+
+buildah config --env 1234- containerID
 
 ## SEE ALSO
 buildah(1)


### PR DESCRIPTION
Currently we can remove configuration data in buildah config
by adding a trailing "-". This PR adds support for this in --port
calls.  Also added support for clearing all config for a specified
option, if the user specifies "-".

Currently the code blocks setting ANNOTATIONS and LABELS without a
value.  This is broken and should be allowed.

Similarly we were not expaning envioronment variables from the host when
they were not set.

podman run --env foobar
is valid,
so
buildah config --env foobar
should also be valid.

Fixes: https://github.com/containers/buildah/issues/2859

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

