### PR TITLE
Cirrus: Temp. disable prior-fedora (F32) testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -237,9 +237,9 @@ integration_task:
         - env:
             DISTRO_NV: "${FEDORA_NAME}"
             IMAGE_NAME: "${FEDORA_CACHE_IMAGE_NAME}"
-        - env:
-            DISTRO_NV: "${PRIOR_FEDORA_NAME}"
-            IMAGE_NAME: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
+        # - env:
+        #     DISTRO_NV: "${PRIOR_FEDORA_NAME}"
+        #     IMAGE_NAME: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
         - env:
             DISTRO_NV: "${UBUNTU_NAME}"
             IMAGE_NAME: "${UBUNTU_CACHE_IMAGE_NAME}"


### PR DESCRIPTION
In anticipation of F34beta support, preemptively disable testing on
"prior-Fedora". This will allow development to move forward without
a soon-to-be-EOL distro. holding anything back.