### PR TITLE
Add kernel version requirement for fuse-overlayfs

### DIFF
--- a/install.md
+++ b/install.md
@@ -154,7 +154,7 @@ sudo apt-get -qq -y install buildah
 ### Kernel Version Requirements
 To run Buildah on Red Hat Enterprise Linux or CentOS, version 7.4 or higher is required.
 On other Linux distributions Buildah requires a kernel version of 4.0 or
-higher in order to support the OverlayFS filesystem.  The kernel version can be checked
+higher in order to support the OverlayFS filesystem, or later than 4.18.0 for [fuse-overlayfs](https://github.com/containers/fuse-overlayfs/blob/master/README.md).  The kernel version can be checked
 with the 'uname -a' command.
 
 ### runc Requirement


### PR DESCRIPTION
/kind documentation

#### What this PR does / why we need it:

The fuse-overlayfs README says:

> Also, please note that, when using fuse-overlayfs from a user namespace (for example, when using rootless podman) a Linux Kernel > v4.18.0 is required.

#### How to verify it

Ran into this when trying to run with fuse-overlayfs on 4.8.0 -- doesn't work, throws an EINVAL -- see https://github.com/containers/podman/issues/10100.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

```release-note
None
```

