### PR TITLE
Remove 'buildah run --security-opt' from completion

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -498,7 +498,6 @@ return 1
      --pid
      --runtime
      --runtime-flag
-     --security-opt
      --user
      --uts
      --volume


### PR DESCRIPTION
Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:

Remove `--security-opt` flag from completion of `buildah run`. As mentioned in #2642, this flag is not implemented.

#### How to verify it

Set the completion:
```
source contrib/completions/bash/buildah
```
Then, confirm `--security-opt` doesn't appear for `buildah run`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
