### PR TITLE
Add Tag format placeholder to docs

### DIFF
--- a/docs/buildah-images.md
+++ b/docs/buildah-images.md
@@ -50,10 +50,11 @@ Valid placeholders for the Go template are listed below:
 
 | **Placeholder** | **Description**                          |
 | --------------- | -----------------------------------------|
+| .Tag            | Image Tag                                |
 | .ID             | Image ID                                 |
 | .Name           | Image Name                               |
 | .Digest         | Image Digest                             |
-| .CreatedAt      | Creation date Pretty Formatted            |
+| .CreatedAt      | Creation date Pretty Formatted           |
 | .Size           | Image Size                               |
 | .CreatedAtRaw   | Creation date in raw format              |
 | .ReadOnly       | Indicates if image came from a R/O store |


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind documentation

#### What this PR does / why we need it:
Adds Tag placeholder for `buildah image --format` to docs (and fixes spacing on `CreatedAt` table). The Tag placeholder ![exists](https://github.com/containers/buildah/blob/35300f3ba8191e57bbdc77b3b7e923d72acb29a0/cmd/buildah/images.go#L37) and is useful, but is missing from the `buildah images` docs.

#### How to verify it
```
buildah images --format '{{.Name}} {{.Tag}}'
```

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
