### PR TITLE
containerImageRef.createConfigsAndManifests(): squashed images have no parent images

### DIFF
--- a/image.go
+++ b/image.go
@@ -222,9 +222,11 @@ func (i *containerImageRef) createConfigsAndManifests() (v1.Image, v1.Manifest, 
 	dimage.RootFS = &docker.V2S2RootFS{}
 	dimage.RootFS.Type = docker.TypeLayers
 	dimage.RootFS.DiffIDs = []digest.Digest{}
-	// Only clear the history if we're squashing, otherwise leave it be so that we can append
-	// entries to it.
+	// Only clear the history if we're squashing, otherwise leave it be so
+	// that we can append entries to it.  Clear the parent, too, we no
+	// longer include its layers and history.
 	if i.squash {
+		dimage.Parent = ""
 		dimage.History = []docker.V2S2History{}
 	}
 

--- a/tests/squash.bats
+++ b/tests/squash.bats
@@ -121,4 +121,8 @@ function check_lengths() {
 	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash -t squashed ${TESTDIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
         expect_output "1" "len(DiffIDs) - image with FROM, USER, and 2xCOPY (--layers)"
+
+	run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json --squash --format docker -t squashed ${TESTDIR}/squashed
+	run_buildah inspect -t image -f '{{.Docker.Parent}}' squashed
+        expect_output "" "should have no parent image set"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Remove the parent image's ID from the config blob when we're squashing the image, since after squashing, we share no layers or history with what was once our base image, and leaving it set triggers verification errors in registries that expect consistency between parent IDs and perhaps layers and history.

#### How to verify it

We've gotten at least one report that combining our `--squash` option with `--format docker` at commit time causes such a rejection when attempting to push the resulting image to quay 3.3.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```