### PR TITLE
Fix copy race while walking paths

### DIFF
--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -392,6 +392,23 @@ stuff/mystuff"
   cmp ${TESTDIR}/randomfile ${croot}/tmp/random2
 }
 
+@test "copy-container-root" {
+  _prefetch busybox
+  createrandom ${TESTDIR}/randomfile
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  from=$output
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  cid=$output
+  run_buildah copy --quiet $from ${TESTDIR}/randomfile /tmp/random
+  expect_output ""
+  run_buildah copy --quiet --signature-policy ${TESTSDIR}/policy.json --from $from $cid / /tmp/
+  expect_output "" || \
+    expect_output --substring "copier: file disappeared while reading"
+  run_buildah mount $cid
+  croot=$output
+  cmp ${TESTDIR}/randomfile ${croot}/tmp/tmp/random
+}
+
 @test "copy-from-image" {
   _prefetch busybox
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

During a copy operation which descends through a directory tree,
It's possible for a referenced file to become inaccessible (by unlink
or permission change or whatever).  During the walk of paths to copy,
an `Lstat()` is run on each item, and any error passed into the handler
function to deal with.  Subsequently, if there is no error, the file
is examined for inclusion/exclusion by the handler.

Unfortunately, this introduces a TOCTOU race condition for files which
become inaccessible even if they would otherwise be excluded.  For
example a file or directory under /proc or /sys (which frequently and
unpredictably change).  This was the original cause encountered during
podman integration testing.

It's impractical to actually fix this race at the file-level, without
introducing negative effects to any source-container operations.  It's
also questionably useful to offer a command-line option to offload the
choice to the user.  Instead, follow the behavior of the `tar` command
for this situation: Issue a warning to the user, and ignore the
problematic item (don't copy it).

Also add a test resembling the podman test which originally caught this
race.  While not reliable, it does introduce a non-zero chance of
hitting the race condition - and handling the new warning properly.

#### How to verify it

Since the desired/expected race condition behavior is negative (warning + ignore the file), verifying through testing is likely
extremely difficult.  The newly added test should eventually catch and confirm the warning message, given sufficient runtime (possibly after 1,000,000 years of continuous testing).

#### Which issue(s) this PR fixes:

Fixes #9997

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The copy operation will now issue a warning message if source file/dir becomes inaccessible. In this case, the item will *not* be copied.
```