### PR TITLE
Remove specific kernel version number requirement from install.md

### DIFF
--- a/install.md
+++ b/install.md
@@ -153,9 +153,7 @@ sudo apt-get -qq -y install buildah
 
 ### Kernel Version Requirements
 To run Buildah on Red Hat Enterprise Linux or CentOS, version 7.4 or higher is required.
-On other Linux distributions Buildah requires a kernel version of 4.0 or
-higher in order to support the OverlayFS filesystem.  The kernel version can be checked
-with the 'uname -a' command.
+On other Linux distributions Buildah requires a kernel version that supports the OverlayFS and/or fuse-overlayfs filesystem -- you'll need to consult your distribution's documentation to determine a minimum version number.
 
 ### runc Requirement
 


### PR DESCRIPTION
Existing specific version number requirement is misleading.  So far consensus in #3295 appears to eschew specific version numbers.  This PR should be rejected if #3295 is accepted, and vice versa.

/kind documentation
