### PR TITLE
Fix documentation of the --format option of buildah push

### DIFF
--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -78,7 +78,7 @@ func init() {
 	flags.StringVar(&opts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	flags.StringVar(&opts.digestfile, "digestfile", "", "after copying the image, write the digest of the resulting image to the file")
 	flags.BoolVarP(&opts.disableCompression, "disable-compression", "D", false, "don't compress layers")
-	flags.StringVarP(&opts.format, "format", "f", "", "manifest type (oci, v2s1, or v2s2) to use when saving image using the 'dir:' transport (default is manifest type of source)")
+	flags.StringVarP(&opts.format, "format", "f", "", "manifest type (oci, v2s1, or v2s2) to use in the destination (default is manifest type of source, with fallbacks)")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "don't output progress information when pushing images")
 	flags.BoolVar(&opts.rm, "rm", false, "remove the manifest list if push succeeds")
 	flags.BoolVarP(&opts.removeSignatures, "remove-signatures", "", false, "don't copy signatures when pushing image")

--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -85,7 +85,7 @@ Layer(s) to encrypt: 0-indexed layer indices with support for negative indexing 
 
 **--format**, **-f**
 
-Manifest Type (oci, v2s2, or v2s1) to use when pushing an image. (default is manifest type of the source image)
+Manifest Type (oci, v2s2, or v2s1) to use when pushing an image. (default is manifest type of the source image, with fallbacks)
 
 **--quiet**, **-q**
 

--- a/push.go
+++ b/push.go
@@ -40,7 +40,7 @@ type PushOptions struct {
 	// github.com/containers/image/types SystemContext to hold credentials
 	// and other authentication/authorization information.
 	SystemContext *types.SystemContext
-	// ManifestType is the format to use when saving the image using the 'dir' transport
+	// ManifestType is the format to use
 	// possible options are oci, v2s1, and v2s2
 	ManifestType string
 	// BlobDirectory is the name of a directory in which we'll look for


### PR DESCRIPTION

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The `push --format` option affects all transports; and without `--format`, we try several manifest formats.

#### How to verify it

Manual inspection.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

