### PR TITLE
Add `--env` and `--workingdir` flags to run command

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -17,6 +17,7 @@ type runInputOptions struct {
 	addHistory  bool
 	capAdd      []string
 	capDrop     []string
+	env         []string
 	hostname    string
 	isolation   string
 	mounts      []string
@@ -25,6 +26,7 @@ type runInputOptions struct {
 	noPivot     bool
 	terminal    bool
 	volumes     []string
+	workingDir  string
 	*buildahcli.NameSpaceResults
 }
 
@@ -56,6 +58,7 @@ func init() {
 	flags.BoolVar(&opts.addHistory, "add-history", false, "add an entry for this operation to the image's history.  Use BUILDAH_HISTORY environment variable to override. (default false)")
 	flags.StringSliceVar(&opts.capAdd, "cap-add", []string{}, "add the specified capability (default [])")
 	flags.StringSliceVar(&opts.capDrop, "cap-drop", []string{}, "drop the specified capability (default [])")
+	flags.StringArrayVarP(&opts.env, "env", "e", []string{}, "add environment variable to be set temporarily when running command (default [])")
 	flags.StringVar(&opts.hostname, "hostname", "", "set the hostname inside of the container")
 	flags.StringVar(&opts.isolation, "isolation", "", "`type` of process isolation to use. Use BUILDAH_ISOLATION environment variable to override.")
 	// Do not set a default runtime here, we'll do that later in the processing.
@@ -65,6 +68,7 @@ func init() {
 	flags.BoolVarP(&opts.terminal, "terminal", "t", false, "allocate a pseudo-TTY in the container")
 	flags.StringArrayVarP(&opts.volumes, "volume", "v", []string{}, "bind mount a host location into the container while running the command")
 	flags.StringArrayVar(&opts.mounts, "mount", []string{}, "Attach a filesystem mount to the container (default [])")
+	flags.StringVar(&opts.workingDir, "workingdir", "", "temporarily set working directory for command (default to container's workingdir)")
 
 	userFlags := getUserFlags()
 	namespaceFlags := buildahcli.GetNameSpaceFlags(&namespaceResults)
@@ -130,6 +134,8 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 		CNIConfigDir:     iopts.CNIConfigDir,
 		AddCapabilities:  iopts.capAdd,
 		DropCapabilities: iopts.capDrop,
+		Env:              iopts.env,
+		WorkingDir:       iopts.workingDir,
 	}
 
 	if c.Flag("terminal").Changed {

--- a/docs/buildah-run.md
+++ b/docs/buildah-run.md
@@ -58,6 +58,12 @@ not disabled.
 List of directories in which the CNI plugins which will be used for configuring
 network namespaces can be found.
 
+**--env**, **-e** *env=value*
+
+Temporarily add a value (e.g. env=*value*) to the environment for the running
+process. Unlike `buildah config --env`, the environment will not persist to
+later calls to `buildah run` or to the built image. Can be used multiple times.
+
 **--hostname**
 
 Set the hostname inside of the running container.
@@ -258,6 +264,12 @@ example, to bind mount the source directory `/foo` do
 will convert /foo into a `shared` mount point.  The propagation properties of the source
 mount can be changed directly. For instance if `/` is the source mount for
 `/foo`, then use `mount --make-shared /` to convert `/` into a `shared` mount.
+
+**--workingdir** *directory*
+
+Temporarily set the working *directory* for the running process. Unlike
+`buildah config --workingdir`, the workingdir will not persist to later
+calls to `buildah run` or the built image.
 
 
 NOTE: End parsing of options with the `--` option, so that other


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds an `--env` and a `--workingdir` flag to the `buildah run` command:

- `--env` allows adding additional environment variables that are added to the working container's environment, but are not persisted to further `run`s or produced images
- `--workingdir` allows overriding the container's current `workingdir` config, just for this specific `run`

`builder.Run()` already supported these options via the `buildah.RunOptions` struct, they were just missing CLI flags.

#### How to verify it

```
buildah run --env foo=bar $cid ...
buildah run --workingdir /path $cid ...
```

I have added two tests as well.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Any feedback welcome!

#### Does this PR introduce a user-facing change?

```release-note
Added --env and --workingdir flags to run command
```
