### PR TITLE
[CI:DOCS] Update cirrus-cron notification GH workflow

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -1,7 +1,7 @@
 ---
 
 # See also:
-# https://github.com/containers/podman/blob/master/.github/workflows/check_cirrus_cron.yml
+# https://github.com/containers/podman/blob/main/.github/workflows/check_cirrus_cron.yml
 
 # Format Ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
 
@@ -11,8 +11,10 @@ name: check_cirrus_cron
 on:
     # Note: This only applies to the default branch.
     schedule:
-        # Assume cirrus cron jobs runs at least once per day
-        - cron:  '59 23 * * *'
+        # N/B: This should correspond to a period slightly after
+        # the last job finishes running.  See job defs. at:
+        # https://cirrus-ci.com/settings/repository/5138144844840960
+        - cron:  '59 23 * * 1-5'
     # Debug: Allow triggering job manually in github-actions WebUI
     workflow_dispatch: {}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Simple update due to master->main rename.  The only functional change is
to only run the workflow on weekdays.  Nobody's around on the weekend to
respond anyway.

#### How to verify it

This is painfully difficult to verify/check before merging.  The workflow can only run from the default branch of a repository due to Github's broken security design.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

None