### PR TITLE
[CI:DOCS] Notification email for cirrus-cron build failures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,7 +135,7 @@ vendor_task:
 unit_task:
     name: 'Unit tests w/ $STORAGE_DRIVER'
     alias: unit
-
+    only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
     depends_on:
       - smoke
       - vendor
@@ -159,7 +159,7 @@ unit_task:
 conformance_task:
     name: 'Build Conformance w/ $STORAGE_DRIVER'
     alias: conformance
-
+    only_if: *not_docs
     depends_on:
       - unit
 
@@ -182,7 +182,7 @@ conformance_task:
 cross_build_task:
     name: "Cross Compile"
     alias: cross_build
-
+    only_if: *not_docs
     depends_on:
       - unit
 
@@ -202,7 +202,7 @@ cross_build_task:
 static_build_task:
     name: "Static Build"
     alias: static_build
-
+    only_if: *not_docs
     depends_on:
       - unit
 
@@ -252,7 +252,7 @@ static_build_task:
 integration_task:
     name: "Integration $DISTRO_NV w/ $STORAGE_DRIVER"
     alias: integration
-
+    only_if: *not_docs
     depends_on:
       - unit
 
@@ -317,7 +317,7 @@ integration_task:
 in_podman_task:
     name: "Containerized Integration"
     alias: in_podman
-
+    only_if: *not_docs
     depends_on:
         - unit
 

--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -1,0 +1,94 @@
+---
+
+# See also:
+# https://github.com/containers/podman/blob/master/.github/workflows/check_cirrus_cron.yml
+
+# Format Ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+
+# Required to un-FUBAR default ${{github.workflow}} value
+name: check_cirrus_cron
+
+on:
+    # Note: This only applies to the master branch.
+    schedule:
+        # Assume cirrus cron jobs runs at least once per day
+        - cron:  '59 23 * * *'
+    # Debug: Allow triggering job manually in github-actions WebUI
+    workflow_dispatch: {}
+
+env:
+    # Debug-mode can reveal secrets, only enable by a secret value.
+    # Ref: https://help.github.com/en/actions/configuring-and-managing-workflows/managing-a-workflow-run#enabling-step-debug-logging
+    ACTIONS_STEP_DEBUG: '${{ secrets.ACTIONS_STEP_DEBUG }}'
+    # Use same destination addresses from podman repository
+    FAILMAILCSV: './_podman/contrib/cirrus/cron-fail_addrs.csv'
+    # Filename for table of cron-name to build-id data
+    # (must be in $GITHUB_WORKSPACE/artifacts/)
+    NAME_ID_FILEPATH: './artifacts/name_id.txt'
+
+jobs:
+    cron_failures:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  ref: master
+                  persist-credentials: false
+
+            # Avoid duplicating cron_failures.sh in buildah repo.
+            - uses: actions/checkout@v2
+              with:
+                  repository: https://github.com/containers/podman.git
+                  # This job always/must only run from podman master
+                  ref: master
+                  path: '_podman'
+                  persist-credentials: false
+
+            - name: Get failed cron names and Build IDs
+              id: cron
+              run: './_podman/.github/actions/${{ github.workflow }}/${{ github.job }}.sh'
+
+            - if: steps.cron.outputs.failures > 0
+              shell: bash
+              # Must be inline, since context expressions are used.
+              # Ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions
+              run: |
+                set -eo pipefail
+                (
+                echo "Detected one or more Cirrus-CI cron-triggered jobs have failed recently:"
+                echo ""
+
+                while read -r NAME BID; do
+                    echo "Cron build '$NAME' Failed: https://cirrus-ci.com/build/$BID"
+                done < "$NAME_ID_FILEPATH"
+
+                echo ""
+                echo "# Source: ${{ github.workflow }} workflow on ${{ github.repository }}."
+                # Separate content from sendgrid.com automatic footer.
+                echo ""
+                echo ""
+                ) > ./artifacts/email_body.txt
+
+            - if: steps.cron.outputs.failures > 0
+              id: mailto
+              run: printf "::set-output name=csv::%s\n" $(cat "$FAILMAILCSV")
+
+            - if: steps.mailto.outputs.csv != ''
+              name: Send failure notification e-mail
+              # Ref: https://github.com/dawidd6/action-send-mail
+              uses: dawidd6/action-send-mail@v2.2.2
+              with:
+                server_address: ${{secrets.ACTION_MAIL_SERVER}}
+                server_port: 465
+                username: ${{secrets.ACTION_MAIL_USERNAME}}
+                password: ${{secrets.ACTION_MAIL_PASSWORD}}
+                subject: Cirrus-CI cron build failures on ${{github.repository}}
+                to: ${{steps.mailto.outputs.csv}}
+                from: ${{secrets.ACTION_MAIL_SENDER}}
+                body: file://./artifacts/email_body.txt
+
+            - if: always()
+              uses: actions/upload-artifact@v2
+              with:
+                  name: ${{ github.job }}_artifacts
+                  path: artifacts/*


### PR DESCRIPTION
This duplicates the github-action workflow of the same name/purpose from
the podman reposiory.  Every day it will check the most recent list
of Cirrus-cron initiated builds, and only send an e-mail if any failed.

Some measures are taken in this version to re-use a script and some
data from the podman repo.  There is no way (as of this commit) to
avoid duplicating the workflow file.