### PR TITLE
Reuse code from containers/common/pkg/parse

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -15,6 +15,7 @@ import (
 	"unicode"
 
 	"github.com/containers/buildah/define"
+	"github.com/containers/common/pkg/parse"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/unshare"
@@ -205,13 +206,13 @@ func Volume(volume string) (specs.Mount, error) {
 	if err := validateVolumeMountHostDir(arr[0]); err != nil {
 		return mount, err
 	}
-	if err := ValidateVolumeCtrDir(arr[1]); err != nil {
+	if err := parse.ValidateVolumeCtrDir(arr[1]); err != nil {
 		return mount, err
 	}
 	mountOptions := ""
 	if len(arr) > 2 {
 		mountOptions = arr[2]
-		if _, err := ValidateVolumeOpts(strings.Split(arr[2], ",")); err != nil {
+		if _, err := parse.ValidateVolumeOpts(strings.Split(arr[2], ",")); err != nil {
 			return mount, err
 		}
 	}
@@ -360,7 +361,7 @@ func GetBindMount(args []string) (specs.Mount, error) {
 			if len(kv) == 1 {
 				return newMount, errors.Wrapf(optionArgError, kv[0])
 			}
-			if err := ValidateVolumeHostDir(kv[1]); err != nil {
+			if err := parse.ValidateVolumeHostDir(kv[1]); err != nil {
 				return newMount, err
 			}
 			newMount.Source = kv[1]
@@ -369,7 +370,7 @@ func GetBindMount(args []string) (specs.Mount, error) {
 			if len(kv) == 1 {
 				return newMount, errors.Wrapf(optionArgError, kv[0])
 			}
-			if err := ValidateVolumeCtrDir(kv[1]); err != nil {
+			if err := parse.ValidateVolumeCtrDir(kv[1]); err != nil {
 				return newMount, err
 			}
 			newMount.Destination = kv[1]
@@ -391,7 +392,7 @@ func GetBindMount(args []string) (specs.Mount, error) {
 		newMount.Source = newMount.Destination
 	}
 
-	opts, err := ValidateVolumeOpts(newMount.Options)
+	opts, err := parse.ValidateVolumeOpts(newMount.Options)
 	if err != nil {
 		return newMount, err
 	}
@@ -433,7 +434,7 @@ func GetTmpfsMount(args []string) (specs.Mount, error) {
 			if len(kv) == 1 {
 				return newMount, errors.Wrapf(optionArgError, kv[0])
 			}
-			if err := ValidateVolumeCtrDir(kv[1]); err != nil {
+			if err := parse.ValidateVolumeCtrDir(kv[1]); err != nil {
 				return newMount, err
 			}
 			newMount.Destination = kv[1]
@@ -452,17 +453,7 @@ func GetTmpfsMount(args []string) (specs.Mount, error) {
 
 // ValidateVolumeHostDir validates a volume mount's source directory
 func ValidateVolumeHostDir(hostDir string) error {
-	if len(hostDir) == 0 {
-		return errors.Errorf("host directory cannot be empty")
-	}
-	if filepath.IsAbs(hostDir) {
-		if _, err := os.Stat(hostDir); err != nil {
-			return errors.WithStack(err)
-		}
-	}
-	// If hostDir is not an absolute path, that means the user wants to create a
-	// named volume. This will be done later on in the code.
-	return nil
+	return parse.ValidateVolumeHostDir(hostDir)
 }
 
 // validates the host path of buildah --volume
@@ -478,75 +469,12 @@ func validateVolumeMountHostDir(hostDir string) error {
 
 // ValidateVolumeCtrDir validates a volume mount's destination directory.
 func ValidateVolumeCtrDir(ctrDir string) error {
-	if len(ctrDir) == 0 {
-		return errors.Errorf("container directory cannot be empty")
-	}
-	if !filepath.IsAbs(ctrDir) {
-		return errors.Errorf("invalid container path %q, must be an absolute path", ctrDir)
-	}
-	return nil
+	return parse.ValidateVolumeCtrDir(ctrDir)
 }
 
 // ValidateVolumeOpts validates a volume's options
 func ValidateVolumeOpts(options []string) ([]string, error) {
-	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid, foundChown int
-	finalOpts := make([]string, 0, len(options))
-	for _, opt := range options {
-		switch opt {
-		case "noexec", "exec":
-			foundExec++
-			if foundExec > 1 {
-				return nil, errors.Errorf("invalid options %q, can only specify 1 'noexec' or 'exec' option", strings.Join(options, ", "))
-			}
-		case "nodev", "dev":
-			foundDev++
-			if foundDev > 1 {
-				return nil, errors.Errorf("invalid options %q, can only specify 1 'nodev' or 'dev' option", strings.Join(options, ", "))
-			}
-		case "nosuid", "suid":
-			foundSuid++
-			if foundSuid > 1 {
-				return nil, errors.Errorf("invalid options %q, can only specify 1 'nosuid' or 'suid' option", strings.Join(options, ", "))
-			}
-		case "rw", "ro":
-			foundRWRO++
-			if foundRWRO > 1 {
-				return nil, errors.Errorf("invalid options %q, can only specify 1 'rw' or 'ro' option", strings.Join(options, ", "))
-			}
-		case "z", "Z", "O":
-			foundLabelChange++
-			if foundLabelChange > 1 {
-				return nil, errors.Errorf("invalid options %q, can only specify 1 'z', 'Z', or 'O' option", strings.Join(options, ", "))
-			}
-		case "U":
-			foundChown++
-			if foundChown > 1 {
-				return nil, errors.Errorf("invalid options %q, can only specify 1 'U' option", strings.Join(options, ", "))
-			}
-		case "private", "rprivate", "shared", "rshared", "slave", "rslave", "unbindable", "runbindable":
-			foundRootPropagation++
-			if foundRootPropagation > 1 {
-				return nil, errors.Errorf("invalid options %q, can only specify 1 '[r]shared', '[r]private', '[r]slave' or '[r]unbindable' option", strings.Join(options, ", "))
-			}
-		case "bind", "rbind":
-			bindType++
-			if bindType > 1 {
-				return nil, errors.Errorf("invalid options %q, can only specify 1 '[r]bind' option", strings.Join(options, ", "))
-			}
-		case "cached", "delegated":
-			// The discarded ops are OS X specific volume options
-			// introduced in a recent Docker version.
-			// They have no meaning on Linux, so here we silently
-			// drop them. This matches Docker's behavior (the options
-			// are intended to be always safe to use, even not on OS
-			// X).
-			continue
-		default:
-			return nil, errors.Errorf("invalid option type %q", opt)
-		}
-		finalOpts = append(finalOpts, opt)
-	}
-	return finalOpts, nil
+	return parse.ValidateVolumeOpts(options)
 }
 
 // validateExtraHost validates that the specified string is a valid extrahost and returns it.

--- a/vendor/github.com/containers/common/pkg/parse/parse.go
+++ b/vendor/github.com/containers/common/pkg/parse/parse.go
@@ -1,0 +1,162 @@
+package parse
+
+// this package contains functions that parse and validate
+// user input and is shared either amongst container engine subcommands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ValidateVolumeOpts validates a volume's options
+func ValidateVolumeOpts(options []string) ([]string, error) {
+	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid, foundChown int
+	finalOpts := make([]string, 0, len(options))
+	for _, opt := range options {
+		switch opt {
+		case "noexec", "exec":
+			foundExec++
+			if foundExec > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'noexec' or 'exec' option", strings.Join(options, ", "))
+			}
+		case "nodev", "dev":
+			foundDev++
+			if foundDev > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'nodev' or 'dev' option", strings.Join(options, ", "))
+			}
+		case "nosuid", "suid":
+			foundSuid++
+			if foundSuid > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'nosuid' or 'suid' option", strings.Join(options, ", "))
+			}
+		case "rw", "ro":
+			foundRWRO++
+			if foundRWRO > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'rw' or 'ro' option", strings.Join(options, ", "))
+			}
+		case "z", "Z", "O":
+			foundLabelChange++
+			if foundLabelChange > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'z', 'Z', or 'O' option", strings.Join(options, ", "))
+			}
+		case "U":
+			foundChown++
+			if foundChown > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'U' option", strings.Join(options, ", "))
+			}
+		case "private", "rprivate", "shared", "rshared", "slave", "rslave", "unbindable", "runbindable":
+			foundRootPropagation++
+			if foundRootPropagation > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 '[r]shared', '[r]private', '[r]slave' or '[r]unbindable' option", strings.Join(options, ", "))
+			}
+		case "bind", "rbind":
+			bindType++
+			if bindType > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 '[r]bind' option", strings.Join(options, ", "))
+			}
+		case "cached", "delegated":
+			// The discarded ops are OS X specific volume options
+			// introduced in a recent Docker version.
+			// They have no meaning on Linux, so here we silently
+			// drop them. This matches Docker's behavior (the options
+			// are intended to be always safe to use, even not on OS
+			// X).
+			continue
+		default:
+			return nil, errors.Errorf("invalid option type %q", opt)
+		}
+		finalOpts = append(finalOpts, opt)
+	}
+	return finalOpts, nil
+}
+
+// Device parses device mapping string to a src, dest & permissions string
+// Valid values for device looklike:
+//    '/dev/sdc"
+//    '/dev/sdc:/dev/xvdc"
+//    '/dev/sdc:/dev/xvdc:rwm"
+//    '/dev/sdc:rm"
+func Device(device string) (src, dest, permissions string, err error) {
+	permissions = "rwm"
+	arr := strings.Split(device, ":")
+	switch len(arr) {
+	case 3:
+		if !isValidDeviceMode(arr[2]) {
+			return "", "", "", errors.Errorf("invalid device mode: %s", arr[2])
+		}
+		permissions = arr[2]
+		fallthrough
+	case 2:
+		if isValidDeviceMode(arr[1]) {
+			permissions = arr[1]
+		} else {
+			if arr[1] == "" || arr[1][0] != '/' {
+				return "", "", "", errors.Errorf("invalid device mode: %s", arr[1])
+			}
+			dest = arr[1]
+		}
+		fallthrough
+	case 1:
+		if len(arr[0]) > 0 {
+			src = arr[0]
+			break
+		}
+		fallthrough
+	default:
+		return "", "", "", errors.Errorf("invalid device specification: %s", device)
+	}
+
+	if dest == "" {
+		dest = src
+	}
+	return src, dest, permissions, nil
+}
+
+// isValidDeviceMode checks if the mode for device is valid or not.
+// isValid mode is a composition of r (read), w (write), and m (mknod).
+func isValidDeviceMode(mode string) bool {
+	var legalDeviceMode = map[rune]bool{
+		'r': true,
+		'w': true,
+		'm': true,
+	}
+	if mode == "" {
+		return false
+	}
+	for _, c := range mode {
+		if !legalDeviceMode[c] {
+			return false
+		}
+		legalDeviceMode[c] = false
+	}
+	return true
+}
+
+// ValidateVolumeHostDir validates a volume mount's source directory
+func ValidateVolumeHostDir(hostDir string) error {
+	if hostDir == "" {
+		return errors.New("host directory cannot be empty")
+	}
+	if filepath.IsAbs(hostDir) {
+		if _, err := os.Stat(hostDir); err != nil {
+			return err
+		}
+	}
+	// If hostDir is not an absolute path, that means the user wants to create a
+	// named volume. This will be done later on in the code.
+	return nil
+}
+
+// ValidateVolumeCtrDir validates a volume mount's destination directory.
+func ValidateVolumeCtrDir(ctrDir string) error {
+	if ctrDir == "" {
+		return errors.New("container directory cannot be empty")
+	}
+	if !filepath.IsAbs(ctrDir) {
+		return errors.Errorf("invalid container path %q, must be an absolute path", ctrDir)
+	}
+	return nil
+}

--- a/vendor/github.com/containers/common/pkg/parse/parse_unix.go
+++ b/vendor/github.com/containers/common/pkg/parse/parse_unix.go
@@ -1,0 +1,50 @@
+// +build linux darwin
+
+package parse
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/containers/storage/pkg/unshare"
+	"github.com/opencontainers/runc/libcontainer/devices"
+	"github.com/pkg/errors"
+)
+
+func DeviceFromPath(device string) ([]devices.Device, error) {
+	var devs []devices.Device
+	src, dst, permissions, err := Device(device)
+	if err != nil {
+		return nil, err
+	}
+	if unshare.IsRootless() && src != dst {
+		return nil, errors.Errorf("Renaming device %s to %s is not supported in rootless containers", src, dst)
+	}
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return nil, err
+	}
+
+	if !srcInfo.IsDir() {
+
+		dev, err := devices.DeviceFromPath(src, permissions)
+		if err != nil {
+			return nil, errors.Wrapf(err, "%s is not a valid device", src)
+		}
+		dev.Path = dst
+		devs = append(devs, *dev)
+		return devs, nil
+	}
+
+	// If source device is a directory
+	srcDevices, err := devices.GetDevices(src)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting source devices from directory %s", src)
+	}
+	for _, d := range srcDevices {
+		d.Path = filepath.Join(dst, filepath.Base(d.Path))
+		d.Permissions = devices.Permissions(permissions)
+		devs = append(devs, *d)
+	}
+	return devs, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,6 +74,7 @@ github.com/containers/common/pkg/config
 github.com/containers/common/pkg/defaultnet
 github.com/containers/common/pkg/filters
 github.com/containers/common/pkg/manifests
+github.com/containers/common/pkg/parse
 github.com/containers/common/pkg/retry
 github.com/containers/common/pkg/seccomp
 github.com/containers/common/pkg/signal


### PR DESCRIPTION
At some point code from buildah/pkg/parse we copied into
containers/common/pkg/parse.  Buildah should use the new code
now, so that we only have to make changes in one place.

[NO TESTS NEEDED] Since there is no new code added.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

