### PR TITLE
pr-should-include-tests: recognized "renamed" tests

### DIFF
--- a/tests/validate/pr-should-include-tests
+++ b/tests/validate/pr-should-include-tests
@@ -25,7 +25,8 @@ base=$(git merge-base ${DEST_BRANCH:-master} $head)
 #    A    foo.c
 #    M    bar.c
 # We look for Added or Modified (not Deleted!) files under 'tests'.
-if git diff --name-status $base $head | egrep -q '^[AM]\s+(tests/|.*_test\.go)'; then
+# --no-renames ensures that renamed tests show up as 'A'dded.
+if git diff --name-status --no-renames $base $head | egrep -q '^[AM]\s+(tests/|.*_test\.go)'; then
     exit 0
 fi
 


### PR DESCRIPTION
git tries to recognize renamed files. This isn't always
as helpful as intended. Turn it off, so we'll always see
files as 'A'dded.

This is a simple copy of podman PR 9468, but without a
test case because I can find no instances of a .bats
file being renamed in the buildah git history.

Signed-off-by: Ed Santiago <santiago@redhat.com>
