### PR TITLE
Send logrus messages back to caller when building

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -89,6 +89,9 @@ const (
 type Builder struct {
 	store storage.Store
 
+	// Logger is the logrus logger to write log messages with
+	Logger *logrus.Logger `json:"-"`
+
 	// Args define variables that users can pass at build-time to the builder
 	Args map[string]string
 	// Type is used to help identify a build container's metadata.  It
@@ -395,6 +398,7 @@ func OpenBuilder(store storage.Store, container string) (*Builder, error) {
 	}
 	b.store = store
 	b.fixupConfig()
+	b.setupLogger()
 	return b, nil
 }
 
@@ -430,6 +434,7 @@ func OpenBuilderByPath(store storage.Store, path string) (*Builder, error) {
 		if err == nil && b.Type == containerType && builderMatchesPath(b, abs) {
 			b.store = store
 			b.fixupConfig()
+			b.setupLogger()
 			return b, nil
 		}
 		if err != nil {
@@ -465,6 +470,7 @@ func OpenAllBuilders(store storage.Store) (builders []*Builder, err error) {
 		err = json.Unmarshal(buildstate, &b)
 		if err == nil && b.Type == containerType {
 			b.store = store
+			b.setupLogger()
 			b.fixupConfig()
 			builders = append(builders, b)
 			continue

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package buildah
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -85,6 +86,7 @@ func (b *Builder) initConfig(ctx context.Context, img types.Image) error {
 		}
 	}
 
+	b.setupLogger()
 	b.fixupConfig()
 	return nil
 }
@@ -111,6 +113,14 @@ func (b *Builder) fixupConfig() {
 	}
 	if b.Format == define.Dockerv2ImageManifest && b.Hostname() == "" {
 		b.SetHostname(stringid.TruncateID(stringid.GenerateRandomID()))
+	}
+}
+
+func (b *Builder) setupLogger() {
+	if b.Logger == nil {
+		b.Logger = logrus.New()
+		b.Logger.SetOutput(os.Stderr)
+		b.Logger.SetLevel(logrus.GetLevel())
 	}
 }
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -50,6 +50,14 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 	if len(paths) == 0 {
 		return "", nil, errors.Errorf("error building: no dockerfiles specified")
 	}
+	logger := logrus.New()
+	if options.Err != nil {
+		logger.SetOutput(options.Err)
+	} else {
+		logger.SetOutput(os.Stderr)
+	}
+	logger.SetLevel(logrus.GetLevel())
+
 	var dockerfiles []io.ReadCloser
 	defer func(dockerfiles ...io.ReadCloser) {
 		for _, d := range dockerfiles {
@@ -140,7 +148,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 		return "", nil, errors.Wrapf(err, "error parsing main Dockerfile: %s", dockerfiles[0])
 	}
 
-	warnOnUnsetBuildArgs(mainNode, options.Args)
+	warnOnUnsetBuildArgs(logger, mainNode, options.Args)
 
 	for _, d := range dockerfiles[1:] {
 		additionalNode, err := imagebuilder.ParseDockerfile(d)
@@ -149,7 +157,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 		}
 		mainNode.Children = append(mainNode.Children, additionalNode.Children...)
 	}
-	exec, err := NewExecutor(store, options, mainNode)
+	exec, err := NewExecutor(logger, store, options, mainNode)
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "error creating build executor")
 	}
@@ -173,7 +181,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 	return exec.Build(ctx, stages)
 }
 
