### PR TITLE
Fix copy into workdir for a single file

### DIFF
--- a/add.go
+++ b/add.go
@@ -287,7 +287,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			destination = tmpDestination
 		}
 	}
-	destMustBeDirectory := (len(sources) > 1) || strings.HasSuffix(destination, string(os.PathSeparator))
+	destMustBeDirectory := (len(sources) > 1) || strings.HasSuffix(destination, string(os.PathSeparator)) || destination == b.WorkDir()
 	destCanBeFile := false
 	if len(sources) == 1 {
 		if len(remoteSources) == 1 {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1830,6 +1830,20 @@ _EOF
   test -s "${root}"/subdir/file2.txt
 }
 
+# regression test for https://github.com/containers/podman/issues/10671
+@test "bud-copy-workdir --layers" {
+  _prefetch alpine
+
+  target=testimage
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile.2 ${TESTSDIR}/bud/copy-workdir
+  run_buildah from ${target}
+  cid="$output"
+  run_buildah mount "${cid}"
+  root="$output"
+  test -d "${root}"/subdir
+  test -s "${root}"/subdir/file1.txt
+}
+
 @test "bud-build-arg-cache" {
   _prefetch busybox alpine
   target=derived-image

--- a/tests/bud/copy-workdir/Dockerfile.2
+++ b/tests/bud/copy-workdir/Dockerfile.2
@@ -1,0 +1,4 @@
+FROM alpine
+WORKDIR /subdir
+COPY file1.txt /subdir
+RUN ls


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:
When copying a single file to the workdir make sure to create the workdir
and not to overwrite it as file.

#### How to verify it
see added test

#### Which issue(s) this PR fixes:


Fixes containers/podman#10671

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

