### PR TITLE
Make PolicyMap and PullPolicy names align

### DIFF
--- a/define/pull.go
+++ b/define/pull.go
@@ -25,24 +25,19 @@ const (
 	// take, signalling that the source image should not be pulled from a
 	// registry.
 	PullNever
-
-	// OCI used to define the "oci" image format
-	OCI = "oci"
-	// DOCKER used to define the "docker" image format
-	DOCKER = "docker"
 )
 
 // String converts a PullPolicy into a string.
 func (p PullPolicy) String() string {
 	switch p {
 	case PullIfMissing:
-		return "PullIfMissing"
+		return "missing"
 	case PullAlways:
-		return "PullAlways"
+		return "always"
 	case PullIfNewer:
-		return "PullIfNewer"
+		return "ifnewer"
 	case PullNever:
-		return "PullNever"
+		return "never"
 	}
 	return fmt.Sprintf("unrecognized policy %d", p)
 }

--- a/define/pull_test.go
+++ b/define/pull_test.go
@@ -1,0 +1,13 @@
+package define
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPullPolicy(t *testing.T) {
+	for name, val := range PolicyMap {
+		assert.Equal(t, name, val.String())
+	}
+}

--- a/define/types.go
+++ b/define/types.go
@@ -45,6 +45,11 @@ const (
 	// manifest, suitable for specifying as a value of the
 	// PreferredManifestType member of a CommitOptions structure.
 	Dockerv2ImageManifest = manifest.DockerV2Schema2MediaType
+
+	// OCI used to define the "oci" image format
+	OCI = "oci"
+	// DOCKER used to define the "docker" image format
+	DOCKER = "docker"
 )
 
 var (


### PR DESCRIPTION
Currently it is impossible to switch from a PullPolicy type
and PolicyMap via strings.  This PR Makes the types align.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

