### PR TITLE
fix local image lookup for custom platform

### DIFF
--- a/new.go
+++ b/new.go
@@ -122,6 +122,10 @@ func resolveLocalImage(systemContext *types.SystemContext, store storage.Store, 
 		if err != nil {
 			return nil, "", "", nil, errors.Wrapf(err, "error parsing reference to image %q", img.ID)
 		}
+		if !imageMatch(context.Background(), ref, systemContext) {
+			logrus.Debugf("Found local image %s but it does not match the provided context", imageName)
+			continue
+		}
 		return ref, ref.Transport().Name(), imageName, img, nil
 	}
 
@@ -188,7 +192,7 @@ func resolveImage(ctx context.Context, systemContext *types.SystemContext, store
 	}
 
 	if options.PullPolicy == define.PullNever || options.PullPolicy == define.PullIfMissing {
-		if localImage != nil && imageMatch(ctx, localImageRef, systemContext) {
+		if localImage != nil {
 			return localImageRef, localImageRef.Transport().Name(), localImage, nil
 		}
 		if options.PullPolicy == define.PullNever {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2738,6 +2738,9 @@ _EOF
   run_buildah inspect --format '{{ index .Docker.Config.Labels "architecture" }}' image-amd
   expect_output --substring x86_64
 
+  # Tag the image to localhost/ubi8-minimal to make sure that the image gets
+  # pulled since the local one does not match the requested architecture.
+  run_buildah tag image-amd localhost/ubi8-minimal
   run_buildah bud -f Containerfile --pull=false -q --arch=arm64 -t image-arm --signature-policy ${TESTSDIR}/policy.json ${mytmpdir}
   run_buildah inspect --format '{{ index .Docker.Config.Labels "architecture" }}' image-arm
   expect_output --substring arm64


### PR DESCRIPTION
Move the platform check into `resolveLocalImage` and inspect each of the
candidates in the given order.  This preserves the local lookup order
and fixes a bug reported in containers/podman/issues/9915.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>