### PR TITLE
Add buildah manifest rm command

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -765,6 +765,7 @@ return 1
         inspect
         push
         remove
+        rm
      "
      __buildah_subcommands "$subcommands" && return
 
@@ -900,6 +901,24 @@ return 1
  }
 
  _buildah_manifest_remove() {
+     local boolean_options="
+     --help
+     -h
+  "
+
+     local options_with_args="
+  "
+
+     local all_options="$options_with_args $boolean_options"
+
+     case "$cur" in
+         -*)
+             COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+             ;;
+     esac
+ }
+
+ _buildah_manifest_rm() {
      local boolean_options="
      --help
      -h

--- a/docs/buildah-manifest-rm.md
+++ b/docs/buildah-manifest-rm.md
@@ -1,0 +1,25 @@
+# buildah-manifest-rm "1" "April 2021" "buildah"
+
+## NAME
+buildah\-manifest\-rm - Removes one or more manifest lists.
+
+## SYNOPSIS
+**buildah manifest rm** [*listNameOrIndexName* ...]
+
+## DESCRIPTION
+Removes one or more locally stored manifest lists.
+
+## EXAMPLE
+
+buildah manifest rm <list>
+
+buildah manifest-rm listID1 listID2
+
+**storage.conf** (`/etc/containers/storage.conf`)
+
+storage.conf is the storage configuration file for all tools using containers/storage
+
+The storage configuration file specifies all of the available container storage options for tools using shared container storage.
+
+## SEE ALSO
+buildah(1), containers-storage.conf(5), buildah-manifest(1)

--- a/docs/buildah-manifest.md
+++ b/docs/buildah-manifest.md
@@ -25,6 +25,7 @@ The `buildah manifest` command provides subcommands which can be used to:
 | inspect  | [buildah-manifest-inspect(1)](buildah-manifest-inspect.md)   | Display the contents of a manifest list or image index.                     |
 | push     | [buildah-manifest-push(1)](buildah-manifest-push.md)         | Push a manifest list or image index to a registry or other location.        |
 | remove   | [buildah-manifest-remove(1)](buildah-manifest-remove.md)     | Remove an image from a manifest list or image index.                        |
+| rm       | [buildah-manifest-rm(1)](buildah-manifest-rm.md)             | Remove manifest list from local storage.                                    |
 
 ## SEE ALSO
-buildah(1), buildah-manifest-create(1), buildah-manifest-add(1), buildah-manifest-remove(1), buildah-manifest-annotate(1), buildah-manifest-inspect(1), buildah-manifest-push(1)
+buildah(1), buildah-manifest-create(1), buildah-manifest-add(1), buildah-manifest-remove(1), buildah-manifest-annotate(1), buildah-manifest-inspect(1), buildah-manifest-push(1), buildah-manifest-rm(1)

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -24,6 +24,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 @test "manifest-add" {
     run_buildah manifest create foo
     run_buildah manifest add foo ${IMAGE_LIST}
+    run_buildah manifest rm foo
 }
 
 @test "manifest-add local image" {
@@ -31,6 +32,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
     run_buildah manifest create foo
     run_buildah manifest add foo ${target}
+    run_buildah manifest rm foo
 }
 
 @test "manifest-add-one" {
@@ -74,6 +76,11 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest create foo
     run_buildah manifest add foo ${IMAGE_LIST}
     run_buildah 125 manifest remove foo sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+}
+
+@test "manifest-rm failures" {
+    run_buildah 125 manifest rm foo1
+    expect_output --substring "foo1: image not known"
 }
 
 @test "manifest-push" {


### PR DESCRIPTION
Add command to actually remove the manifest list. This
uses the same basic code that buildah rmi uses, but makes
the error messages more specific to a manifest list.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

