### PR TITLE
pr-should-include-tests: try to make work in buildah

### DIFF
--- a/tests/validate/pr-should-include-tests
+++ b/tests/validate/pr-should-include-tests
@@ -19,7 +19,16 @@ fi
 # HEAD should be good enough, but the CIRRUS envariable allows us to test
 head=${CIRRUS_CHANGE_IN_REPO:-HEAD}
 # Base of this PR. Here we absolutely rely on cirrus.
-base=$(git merge-base ${DEST_BRANCH:-master} $head)
+base=$(git merge-base ${GITVALIDATE_EPOCH:-master} $head)
+
+# Sanity check:
+if [[ -z "$base" ]]; then
+    echo "$(basename $0): internal error: could not determine merge-base"
+    echo "   head                  = $head"
+    echo "   CIRRUS_CHANGE_IN_REPO = $CIRRUS_CHANGE_IN_REPO"
+    echo "   GITVALIDATE_EPOCH     = $GITVALIDATE_EPOCH"
+    exit 1
+fi
 
 # This gives us a list of files touched in all commits, e.g.
 #    A    foo.c


### PR DESCRIPTION
Looks like this script wasn't working in the buildah environment,
apparently because we're in a shallow git checkout without a
master branch? Let's see if we can use $GITVALIDATE_EPOCH
instead.

And, add a sanity check so we catch this if it happens again.

Signed-off-by: Ed Santiago <santiago@redhat.com>
