### PR TITLE
Sort all mounts by destination directory

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -519,8 +519,9 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 		return err
 	}
 
+	allMounts := util.SortMounts(append(append(append(append(append(volumes, builtins...), secretMounts...), bindFileMounts...), specMounts...), sysfsMount...))
 	// Add them all, in the preferred order, except where they conflict with something that was previously added.
-	for _, mount := range append(append(append(append(append(volumes, builtins...), secretMounts...), bindFileMounts...), specMounts...), sysfsMount...) {
+	for _, mount := range allMounts {
 		if haveMount(mount.Destination) {
 			// Already mounting something there, no need to bother with this one.
 			continue

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -250,6 +250,9 @@ function configure_and_check_user() {
 	run_buildah run -v ${TESTDIR}/was-empty:/var/multi-level/subdirectory        $cid touch /var/multi-level/subdirectory/testfile
 	# And check the same for file volumes.
 	run_buildah run -v ${TESTDIR}/was-empty/testfile:/var/different-multi-level/subdirectory/testfile        $cid touch /var/different-multi-level/subdirectory/testfile
+	# And check the same for file volumes.
+	# Make sure directories show up inside of container on builtin mounts
+	run_buildah run -v ${TESTDIR}/was-empty:/run/secrets/testdir $cid ls -ld /run/secrets/testdir
 }
 
 @test "run --volume with U flag" {

--- a/util/util.go
+++ b/util/util.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -473,4 +475,27 @@ func MergeEnv(defaults, overrides []string) []string {
 		index[envVar[0]] = len(s) - 1
 	}
 	return s
+}
+
+type byDestination []specs.Mount
+
+func (m byDestination) Len() int {
+	return len(m)
+}
+
+func (m byDestination) Less(i, j int) bool {
+	return m.parts(i) < m.parts(j)
+}
+
+func (m byDestination) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
+}
+
+func (m byDestination) parts(i int) int {
+	return strings.Count(filepath.Clean(m[i].Destination), string(os.PathSeparator))
+}
+
+func SortMounts(m []specs.Mount) []specs.Mount {
+	sort.Sort(byDestination(m))
+	return m
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/containers/common/pkg/config"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func TestMergeEnv(t *testing.T) {
@@ -40,6 +41,7 @@ func TestMergeEnv(t *testing.T) {
 		})
 	}
 }
+
 func TestRuntime(t *testing.T) {
 	os.Setenv("CONTAINERS_CONF", "/dev/null")
 	conf, _ := config.Default()
@@ -54,4 +56,82 @@ func TestRuntime(t *testing.T) {
 	if runtime != defaultRuntime {
 		t.Fatalf("expected %v, got %v", runtime, defaultRuntime)
 	}
+}
+
+func TestMountsSort(t *testing.T) {
+	mounts1a := []specs.Mount{
+		{
+			Source:      "/a/bb/c",
+			Destination: "/a/bb/c",
+		},
+		{
+			Source:      "/a/b/c",
+			Destination: "/a/b/c",
+		},
+		{
+			Source:      "/a",
+			Destination: "/a",
+		},
+		{
+			Source:      "/a/b",
+			Destination: "/a/b",
+		},
+		{
+			Source:      "/d/e",
+			Destination: "/a/c",
+		},
+		{
+			Source:      "/b",
+			Destination: "/b",
+		},
+		{
+			Source:      "/",
+			Destination: "/",
+		},
+		{
+			Source:      "/a/b/c",
+			Destination: "/aa/b/c",
+		},
+	}
+	mounts1b := []specs.Mount{
+		{
+			Source:      "/xyz",
+			Destination: "/",
+		},
+		{
+			Source:      "/a",
+			Destination: "/a",
+		},
+		{
+			Source:      "/b",
+			Destination: "/b",
+		},
+		{
+			Source:      "/a/b",
+			Destination: "/a/b",
+		},
+		{
+			Source:      "/d/e",
+			Destination: "/a/c",
+		},
+		{
+			Source:      "/a/b/c",
+			Destination: "/a/b/c",
+		},
+		{
+			Source:      "/a/bb/c",
+			Destination: "/a/bb/c",
+		},
+		{
+			Source:      "/a/b/c",
+			Destination: "/aa/b/c",
+		},
+	}
+	sorted := SortMounts(mounts1a)
+	for i := range sorted {
+		if sorted[i].Destination != mounts1b[i].Destination {
+			t.Fatalf("failed sort \n%+v\n%+v", mounts1b, sorted)
+		}
+	}
+
 }


### PR DESCRIPTION
Currently depending on the sort order of mount points, we can overmount
a volume specified from the user. Podman has a function sortMount that
sorts all mounts based on destination directory to ensure all mounts
show up. This PR moves the function from Podman to Buildah. Once merged
I will change Podman to use the buildah function.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

