### PR TITLE
CLI add/copy: add a --from option

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -140,7 +140,7 @@ unit_task:
       - smoke
       - vendor
 
-    timeout_in: 45m
+    timeout_in: 50m
 
     matrix:
         - env:

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ tests/testreport/testreport: tests/testreport/testreport.go
 
 .PHONY: test-unit
 test-unit: tests/testreport/testreport
-	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover -race $(shell $(GO) list ./... | grep -v vendor | grep -v tests | grep -v cmd) -timeout 40m
+	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover -race $(shell $(GO) list ./... | grep -v vendor | grep -v tests | grep -v cmd) -timeout 45m
 	tmp=$(shell mktemp -d) ; \
 	mkdir -p $$tmp/root $$tmp/runroot; \
 	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover -race ./cmd/buildah -args --root $$tmp/root --runroot $$tmp/runroot --storage-driver vfs --signature-policy $(shell pwd)/tests/policy.json --registries-conf $(shell pwd)/tests/registries.conf

--- a/buildah.go
+++ b/buildah.go
@@ -357,6 +357,9 @@ type ImportFromImageOptions struct {
 
 // NewBuilder creates a new build container.
 func NewBuilder(ctx context.Context, store storage.Store, options BuilderOptions) (*Builder, error) {
+	if options.CommonBuildOpts == nil {
+		options.CommonBuildOpts = &CommonBuildOptions{}
+	}
 	return newBuilder(ctx, store, options)
 }
 

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -534,6 +534,8 @@ return 1
      -h
      --quiet
      -q
+     --tls-verify
+     --remove-signatures
   "
 
      local options_with_args="
@@ -541,6 +543,11 @@ return 1
      --chmod
      --contextdir
      --ignorefile
+     --from
+     --authfile
+     --cert-dir
+     --creds
+     --decryption-key
   "
 
      local all_options="$options_with_args $boolean_options"
@@ -559,6 +566,8 @@ return 1
      -h
      --quiet
      -q
+     --tls-verify
+     --remove-signatures
     "
 
      local options_with_args="
@@ -566,6 +575,11 @@ return 1
      --chmod
      --contextdir
      --ignorefile
+     --from
+     --authfile
+     --cert-dir
+     --creds
+     --decryption-key
   "
 
      local all_options="$options_with_args $boolean_options"

--- a/docs/buildah-add.md
+++ b/docs/buildah-add.md
@@ -1,4 +1,4 @@
-# buildah-add "1" "March 2017" "buildah"
+# buildah-add "1" "April 2021" "buildah"
 
 ## NAME
 buildah\-add - Add the contents of a file, URL, or a directory to a container.
@@ -37,6 +37,13 @@ Build context directory. Specifying a context directory causes Buildah to
 chroot into that context directory. This means copying files pointed at
 by symbolic links outside of the chroot will fail.
 
+**--from** *containerOrImage*
+
+Use the root directory of the specified working container or image as the root
+directory when resolving absolute source paths and the path of the context
+directory.  If an image needs to be pulled, options recognized by `buildah pull`
+can be used.
+
 **--ignorefile**
 
 Path to an alternative .containerignore (.dockerignore) file. Requires \-\-contextdir be specified.
@@ -70,11 +77,11 @@ buildah add containerID 'passwd' 'certs.d' /etc
 If the .containerignore/.dockerignore file exists in the context directory,
 `buildah add` reads its contents. If both exist, then .containerignore is used.
 
-When the \fB\fC\-\-ignorefile\fR option is specified Buildah reads the
-content to exclude files and directories from the source directory, when
-copying content into the image.
+When the \fB\fC\-\-ignorefile\fR option is specified Buildah reads it and
+uses it to decide which content to exclude when copying content into the
+working container.
 
-Users can specify a series of Unix shell globals in a ignore file to
+Users can specify a series of Unix shell glob patterns in an ignore file to
 identify files/directories to exclude.
 
 Buildah supports a special wildcard string `**` which matches any number of
@@ -107,7 +114,7 @@ mechanism:
 !Help.doc
 ```
 
-Exclude all doc files except Help.doc from the image.
+Exclude all doc files except Help.doc when copying content into the container.
 
 This functionality is compatible with the handling of .dockerignore files described here:
 

--- a/docs/buildah-copy.md
+++ b/docs/buildah-copy.md
@@ -1,4 +1,4 @@
-# buildah-copy "1" "March 2017" "buildah"
+# buildah-copy "1" "April 2021" "buildah"
 
 ## NAME
 buildah\-copy - Copies the contents of a file, URL, or directory into a container's working directory.
@@ -35,6 +35,13 @@ Build context directory. Specifying a context directory causes Buildah to
 chroot into a the context directory. This means copying files pointed at
 by symbolic links outside of the chroot will fail.
 
+**--from** *containerOrImage*
+
+Use the root directory of the specified working container or image as the root
+directory when resolving absolute source paths and the path of the context
+directory.  If an image needs to be pulled, options recognized by `buildah pull`
+can be used.
+
 **--ignorefile**
 
 Path to an alternative .containerignore (.dockerignore) file. Requires \-\-contextdir be specified.
@@ -68,11 +75,11 @@ buildah copy containerID 'passwd' 'certs.d' /etc
 If the .containerignore/.dockerignore file exists in the context directory,
 `buildah copy` reads its contents. If both exist, then .containerignore is used.
 
-When the \fB\fC\-\-ignorefile\fR option is specified Buildah reads the
-content to exclude files and directories from the source directory, when
-copying content into the image.
+When the \fB\fC\-\-ignorefile\fR option is specified Buildah reads it and
+uses it to decide which content to exclude when copying content into the
+working container.
 
-Users can specify a series of Unix shell globals in a ignore file to
+Users can specify a series of Unix shell glob patterns in an ignore file to
 identify files/directories to exclude.
 
 Buildah supports a special wildcard string `**` which matches any number of
@@ -105,7 +112,7 @@ mechanism:
 !Help.doc
 ```
 
-Exclude all doc files except Help.doc from the image.
+Exclude all doc files except Help.doc when copying content into the container.
 
 This functionality is compatible with the handling of .dockerignore files described here:
 

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -361,3 +361,40 @@ stuff/mystuff"
   run_buildah umount $cid
   run_buildah rm $cid
 }
