### PR TITLE
run_linux: warn on overlapping bind mounts

### DIFF
--- a/run.go
+++ b/run.go
@@ -3,6 +3,7 @@ package buildah
 import (
 	"fmt"
 	"io"
+	"path/filepath"
 
 	"github.com/containers/buildah/define"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -134,4 +135,21 @@ type RunOptions struct {
 	DropCapabilities []string
 	// Devices are the additional devices to add to the containers
 	Devices define.ContainerDevices
+}
+
+func pathCovers(parent, subdirectory string) bool {
+	parent = filepath.Clean(parent)
+	dir := filepath.Clean(subdirectory)
+	for dir != "" {
+		if dir == parent {
+			return true
+		}
+		up, _ := filepath.Split(dir)
+		up = filepath.Clean(up)
+		if up == dir {
+			return false
+		}
+		dir = up
+	}
+	return false
 }

--- a/run_linux.go
+++ b/run_linux.go
@@ -525,6 +525,11 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 			// Already mounting something there, no need to bother with this one.
 			continue
 		}
+		for _, knownMount := range mounts {
+			if pathCovers(mount.Destination, knownMount.Destination) {
+				logrus.Warnf("configured mount %q hides other configured mount %q", mount.Destination, knownMount.Destination)
+			}
+		}
 		// Add the mount.
 		mounts = append(mounts, mount)
 	}

--- a/run_test.go
+++ b/run_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAddRlimits(t *testing.T) {
@@ -78,6 +79,28 @@ func TestAddRlimits(t *testing.T) {
 		err := addRlimits(tst.ulimit, &g, []string{})
 		if testErr := tst.test(err, &g); testErr != nil {
 			t.Errorf("test %#v failed: %v", tst.name, testErr)
+		}
+	}
+}
+
+func TestPathCovers(t *testing.T) {
+	testCases := []struct {
+		parent, subdirectory string
+		covers               bool
+	}{
+		{"/", "/subdirectory", true},
+		{"/run/secrets", "/run/secrets/other", true},
+		{"/run/secrets", "/run/tmp", false},
+		{"/run/secrets", "/run/secrets2", false},
+		{"/run/secrets", "/tmp", false},
+		{"/run", "/tmp", false},
+		{"/run", "/run", true},
+	}
+	for i, testCase := range testCases {
+		if testCase.covers {
+			assert.Truef(t, pathCovers(testCase.parent, testCase.subdirectory), "case %d: parent=%q,subdirectory=%q", i, testCase.parent, testCase.subdirectory)
+		} else {
+			assert.Falsef(t, pathCovers(testCase.parent, testCase.subdirectory), "case %d: parent=%q,subdirectory=%q", i, testCase.parent, testCase.subdirectory)
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Warn when one configured bind mount will "hide" the contents of another configured bind mount.  The list of mounts comes from multiple places now, so it can be hard to troubleshoot this problem.

#### How to verify it

`buildah run -v /var/tmp/foo:/run/secrets/foo $container /bin/sh` will not be able to see `/run/secrets/foo` because it's hidden by a mount at `/run/secrets`.  At least now you'll get a warning about it.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```