### PR TITLE
Restore log timestamps

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -61,8 +61,6 @@ var (
 )
 
 func init() {
-	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
-
 	var (
 		defaultStoreDriverOptions []string
 	)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The rationale for removing them was that they were always zero, but that was only the case when the command ran to completion less than one second.

#### How to verify it

Observe log messages in commands that take more than a second to run.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
Logged debugging and error messages will once again include a count of seconds elapsed since `buildah` was started.
```