### PR TITLE
push to docker test: don't get fooled by podman

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -358,3 +358,17 @@ function skip_if_in_container() {
         skip "This test is not working inside a container"
     fi
 }
+
+#######################
+#  skip_if_no_docker  #
+#######################
+function skip_if_no_docker() {
+  which docker                  || skip "docker is not installed"
+  systemctl -q is-active docker || skip "docker.service is not active"
+
+  # Confirm that this is really truly docker, not podman.
+  docker_version=$(docker --version)
+  if [[ $docker_version =~ podman ]]; then
+    skip "this test needs actual docker, not podman-docker"
+  fi
+}

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -92,15 +92,8 @@ load helpers
 }
 
 @test "pull-from-docker-daemon" {
-  run systemctl status docker
-  if [[ ! "$output" =~ "active (running)" ]]
-  then
-     skip "Skip the test as docker services is not running"
-  fi
+  skip_if_no_docker
 
-  run systemctl start docker
-  echo "$output"
-  [ "$status" -eq 0 ]
   run docker pull alpine
   echo "$output"
   [ "$status" -eq 0 ]

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -140,10 +140,7 @@ load helpers
 }
 
 @test "buildah push image to docker and docker registry" {
-  run which docker
-  if [[ $status -ne 0 ]]; then
-    skip "docker is not installed"
-  fi
+  skip_if_no_docker
 
   _prefetch busybox
   run_buildah push --signature-policy ${TESTSDIR}/policy.json busybox docker-daemon:buildah/busybox:latest


### PR DESCRIPTION
Gating tests have failed (at least) twice already because
one of the push.bats tests runs "which docker" and skips
if it's missing. Sadly, some gating-test systems install
podman-docker, possibly when there's a bodhi that combines
podman and buildah. This causes the test to fail.

Solution: confirm that if docker exists, it isn't podman
in disguise.

Signed-off-by: Ed Santiago <santiago@redhat.com>
