### PR TITLE
Stop overriding the location of the blob info cache

### DIFF
--- a/common.go
+++ b/common.go
@@ -56,9 +56,6 @@ func getSystemContext(store storage.Store, defaults *types.SystemContext, signat
 		sc.SignaturePolicyPath = signaturePolicyPath
 	}
 	if store != nil {
-		if sc.BlobInfoCacheDir == "" {
-			sc.BlobInfoCacheDir = filepath.Join(store.GraphRoot(), "cache")
-		}
 		if sc.SystemRegistriesConfPath == "" && unshare.IsRootless() {
 			userRegistriesFile := filepath.Join(store.GraphRoot(), "registries.conf")
 			if _, err := os.Stat(userRegistriesFile); err == nil {


### PR DESCRIPTION
When it was first introduced, the blob info cache's location didn't
change from the system-wide default location when we were running in
rootless mode, so we started setting its location ourselves to avoid
triggering permissions errors when updating it.

The image library has since started taking into account that it was
running in rootless mode, but its hardwired default isn't the same as
the one we were setting, so we ended up creating a second cache file.

Stop doing that.

Signed-off-by: Nalin Dahyabhai <nalin@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

