### PR TITLE
Setup alias for --tty to --terminal

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -46,7 +45,7 @@ func init() {
 
 		},
 		Example: `buildah run containerID -- ps -auxw
-  buildah run --tty containerID /bin/bash
+  buildah run --terminal containerID /bin/bash
   buildah run --volume /path/on/host:/path/in/container:ro,z containerID /bin/sh`,
 	}
 	runCommand.SetUsageTemplate(UsageTemplate())
@@ -62,12 +61,7 @@ func init() {
 	flags.StringVar(&opts.runtime, "runtime", "", "`path` to an alternate OCI runtime")
 	flags.StringSliceVar(&opts.runtimeFlag, "runtime-flag", []string{}, "add global flags for the container runtime")
 	flags.BoolVar(&opts.noPivot, "no-pivot", false, "do not use pivot root to jail process inside rootfs")
-	// TODO add-third alias for tty
 	flags.BoolVarP(&opts.terminal, "terminal", "t", false, "allocate a pseudo-TTY in the container")
-	flags.BoolVar(&opts.terminal, "tty", false, "allocate a pseudo-TTY in the container")
-	if err := flags.MarkHidden("tty"); err != nil {
-		panic(fmt.Sprintf("error marking tty flag as hidden: %v", err))
-	}
 	flags.StringArrayVarP(&opts.volumes, "volume", "v", []string{}, "bind mount a host location into the container while running the command")
 	flags.StringArrayVar(&opts.mounts, "mount", []string{}, "Attach a filesystem mount to the container (default [])")
 

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -481,7 +481,6 @@ return 1
      --add-history
      --help
      -t
-     --tty
      --terminal
      -h
   "

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -403,6 +403,8 @@ func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "os"
 	case "purge":
 		name = "rm"
+	case "tty":
+		name = "terminal"
 	}
 	return pflag.NormalizedName(name)
 }

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -341,7 +341,7 @@ general_namespace() {
             [ "$output" != "" ]
             run_buildah run --tty=true  $ctr pwd
             [ "$output" != "" ]
-            run_buildah run --tty=false $ctr pwd
+            run_buildah run --terminal=false $ctr pwd
             [ "$output" != "" ]
           done
         done


### PR DESCRIPTION
Need to properly handle the --tty hidden flag.

Replaces: https://github.com/containers/buildah/pull/3123

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

