### PR TITLE
[CI:DOCS] Fix multi-arch image build logic and docs

### DIFF
--- a/.github/workflows/multi-arch-build.yaml
+++ b/.github/workflows/multi-arch-build.yaml
@@ -122,11 +122,11 @@ jobs:
                       docker://$CONTAINERS_QUAY_REGISTRY/buildah | \
                       jq -r '.Tags[]')
 
-            # New image? Push quay.io/containers/buildah:vX.X.X and :latest
+            # New image? Push quay.io/containers/buildah:vX.X.X
             if ! fgrep -qx "$VERSION" <<<"$ALLTAGS"; then
-              FQIN="$CONTAINERS_QUAY_REGISTRY/buildah:$VERSION,$CONTAINERS_QUAY_REGISTRY/buildah:latest"
-            else # Not a new version-tagged image, but contents may be updated
-              FQIN="$CONTAINERS_QUAY_REGISTRY/buildah:latest"
+              FQIN="$CONTAINERS_QUAY_REGISTRY/buildah:$VERSION"
+            else # Not a new version-tagged image, do nothing
+              FQIN=""
             fi
           elif [[ "${{ matrix.source }}" == 'upstream' ]]; then
             FQIN="$CONTAINERS_QUAY_REGISTRY/buildah:latest"
@@ -134,9 +134,13 @@ jobs:
             echo "::error::Unknown matrix item '${{ matrix.source }}'"
             exit 1
           fi
-          echo "::warning::Pushing $FQIN"
-          echo "::set-output name=fqin::${FQIN}"
-          echo '::set-output name=push::true'
+          if [[ -n "$FQIN" ]]; then
+            echo "::warning::Pushing $FQIN"
+            echo "::set-output name=fqin::${FQIN}"
+            echo '::set-output name=push::true'
+          else
+            echo '::set-output name=push::false'
+          fi
 
       - name: Define LABELS multi-line env. var. value
         run: |

--- a/contrib/buildahimage/README.md
+++ b/contrib/buildahimage/README.md
@@ -23,7 +23,7 @@ The container images are:
     please [see the configuration file](stable/Dockerfile).
   * `quay.io/containers/buildah:latest` and `quay.io/buildah/stable:latest` -
     Built daily using the same Dockerfile as above.  The buildah version
-    will remain the "latest" available in Fedora, however the other image
+    will remain the "latest" available in Fedora, however the image
     contents may vary compared to the version-tagged images.
   * `quay.io/buildah/testing:latest` - This image is built daily, using the
     latest version of Buildah that was in the Fedora `updates-testing` repository.


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Previously the conditional for both the `stable` and
`upstream` resulted in pushing `quay.io/containers/podman:latest`
(overwriting each other).  Fix this by only pushing `upstream` to the
"latest" tag, and `stable` to the version-named tag.  Also make a small
clarification update to documentation.

#### How to verify it

After PR merges, the daily multi-arch github actions job may be started manually.  It should no longer push two images to `quay.io/containers/buildah:latest` - indicated by "warning" messages on the summary page.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

See also https://github.com/containers/podman/pull/10414

#### Does this PR introduce a user-facing change?

None