### PR TITLE
Add rusage-logfile flag to optionally send rusage to a file

### DIFF
--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -334,6 +334,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		Isolation:               isolation,
 		Labels:                  iopts.Label,
 		Layers:                  layers,
+		LogRusage:               iopts.LogRusage,
 		Manifest:                iopts.Manifest,
 		MaxPullPushRetries:      maxPullPushRetries,
 		NamespaceOptions:        namespaceOptions,
@@ -349,6 +350,7 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		ReportWriter:            reporter,
 		Runtime:                 iopts.Runtime,
 		RuntimeArgs:             runtimeFlags,
+		RusageLogFile:           iopts.RusageLogFile,
 		SignBy:                  iopts.SignBy,
 		SignaturePolicyPath:     iopts.SignaturePolicy,
 		Squash:                  iopts.Squash,
@@ -357,7 +359,6 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		TransientMounts:         iopts.Volumes,
 		OciDecryptConfig:        decConfig,
 		Jobs:                    &iopts.Jobs,
-		LogRusage:               iopts.LogRusage,
 	}
 	if iopts.IgnoreFile != "" {
 		excludes, err := parseDockerignore(iopts.IgnoreFile)

--- a/define/build.go
+++ b/define/build.go
@@ -217,6 +217,8 @@ type BuildOptions struct {
 	Jobs *int
 	// LogRusage logs resource usage for each step.
 	LogRusage bool
+	// File to which the Rusage logs will be saved to instead of stdout
+	RusageLogFile string
 	// Excludes is a list of excludes to be used instead of the .dockerignore file.
 	Excludes []string
 	// From is the image name to use to replace the value specified in the first

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -704,8 +704,8 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				fmt.Fprintf(s.executor.out, "error gathering resource usage information: %v\n", err)
 				return
 			}
-			if !s.executor.quiet && s.executor.logRusage {
-				fmt.Fprintf(s.executor.out, "%s\n", rusage.FormatDiff(usage.Subtract(resourceUsage)))
+			if s.executor.rusageLogFile != nil {
+				fmt.Fprintf(s.executor.rusageLogFile, "%s\n", rusage.FormatDiff(usage.Subtract(resourceUsage)))
 			}
 			resourceUsage = usage
 		}

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -84,6 +84,7 @@ type BudResults struct {
 	TLSVerify           bool
 	Jobs                int
 	LogRusage           bool
+	RusageLogFile       string
 }
 
 // FromAndBugResults represents the results for common flags
@@ -198,6 +199,10 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.BoolVar(&flags.LogRusage, "log-rusage", false, "log resource usage at each build step")
 	if err := fs.MarkHidden("log-rusage"); err != nil {
 		panic(fmt.Sprintf("error marking the log-rusage flag as hidden: %v", err))
+	}
+	fs.StringVar(&flags.RusageLogFile, "rusage-logfile", "", "destination file to which rusage should be logged to instead of stdout (= the default).")
+	if err := fs.MarkHidden("rusage-logfile"); err != nil {
+		panic(fmt.Sprintf("error marking the rusage-logfile flag as hidden: %v", err))
 	}
 	fs.StringVar(&flags.Manifest, "manifest", "", "add the image to the specified manifest list. Creates manifest if it does not exist")
 	fs.BoolVar(&flags.NoCache, "no-cache", false, "Do not use existing cached images for the container build. Build from the start with a new set of cached layers.")


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Currently the rusage is reported to stdout and rather cumbersome to parse. The
new flag rusage-logfile can be used to specify a file to which the log will be
written instead.

#### How to verify it

Run `buildah bud --log-rusage --rusage-logfile "tests.log"`

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

I'd like to add a bats integration test as well, but am unfamiliar with bats. If anyone could help me out with that, that would be greatly appreciated.

#### Does this PR introduce a user-facing change?

```release-note
- add --rusage-logfile flag to log rusage into a file
```
