### PR TITLE
Revert patch to allow copying of empty dirs.

### DIFF
--- a/add.go
+++ b/add.go
@@ -303,13 +303,6 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		renameTarget = filepath.Base(extractDirectory)
 		extractDirectory = filepath.Dir(extractDirectory)
 	}
-
-	// if the destination is a directory that doesn't yet exist, let's copy it.
-	newDestDirFound := false
-	if (len(destStats) == 1 || len(destStats[0].Globbed) == 0) && destMustBeDirectory && !destCanBeFile {
-		newDestDirFound = true
-	}
-
 	if len(destStats) == 1 && len(destStats[0].Globbed) == 1 && destStats[0].Results[destStats[0].Globbed[0]].IsRegular {
 		if destMustBeDirectory {
 			return errors.Errorf("destination %v already exists but is not a directory", destination)
@@ -400,12 +393,6 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 
 		// Iterate through every item that matched the glob.
 		itemsCopied := 0
-
-		// if the destination is a directory that doesn't yet exist, let's copy it.
-		if newDestDirFound {
-			itemsCopied++
-		}
-
 		for _, glob := range localSourceStat.Globbed {
 			rel, err := filepath.Rel(contextDir, glob)
 			if err != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2562,25 +2562,3 @@ _EOF
   run_buildah manifest inspect testlist
   expect_output --substring $digest
 }
-
-@test "bud test empty newdir" {
-  _prefetch alpine
-  mytmpdir=${TESTDIR}/my-dir
-  mkdir -p ${mytmpdir}
-cat > $mytmpdir/Containerfile << _EOF
-FROM alpine as galaxy
-
-RUN mkdir -p /usr/share/ansible/roles /usr/share/ansible/collections
-RUN echo "bar"
-RUN echo "foo" > /usr/share/ansible/collections/file.txt
-
-FROM galaxy
-
-RUN mkdir -p /usr/share/ansible/roles /usr/share/ansible/collections
-COPY --from=galaxy /usr/share/ansible/roles /usr/share/ansible/roles
-COPY --from=galaxy /usr/share/ansible/collections /usr/share/ansible/collections
-_EOF
-
-  run_buildah bud --layers --signature-policy ${TESTSDIR}/policy.json -t testbud $mytmpdir                                                   
-  expect_output --substring "COPY --from=galaxy /usr/share/ansible/collections /usr/share/ansible/collections"
-}


### PR DESCRIPTION
Revert patch to allow COPY/ADD of empty dirs.

This Patch breaks conformance with Docker.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

