### PR TITLE
Use faster way to check image tag existence during multi-arch build

### DIFF
--- a/.github/workflows/multi-arch-build.yaml
+++ b/.github/workflows/multi-arch-build.yaml
@@ -81,13 +81,13 @@ jobs:
             VERSION=v"$(echo "${{ steps.sniff_test.outputs.version_output }}" | head -n 1 | awk '{print $2}')"
             # quay.io/buildah/stable:vX.X.X
             # Check if stable image with current version already exists and make decision if new one needs to be pushed
-            PUSH=$(docker pull ${{ env.BUILDAH_QUAY_REGISTRY}}/${{ matrix.source }}:${VERSION} &>/dev/null && echo 'false' || echo 'true')
+            PUSH=$(skopeo list-tags docker://${{ env.BUILDAH_QUAY_REGISTRY}}/${{ matrix.source }} | jq -r .Tags[] | grep -q "^${VERSION}$" && echo 'false' || echo 'true')
             echo ::set-output name=buildah_push::${PUSH}
             echo ::set-output name=buildah_tag::"${{ env.BUILDAH_QUAY_REGISTRY}}/${{ matrix.source }}:${VERSION}"
 
             # quay.io/contaners/buildah:vX.X.X
             # Check if stable image with current version already exists and make decision if new one needs to be pushed
-            PUSH=$(docker pull ${{ env.CONTAINERS_QUAY_REGISTRY}}/buildah:${VERSION} &>/dev/null && echo 'false' || echo 'true')
+            PUSH=$(skopeo list-tags docker://${{ env.CONTAINERS_QUAY_REGISTRY}}/buildah| jq -r .Tags[] | grep -q "^${VERSION}$" && echo 'false' || echo 'true')
             echo ::set-output name=containers_push::${PUSH}
             echo ::set-output name=containers_tag::"${{ env.CONTAINERS_QUAY_REGISTRY}}/buildah:${VERSION}"
           fi


### PR DESCRIPTION

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Use `skopeo list-tags` instead of `docker pull` makes check of image tag existence during multi-arch image build workflow much faster.
This is slight modification of the approach suggested by @cevich in previous [PR](https://github.com/containers/buildah/pull/3059#discussion_r590478210) for multi-arch build.
