### PR TITLE
tests: prefetch: use buildah, not podman, for pulls

### DIFF
--- a/tests/from.bats
+++ b/tests/from.bats
@@ -425,7 +425,7 @@ load helpers
   fi
 
   _prefetch docker.io/busybox
-  podman run --name busyboxc-podman -d busybox top
+  podman run --name busyboxc-podman -d docker.io/busybox top
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc docker.io/busybox
   expect_output --substring "busyboxc"
   podman rm -f busyboxc-podman

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -79,12 +79,12 @@ function _prefetch() {
                 echo "# [restoring from cache: $_BUILDAH_IMAGE_CACHEDIR / $img]" >&2
                 podman $_podman_opts load -i $_BUILDAH_IMAGE_CACHEDIR/$fname.tar
             else
-                echo "# [podman pull $img]" >&2
-                podman $_podman_opts pull $img || (
+                echo "# [buildah pull $img]" >&2
+                buildah pull $img || (
                     echo "Retrying:"
-                    podman $_podman_opts pull $img || (
+                    buildah pull $img || (
                         echo "Re-retrying:"
-                        podman $_podman_opts pull $img
+                        buildah pull $img
                     )
                 )
                 rm -f $_BUILDAH_IMAGE_CACHEDIR/$fname.tar

--- a/tests/registries.conf
+++ b/tests/registries.conf
@@ -15,3 +15,10 @@ location="mirror.gcr.io"
 [[registry]]
 prefix="docker.io/library"
 location="quay.io/libpod"
+
+# 2021-03-23 these are used in buildah system tests, but not (yet?)
+# listed in the global shortnames.conf.
+[aliases]
+busybox="docker.io/library/busybox"
+ubuntu="docker.io/library/ubuntu"
+php="docker.io/library/php"


### PR DESCRIPTION
The _prefetch helper has proven invaluable in reducing pull-
related flakes. However, it is now failing because it uses
podman to pull, and buildah tests rely on shortnames, and
podman no longer works with shortnames.

Solution: use buildah, not podman, for initial image pulls.
(The reason we used podman in the first place is because
buildah does not have save/load. But since image store
is shared, we can use buildah for pull and podman for save
and load.)

Add shortname config to registries.conf. I don't think it's
actually necessary or even used, but we can tweak it later.

And, fix one test in from.bats that was using inconsistent
names between buildah and podman.

Fixes: #3096 

Signed-off-by: Ed Santiago <santiago@redhat.com>
