### PR TITLE
COPY --chown: expand the conformance test

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -1967,7 +1967,7 @@ func getDNSIP(dnsServers []string) (dns []net.IP, err error) {
 
 func (b *Builder) configureUIDGID(g *generate.Generator, mountPoint string, options RunOptions) (string, error) {
 	// Set the user UID/GID/supplemental group list/capabilities lists.
-	user, homeDir, err := b.user(mountPoint, options.User)
+	user, homeDir, err := b.userForRun(mountPoint, options.User)
 	if err != nil {
 		return "", err
 	}

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1375,6 +1375,12 @@ var internalTestCases = []testCase{
 	},
 
 	{
+		name:       "copy with --chown",
+		contextDir: "copychown",
+		fsSkip:     []string{"(dir):usr:(dir):bin:mtime", "(dir):usr:(dir):local:(dir):bin:mtime"},
+	},
+
+	{
 		name:       "directory with slash",
 		contextDir: "overlapdirwithslash",
 	},

--- a/tests/conformance/testdata/copychown/Dockerfile
+++ b/tests/conformance/testdata/copychown/Dockerfile
@@ -1,0 +1,11 @@
+FROM centos:7
+COPY --chown=1:2    script /usr/bin/script.12
+COPY --chown=1:adm  script /usr/bin/script.1-adm
+COPY --chown=1      script /usr/bin/script.1
+COPY --chown=lp:adm script /usr/bin/script.lp-adm
+COPY --chown=2:mail script /usr/bin/script.2-mail
+COPY --chown=2      script /usr/bin/script.2
+COPY --chown=bin    script /usr/bin/script.bin
+COPY --chown=lp     script /usr/bin/script.lp
+COPY --chown=3      script script2 /usr/local/bin/
+RUN ls -al /usr/bin/script

--- a/tests/conformance/testdata/copychown/script
+++ b/tests/conformance/testdata/copychown/script
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 0

--- a/tests/conformance/testdata/copychown/script2
+++ b/tests/conformance/testdata/copychown/script2
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Expand conformance test coverage for COPY --chown, and correct our behavior when the argument is a single number: instead of assuming the number is the UID and the GID = 0, the GID should be the same as the UID.

#### How to verify it

New conformance test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Grew out of the conformance tests for https://github.com/openshift/imagebuilder/pull/188.

#### Does this PR introduce a user-facing change?

```
When `COPY --chown` specifies an owner that's just a single number (e.g. "12"), the UID on copied content is set to the specified value, and the GID was previously set to 0.  This changes the GID to be set to the same value as the UID.
```