### PR TITLE
[CI:DOCS] Fix docs links due to branch rename

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,3 +1,3 @@
 ## The Buildah Project Community Code of Conduct
 
-The Buildah Project follows the [Containers Community Code of Conduct](https://github.com/containers/common/blob/master/CODE-OF-CONDUCT.md).
+The Buildah Project follows the [Containers Community Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 ## Security and Disclosure Information Policy for the Buildah Project
 
-The Buildah Project follows the [Security and Disclosure Information Policy](https://github.com/containers/common/blob/master/SECURITY.md) for the Containers Projects.
+The Buildah Project follows the [Security and Disclosure Information Policy](https://github.com/containers/common/blob/main/SECURITY.md) for the Containers Projects.


### PR DESCRIPTION
Ref: https://github.com/containers/common/issues/549

Signed-off-by: Chris Evich <cevich@redhat.com>