### PR TITLE
Remove unused util.StartsWithValidTransport

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -123,12 +123,6 @@ func resolveName(name string, sc *types.SystemContext, store storage.Store) ([]s
 	return candidates, DefaultTransport, searchRegistriesAreEmpty, nil
 }
 
-// StartsWithValidTransport validates the name starts with Buildah supported transport
-// to avoid the corner case image name same as the transport name
-func StartsWithValidTransport(name string) bool {
-	return strings.HasPrefix(name, "dir:") || strings.HasPrefix(name, "docker://") || strings.HasPrefix(name, "docker-archive:") || strings.HasPrefix(name, "docker-daemon:") || strings.HasPrefix(name, "oci:") || strings.HasPrefix(name, "oci-archive:")
-}
-
 // ExpandNames takes unqualified names, parses them as image names, and returns
 // the fully expanded result, including a tag.  Names which don't include a registry
 // name will be marked for the most-preferred registry (i.e., the first one in our


### PR DESCRIPTION
#### What type of PR is this?

> /kind cleanup

#### What this PR does / why we need it:

Remove unused `util.StartsWithValidTransport`

It is not used, and it should check the current list of transports from c/image/transports instead of hard-coding (like `cmd/buildah/push.go` currently does).

#### How to verify it

Just see that everything still builds.

#### Which issue(s) this PR fixes:

Fixes #3313

#### Special notes for your reviewer:

Is this an API break that shouldn’t happen?

#### Does this PR introduce a user-facing change?

```release-note
None
```
