### PR TITLE
Lookup Containerfile if user specifies a directory

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -84,12 +84,21 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 				return "", nil, err
 			}
 
+			var contents *os.File
 			// If given a directory, add '/Dockerfile' to it.
 			if dinfo.Mode().IsDir() {
-				dfile = filepath.Join(dfile, "Dockerfile")
+				for _, file := range []string{"Containerfile", "Dockerfile"} {
+					f := filepath.Join(dfile, file)
+					logrus.Debugf("reading local %q", f)
+					contents, err = os.Open(f)
+					if err == nil {
+						break
+					}
+				}
+			} else {
+				contents, err = os.Open(dfile)
 			}
-			logrus.Debugf("reading local Dockerfile %q", dfile)
-			contents, err := os.Open(dfile)
+
 			if err != nil {
 				return "", nil, err
 			}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2701,3 +2701,14 @@ _EOF
   run_buildah inspect --format '{{ index .OCIv1.Architecture  }}'  $fromiid
   expect_output --substring arm64
 }
+
+@test "bud --file with directory" {
+  _prefetch alpine
+  mytmpdir=${TESTDIR}/my-dir1
+  mkdir -p ${mytmpdir}
+  cat > $mytmpdir/Containerfile << _EOF
+FROM alpine
+_EOF
+
+  run_buildah bud -t testbud --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+}


### PR DESCRIPTION
Currently if the user specifies a --file path
and path is a directory, we only append on Dockerfile.
This PR searches for Containerfile and then Dockerfile.

Fixes: https://github.com/containers/buildah/issues/3078

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

