### PR TITLE
Fix '--tty' flag in run subcommand

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -137,7 +137,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 		DropCapabilities: iopts.capDrop,
 	}
 
-	if c.Flag("terminal").Changed {
+	if c.Flag("terminal").Changed || c.Flag("tty").Changed {
 		if iopts.terminal {
 			options.Terminal = buildah.WithTerminal
 		} else {


### PR DESCRIPTION
Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
See if '--tty' flag is specified as well as '--terminal' flag in `run` subcommand.

#### How to verify it
You can verify with the following procedure.

~~~
$ buildah from busybox 
$ buildah run --tty=true busybox-working-container ls --color=auto
$ buildah run --tty=false busybox-working-container ls --color=auto
~~~

The output with `--tty=true` should be colored while the output with `--tty=false` should be uncolored.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

