### PR TITLE
copier: add GetOptions.NoCrossDevice

### DIFF
--- a/copier/copier_unix_test.go
+++ b/copier/copier_unix_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestPutChroot(t *testing.T) {
 	if uid != 0 {
-		t.Skipf("chroot() requires root privileges, skipping")
+		t.Skip("chroot() requires root privileges, skipping")
 	}
 	couldChroot := canChroot
 	canChroot = true
@@ -18,7 +18,7 @@ func TestPutChroot(t *testing.T) {
 
 func TestStatChroot(t *testing.T) {
 	if uid != 0 {
-		t.Skipf("chroot() requires root privileges, skipping")
+		t.Skip("chroot() requires root privileges, skipping")
 	}
 	couldChroot := canChroot
 	canChroot = true
@@ -28,7 +28,7 @@ func TestStatChroot(t *testing.T) {
 
 func TestGetSingleChroot(t *testing.T) {
 	if uid != 0 {
-		t.Skipf("chroot() requires root privileges, skipping")
+		t.Skip("chroot() requires root privileges, skipping")
 	}
 	couldChroot := canChroot
 	canChroot = true
@@ -38,7 +38,7 @@ func TestGetSingleChroot(t *testing.T) {
 
 func TestGetMultipleChroot(t *testing.T) {
 	if uid != 0 {
-		t.Skipf("chroot() requires root privileges, skipping")
+		t.Skip("chroot() requires root privileges, skipping")
 	}
 	couldChroot := canChroot
 	canChroot = true
@@ -48,7 +48,7 @@ func TestGetMultipleChroot(t *testing.T) {
 
 func TestEvalChroot(t *testing.T) {
 	if uid != 0 {
-		t.Skipf("chroot() requires root privileges, skipping")
+		t.Skip("chroot() requires root privileges, skipping")
 	}
 	couldChroot := canChroot
 	canChroot = true
@@ -58,7 +58,7 @@ func TestEvalChroot(t *testing.T) {
 
 func TestMkdirChroot(t *testing.T) {
 	if uid != 0 {
-		t.Skipf("chroot() requires root privileges, skipping")
+		t.Skip("chroot() requires root privileges, skipping")
 	}
 	couldChroot := canChroot
 	canChroot = true

--- a/copier/syscall_windows.go
+++ b/copier/syscall_windows.go
@@ -77,6 +77,11 @@ func lutimes(isSymlink bool, path string, atime, mtime time.Time) error {
 	return windows.UtimesNano(path, []windows.Timespec{windows.NsecToTimespec(atime.UnixNano()), windows.NsecToTimespec(mtime.UnixNano())})
 }
 
+// sameDevice returns true since we can't be sure that they're not on the same device
+func sameDevice(a, b os.FileInfo) bool {
+	return true
+}
+
 const (
 	testModeMask           = int64(0600)
 	testIgnoreSymlinkDates = true


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a `NoCrossDevice` flag to `copier.GetOptions`, telling it to ignore subdirectories on devices different than the top reference directory that we start from, i.e., ignore the contents of mounted filesystems.

#### How to verify it

New unit test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Not _completely_ sure if the home device of the directory passed as the second parameter to Get() is the right thing to compare to, but if we used the top of a directory tree as the baseline when descending into directories, if the top directory was a mountpoint (e.g., if we were copying "*" from "/", and the glob matched "/proc"), the flag wouldn't end up changing the archive we produced.

#### Does this PR introduce a user-facing change?

```
None
```