### PR TITLE
Add --json flags to `mount` and `version` commands

### DIFF
--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -48,52 +48,7 @@ func init() {
 		Short: "Display the Buildah version information",
 		Long:  "Displays Buildah version information.",
 		RunE: func(c *cobra.Command, args []string) error {
-			var err error
-			buildTime := int64(0)
-			if buildInfo != "" {
-				//converting unix time from string to int64
-				buildTime, err = strconv.ParseInt(buildInfo, 10, 64)
-				if err != nil {
-					return err
-				}
-			}
-
-			version := versionInfo{
-				Version:       define.Version,
-				GoVersion:     runtime.Version(),
-				ImageSpec:     ispecs.Version,
-				RuntimeSpec:   rspecs.Version,
-				CniSpec:       cniversion.Current(),
-				LibcniVersion: cniVersion,
-				ImageVersion:  iversion.Version,
-				GitCommit:     GitCommit,
-				Built:         time.Unix(buildTime, 0).Format(time.ANSIC),
-				OsArch:        runtime.GOOS + "/" + runtime.GOARCH,
-			}
-
-			if opts.json {
-				data, err := json.MarshalIndent(version, "", "    ")
-				if err != nil {
-					return err
-				}
-				fmt.Printf("%s\n", data)
-				return nil
-			}
-
-			fmt.Println("Version:        ", version.Version)
-			fmt.Println("Go Version:     ", version.GoVersion)
-			fmt.Println("Image Spec:     ", version.ImageSpec)
-			fmt.Println("Runtime Spec:   ", version.RuntimeSpec)
-			fmt.Println("CNI Spec:       ", version.CniSpec)
-			fmt.Println("libcni Version: ", version.LibcniVersion)
-			fmt.Println("image Version:  ", version.ImageVersion)
-			fmt.Println("Git Commit:     ", version.GitCommit)
-
-			//Prints out the build time in readable format
-			fmt.Println("Built:          ", version.Built)
-			fmt.Println("OS/Arch:        ", version.OsArch)
-
-			return nil
+			return versionCmd(c, args, opts)
 		},
 		Args:    cobra.NoArgs,
 		Example: `buildah version`,
@@ -104,4 +59,53 @@ func init() {
 	flags.BoolVar(&opts.json, "json", false, "output in JSON format")
 
 	rootCmd.AddCommand(versionCommand)
+}
+
+func versionCmd(c *cobra.Command, args []string, opts versionOptions) error {
+	var err error
+	buildTime := int64(0)
+	if buildInfo != "" {
+		//converting unix time from string to int64
+		buildTime, err = strconv.ParseInt(buildInfo, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+
+	version := versionInfo{
+		Version:       define.Version,
+		GoVersion:     runtime.Version(),
+		ImageSpec:     ispecs.Version,
+		RuntimeSpec:   rspecs.Version,
+		CniSpec:       cniversion.Current(),
+		LibcniVersion: cniVersion,
+		ImageVersion:  iversion.Version,
+		GitCommit:     GitCommit,
+		Built:         time.Unix(buildTime, 0).Format(time.ANSIC),
+		OsArch:        runtime.GOOS + "/" + runtime.GOARCH,
+	}
+
+	if opts.json {
+		data, err := json.MarshalIndent(version, "", "    ")
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s\n", data)
+		return nil
+	}
+
+	fmt.Println("Version:        ", version.Version)
+	fmt.Println("Go Version:     ", version.GoVersion)
+	fmt.Println("Image Spec:     ", version.ImageSpec)
+	fmt.Println("Runtime Spec:   ", version.RuntimeSpec)
+	fmt.Println("CNI Spec:       ", version.CniSpec)
+	fmt.Println("libcni Version: ", version.LibcniVersion)
+	fmt.Println("image Version:  ", version.ImageVersion)
+	fmt.Println("Git Commit:     ", version.GitCommit)
+
+	//Prints out the build time in readable format
+	fmt.Println("Built:          ", version.Built)
+	fmt.Println("OS/Arch:        ", version.OsArch)
+
+	return nil
 }

--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
 	"strconv"
@@ -21,45 +22,86 @@ var (
 	cniVersion string
 )
 
-//Function to get and print info for version command
-func versionCmd(c *cobra.Command, args []string) error {
-	var err error
-	buildTime := int64(0)
-	if buildInfo != "" {
-		//converting unix time from string to int64
-		buildTime, err = strconv.ParseInt(buildInfo, 10, 64)
-		if err != nil {
-			return err
-		}
-	}
-
-	fmt.Println("Version:        ", define.Version)
-	fmt.Println("Go Version:     ", runtime.Version())
-	fmt.Println("Image Spec:     ", ispecs.Version)
-	fmt.Println("Runtime Spec:   ", rspecs.Version)
-	fmt.Println("CNI Spec:       ", cniversion.Current())
-	fmt.Println("libcni Version: ", cniVersion)
-	fmt.Println("image Version:  ", iversion.Version)
-	fmt.Println("Git Commit:     ", GitCommit)
-
-	//Prints out the build time in readable format
-	fmt.Println("Built:          ", time.Unix(buildTime, 0).Format(time.ANSIC))
-	fmt.Println("OS/Arch:        ", runtime.GOOS+"/"+runtime.GOARCH)
-
-	return nil
+type versionInfo struct {
+	Version       string `json:"version"`
+	GoVersion     string `json:"goVersion"`
+	ImageSpec     string `json:"imageSpec"`
+	RuntimeSpec   string `json:"runtimeSpec"`
+	CniSpec       string `json:"cniSpec"`
+	LibcniVersion string `json:"libcniVersion"`
+	ImageVersion  string `json:"imageVersion"`
+	GitCommit     string `json:"gitCommit"`
+	Built         string `json:"built"`
+	OsArch        string `json:"osArch"`
 }
 
-//cli command to print out the version info of buildah
-var versionCommand = &cobra.Command{
-	Use:     "version",
-	Short:   "Display the Buildah version information",
-	Long:    "Displays Buildah version information.",
-	RunE:    versionCmd,
-	Args:    cobra.NoArgs,
-	Example: `buildah version`,
+type versionOptions struct {
+	json bool
 }
 
 func init() {
+	var opts versionOptions
+
+	//cli command to print out the version info of buildah
+	versionCommand := &cobra.Command{
+		Use:   "version",
+		Short: "Display the Buildah version information",
+		Long:  "Displays Buildah version information.",
+		RunE: func(c *cobra.Command, args []string) error {
+			var err error
+			buildTime := int64(0)
+			if buildInfo != "" {
+				//converting unix time from string to int64
+				buildTime, err = strconv.ParseInt(buildInfo, 10, 64)
+				if err != nil {
+					return err
+				}
+			}
+
+			version := versionInfo{
+				Version:       define.Version,
+				GoVersion:     runtime.Version(),
+				ImageSpec:     ispecs.Version,
+				RuntimeSpec:   rspecs.Version,
+				CniSpec:       cniversion.Current(),
+				LibcniVersion: cniVersion,
+				ImageVersion:  iversion.Version,
+				GitCommit:     GitCommit,
+				Built:         time.Unix(buildTime, 0).Format(time.ANSIC),
+				OsArch:        runtime.GOOS + "/" + runtime.GOARCH,
+			}
+
+			if opts.json {
+				data, err := json.MarshalIndent(version, "", "    ")
+				if err != nil {
+					return err
+				}
+				fmt.Printf("%s\n", data)
+				return nil
+			}
+
+			fmt.Println("Version:        ", version.Version)
+			fmt.Println("Go Version:     ", version.GoVersion)
+			fmt.Println("Image Spec:     ", version.ImageSpec)
+			fmt.Println("Runtime Spec:   ", version.RuntimeSpec)
+			fmt.Println("CNI Spec:       ", version.CniSpec)
+			fmt.Println("libcni Version: ", version.LibcniVersion)
+			fmt.Println("image Version:  ", version.ImageVersion)
+			fmt.Println("Git Commit:     ", version.GitCommit)
+
+			//Prints out the build time in readable format
+			fmt.Println("Built:          ", version.Built)
+			fmt.Println("OS/Arch:        ", version.OsArch)
+
+			return nil
+		},
+		Args:    cobra.NoArgs,
+		Example: `buildah version`,
+	}
 	versionCommand.SetUsageTemplate(UsageTemplate())
+
+	flags := versionCommand.Flags()
+	flags.BoolVar(&opts.json, "json", false, "output in JSON format")
+
 	rootCmd.AddCommand(versionCommand)
 }

--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -48,7 +48,7 @@ func init() {
 		Short: "Display the Buildah version information",
 		Long:  "Displays Buildah version information.",
 		RunE: func(c *cobra.Command, args []string) error {
-			return versionCmd(c, args, opts)
+			return versionCmd(opts)
 		},
 		Args:    cobra.NoArgs,
 		Example: `buildah version`,
@@ -61,7 +61,7 @@ func init() {
 	rootCmd.AddCommand(versionCommand)
 }
 
-func versionCmd(c *cobra.Command, args []string, opts versionOptions) error {
+func versionCmd(opts versionOptions) error {
 	var err error
 	buildTime := int64(0)
 	if buildInfo != "" {

--- a/docs/buildah-mount.md
+++ b/docs/buildah-mount.md
@@ -26,6 +26,10 @@ returned.
 
 ## OPTIONS
 
+**--json**
+
+Output in JSON format.
+
 ## EXAMPLE
 
 ```

--- a/docs/buildah-version.md
+++ b/docs/buildah-version.md
@@ -12,7 +12,12 @@ Shows the following information: Version, Go Version, Image Spec, Runtime Spec, 
 ## OPTIONS
 
 **--help, -h**
-  Print usage statement
+
+Print usage statement
+
+**--json**
+
+Output in JSON format.
 
 ## EXAMPLE
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a `--json` flag to the `buildah mount` and `buildah version` commands. When this flag is provided, the output from each command is printed as JSON.

In the case of `buildah mount --json`, output is printed like:

```json
[
    {
        "container": "xxxxxxxxxxxxxxxx",
        "mountPoint": "/path/to/mount/point"
    }
]
```

And in the case of `buildah version --json`, output is printed like:

```json
{
    "version": "1.22.0-dev",
    "goVersion": "go1.16.5",
    "imageSpec": "1.0.1-dev",
    "runtimeSpec": "1.0.2-dev",
    "cniSpec": "0.4.0",
    "libcniVersion": "v0.8.1",
    "imageVersion": "5.13.2",
    "gitCommit": "5181b9ce",
    "built": "Sun Jun 20 20:49:49 2021",
    "osArch": "linux/amd64"
}
```

I am currently working on a TypeScript wrapper for `buildah` that exposes all of the Buildah API, but via TypeScript executing the binary. When integrating with another tool/language, it is more convenient for Buildah's output to be structured, rather than needing to re-parse the output with regex. There is already a `--json` flag for commands like `image` and `container`, so this PR extends that flag to `mount` and `version`.

#### How to verify it

Run `buildah mount --json` and `buildah version --json`.


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Let me know if you would like anything adjusted. I have tried to follow existing patterns from other commands, but I'm flexible.

#### Does this PR introduce a user-facing change?

```release-note
Added --json flag to mount and version commands to print output as JSON
```

