### PR TITLE
Chown with environment variables not set should fail

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1231,6 +1231,14 @@ function _test_http() {
   expect_output --substring "COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image|stage> flags"
 }
 
+@test "bud with chown copy with unknown substitutions in Dockerfile" {
+  _prefetch alpine
+  imgName=alpine-image
+  ctrName=alpine-chown
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json -t ${imgName} -f ${TESTSDIR}/bud/copy-chown/Dockerfile.bad2 ${TESTSDIR}/bud/copy-chown
+  expect_output --substring "error looking up UID/GID for \":\": can't find uid for user"
+}
+
 @test "bud with chmod copy" {
   _prefetch alpine
   imgName=alpine-image

--- a/tests/bud/copy-chown/Dockerfile.bad2
+++ b/tests/bud/copy-chown/Dockerfile.bad2
@@ -1,0 +1,4 @@
+FROM alpine
+
+COPY --chown=${BOGUS}:${BOGUS} copychown.txt /tmp
+CMD /bin/sh


### PR DESCRIPTION
Fixes: https://github.com/containers/buildah/issues/3380

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

