### PR TITLE
Output names of multiple tags in buildah bud

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -341,30 +341,6 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 		systemContext.OCIInsecureSkipTLSVerify = true
 		systemContext.DockerDaemonInsecureSkipTLSVerify = true
 	}
-	if len(options.AdditionalTags) > 0 {
-		names, err := util.ExpandNames(options.AdditionalTags, "", systemContext, b.store)
-		if err != nil {
-			return imgID, nil, "", err
-		}
-		for _, name := range names {
-			additionalDest, err := docker.Transport.ParseReference(name)
-			if err != nil {
-				return imgID, nil, "", errors.Wrapf(err, "error parsing image name %q as an image reference", name)
-			}
-			insecure, err := checkRegistrySourcesAllows("commit to", additionalDest)
-			if err != nil {
-				return imgID, nil, "", err
-			}
-			if insecure {
-				if systemContext.DockerInsecureSkipTLSVerify == types.OptionalBoolFalse {
-					return imgID, nil, "", errors.Errorf("can't require tls verification on an insecured registry")
-				}
-				systemContext.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
-				systemContext.OCIInsecureSkipTLSVerify = true
-				systemContext.DockerDaemonInsecureSkipTLSVerify = true
-			}
-		}
-	}
 	logrus.Debugf("committing image with reference %q is allowed by policy", transports.ImageName(dest))
 
 	// Check if the base image is already in the destination and it's some kind of local

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -396,6 +396,16 @@ symlink(subdir)"
   expect_output "${target}-working-container"
 }
 
+@test "bud with --tag " {
+  target=scratch-image
+  run_buildah bud --quiet=false --tag test1 --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  expect_output --substring "Successfully tagged localhost/test1:latest"
+
+  run_buildah bud --quiet=false --tag test1 --tag test2 --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  expect_output --substring "Successfully tagged localhost/test1:latest"
+  expect_output --substring "Successfully tagged localhost/test2:latest"
+}
+
 @test "bud-from-scratch-iid" {
   target=scratch-image
   run_buildah bud --iidfile ${TESTDIR}/output.iid --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch


### PR DESCRIPTION
Buildah currently handles multiple tags when building, but does not
report it to the user by default. This reports the tags back to the
user.

Removed some unused code from commit.go, that would blow up if a user
specified AdditionalTags to the commit command, even though this is not
exposed to the user currently.  In a previous try to fix this, the
removed code was causing breakage, and I did not see a real purpose in
the code.

Fixes: https://github.com/containers/buildah/issues/3084

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

