### PR TITLE
Chmod flag for add and copy

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -13,6 +13,7 @@ import (
 
 type addCopyResults struct {
 	addHistory bool
+	chmod      string
 	chown      string
 	quiet      bool
 	ignoreFile string
@@ -56,6 +57,7 @@ func init() {
 	addFlags.SetInterspersed(false)
 	addFlags.BoolVar(&addOpts.addHistory, "add-history", false, "add an entry for this operation to the image's history.  Use BUILDAH_HISTORY environment variable to override. (default false)")
 	addFlags.StringVar(&addOpts.chown, "chown", "", "set the user and group ownership of the destination content")
+	addFlags.StringVar(&addOpts.chmod, "chmod", "", "set the access permissions of the destination content")
 	addFlags.StringVar(&addOpts.contextdir, "contextdir", "", "context directory path")
 	addFlags.StringVar(&addOpts.ignoreFile, "ignorefile", "", "path to .dockerignore file")
 	addFlags.BoolVarP(&addOpts.quiet, "quiet", "q", false, "don't output a digest of the newly-added/copied content")
@@ -65,6 +67,7 @@ func init() {
 	copyFlags.SetInterspersed(false)
 	copyFlags.BoolVar(&copyOpts.addHistory, "add-history", false, "add an entry for this operation to the image's history.  Use BUILDAH_HISTORY environment variable to override. (default false)")
 	copyFlags.StringVar(&copyOpts.chown, "chown", "", "set the user and group ownership of the destination content")
+	copyFlags.StringVar(&copyOpts.chmod, "chmod", "", "set the access permissions of the destination content")
 	copyFlags.StringVar(&copyOpts.ignoreFile, "ignorefile", "", "path to .dockerignore file")
 	copyFlags.StringVar(&copyOpts.contextdir, "contextdir", "", "context directory path")
 	copyFlags.BoolVarP(&copyOpts.quiet, "quiet", "q", false, "don't output a digest of the newly-added/copied content")
@@ -108,6 +111,7 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, extractLocalArc
 	builder.ContentDigester.Restart()
 
 	options := buildah.AddAndCopyOptions{
+		Chmod:      iopts.chmod,
 		Chown:      iopts.chown,
 		ContextDir: iopts.contextdir,
 	}

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -539,6 +539,7 @@ return 1
 
      local options_with_args="
      --chown
+     --chmod
      --contextdir
      --ignorefile
   "
@@ -562,7 +563,8 @@ return 1
     "
 
      local options_with_args="
-     -chown
+     --chown
+     --chmod
      --contextdir
      --ignorefile
   "

--- a/docs/buildah-add.md
+++ b/docs/buildah-add.md
@@ -23,6 +23,10 @@ Defaults to false.
 Note: You can also override the default value of --add-history by setting the
 BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
 
+**--chmod** *permissions*
+
+Sets the access permissions of the destination content. Accepts the numerical format.
+
 **--chown** *owner*:*group*
 
 Sets the user and group ownership of the destination content.

--- a/docs/buildah-copy.md
+++ b/docs/buildah-copy.md
@@ -21,6 +21,10 @@ Defaults to false.
 Note: You can also override the default value of --add-history by setting the
 BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
 
+**--chmod** *permissions*
+
+Sets the access permissions of the destination content. Accepts the numerical format.
+
 **--chown** *owner*:*group*
 
 Sets the user and group ownership of the destination content.

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
 	github.com/opencontainers/runtime-tools v0.9.0
 	github.com/opencontainers/selinux v1.8.0
-	github.com/openshift/imagebuilder v1.1.8
+	github.com/openshift/imagebuilder v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20200616122406-847368b35ebf
 	github.com/sirupsen/logrus v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,8 @@ github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pK
 github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/opencontainers/selinux v1.8.0 h1:+77ba4ar4jsCbL1GLbFL8fFM57w6suPfSS9PDLDY7KM=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
-github.com/openshift/imagebuilder v1.1.8 h1:gjiIl8pbNj0eC4XWvFJHATdDvYm64p9/pLDLQWoLZPA=
-github.com/openshift/imagebuilder v1.1.8/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
+github.com/openshift/imagebuilder v1.2.0 h1:uoZFjJICLlTMjlAL/UG2PA2kM8RjAsVflGfHJK7MMDk=
+github.com/openshift/imagebuilder v1.2.0/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913 h1:TnbXhKzrTOyuvWrjI8W6pcoI9XPbLHFXCdN2dtUw7Rw=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -322,6 +322,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 			}
 		}
 		options := buildah.AddAndCopyOptions{
+			Chmod:             copy.Chmod,
 			Chown:             copy.Chown,
 			PreserveOwnership: preserveOwnership,
 			ContextDir:        contextDir,
@@ -723,15 +724,15 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		}
 
 		// Check if there's a --from if the step command is COPY.
-		// Also check the chown flag for validity.
+		// Also check the chmod and the chown flags for validity.
 		for _, flag := range step.Flags {
 			command := strings.ToUpper(step.Command)
-			// chown and from flags should have an '=' sign, '--chown=' or '--from='
-			if command == "COPY" && (flag == "--chown" || flag == "--from") {
-				return "", nil, errors.Errorf("COPY only supports the --chown=<uid:gid> and the --from=<image|stage> flags")
+			// chmod, chown and from flags should have an '=' sign, '--chmod=', '--chown=' or '--from='
+			if command == "COPY" && (flag == "--chmod" || flag == "--chown" || flag == "--from") {
+				return "", nil, errors.Errorf("COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image|stage> flags")
 			}
-			if command == "ADD" && flag == "--chown" {
-				return "", nil, errors.Errorf("ADD only supports the --chown=<uid:gid> flag")
+			if command == "ADD" && (flag == "--chmod" || flag == "--chown") {
+				return "", nil, errors.Errorf("ADD only supports the --chmod=<permissions> and the --chown=<uid:gid> flags")
 			}
 			if strings.Contains(flag, "--from") && command == "COPY" {
 				arr := strings.Split(flag, "=")

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -162,6 +162,17 @@ load helpers
   expect_output --substring bin.*bin
 }
 
+@test "add with chmod" {
+  _prefetch busybox
+  createrandom ${TESTDIR}/randomfile
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  cid=$output
+  run_buildah add --chmod 777 $cid ${TESTDIR}/randomfile /tmp/random
+  run_buildah run $cid ls -l /tmp/random
+
+  expect_output --substring rwxrwxrwx
+}
+
 @test "add url" {
   _prefetch busybox
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox

--- a/tests/bud/add-chmod/Dockerfile
+++ b/tests/bud/add-chmod/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine
+
+ADD --chmod=777 addchmod.txt /tmp 
+RUN ls -l /tmp/addchmod.txt 
+CMD /bin/sh
+

--- a/tests/bud/add-chmod/Dockerfile.bad
+++ b/tests/bud/add-chmod/Dockerfile.bad
@@ -1,0 +1,6 @@
+FROM alpine
+
+ADD --chmod 777 addchmod.txt /tmp 
+RUN ls -l /tmp/addchmod.txt 
+CMD /bin/sh
+

--- a/tests/bud/add-chmod/Dockerfile.combined
+++ b/tests/bud/add-chmod/Dockerfile.combined
@@ -1,0 +1,6 @@
+FROM alpine
+
+ADD --chmod=777 --chown=2367:3267 addchmod.txt /tmp 
+RUN stat -c "chmod:%a user:%u group:%g"  /tmp/addchmod.txt 
+CMD /bin/sh
+

--- a/tests/bud/add-chmod/addchmod.txt
+++ b/tests/bud/add-chmod/addchmod.txt
@@ -1,0 +1,1 @@
+File for testing ADD with chmod in a Dockerfile.

--- a/tests/bud/copy-chmod/Dockerfile
+++ b/tests/bud/copy-chmod/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine
+
+COPY --chmod=777 copychmod.txt /tmp 
+RUN ls -l /tmp/copychmod.txt 
+CMD /bin/sh
+

--- a/tests/bud/copy-chmod/Dockerfile.bad
+++ b/tests/bud/copy-chmod/Dockerfile.bad
@@ -1,0 +1,7 @@
+FROM alpine
+
+COPY --chmod 777 copychmod.txt /tmp 
+RUN ls -l /tmp/copychmod.txt 
+CMD /bin/sh
+
+

--- a/tests/bud/copy-chmod/Dockerfile.combined
+++ b/tests/bud/copy-chmod/Dockerfile.combined
@@ -1,0 +1,6 @@
+FROM alpine
+
+COPY --chmod=777 --chown=2367:3267 copychmod.txt /tmp 
+RUN stat -c "chmod:%a user:%u group:%g"  /tmp/copychmod.txt 
+CMD /bin/sh
+

--- a/tests/bud/copy-chmod/copychmod.txt
+++ b/tests/bud/copy-chmod/copychmod.txt
@@ -1,0 +1,1 @@
+File for testing COPY with chmod in a Dockerfile.

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -194,6 +194,48 @@ load helpers
   expect_output "nobody:root" "stat UG /subdir"
 }
 
+@test "copy --chmod" {
+  mkdir -p ${TESTDIR}/subdir
+  mkdir -p ${TESTDIR}/other-subdir
+  createrandom ${TESTDIR}/subdir/randomfile
+  createrandom ${TESTDIR}/subdir/other-randomfile
+  createrandom ${TESTDIR}/randomfile
+  createrandom ${TESTDIR}/other-subdir/randomfile
+  createrandom ${TESTDIR}/other-subdir/other-randomfile
+
+  _prefetch alpine
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
+  run_buildah config --workingdir / $cid
+  run_buildah copy --chmod 777 $cid ${TESTDIR}/randomfile
+  run_buildah copy --chmod 700 $cid ${TESTDIR}/randomfile /randomfile2
+  run_buildah copy --chmod 755 $cid ${TESTDIR}/randomfile /randomfile3
+  run_buildah copy --chmod 660 $cid ${TESTDIR}/subdir /subdir
+
+  run_buildah run $cid ls -l /randomfile
+  expect_output --substring rwxrwxrwx
+
+  run_buildah run $cid ls -l /randomfile2
+  expect_output --substring rwx------
+
+  run_buildah run $cid ls -l /randomfile3
+  expect_output --substring rwxr-xr-x
+
+  for i in randomfile other-randomfile ; do
+      run_buildah run $cid ls -l /subdir/$i
+      expect_output --substring rw-rw----
+  done
+
+  run_buildah run $cid ls -l /subdir
+  expect_output --substring rw-rw----
+
+  run_buildah copy --chmod 600 $cid ${TESTDIR}/other-subdir /subdir
+  for i in randomfile other-randomfile ; do
+      run_buildah run $cid ls -l /subdir/$i
+      expect_output --substring rw-------
+  done
+}
+
 @test "copy-symlink" {
   createrandom ${TESTDIR}/randomfile
   ln -s ${TESTDIR}/randomfile ${TESTDIR}/link-randomfile

--- a/vendor/github.com/openshift/imagebuilder/builder.go
+++ b/vendor/github.com/openshift/imagebuilder/builder.go
@@ -30,6 +30,7 @@ type Copy struct {
 	// If set, the owner:group for the destination.  This value is passed
 	// to the executor for handling.
 	Chown string
+	Chmod string
 }
 
 // Run defines a run operation required in the container.
@@ -60,7 +61,7 @@ func (logExecutor) EnsureContainerPath(path string) error {
 
 func (logExecutor) Copy(excludes []string, copies ...Copy) error {
 	for _, c := range copies {
-		log.Printf("COPY %v -> %s (from:%s download:%t), chown: %s", c.Src, c.Dest, c.From, c.Download, c.Chown)
+		log.Printf("COPY %v -> %s (from:%s download:%t), chown: %s, chmod %s", c.Src, c.Dest, c.From, c.Download, c.Chown, c.Chmod)
 	}
 	return nil
 }
@@ -562,22 +563,39 @@ var builtinAllowedBuildArgs = map[string]bool{
 	"no_proxy":    true,
 }
 
-// ParseDockerIgnore returns a list of the excludes in the .dockerignore file.
+// ParseIgnore returns a list of the excludes in the specified path
+// path should be a file with the .dockerignore format
 // extracted from fsouza/go-dockerclient and modified to drop comments and
 // empty lines.
-func ParseDockerignore(root string) ([]string, error) {
+func ParseIgnore(path string) ([]string, error) {
 	var excludes []string
-	ignore, err := ioutil.ReadFile(filepath.Join(root, ".dockerignore"))
-	if err != nil && !os.IsNotExist(err) {
-		return excludes, fmt.Errorf("error reading .dockerignore: '%s'", err)
+
+	ignores, err := ioutil.ReadFile(path)
+	if err != nil {
+		return excludes, err
 	}
-	for _, e := range strings.Split(string(ignore), "\n") {
-		if len(e) == 0 || e[0] == '#' {
+	for _, ignore := range strings.Split(string(ignores), "\n") {
+		if len(ignore) == 0 || ignore[0] == '#' {
 			continue
 		}
-		excludes = append(excludes, e)
+		ignore = strings.Trim(ignore, "/")
+		if len(ignore) > 0 {
+			excludes = append(excludes, ignore)
+		}
 	}
 	return excludes, nil
+}
+
+// ParseDockerIgnore returns a list of the excludes in the .containerignore or .dockerignore file.
+func ParseDockerignore(root string) ([]string, error) {
+	excludes, err := ParseIgnore(filepath.Join(root, ".containerignore"))
+	if err != nil && os.IsNotExist(err) {
+		excludes, err = ParseIgnore(filepath.Join(root, ".dockerignore"))
+	}
+	if err != nil && os.IsNotExist(err) {
+		return excludes, nil
+	}
+	return excludes, err
 }
 
 // ExportEnv creates an export statement for a shell that contains all of the

--- a/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
+++ b/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
@@ -12,7 +12,7 @@
 #
 
 %global golang_version 1.8.1
-%{!?version: %global version 1.1.8}
+%{!?version: %global version 1.2.0}
 %{!?release: %global release 1}
 %global package_name imagebuilder
 %global product_name Container Image Builder

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -380,7 +380,7 @@ github.com/opencontainers/runtime-tools/validate
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
-# github.com/openshift/imagebuilder v1.1.8
+# github.com/openshift/imagebuilder v1.2.0
 github.com/openshift/imagebuilder
 github.com/openshift/imagebuilder/dockerclient
 github.com/openshift/imagebuilder/dockerfile/command


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Adds chmod flag to ADD and COPY
#### How to verify it
Used bats files, but open to suggestions

#### Which issue(s) this PR fixes:
Fixes #2961

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes

```
Support added for --chmod flag to ADD/COPY in Dockerfile
Support added for --chmod flag to buildah cli ADD/COPY
```
