### PR TITLE
Fix handling of auth.json file while in a user namespace

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -132,7 +132,7 @@ func before(cmd *cobra.Command) error {
 	}
 
 	switch cmd.Use {
-	case "", "help", "version", "mount", "login", "logout":
+	case "", "help", "version", "mount":
 		return nil
 	}
 	unshare.MaybeReexecUsingUserNamespace(false)


### PR DESCRIPTION
If you are running buildah within a user namespace, without
XDG_RUNTIME_DIR being set, we need to make sure buildah login, logout
handle XDG_RUNTIME_DIR the same was as buildah push.

Running buildah within a container is triggering failures, where buildah
login puts the auth.json file in /run/containers/0/auth.json but buildah
push looks for it in
/tmp/container-user-0/containers/containers/auth.json

Fixes: https://github.com/containers/buildah/issues/3259

[NO TESTS NEEDED] The existing tests should see if this causes any
problems.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