+
+@test "copy-from-container" {
+  _prefetch busybox
+  createrandom ${TESTDIR}/randomfile
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  from=$output
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  cid=$output
+  run_buildah copy --quiet $from ${TESTDIR}/randomfile /tmp/random
+  expect_output ""
+  run_buildah copy --quiet --signature-policy ${TESTSDIR}/policy.json --from $from $cid /tmp/random /tmp/random # absolute path
+  expect_output ""
+  run_buildah copy --quiet --signature-policy ${TESTSDIR}/policy.json --from $from $cid  tmp/random /tmp/random2 # relative path
+  expect_output ""
+  run_buildah mount $cid
+  croot=$output
+  cmp ${TESTDIR}/randomfile ${croot}/tmp/random
+  cmp ${TESTDIR}/randomfile ${croot}/tmp/random2
+}
+
+@test "copy-from-image" {
+  _prefetch busybox
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  cid=$output
+  run_buildah add --signature-policy ${TESTSDIR}/policy.json --quiet --from ubuntu $cid /etc/passwd /tmp/passwd # should pull the image, absolute path
+  expect_output ""
+  run_buildah add --quiet --signature-policy ${TESTSDIR}/policy.json --from ubuntu $cid  etc/passwd /tmp/passwd2 # relative path
+  expect_output ""
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ubuntu
+  ubuntu=$output
+  run_buildah mount $cid
+  croot=$output
+  run_buildah mount $ubuntu
+  ubuntu=$output
+  cmp $ubuntu/etc/passwd ${croot}/tmp/passwd
+  cmp $ubuntu/etc/passwd ${croot}/tmp/passwd2
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a --from option to `buildah add` and `buildah copy`, mirroring the option for the Dockerfile instruction.

#### How to verify it

New integration tests!

#### Which issue(s) this PR fixes:

Fixes #3127.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah add` and `buildah copy` now accept a `--from` option, which can be used to copy content from other working containers or images.
```