### PR TITLE
Adjust conformance-test error-message regex

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -358,9 +358,12 @@ success_task:
       - static_build
 
     container:
-        image: "quay.io/libpod/fedora-minimal:latest"
+        image: "quay.io/libpod/alpine:latest"
         cpu: 1
         memory: 1
+
+    env:
+        CIRRUS_SHELL: direct  # execute command directly
 
     clone_script: mkdir -p $CIRRUS_WORKING_DIR
     script: /bin/true

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1975,7 +1975,7 @@ var internalTestCases = []testCase{
 		name:         "copy-integration1",
 		contextDir:   "dockerignore/integration1",
 		shouldFailAt: 3,
-		failureRegex: "(no such file or directory)|(file not found)",
+		failureRegex: "(no such file or directory)|(file not found)|(file does not exist)",
 	},
 
 	{
@@ -1987,7 +1987,7 @@ var internalTestCases = []testCase{
 		name:         "copy-integration3",
 		contextDir:   "dockerignore/integration3",
 		shouldFailAt: 4,
-		failureRegex: "(no such file or directory)|(file not found)",
+		failureRegex: "(no such file or directory)|(file not found)|(file does not exist)",
 	},
 
 	{
@@ -2765,14 +2765,14 @@ var internalTestCases = []testCase{
 		name:         "dockerignore-allowlist-subdir-nofile-dir",
 		contextDir:   "dockerignore/allowlist/subdir-nofile",
 		shouldFailAt: 2,
-		failureRegex: "(no such file or directory)|(file not found)",
+		failureRegex: "(no such file or directory)|(file not found)|(file does not exist)",
 	},
 
 	{
 		name:         "dockerignore-allowlist-subdir-nofile-file",
 		contextDir:   "dockerignore/allowlist/subdir-nofile",
 		shouldFailAt: 2,
-		failureRegex: "(no such file or directory)|(file not found)",
+		failureRegex: "(no such file or directory)|(file not found)|(file does not exist)",
 	},
 
 	{
@@ -2843,14 +2843,14 @@ var internalTestCases = []testCase{
 		name:         "dockerignore-allowlist-alternating-nothing",
 		contextDir:   "dockerignore/allowlist/alternating-nothing",
 		shouldFailAt: 7,
-		failureRegex: "(no such file or directory)|(file not found)",
+		failureRegex: "(no such file or directory)|(file not found)|(file does not exist)",
 	},
 
 	{
 		name:         "dockerignore-allowlist-alternating-other",
 		contextDir:   "dockerignore/allowlist/alternating-other",
 		shouldFailAt: 7,
-		failureRegex: "(no such file or directory)|(file not found)",
+		failureRegex: "(no such file or directory)|(file not found)|(file does not exist)",
 	},
 
 	{


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test 

#### What this PR does / why we need it:

Sometime around `docker 20.10.2-0ubuntu1~20.04.2` several error
message strings were updated from `file not found` to `file does not
exist`.  This breaks conformance testing.  Fix this by adding in
the new error message.

#### How to verify it

CI Testing will continue pass - specifically the conformance tests.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Since the version of docker is fixed at VM Image buld-time, this change isn't strictly necessary on this branch (until the next image update).  However, there are a number of open PRs to fix testing on older branches which install the latest docker at runtime.  The commit in this PR will be cherry-picked to them to help the tests pass.

- 1.16 - https://github.com/containers/buildah/pull/3355
- 1.17 - https://github.com/containers/buildah/pull/3354
- 1.18 - https://github.com/containers/buildah/pull/3351
- 1.19 - https://github.com/containers/buildah/pull/3353
- 1.21 - https://github.com/containers/buildah/pull/3352

#### Does this PR introduce a user-facing change?

None