### PR TITLE
Clarify image name match failure message

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -360,7 +360,7 @@ func outputImages(ctx context.Context, systemContext *types.SystemContext, store
 	}
 
 	if !found && argName != "" {
-		return errors.Errorf("No such image %s", argName)
+		return errors.Errorf("No such image: %s", argName)
 	}
 	if opts.json {
 		data, err := json.MarshalIndent(jsonImages, "", "    ")

--- a/cmd/buildah/images_test.go
+++ b/cmd/buildah/images_test.go
@@ -176,7 +176,7 @@ func TestOutputImagesArgNoMatch(t *testing.T) {
 	_, err = captureOutputWithError(func() error {
 		return outputImages(getContext(), &testSystemContext, store, images[:1], nil, "foo:", opts)
 	})
-	if err == nil || err.Error() != "No such image foo:" {
+	if err == nil || err.Error() != "No such image: foo:" {
 		t.Fatalf("expected error arg no match")
 	}
 }

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -148,7 +148,7 @@ load helpers
 
 @test "specify a nonexistent image" {
   run_buildah 125 images alpine
-  expect_output --from="${lines[0]}" "No such image alpine"
+  expect_output --from="${lines[0]}" "No such image: alpine"
   expect_line_count 1
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

This PR changes the output text for an image name match failure to be more clear about what's going on. Being new to buildah, I ran this: `buildah images list`, much like the `buildah list` command, but for images (so I thought). The way I read the error message (`No such image list`), implied that there was no such thing, rather than a simple syntax error. Some confusion ensued, mostly because I was being dumb. :)

This changes the error message to read: `No such image: list`, which should help anyone who does the same thing I did realize it faster.

#### How to verify it

The test case has been updated to match.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Added a colon to the `buildah images <image_name>` error message to help differentiate the error message from the error inducing image name.
```

