### PR TITLE
imagebuildah: ignore signatures when tagging images

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1166,7 +1166,10 @@ func (s *StageExecutor) tagExistingImage(ctx context.Context, cacheID, output st
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "error getting source imageReference for %q", cacheID)
 	}
-	manifestBytes, err := cp.Image(ctx, policyContext, dest, src, nil)
+	options := cp.Options{
+		RemoveSignatures: true, // more like "ignore signatures", since they don't get removed when src and dest are the same image
+	}
+	manifestBytes, err := cp.Image(ctx, policyContext, dest, src, &options)
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "error copying image %q", cacheID)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We re-tag images produced for Dockerfiles which contain no instructions by "copying" them from their current names to their destination names, letting the lower storage libraries deduplicate them into the same image record.

When the source included signatures, which can happen when the base image included signatures, this would break because containers-storage can't guarantee that the compressed version of the blob it will produce for a given layer will have the same digest that the version referenced by the manifest had, so the image library would refuse to "copy" them.

When the source and destination are the same, though, the `RemoveSignatures` option doesn't cause the signatures to be deleted, but it does bypass that check in the image library, so toggling it on works around the problem.

#### How to verify it

Tests should continue to pass when base images come from registries which have signature storage URLs ("sigstore") configured for them.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Should fix https://bugzilla.redhat.com/show_bug.cgi?id=1955166.

#### Does this PR introduce a user-facing change?

```
None
```