-func warnOnUnsetBuildArgs(node *parser.Node, args map[string]string) {
+func warnOnUnsetBuildArgs(logger *logrus.Logger, node *parser.Node, args map[string]string) {
 	argFound := make(map[string]bool)
 	for _, child := range node.Children {
 		switch strings.ToUpper(child.Value) {
@@ -190,7 +198,7 @@ func warnOnUnsetBuildArgs(node *parser.Node, args map[string]string) {
 				argHasValue = argFound[argName]
 			}
 			if _, ok := args[argName]; !argHasValue && !ok {
-				logrus.Warnf("missing %q build argument. Try adding %q to the command line", argName, fmt.Sprintf("--build-arg %s=<VALUE>", argName))
+				logger.Warnf("missing %q build argument. Try adding %q to the command line", argName, fmt.Sprintf("--build-arg %s=<VALUE>", argName))
 			}
 		default:
 			continue

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -428,6 +428,7 @@ func (s *StageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 		stdin = devNull
 	}
 	options := buildah.RunOptions{
+		Logger:           s.executor.logger,
 		Hostname:         config.Hostname,
 		Runtime:          s.executor.runtime,
 		Args:             s.executor.runtimeArgs,
@@ -487,11 +488,11 @@ func (s *StageExecutor) UnrecognizedInstruction(step *imagebuilder.Step) error {
 
 	switch logrus.GetLevel() {
 	case logrus.ErrorLevel:
-		logrus.Errorf(errStr)
+		s.executor.logger.Errorf(errStr)
 	case logrus.DebugLevel:
 		logrus.Debugf(err)
 	default:
-		logrus.Errorf("+(UNHANDLED LOGLEVEL) %#v", step)
+		s.executor.logger.Errorf("+(UNHANDLED LOGLEVEL) %#v", step)
 	}
 
 	return errors.Errorf(err)

--- a/import.go
+++ b/import.go
@@ -163,5 +163,6 @@ func importBuilderFromImage(ctx context.Context, store storage.Store, options Im
 		return nil, errors.Wrapf(err, "error importing build settings from image %q", options.Image)
 	}
 
+	builder.setupLogger()
 	return builder, nil
 }

--- a/run.go
+++ b/run.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containers/buildah/define"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -70,6 +71,8 @@ const (
 
 // RunOptions can be used to alter how a command is run in the container.
 type RunOptions struct {
+	// Logger is the logrus logger to write log messages with
+	Logger *logrus.Logger `json:"-"`
 	// Hostname is the hostname we set for the running container.
 	Hostname string
 	// Isolation is either IsolationDefault, IsolationOCI, IsolationChroot, or IsolationOCIRootless.

--- a/run_linux.go
+++ b/run_linux.go
@@ -76,7 +76,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	logrus.Debugf("using %q to hold bundle data", path)
 	defer func() {
 		if err2 := os.RemoveAll(path); err2 != nil {
-			logrus.Error(err2)
+			options.Logger.Error(err2)
 		}
 	}()
 
@@ -120,7 +120,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	}
 	defer func() {
 		if err := b.Unmount(); err != nil {
-			logrus.Errorf("error unmounting container: %v", err)
+			options.Logger.Errorf("error unmounting container: %v", err)
 		}
 	}()
 	g.SetRootPath(mountPoint)
@@ -253,7 +253,7 @@ rootless=%d
 
 	defer func() {
 		if err := cleanupRunMounts(runMountTargets, mountPoint); err != nil {
-			logrus.Errorf("unabe to cleanup run mounts %v", err)
+			options.Logger.Errorf("unabe to cleanup run mounts %v", err)
 		}
 	}()
 
@@ -709,7 +709,7 @@ func runUsingRuntime(isolation define.Isolation, options RunOptions, configureNe
 	if unmountAll != nil {
 		defer func() {
 			if err := unmountAll(); err != nil {
-				logrus.Error(err)
+				options.Logger.Error(err)
 			}
 		}()
 	}
@@ -829,7 +829,7 @@ func runUsingRuntime(isolation define.Isolation, options RunOptions, configureNe
 	logrus.Debugf("Running %q", create.Args)
 	err = create.Run()
 	if err != nil {
-		return 1, errors.Wrapf(err, "error from %s creating container for %v: %s", runtime, pargs, runCollectOutput(errorFds, closeBeforeReadingErrorFds))
+		return 1, errors.Wrapf(err, "error from %s creating container for %v: %s", runtime, pargs, runCollectOutput(options.Logger, errorFds, closeBeforeReadingErrorFds))
 	}
 	defer func() {
 		err2 := del.Run()
@@ -837,7 +837,7 @@ func runUsingRuntime(isolation define.Isolation, options RunOptions, configureNe
 			if err == nil {
 				err = errors.Wrapf(err2, "error deleting container")
 			} else {
-				logrus.Infof("error from %s deleting container: %v", runtime, err2)
+				options.Logger.Infof("error from %s deleting container: %v", runtime, err2)
 			}
 		}
 	}()
@@ -860,7 +860,7 @@ func runUsingRuntime(isolation define.Isolation, options RunOptions, configureNe
 		_, err = unix.Wait4(pid, &wstatus, 0, nil)
 		if err != nil {
 			wstatus = 0
-			logrus.Errorf("error waiting for container child process %d: %v\n", pid, err)
+			options.Logger.Errorf("error waiting for container child process %d: %v\n", pid, err)
 		}
 		stopped = true
 	}()
@@ -886,7 +886,7 @@ func runUsingRuntime(isolation define.Isolation, options RunOptions, configureNe
 
 	// Handle stdio for the container in the background.
 	stdio.Add(1)
-	go runCopyStdio(&stdio, copyPipes, stdioPipe, copyConsole, consoleListener, finishCopy, finishedCopy, spec)
+	go runCopyStdio(options.Logger, &stdio, copyPipes, stdioPipe, copyConsole, consoleListener, finishCopy, finishedCopy, spec)
 
 	// Start the container.
 	logrus.Debugf("Running %q", start.Args)
@@ -897,7 +897,7 @@ func runUsingRuntime(isolation define.Isolation, options RunOptions, configureNe
 	defer func() {
 		if !stopped {
 			if err2 := kill.Run(); err2 != nil {
-				logrus.Infof("error from %s stopping container: %v", runtime, err2)
+				options.Logger.Infof("error from %s stopping container: %v", runtime, err2)
 			}
 		}
 	}()
@@ -952,7 +952,7 @@ func runUsingRuntime(isolation define.Isolation, options RunOptions, configureNe
 	return wstatus, nil
 }
 
-func runCollectOutput(fds, closeBeforeReadingFds []int) string {
+func runCollectOutput(logger *logrus.Logger, fds, closeBeforeReadingFds []int) string { //nolint:interfacer
 	for _, fd := range closeBeforeReadingFds {
 		unix.Close(fd)
 	}
@@ -964,11 +964,11 @@ func runCollectOutput(fds, closeBeforeReadingFds []int) string {
 			if errno, isErrno := err.(syscall.Errno); isErrno {
 				switch errno {
 				default:
-					logrus.Errorf("error reading from pipe %d: %v", fd, err)
+					logger.Errorf("error reading from pipe %d: %v", fd, err)
 				case syscall.EINTR, syscall.EAGAIN:
 				}
 			} else {
-				logrus.Errorf("unable to wait for data from pipe %d: %v", fd, err)
+				logger.Errorf("unable to wait for data from pipe %d: %v", fd, err)
 			}
 			continue
 		}
@@ -976,7 +976,7 @@ func runCollectOutput(fds, closeBeforeReadingFds []int) string {
 			r := buf[:nread]
 			if nwritten, err := b.Write(r); err != nil || nwritten != len(r) {
 				if nwritten != len(r) {
-					logrus.Errorf("error buffering data from pipe %d: %v", fd, err)
+					logger.Errorf("error buffering data from pipe %d: %v", fd, err)
 					break
 				}
 			}
@@ -985,11 +985,11 @@ func runCollectOutput(fds, closeBeforeReadingFds []int) string {
 				if errno, isErrno := err.(syscall.Errno); isErrno {
 					switch errno {
 					default:
-						logrus.Errorf("error reading from pipe %d: %v", fd, err)
+						logger.Errorf("error reading from pipe %d: %v", fd, err)
 					case syscall.EINTR, syscall.EAGAIN:
 					}
 				} else {
-					logrus.Errorf("unable to wait for data from pipe %d: %v", fd, err)
+					logger.Errorf("unable to wait for data from pipe %d: %v", fd, err)
 				}
 				break
 			}
@@ -1145,7 +1145,7 @@ func runConfigureNetwork(isolation define.Isolation, options RunOptions, configu
 	teardown = func() {
 		for _, nc := range undo {
 			if err = cni.DelNetworkList(context.Background(), nc, rtconf[nc]); err != nil {
-				logrus.Errorf("error cleaning up network %v for %v: %v", rtconf[nc].IfName, command, err)
+				options.Logger.Errorf("error cleaning up network %v for %v: %v", rtconf[nc].IfName, command, err)
 			}
 		}
 		unix.Close(netFD)
@@ -1170,19 +1170,19 @@ func runConfigureNetwork(isolation define.Isolation, options RunOptions, configu
 	return teardown, nil
 }
 
-func setNonblock(fd int, description string, nonblocking bool) error {
+func setNonblock(logger *logrus.Logger, fd int, description string, nonblocking bool) error { //nolint:interfacer
 	err := unix.SetNonblock(fd, nonblocking)
 	if err != nil {
 		if nonblocking {
-			logrus.Errorf("error setting %s to nonblocking: %v", description, err)
+			logger.Errorf("error setting %s to nonblocking: %v", description, err)
 		} else {
-			logrus.Errorf("error setting descriptor %s blocking: %v", description, err)
+			logger.Errorf("error setting descriptor %s blocking: %v", description, err)
 		}
 	}
 	return err
 }
 
-func runCopyStdio(stdio *sync.WaitGroup, copyPipes bool, stdioPipe [][]int, copyConsole bool, consoleListener *net.UnixListener, finishCopy []int, finishedCopy chan struct{}, spec *specs.Spec) {
+func runCopyStdio(logger *logrus.Logger, stdio *sync.WaitGroup, copyPipes bool, stdioPipe [][]int, copyConsole bool, consoleListener *net.UnixListener, finishCopy []int, finishedCopy chan struct{}, spec *specs.Spec) {
 	defer func() {
 		unix.Close(finishCopy[0])
 		if copyPipes {
@@ -1203,9 +1203,9 @@ func runCopyStdio(stdio *sync.WaitGroup, copyPipes bool, stdioPipe [][]int, copy
 	// Set up the terminal descriptor or pipes for polling.
 	if copyConsole {
 		// Accept a connection over our listening socket.
-		fd, err := runAcceptTerminal(consoleListener, spec.Process.ConsoleSize)
+		fd, err := runAcceptTerminal(logger, consoleListener, spec.Process.ConsoleSize)
 		if err != nil {
-			logrus.Errorf("%v", err)
+			logger.Errorf("%v", err)
 			return
 		}
 		terminalFD := fd
@@ -1222,11 +1222,11 @@ func runCopyStdio(stdio *sync.WaitGroup, copyPipes bool, stdioPipe [][]int, copy
 		// terminal input to the terminal in the container.
 		if terminal.IsTerminal(unix.Stdin) {
 			if state, err := terminal.MakeRaw(unix.Stdin); err != nil {
-				logrus.Warnf("error setting terminal state: %v", err)
+				logger.Warnf("error setting terminal state: %v", err)
 			} else {
 				defer func() {
 					if err = terminal.Restore(unix.Stdin, state); err != nil {
-						logrus.Errorf("unable to restore terminal state: %v", err)
+						logger.Errorf("unable to restore terminal state: %v", err)
 					}
 				}()
 			}
@@ -1249,14 +1249,14 @@ func runCopyStdio(stdio *sync.WaitGroup, copyPipes bool, stdioPipe [][]int, copy
 	}
 	// Set our reading descriptors to non-blocking.
 	for rfd, wfd := range relayMap {
-		if err := setNonblock(rfd, readDesc[rfd], true); err != nil {
+		if err := setNonblock(logger, rfd, readDesc[rfd], true); err != nil {
 			return
 		}
-		setNonblock(wfd, writeDesc[wfd], false) // nolint:errcheck
+		setNonblock(logger, wfd, writeDesc[wfd], false) // nolint:errcheck
 	}
 
 	if copyPipes {
-		setNonblock(stdioPipe[unix.Stdin][1], writeDesc[stdioPipe[unix.Stdin][1]], true) // nolint:errcheck
+		setNonblock(logger, stdioPipe[unix.Stdin][1], writeDesc[stdioPipe[unix.Stdin][1]], true) // nolint:errcheck
 	}
 
 	runCopyStdioPassData(copyPipes, stdioPipe, finishCopy, relayMap, relayBuffer, readDesc, writeDesc)
@@ -1394,7 +1394,7 @@ func runCopyStdioPassData(copyPipes bool, stdioPipe [][]int, finishCopy []int, r
 	}
 }
 
-func runAcceptTerminal(consoleListener *net.UnixListener, terminalSize *specs.Box) (int, error) {
+func runAcceptTerminal(logger *logrus.Logger, consoleListener *net.UnixListener, terminalSize *specs.Box) (int, error) {
 	defer consoleListener.Close()
 	c, err := consoleListener.AcceptUnix()
 	if err != nil {
@@ -1447,7 +1447,7 @@ func runAcceptTerminal(consoleListener *net.UnixListener, terminalSize *specs.Bo
 		if terminal.IsTerminal(unix.Stdin) {
 			// Use the size of our terminal.
 			if winsize, err = unix.IoctlGetWinsize(unix.Stdin, unix.TIOCGWINSZ); err != nil {
-				logrus.Warnf("error reading size of controlling terminal: %v", err)
+				logger.Warnf("error reading size of controlling terminal: %v", err)
 				winsize.Row = 0
 				winsize.Col = 0
 			}
@@ -1455,7 +1455,7 @@ func runAcceptTerminal(consoleListener *net.UnixListener, terminalSize *specs.Bo
 	}
 	if winsize.Row != 0 && winsize.Col != 0 {
 		if err = unix.IoctlSetWinsize(terminalFD, unix.TIOCSWINSZ, winsize); err != nil {
-			logrus.Warnf("error setting size of container pseudoterminal: %v", err)
+			logger.Warnf("error setting size of container pseudoterminal: %v", err)
 		}
 		// FIXME - if we're connected to a terminal, we should
 		// be passing the updated terminal size down when we
@@ -1531,7 +1531,7 @@ func runUsingRuntimeMain() {
 	os.Exit(1)
 }
 
-func setupNamespaces(g *generate.Generator, namespaceOptions define.NamespaceOptions, idmapOptions define.IDMappingOptions, policy define.NetworkConfigurationPolicy) (configureNetwork bool, configureNetworks []string, configureUTS bool, err error) {
+func setupNamespaces(logger *logrus.Logger, g *generate.Generator, namespaceOptions define.NamespaceOptions, idmapOptions define.IDMappingOptions, policy define.NetworkConfigurationPolicy) (configureNetwork bool, configureNetworks []string, configureUTS bool, err error) {
 	// Set namespace options in the container configuration.
 	configureUserns := false
 	specifiedNetwork := false
@@ -1623,7 +1623,7 @@ func setupNamespaces(g *generate.Generator, namespaceOptions define.NamespaceOpt
 			if err == nil {
 				g.AddLinuxSysctl(name, val)
 			} else {
-				logrus.Warnf("ignoring sysctl %s since %s doesn't exist", name, p)
+				logger.Warnf("ignoring sysctl %s since %s doesn't exist", name, p)
 			}
 		}
 	}
@@ -1645,7 +1645,7 @@ func (b *Builder) configureNamespaces(g *generate.Generator, options RunOptions)
 		networkPolicy = b.ConfigureNetwork
 	}
 
-	configureNetwork, configureNetworks, configureUTS, err := setupNamespaces(g, namespaceOptions, b.IDMappingOptions, networkPolicy)
+	configureNetwork, configureNetworks, configureUTS, err := setupNamespaces(options.Logger, g, namespaceOptions, b.IDMappingOptions, networkPolicy)
 	if err != nil {
 		return false, nil, err
 	}
@@ -1714,7 +1714,7 @@ func (b *Builder) cleanupTempVolumes() {
 	for tempVolume, val := range b.TempVolumes {
 		if val {
 			if err := overlay.RemoveTemp(tempVolume); err != nil {
-				logrus.Errorf(err.Error())
+				b.Logger.Errorf(err.Error())
 			}
 			b.TempVolumes[tempVolume] = false
 		}


### PR DESCRIPTION
We want Info, Warning and Debug logrus messages to be writen to the
buildah stderr. this way when podman-remote is using build, it will
get the messages back on the client side.

[NO TESTS NEEDED] Since this will be tested in Podman.

Fixes: https://github.com/containers/buildah/issues/3214

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

