### PR TITLE
[release-1.19] DO NOT MERGE Add base image name to comment

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -126,6 +126,8 @@ symlink(subdir)"
   expect_output "map[8080/tcp:{}]"
   run_buildah inspect --format "{{.Docker.ContainerConfig.ExposedPorts}}" test2
   expect_output "map[8080/tcp:{}]"
+  run_buildah inspect --format "{{index .Docker.History 2}}" test1
+  expect_output --substring "FROM localhost/alpine:latest"
 
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTDIR}/use-layers
   run_buildah images -a


### PR DESCRIPTION
Cherry-pick of https://github.com/containers/buildah/pull/2996

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

 /kind feature


#### What this PR does / why we need it:
Add the name of the base image being used by the build
in the comments of the first layer created.

#### How to verify it

Build an image and run podman history for that image, you will see the base image in the comment.

#### Which issue(s) this PR fixes:

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1649044

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Base image used during build will show up as a comment when looking at the image history.
```

