### PR TITLE
add stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Mark stale issues and pull requests
+
+# Please refer to https://github.com/actions/stale/blob/master/action.yml
+# to see all config knobs of the stale action.
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'A friendly reminder that this issue had no activity for 30 days.'
+        stale-pr-message: 'A friendly reminder that this PR had no activity for 30 days.'
+        stale-issue-label: 'stale-issue'
+        stale-pr-label: 'stale-pr'
+        days-before-stale: 30
+        days-before-close: 365
+        remove-stale-when-updated: true


### PR DESCRIPTION
By popular demand, add the stale bot which we'are already using at
Podman.  The bot will remind us every 30 days of inactivity on specific
issues or pull requests and has turned into a useful tool to keep things
on the radar.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>