### PR TITLE
Only check authfile if the user specified it at command line

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -107,8 +107,10 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 			tags = tags[1:]
 		}
 	}
-	if err := auth.CheckAuthFile(iopts.BudResults.Authfile); err != nil {
-		return err
+	if c.Flag("authfile").Changed {
+		if err := auth.CheckAuthFile(iopts.BudResults.Authfile); err != nil {
+			return err
+		}
 	}
 
 	pullPolicy := define.PullIfMissing

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -112,8 +112,10 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
 		return err
 	}
-	if err := auth.CheckAuthFile(iopts.authfile); err != nil {
-		return err
+	if c.Flag("authfile").Changed {
+		if err := auth.CheckAuthFile(iopts.authfile); err != nil {
+			return err
+		}
 	}
 
 	name := args[0]

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -188,9 +188,12 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 		return errors.Errorf("too many arguments specified")
 	}
 
-	if err := auth.CheckAuthFile(iopts.authfile); err != nil {
-		return err
+	if c.Flag("authfile").Changed {
+		if err := auth.CheckAuthFile(iopts.authfile); err != nil {
+			return err
+		}
 	}
+
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
 		return errors.Wrapf(err, "error building system context")

--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -270,8 +270,10 @@ func manifestCreateCmd(c *cobra.Command, args []string, opts manifestCreateOpts)
 }
 
 func manifestAddCmd(c *cobra.Command, args []string, opts manifestAddOpts) error {
-	if err := auth.CheckAuthFile(opts.authfile); err != nil {
-		return err
+	if c.Flag("authfile").Changed {
+		if err := auth.CheckAuthFile(opts.authfile); err != nil {
+			return err
+		}
 	}
 
 	listImageSpec := ""
@@ -729,8 +731,10 @@ func manifestInspect(ctx context.Context, store storage.Store, systemContext *ty
 }
 
 func manifestPushCmd(c *cobra.Command, args []string, opts pushOptions) error {
-	if err := auth.CheckAuthFile(opts.authfile); err != nil {
-		return err
+	if c.Flag("authfile").Changed {
+		if err := auth.CheckAuthFile(opts.authfile); err != nil {
+			return err
+		}
 	}
 
 	listImageSpec := ""

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -86,8 +86,10 @@ func pullCmd(c *cobra.Command, args []string, iopts pullOptions) error {
 	if len(args) > 1 {
 		return errors.Errorf("too many arguments specified")
 	}
-	if err := auth.CheckAuthFile(iopts.authfile); err != nil {
-		return err
+	if c.Flag("authfile").Changed {
+		if err := auth.CheckAuthFile(iopts.authfile); err != nil {
+			return err
+		}
 	}
 
 	systemContext, err := parse.SystemContextFromOptions(c)

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -104,8 +104,10 @@ func pushCmd(c *cobra.Command, args []string, iopts pushOptions) error {
 	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
 		return err
 	}
-	if err := auth.CheckAuthFile(iopts.authfile); err != nil {
-		return err
+	if c.Flag("authfile").Changed {
+		if err := auth.CheckAuthFile(iopts.authfile); err != nil {
+			return err
+		}
 	}
 
 	switch len(args) {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2193,6 +2193,13 @@ _EOF
   run_buildah 125 bud --authfile /tmp/nonexistent --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
 }
 
+@test "bud with nonexistent REGISTRY_AUTH_FILE: succeeds" {
+  # This field should be ignored
+  export REGISTRY_AUTH_FILE=/tmp/nonexistent
+  target=alpine-image
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
+}
+
 @test "bud COPY with URL should fail" {
   mkdir ${TESTSDIR}/bud/copy
   FILE=${TESTSDIR}/bud/copy/Dockerfile.url

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -117,6 +117,14 @@ load helpers
   run_buildah 125 commit --authfile /tmp/nonexistent --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
 }
 
+@test "commit with nonexistent REGISTRY_AUTH_FILE: succeeds" {
+  # This field should be ignored
+  export REGISTRY_AUTH_FILE=/tmp/nonexistent
+  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
+}
+
 @test "commit-builder-identity" {
 	_prefetch alpine
 	run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -360,6 +360,12 @@ load helpers
   expect_output "checking authfile: stat /no/such/file: no such file or directory"
 }
 
+@test "from with nonexistent REGISTRY_AUTH_FILE: succeeds" {
+  # This field should be ignored
+  export REGISTRY_AUTH_FILE=/tmp/nonexistent
+  run_buildah from --pull --signature-policy ${TESTSDIR}/policy.json alpine
+}
+
 @test "from --pull-always: emits 'Getting' even if image is cached" {
   _prefetch docker.io/busybox
   run buildah pull --signature-policy ${TESTSDIR}/policy.json docker.io/busybox

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -135,6 +135,15 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 
 }
 
+@test "manifest-push with nonexistent REGISTRY_AUTH_FILE: succeeds" {
+  # This field should be ignored
+  export REGISTRY_AUTH_FILE=/tmp/nonexistent
+    run_buildah manifest create foo
+    run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST}
+    run_buildah manifest inspect foo
+    run_buildah manifest push --signature-policy ${TESTSDIR}/policy.json --purge foo dir:${TESTDIR}/pushed
+}
+
 @test "manifest-from-tag" {
     run_buildah from --signature-policy ${TESTSDIR}/policy.json --name test-container ${IMAGE_LIST}
     run_buildah inspect --format ''{{.OCIv1.Architecture}}' ${IMAGE_LIST}

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -176,6 +176,12 @@ load helpers
   run_buildah 125 pull --authfile /tmp/nonexistent --signature-policy ${TESTSDIR}/policy.json alpine
 }
 
+@test "pull with nonexistent REGISTRY_AUTH_FILE: succeeds" {
+  # This field should be ignored
+  export REGISTRY_AUTH_FILE=/tmp/nonexistent
+  run_buildah pull --signature-policy ${TESTSDIR}/policy.json alpine
+}
+
 @test "pull encrypted local image" {
   _prefetch busybox
   mkdir ${TESTDIR}/tmp

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -95,6 +95,17 @@ load helpers
   run_buildah 125 push --signature-policy ${TESTSDIR}/policy.json --authfile /tmp/nonexistent $imageid dir:${TESTDIR}/my-tmp-dir
 }
 
+@test "pull with nonexistent REGISTRY_AUTH_FILE: succeeds" {
+  # This field should be ignored
+  export REGISTRY_AUTH_FILE=/tmp/nonexistent
+  _prefetch alpine
+  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
+  run_buildah images -q
+  imageid=$output
+  run_buildah push --signature-policy ${TESTSDIR}/policy.json $imageid dir:${TESTDIR}/my-tmp-dir
+}
+
 @test "push-denied-by-registry-sources" {
   _prefetch busybox
 


### PR DESCRIPTION
This allows us to have a REGISTRY_AUTH_FILE and only fail when
the authfile is specified to be used.  If the user specifies it
that means he intends to use it.

Fixes: https://github.com/containers/buildah/issues/3259

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

