### PR TITLE
Cirrus: Update Ubuntu images to 21.04

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,8 +28,8 @@ env:
     # See https://github.com/containers/podman/blob/master/contrib/cirrus/README.md#test_build_cache_images_task-task
     FEDORA_NAME: "fedora-34beta"
     PRIOR_FEDORA_NAME: "fedora-33"
-    UBUNTU_NAME: "ubuntu-2010"
-    PRIOR_UBUNTU_NAME: "ubuntu-2004"
+    UBUNTU_NAME: "ubuntu-2104"
+    PRIOR_UBUNTU_NAME: "ubuntu-2010"
 
     IMAGE_SUFFIX: "c5032481331085312"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -42,10 +42,6 @@ esac
 # Previously, golang was not installed
 source $(dirname $0)/lib.sh
 
-X="export GPG_TTY=/dev/null"
-echo "Setting $X in /etc/environment for proper GPG functioning under automation"
-echo "$X" >> /etc/environment
-
 echo "Configuring /etc/containers/registries.conf"
 mkdir -p /etc/containers
 echo -e "[registries.search]\nregistries = ['docker.io', 'registry.fedoraproject.org', 'quay.io']" | tee /etc/containers/registries.conf

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -31,7 +31,6 @@ if [[ "$1" == "--config" ]]; then
     cat <<EOF
 DESTDIR="/var/tmp/go/src/github.com/containers/buildah"
 UPSTREAM_REPO="https://github.com/containers/buildah.git"
-CI_ENVFILE="/etc/environment"
 GCLOUD_PROJECT="buildah"
 GCLOUD_IMGPROJECT="libpod-218412"
 GCLOUD_CFG="buildah"


### PR DESCRIPTION
Also simplify `lib.sh` after supporting changes incorporated
into automation library 2.x+ (present in all VM and container
images).

* No need to force-load `/etc/profile` and handle it's expectation
  to **not** being in `errexit` mode.
* Slightly re-arrange loading of automation library files for
  clarity.
* Remove dependency on updating `/etc/environment` for GPG.
* Remove redundant showrun() function (now present in automation
  library)
* Update comments.

Ref: https://github.com/containers/automation_images/pull/62