### PR TITLE
man pages: clarify `rmi` removes dangling parents

### DIFF
--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -1,26 +1,31 @@
 # buildah-rmi "1" "March 2017" "buildah"
 
 ## NAME
+
 buildah\-rmi - Removes one or more images.
 
 ## SYNOPSIS
+
 **buildah rmi** [*image* ...]
 
 ## DESCRIPTION
+
 Removes one or more locally stored images.
+Passing an argument _image_ deletes it, along with any of its dangling (untagged) parent images.
 
 ## LIMITATIONS
+
 If the image was pushed to a directory path using the 'dir:' transport
-the rmi command can not remove the image.  Instead standard file system
+the rmi command can not remove the image. Instead standard file system
 commands should be used.
-If _imageID_ is a name, but does not include a registry name, buildah will attempt to find and remove an image named using the registry name *localhost*, if no such image is found, it will search for the intended image by attempting to expand the given name using the names of registries provided in the system's registries configuration file, registries.conf.
+If _imageID_ is a name, but does not include a registry name, buildah will attempt to find and remove an image named using the registry name _localhost_, if no such image is found, it will search for the intended image by attempting to expand the given name using the names of registries provided in the system's registries configuration file, registries.conf.
 
 ## OPTIONS
 
 **--all**, **-a**
 
 All local images will be removed from the system that do not have containers using the image as a reference image.
-An image name or id cannot be provided when this option is used.  Read/Only images configured by modifying the  "additionalimagestores" in the /etc/containers/storage.conf file, can not be removed.
+An image name or id cannot be provided when this option is used. Read/Only images configured by modifying the "additionalimagestores" in the /etc/containers/storage.conf file, can not be removed.
 
 **--prune**, **-p**
 
@@ -58,4 +63,5 @@ storage.conf is the storage configuration file for all tools using containers/st
 The storage configuration file specifies all of the available container storage options for tools using shared container storage.
 
 ## SEE ALSO
+
 buildah(1), containers-registries.conf(5), containers-storage.conf(5)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind documentation

#### What this PR does / why we need it:

This PR clarifies that `buildah rmi` removes not just the image it is given but also any of its dangling parents. Documenting this behavior makes `buildah rmi` more explicit & therefore predictable.

#### How to verify it

Read it :D

#### Which issue(s) this PR fixes:

#3202

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

Sorry this took me so long to get to, despite being such a small change!

#### Does this PR introduce a user-facing change?

Yes (changes the man pages) but I think that's too minor to warrant a release note?  Not sure.

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
