### PR TITLE
copier: ignore sockets

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -1128,6 +1128,10 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 						}
 						return errors.Wrapf(err, "copier: get: error reading %q", path)
 					}
+					if info.Mode()&os.ModeType == os.ModeSocket {
+						logrus.Warningf("buildah/copier: skipping socket %q", info.Name())
+						return nil
+					}
 					// compute the path of this item
 					// relative to the top-level directory,
 					// for the tar header


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

fix image squashing that have sockets

#### How to verify it

follow the reproducer here: https://github.com/containers/buildah/issues/3074

#### Which issue(s) this PR fixes:

Fixes: #3074

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
fix squashing of images that contain sockets
```

