### PR TITLE
Log the final error with %+v at logging level "trace"

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -92,7 +92,7 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVar(&globalFlagResults.UserNSUID, "userns-uid-map", []string{}, "default `ctrID:hostID:length` UID mapping to use")
 	rootCmd.PersistentFlags().StringSliceVar(&globalFlagResults.UserNSGID, "userns-gid-map", []string{}, "default `ctrID:hostID:length` GID mapping to use")
 	rootCmd.PersistentFlags().StringVar(&globalFlagResults.DefaultMountsFile, "default-mounts-file", "", "path to default mounts file")
-	rootCmd.PersistentFlags().StringVar(&globalFlagResults.LogLevel, logLevel, "warn", `The log level to be used. Either "debug", "info", "warn" or "error".`)
+	rootCmd.PersistentFlags().StringVar(&globalFlagResults.LogLevel, logLevel, "warn", `The log level to be used. Either "trace", "debug", "info", "warn", "error", "fatal", or "panic".`)
 	rootCmd.PersistentFlags().StringVar(&globalFlagResults.CPUProfile, "cpu-profile", "", "`file` to write CPU profile")
 	rootCmd.PersistentFlags().StringVar(&globalFlagResults.MemoryProfile, "memory-profile", "", "`file` to write memory profile")
 
@@ -220,7 +220,11 @@ func main() {
 	os.Setenv("TMPDIR", parse.GetTempDir())
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
+			fmt.Fprintf(os.Stderr, "%+v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+		}
 		exitCode := cli.ExecErrorCodeGeneric
 		if ee, ok := (errors.Cause(err)).(*exec.ExitError); ok {
 			if w, ok := ee.Sys().(syscall.WaitStatus); ok {

--- a/docs/buildah.md
+++ b/docs/buildah.md
@@ -22,7 +22,7 @@ The Buildah package provides a command line tool which can be used to:
 
 **--log-level** **value**
 
-The log level to be used. Either "debug", "info", "warn" or "error", per default "warn".
+The log level to be used. Either "trace", "debug", "info", "warn", "error", "fatal", or "panic", defaulting to "warn".
 
 **--help, -h**
 

--- a/tests/info.bats
+++ b/tests/info.bats
@@ -13,3 +13,17 @@ load helpers
     expect_output --substring "map.*$key:"
   done
 }
+
+@test "logging levels" {
+  # check that these logging levels are recognized
+  run_buildah --log-level=trace info
+  run_buildah --log-level=debug info
+  run_buildah --log-level=warn  info
+  run_buildah --log-level=info  info
+  run_buildah --log-level=error info
+  run_buildah --log-level=fatal info
+  run_buildah --log-level=panic info
+  # check that we reject bogus logging levels
+  run_buildah 125 --log-level=telepathic info
+  expect_output --substring "unable to parse log level: not a valid logrus Level"
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

If the logging level is at least "trace", log the final error we print, if there is one, using `%+v` as the verb, or `%v` (changed from `%s`) otherwise.  If the error was wrapped using `github.com/pkg/errors`, this will provide a backtrace.

#### How to verify it

New integration test!  It only ensures that the levels we advertise in the help output and docs are all recognized, but still.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Notionally related to https://github.com/containers/podman/pull/10032.

#### Does this PR introduce a user-facing change?

```
None
```