### PR TITLE
imagebuildah: redo step logging

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -49,6 +49,7 @@ import (
 type StageExecutor struct {
 	ctx             context.Context
 	executor        *Executor
+	log             func(format string, args ...interface{})
 	index           int
 	stages          imagebuilder.Stages
 	name            string
@@ -527,7 +528,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 	if initializeIBConfig && rebase {
 		logrus.Debugf("FROM %#v", displayFrom)
 		if !s.executor.quiet {
-			s.executor.log("FROM %s", displayFrom)
+			s.log("FROM %s", displayFrom)
 		}
 	}
 
@@ -740,7 +741,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		}
 		logrus.Debugf(commitMessage)
 		if !s.executor.quiet {
-			s.executor.log(commitMessage)
+			s.log(commitMessage)
 		}
 	}
 	logCacheHit := func(cacheID string) {
@@ -798,7 +799,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		}
 		logrus.Debugf("Parsed Step: %+v", *step)
 		if !s.executor.quiet {
-			s.executor.log("%s", step.Original)
+			s.log("%s", step.Original)
 		}
 
 		// Check if there's a --from if the step command is COPY.

--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -68,7 +68,7 @@ EOM
 
   # bud test this should work
   run_buildah bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds=testuser:testpassword .
-  expect_output --from="${lines[0]}" "STEP 1: FROM localhost:5000/my-alpine"
+  expect_output --from="${lines[0]}" "STEP 1/1: FROM localhost:5000/my-alpine"
   expect_output --substring "Writing manifest to image destination"
 }
 
@@ -116,7 +116,7 @@ EOM
 
   # bud with correct credentials
   run_buildah bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --cert-dir=$BUILDAH_AUTHDIR --tls-verify=true --creds=testuser:testpassword .
-  expect_output --from="${lines[0]}" "STEP 1: FROM localhost:5000/my-alpine"
+  expect_output --from="${lines[0]}" "STEP 1/2: FROM localhost:5000/my-alpine"
   expect_output --substring "Writing manifest to image destination"
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

* Don't try to count COMMIT as a step; it's very confusing and doesn't match the behavior of traditional docker build.
* Include the step count for the stage, which is easy if we're not trying to predict COMMIT, which we don't always do, because we don't always have to, in multi-stage builds.
* In multi-stage builds, prefix the stage number and stage count, which is fun to see when we're building stages in parallel.

#### How to verify it

Visual inspection, and tests which expected output with step counts have been updated.

#### Which issue(s) this PR fixes:

Fixes #1681

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
Builds using Dockerfiles/Containerfiles will now include the number of steps in the stage when logging which instruction is being processed, and multi-stage builds will include an indicator of which stage the build is in.
```