### PR TITLE
buildah copy and buildah add should support .containerignore

### DIFF
--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -409,7 +409,7 @@ stuff/mystuff"
   cmp ${TESTDIR}/randomfile ${croot}/tmp/tmp/random
 }
 
-@test "copy-from-image" {
+@test "add-from-image" {
   _prefetch busybox
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
   cid=$output
@@ -425,4 +425,23 @@ stuff/mystuff"
   ubuntu=$output
   cmp $ubuntu/etc/passwd ${croot}/tmp/passwd
   cmp $ubuntu/etc/passwd ${croot}/tmp/passwd2
+}
+
+@test "copy with .dockerignore" {
+  _prefetch alpine busybox
+  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  from=$output
+  run_buildah copy --contextdir=${TESTSDIR}/bud/dockerignore $from ${TESTSDIR}/bud/dockerignore ./
+
+  run_buildah 1 run $from ls -l test1.txt
+
+  run_buildah run $from ls -l test2.txt
+
+  run_buildah 1 run $from ls -l sub1.txt
+
+  run_buildah 1 run $from ls -l sub2.txt
+
+  run_buildah run $from ls -l subdir/sub1.txt
+
+  run_buildah 1 run $from ls -l subdir/sub2.txt
 }


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/master/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

