### PR TITLE
Minor fixes to Buildah as a library tutorial documentation

### DIFF
--- a/docs/tutorials/04-include-in-your-build-tool.md
+++ b/docs/tutorials/04-include-in-your-build-tool.md
@@ -1,6 +1,7 @@
 ![buildah logo](../../logos/buildah-logo_large.png)
 
 # Buildah Tutorial 4
+
 ## Include Buildah in your build tool
 
 The purpose of this tutorial is to demonstrate how to include Buildah as a library in your build tool.
@@ -14,7 +15,6 @@ In this tutorial I'll show you how to create a simple CLI tool that creates an i
 Bootstrap the installation of development dependencies of Buildah by following the [Building from scratch](https://github.com/slinkydeveloper/buildah/blob/master/install.md#building-from-scratch) instructions and in particular creating a directory for the Buildah project by completing the instructions in the [Installation from GitHub](https://github.com/containers/buildah/blob/master/install.md#installation-from-github) section of that page.
 
 Now let's bootstrap our project. Assuming you are in the directory of the project, run the following to initialize the go modules:
-
 
 ```shell
 go mod init
@@ -55,11 +55,11 @@ Define the builder options:
 
 ```go
 builderOpts := buildah.BuilderOptions{
-    FromImage:        "node:12-alpine", // Starting image
-    Isolation:        define.IsolationChroot, // Isolation environment
-    CommonBuildOpts:  &define.CommonBuildOptions{},
-    ConfigureNetwork: define.NetworkDefault,
-    SystemContext: 	  &types.SystemContext {},
+  FromImage:        "node:12-alpine", // Starting image
+  Isolation:        define.IsolationChroot, // Isolation environment
+  CommonBuildOpts:  &define.CommonBuildOptions{},
+  ConfigureNetwork: define.NetworkDefault,
+  SystemContext:    &types.SystemContext {},
 }
 ```
 
@@ -99,7 +99,7 @@ To enable rootless mode, import `github.com/containers/storage/pkg/unshare` and 
 
 ```go
 if buildah.InitReexec() {
-    return
+  return
 }
 unshare.MaybeReexecUsingUserNamespace(false)
 ```
@@ -112,64 +112,64 @@ This code ensures that your application is re executed in an isolated environmen
 package main
 
 import (
-	"context"
-	"fmt"
-	"github.com/containers/buildah"
-	"github.com/containers/buildah/define"
-	"github.com/containers/storage/pkg/unshare"
-	is "github.com/containers/image/v5/storage"
-	"github.com/containers/image/v5/types"
-	"github.com/containers/storage"
+  "context"
+  "fmt"
+  "github.com/containers/buildah"
+  "github.com/containers/buildah/define"
+  "github.com/containers/storage/pkg/unshare"
+  is "github.com/containers/image/v5/storage"
+  "github.com/containers/image/v5/types"
+  "github.com/containers/storage"
 )
 
 func main() {
-	if buildah.InitReexec() {
-		return
-	}
-	unshare.MaybeReexecUsingUserNamespace(false)
+  if buildah.InitReexec() {
+    return
+  }
+  unshare.MaybeReexecUsingUserNamespace(false)
 
-	buildStoreOptions, err := storage.DefaultStoreOptions(unshare.IsRootless(), unshare.GetRootlessUID())
+  buildStoreOptions, err := storage.DefaultStoreOptions(unshare.IsRootless(), unshare.GetRootlessUID())
 
-	if err != nil {
-		panic(err)
-	}
+  if err != nil {
+    panic(err)
+  }
 
-	buildStore, err := storage.GetStore(buildStoreOptions)
+  buildStore, err := storage.GetStore(buildStoreOptions)
 
-	if err != nil {
-		panic(err)
-	}
+  if err != nil {
+    panic(err)
+  }
 
-	opts := buildah.BuilderOptions{
-		FromImage:        "node:12-alpine",
-		Isolation:        define.IsolationChroot,
-		CommonBuildOpts:  &define.CommonBuildOptions{},
-		ConfigureNetwork: define.NetworkDefault,
-		SystemContext: 	  &types.SystemContext {},
-	}
+  opts := buildah.BuilderOptions{
+    FromImage:        "node:12-alpine",
+    Isolation:        define.IsolationChroot,
+    CommonBuildOpts:  &define.CommonBuildOptions{},
+    ConfigureNetwork: define.NetworkDefault,
+    SystemContext:    &types.SystemContext {},
+  }
 
-	builder, err := buildah.NewBuilder(context.TODO(), buildStore, opts)
+  builder, err := buildah.NewBuilder(context.TODO(), buildStore, opts)
 
-	if err != nil {
-		panic(err)
-	}
+  if err != nil {
+    panic(err)
+  }
 
-	err = builder.Add("/home/node/", false, buildah.AddAndCopyOptions{}, "script.js")
+  err = builder.Add("/home/node/", false, buildah.AddAndCopyOptions{}, "script.js")
 
-	if err != nil {
-		panic(err)
-	}
+  if err != nil {
+    panic(err)
+  }
 
-	builder.SetCmd([]string{"node", "/home/node/script.js"})
+  builder.SetCmd([]string{"node", "/home/node/script.js"})
 
-	imageRef, err := is.Transport.ParseStoreReference(buildStore, "docker.io/myusername/my-image")
+  imageRef, err := is.Transport.ParseStoreReference(buildStore, "docker.io/myusername/my-image")
 
-	if err != nil {
-		panic(err)
-	}
+  if err != nil {
+    panic(err)
+  }
 
-	imageId, _, _, err := builder.Commit(context.TODO(), imageRef, define.CommitOptions{})
+  imageId, _, _, err := builder.Commit(context.TODO(), imageRef, buildah.CommitOptions{})
 
-	fmt.Printf("Image built! %s\n", imageId)
+  fmt.Printf("Image built! %s\n", imageId)
 }
 ```


### PR DESCRIPTION
[CI:DOCS]

Details:
1. CommitOptions struct does not belong to `define` package anymore. The complete example does not compile
2. Formatting fixes threw by MD linter

Signed-off-by: Francisco M. Casares <francares@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind documentation

#### What this PR does / why we need it: 
Fix documentation regarding the use of Buildah as a dependency library

#### How to verify it:
Copy the example in the documentation and compile it.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

