### PR TITLE
Add compabitility wrappers for recently removed packages

### DIFF
--- a/manifests/compat.go
+++ b/manifests/compat.go
@@ -1,0 +1,33 @@
+// This package is deprecated.  Its functionality has been moved to
+// github.com/containers/common/libimage/manifests, which provides the same
+// API.  The stubs here are present for compatibility with older code.  New
+// implementations should use github.com/containers/common/libimage/manifests
+// directly.
+package manifests
+
+import (
+	"github.com/containers/common/libimage/manifests"
+	"github.com/containers/storage"
+)
+
+type (
+	// List is an alias for github.com/containers/common/libimage/manifests.List.
+	List = manifests.List
+	// PushOptions is an alias for github.com/containers/common/libimage/manifests.PushOptions.
+	PushOptions = manifests.PushOptions
+)
+
+var (
+	// ErrListImageUnknown is an alias for github.com/containers/common/libimage/manifests.ErrListImageUnknown
+	ErrListImageUnknown = manifests.ErrListImageUnknown
+)
+
+// Create wraps github.com/containers/common/libimage/manifests.Create().
+func Create() List {
+	return manifests.Create()
+}
+
+// LoadFromImage wraps github.com/containers/common/libimage/manifests.LoadFromImage().
+func LoadFromImage(store storage.Store, image string) (string, List, error) {
+	return manifests.LoadFromImage(store, image)
+}

--- a/pkg/manifests/compat.go
+++ b/pkg/manifests/compat.go
@@ -1,0 +1,28 @@
+// This package is deprecated.  Its functionality has been moved to
+// github.com/containers/common/pkg/manifests, which provides the same API.
+// The stubs and aliases here are present for compatibility with older code.
+// New implementations should use github.com/containers/common/pkg/manifests
+// directly.
+package manifests
+
+import "github.com/containers/common/pkg/manifests"
+
+// List is an alias for github.com/containers/common/pkg/manifests.List.
+type List = manifests.List
+
+var (
+	// ErrDigestNotFound is an alias for github.com/containers/common/pkg/manifests.ErrDigestNotFound.
+	ErrDigestNotFound = manifests.ErrDigestNotFound
+	// ErrManifestTypeNotSupported is an alias for github.com/containers/common/pkg/manifests.ErrManifestTypeNotSupported.
+	ErrManifestTypeNotSupported = manifests.ErrManifestTypeNotSupported
+)
+
+// Create wraps github.com/containers/common/pkg/manifests.Create().
+func Create() List {
+	return manifests.Create()
+}
+
+// FromBlob wraps github.com/containers/common/pkg/manifests.FromBlob().
+func FromBlob(manifestBytes []byte) (List, error) {
+	return manifests.FromBlob(manifestBytes)
+}

--- a/pkg/supplemented/compat.go
+++ b/pkg/supplemented/compat.go
@@ -1,0 +1,26 @@
+// This package is deprecated.  Its functionality has been moved to
+// github.com/containers/common/pkg/supplemented, which provides the same API.
+// The stubs and aliases here are present for compatibility with older code.
+// New implementations should use github.com/containers/common/pkg/supplemented
+// directly.
+package supplemented
+
+import (
+	"github.com/containers/common/pkg/manifests"
+	"github.com/containers/common/pkg/supplemented"
+	cp "github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/types"
+	digest "github.com/opencontainers/go-digest"
+)
+
+var (
+	// ErrDigestNotFound is an alias for github.com/containers/common/pkg/manifests.ErrDigestNotFound.
+	ErrDigestNotFound = manifests.ErrDigestNotFound
+	// ErrBlobNotFound is an alias for github.com/containers/common/pkg/supplemented.ErrBlobNotFound.
+	ErrBlobNotFound = supplemented.ErrBlobNotFound
+)
+
+// Reference wraps github.com/containers/common/pkg/supplemented.Reference().
+func Reference(ref types.ImageReference, supplemental []types.ImageReference, multiple cp.ImageListSelection, instances []digest.Digest) types.ImageReference {
+	return supplemented.Reference(ref, supplemental, multiple, instances)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change
/kind bug

#### What this PR does / why we need it:

Add compatibility wrappers for `manifests`, `pkg/manifests`, and `pkg/supplemented`, which were moved to the `github.com/containers/common` project.

#### How to verify it

The unit test target will verify that the code compiles before noticing that the unit tests aren't there any more, either.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```