### PR TITLE
Isolation strings, should match user input

### DIFF
--- a/define/isolation.go
+++ b/define/isolation.go
@@ -21,14 +21,12 @@ const (
 // String converts a Isolation into a string.
 func (i Isolation) String() string {
 	switch i {
-	case IsolationDefault:
-		return "IsolationDefault"
-	case IsolationOCI:
-		return "IsolationOCI"
+	case IsolationDefault, IsolationOCI:
+		return "oci"
 	case IsolationChroot:
-		return "IsolationChroot"
+		return "chroot"
 	case IsolationOCIRootless:
-		return "IsolationOCIRootless"
+		return "rootless"
 	}
 	return fmt.Sprintf("unrecognized isolation type %d", i)
 }

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -959,7 +959,7 @@ func defaultIsolation() (define.Isolation, error) {
 func IsolationOption(isolation string) (define.Isolation, error) {
 	if isolation != "" {
 		switch strings.ToLower(isolation) {
-		case "oci":
+		case "oci", "default":
 			return define.IsolationOCI, nil
 		case "rootless":
 			return define.IsolationOCIRootless, nil

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -1,6 +1,7 @@
 package parse
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -92,4 +93,32 @@ func TestDeviceFromPath(t *testing.T) {
 	// path of directory has no device
 	_, err = DeviceFromPath("/etc/passwd")
 	assert.Error(t, err)
+}
+
+func TestIsolation(t *testing.T) {
+	def, err := defaultIsolation()
+	if err != nil {
+		assert.Error(t, err)
+	}
+
+	isolations := []string{"", "default", "oci", "chroot", "rootless"}
+	for _, i := range isolations {
+		isolation, err := IsolationOption(i)
+		if err != nil {
+			assert.Error(t, fmt.Errorf("isolation %q not supported", i))
+		}
+		var expected string
+		switch i {
+		case "":
+			expected = def.String()
+		case "default":
+			expected = "oci"
+		default:
+			expected = i
+		}
+
+		if isolation.String() != expected {
+			assert.Error(t, fmt.Errorf("isolation %q not equal to user input %q", isolation.String(), expected))
+		}
+	}
 }


### PR DESCRIPTION
When we parse isolation we expect users to input chroot, oci, rootless.

So when we translate the constants back to strings, we should use the
same values.

These human names need to be passed over the podman-remote build
bindings, so we need to make them match.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

