### PR TITLE
Fix reaping of stages with no instructions

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -420,7 +420,8 @@ func (b *Executor) buildStage(ctx context.Context, cleanupStages map[int]*StageE
 	// build and b.forceRmIntermediateCtrs is set, make sure we
 	// remove the intermediate/build containers, regardless of
 	// whether or not the stage's build fails.
-	if b.forceRmIntermediateCtrs || !b.layers {
+	// Skip cleanup if the stage has no instructions.
+	if b.forceRmIntermediateCtrs || !b.layers && len(stage.Node.Children) > 0 {
 		b.stagesLock.Lock()
 		cleanupStages[stage.Position] = stageExecutor
 		b.stagesLock.Unlock()
@@ -434,7 +435,8 @@ func (b *Executor) buildStage(ctx context.Context, cleanupStages map[int]*StageE
 	// The stage succeeded, so remove its build container if we're
 	// told to delete successful intermediate/build containers for
 	// multi-layered builds.
-	if b.removeIntermediateCtrs {
+	// Skip cleanup if the stage has no instructions.
+	if b.removeIntermediateCtrs && len(stage.Node.Children) > 0 {
 		b.stagesLock.Lock()
 		cleanupStages[stage.Position] = stageExecutor
 		b.stagesLock.Unlock()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
Stages with no instructions are removed which can cause undesired behavior. For example, if a user has an existing image referenced in a Dockerfile:

```
FROM foo
FROM bar
```
`foo` will be removed from the host. This would normally be desired in a similar build:

```
FROM foo as build
RUN make thing
FROM scratch
COPY --from build thing /
```
where we would want to cleanup the `build` stage from the host.

#### How to verify it

- Pull the latest alpine: `buildah pull alpine`.
- Create a Dockerfile:

```
FROM alpine
FROM scratch
RUN touch /foo
```

- Build the image: `buildah bud .`

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

Fixes #1920 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

