### PR TITLE
Cirrus: Install docker from package cache

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ env:
     UBUNTU_NAME: "ubuntu-2104"
     PRIOR_UBUNTU_NAME: "ubuntu-2010"
 
-    IMAGE_SUFFIX: "c6032583541653504"
+    IMAGE_SUFFIX: "c6534244118822912"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
@@ -173,7 +173,7 @@ conformance_task:
         - env:
             STORAGE_DRIVER: 'overlay'
 
-    setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
+    setup_script: '${SCRIPT_BASE}/setup.sh conformance |& ${_TIMESTAMP}'
     conformance_test_script: '${SCRIPT_BASE}/test.sh conformance |& ${_TIMESTAMP}'
 
 

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -87,6 +87,9 @@ ALPINE_FQIN=${ALPINE_FQIN:-docker.io/library/alpine}
 IN_PODMAN_NAME="in_podman_$CIRRUS_TASK_ID"
 IN_PODMAN="${IN_PODMAN:-false}"
 
+# Downloaded, but not installed packages.
+PACKAGE_DOWNLOAD_DIR=/var/cache/download
+
 lilto() { err_retry 8 1000 "" "$@"; }  # just over 4 minutes max
 bigto() { err_retry 7 5670 "" "$@"; }  # 12 minutes max
 

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -33,6 +33,10 @@ EOF
         fi
         ;;
     ubuntu)
+        if [[ "$1" == "conformance" ]]; then
+            msg "Installing previously downloaded/cached packages"
+            bigto dpkg -i $PACKAGE_DOWNLOAD_DIR/*.deb
+        fi
         ;;
     *)
         bad_os_id_ver

--- a/contrib/cirrus/test.sh
+++ b/contrib/cirrus/test.sh
@@ -47,27 +47,6 @@ else
             [[ "$OS_RELEASE_ID" == "ubuntu" ]] || \
                 bad_os_id_ver
 
-            warn "Installing upstream docker from docker.com"
-            # Ref: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
-            curl --fail --silent --location \
-                --url  https://download.docker.com/linux/ubuntu/gpg | \
-                gpg --dearmor > \
-                /etc/apt/trusted.gpg.d/docker_com.gpg
-            add-apt-repository --yes --no-update \
-                "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-                $(lsb_release -cs) \
-                stable"
-            $SHORT_APTGET update
-            $LONG_APTGET install \
-                apt-transport-https \
-                ca-certificates \
-                containerd.io \
-                curl \
-                docker-ce \
-                docker-ce-cli \
-                gnupg-agent \
-                software-properties-common
-
             systemctl enable --now docker
             showrun make test-conformance
             ;;

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2880,6 +2880,7 @@ _EOF
 
   local found_runtime=
 
+  local flag_accepted_rx="level=debug.*msg=.*/runc"
   if [ -n "$(command -v runc)" ]; then
     found_runtime=y
     if is_cgroupsv2; then
@@ -2887,7 +2888,7 @@ _EOF
       run_buildah ? bud --runtime=runc --runtime-flag=debug \
                         -q -t alpine-bud-runc --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
       if [ "$status" -eq 0 ]; then
-        expect_output --substring "nsexec started"
+        expect_output --substring "$flag_accepted_rx"
       else
         # If it fails, this is because this version of runc doesn't support cgroup v2.
         expect_output --substring "this version of runc doesn't work on cgroups v2" "should fail by unsupportability for cgroupv2"
@@ -2895,7 +2896,7 @@ _EOF
     else
       run_buildah bud --runtime=runc --runtime-flag=debug \
                       -q -t alpine-bud-runc --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
-      expect_output --substring "nsexec started"
+      expect_output --substring "$flag_accepted_rx"
     fi
 
   fi


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Installing packages at runtime (from an external source) is problematic
for many reasons.  Specifically in the case of buildah/docker
conformance testing, it means the current "latest" pacakges are
always installed.  This is a problem as new release branches are
created, because it presents an opportunity for test-environment changes
to happen after buildah/test code is stabilized.

Fix this by using new/special VM images which cache the required docker
packages.  At runtime then, the required packages may be installed from
this cache instead of reaching out to the repository.  Since images used
by tests on release branches never change, this will also serve to
stabilize the package versions for that specific environment.

#### How to verify it

The automated 'conformance' testing will pass in this PR

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Ref: https://github.com/containers/automation_images/pull/75

#### Does this PR introduce a user-facing change?

None