### PR TITLE
refine dangling filter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/containernetworking/cni v0.8.1
-	github.com/containers/common v0.40.2-0.20210707094508-0a4a1906d4b2
+	github.com/containers/common v0.41.1-0.20210721112610-c95d2f794edf
 	github.com/containers/image/v5 v5.13.2
 	github.com/containers/ocicrypt v1.1.2
 	github.com/containers/storage v1.32.6

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/containernetworking/cni v0.8.1 h1:7zpDnQ3T3s4ucOuJ/ZCLrYBxzkg0AELFfII
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
-github.com/containers/common v0.40.2-0.20210707094508-0a4a1906d4b2 h1:2ApmOS9jSnJXuSOkZNEAZ7j0/9i8zjoi67b/UpUjPxY=
-github.com/containers/common v0.40.2-0.20210707094508-0a4a1906d4b2/go.mod h1:thow5Jn7O+rP01njI9COQ16L9g/KQ1LcMcYqP2NhYCU=
+github.com/containers/common v0.41.1-0.20210721112610-c95d2f794edf h1:z0ciG0ByyJG3WCBpLYd2XLThCC7UBaH7GeSfXY4sAqc=
+github.com/containers/common v0.41.1-0.20210721112610-c95d2f794edf/go.mod h1:Ba5YVNCnyX6xDtg1JqEHa2EMVMW5UbHmIyEqsEwpeGE=
 github.com/containers/image/v5 v5.13.2 h1:AgYunV/9d2fRkrmo23wH2MkqeHolFd6oQCkK+1PpuFA=
 github.com/containers/image/v5 v5.13.2/go.mod h1:GkWursKDlDcUIT7L7vZf70tADvZCk/Ga0wgS0MuF0ag=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=
@@ -237,7 +237,6 @@ github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B
 github.com/containers/ocicrypt v1.1.2 h1:Ez+GAMP/4GLix5Ywo/fL7O0nY771gsBIigiqUm1aXz0=
 github.com/containers/ocicrypt v1.1.2/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/containers/storage v1.32.2/go.mod h1:YIBxxjfXZTi04Ah49sh1uSGfmT1V89+I5i3deRobzQo=
-github.com/containers/storage v1.32.5/go.mod h1:8/DVVDqniaUlUV0D0q7cEnXK6Bs2uU3FPqNZVPumwEs=
 github.com/containers/storage v1.32.6 h1:NqdFRewXO/PYPjgCAScoigZc5QUA21yapSEj6kqD8cw=
 github.com/containers/storage v1.32.6/go.mod h1:mdB+b89p+jU8zpzLTVXA0gWMmIo0WrkfGMh1R8O2IQw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -612,7 +611,6 @@ github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -621,7 +619,6 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
-github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/onsi/gomega v1.14.0 h1:ep6kpPVwmr/nTbklSx2nrLNSIO62DoYAhnPNIMhK8gI=
 github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -155,6 +155,21 @@ load helpers
   expect_output ""
 }
 
+@test "attempt to prune non-dangling empty images" {
+  # Regression test for containers/podman/issues/10832
+  ctxdir=${TESTDIR}/bud
+  mkdir -p $ctxdir
+  cat >$ctxdir/Dockerfile <<EOF
+FROM scratch
+ENV test1=test1
+ENV test2=test2
+EOF
+
+  run_buildah bud -t test $ctxdir
+  run_buildah rmi --prune
+  expect_output "" "no image gets pruned"
+}
+
 @test "use conflicting commands to remove images" {
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine

--- a/vendor/github.com/containers/common/libimage/filters.go
+++ b/vendor/github.com/containers/common/libimage/filters.go
@@ -88,7 +88,7 @@ func (r *Runtime) compileImageFilters(ctx context.Context, filters []string) ([]
 			if err != nil {
 				return nil, errors.Wrapf(err, "non-boolean value %q for dangling filter", value)
 			}
-			filterFuncs = append(filterFuncs, filterDangling(dangling))
+			filterFuncs = append(filterFuncs, filterDangling(ctx, dangling))
 
 		case "id":
 			filterFuncs = append(filterFuncs, filterID(value))
@@ -201,9 +201,13 @@ func filterContainers(value bool) filterFunc {
 }
 
 // filterDangling creates a dangling filter for matching the specified value.
-func filterDangling(value bool) filterFunc {
+func filterDangling(ctx context.Context, value bool) filterFunc {
 	return func(img *Image) (bool, error) {
-		return img.IsDangling() == value, nil
+		isDangling, err := img.IsDangling(ctx)
+		if err != nil {
+			return false, err
+		}
+		return isDangling == value, nil
 	}
 }
 

--- a/vendor/github.com/containers/common/libimage/image_tree.go
+++ b/vendor/github.com/containers/common/libimage/image_tree.go
@@ -80,6 +80,10 @@ func (i *Image) Tree(traverseChildren bool) (string, error) {
 }
 
 func imageTreeTraverseChildren(node *layerNode, parent gotree.Tree) error {
+	if node.layer == nil {
+		return nil
+	}
+
 	var tags string
 	repoTags, err := node.repoTags()
 	if err != nil {

--- a/vendor/github.com/containers/common/libimage/layer_tree.go
+++ b/vendor/github.com/containers/common/libimage/layer_tree.go
@@ -15,6 +15,9 @@ type layerTree struct {
 	// ociCache is a cache for Image.ID -> OCI Image. Translations are done
 	// on-demand.
 	ociCache map[string]*ociv1.Image
+	// emptyImages do not have any top-layer so we cannot create a
+	// *layerNode for them.
+	emptyImages []*Image
 }
 
 // node returns a layerNode for the specified layerID.
@@ -105,6 +108,7 @@ func (r *Runtime) layerTree() (*layerTree, error) {
 		img := images[i] // do not leak loop variable outside the scope
 		topLayer := img.TopLayer()
 		if topLayer == "" {
+			tree.emptyImages = append(tree.emptyImages, img)
 			continue
 		}
 		node, exists := tree.nodes[topLayer]
@@ -126,22 +130,13 @@ func (r *Runtime) layerTree() (*layerTree, error) {
 // either the same top layer as parent or parent being the true parent layer.
 // Furthermore, the history of the parent and child images must match with the
 // parent having one history item less.  If all is true, all images are
-// returned.  Otherwise, the first image is returned.
+// returned.  Otherwise, the first image is returned.  Note that manifest lists
+// do not have children.
 func (t *layerTree) children(ctx context.Context, parent *Image, all bool) ([]*Image, error) {
 	if parent.TopLayer() == "" {
-		return nil, nil
-	}
-
-	var children []*Image
-
-	parentNode, exists := t.nodes[parent.TopLayer()]
-	if !exists {
-		// Note: erroring out in this case has turned out having been a
-		// mistake. Users may not be able to recover, so we're now
-		// throwing a warning to guide them to resolve the issue and
-		// turn the errors non-fatal.
-		logrus.Warnf("Layer %s not found in layer tree. The storage may be corrupted, consider running `podman system reset`.", parent.TopLayer())
-		return children, nil
+		if isManifestList, _ := parent.IsManifestList(ctx); isManifestList {
+			return nil, nil
+		}
 	}
 
 	parentID := parent.ID()
@@ -161,6 +156,38 @@ func (t *layerTree) children(ctx context.Context, parent *Image, all bool) ([]*I
 		}
 		// History check.
 		return areParentAndChild(parentOCI, childOCI), nil
+	}
+
+	var children []*Image
+
+	// Empty images are special in that they do not have any physical layer
+	// but yet can have a parent-child relation.  Hence, compare the
+	// "parent" image to all other known empty images.
+	if parent.TopLayer() == "" {
+		for i := range t.emptyImages {
+			empty := t.emptyImages[i]
+			isParent, err := checkParent(empty)
+			if err != nil {
+				return nil, err
+			}
+			if isParent {
+				children = append(children, empty)
+				if !all {
+					break
+				}
+			}
+		}
+		return children, nil
+	}
+
+	parentNode, exists := t.nodes[parent.TopLayer()]
+	if !exists {
+		// Note: erroring out in this case has turned out having been a
+		// mistake. Users may not be able to recover, so we're now
+		// throwing a warning to guide them to resolve the issue and
+		// turn the errors non-fatal.
+		logrus.Warnf("Layer %s not found in layer tree. The storage may be corrupted, consider running `podman system reset`.", parent.TopLayer())
+		return children, nil
 	}
 
 	// addChildrenFrom adds child images of parent to children.  Returns
@@ -204,8 +231,37 @@ func (t *layerTree) children(ctx context.Context, parent *Image, all bool) ([]*I
 }
 
 // parent returns the parent image or nil if no parent image could be found.
+// Note that manifest lists do not have parents.
 func (t *layerTree) parent(ctx context.Context, child *Image) (*Image, error) {
 	if child.TopLayer() == "" {
+		if isManifestList, _ := child.IsManifestList(ctx); isManifestList {
+			return nil, nil
+		}
+	}
+
+	childID := child.ID()
+	childOCI, err := t.toOCI(ctx, child)
+	if err != nil {
+		return nil, err
+	}
+
+	// Empty images are special in that they do not have any physical layer
+	// but yet can have a parent-child relation.  Hence, compare the
+	// "child" image to all other known empty images.
+	if child.TopLayer() == "" {
+		for _, empty := range t.emptyImages {
+			if childID == empty.ID() {
+				continue
+			}
+			emptyOCI, err := t.toOCI(ctx, empty)
+			if err != nil {
+				return nil, err
+			}
+			// History check.
+			if areParentAndChild(emptyOCI, childOCI) {
+				return empty, nil
+			}
+		}
 		return nil, nil
 	}
 
@@ -219,14 +275,8 @@ func (t *layerTree) parent(ctx context.Context, child *Image) (*Image, error) {
 		return nil, nil
 	}
 
-	childOCI, err := t.toOCI(ctx, child)
-	if err != nil {
-		return nil, err
-	}
-
 	// Check images from the parent node (i.e., parent layer) and images
 	// with the same layer (i.e., same top layer).
-	childID := child.ID()
 	images := node.images
 	if node.parent != nil {
 		images = append(images, node.parent.images...)

--- a/vendor/github.com/containers/common/libimage/pull.go
+++ b/vendor/github.com/containers/common/libimage/pull.go
@@ -394,8 +394,23 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 		// very likely a bug but a consistent one in Podman/Buildah and should
 		// be addressed at a later point.
 		if pullPolicy != config.PullPolicyAlways {
-			logrus.Debugf("Enforcing pull policy to %q to support custom platform (arch: %q, os: %q, variant: %q)", "always", options.Architecture, options.OS, options.Variant)
-			pullPolicy = config.PullPolicyAlways
+			switch {
+			// User input clearly refer to a local image.
+			case strings.HasPrefix(imageName, "localhost/"):
+				logrus.Debugf("Enforcing pull policy to %q to support custom platform (arch: %q, os: %q, variant: %q)", "never", options.Architecture, options.OS, options.Variant)
+				pullPolicy = config.PullPolicyNever
+
+			// Image resolved to a local one, so let's still have a
+			// look at the registries or aliases but use it
+			// otherwise.
+			case strings.HasPrefix(resolvedImageName, "localhost/"):
+				logrus.Debugf("Enforcing pull policy to %q to support custom platform (arch: %q, os: %q, variant: %q)", "newer", options.Architecture, options.OS, options.Variant)
+				pullPolicy = config.PullPolicyNewer
+
+			default:
+				logrus.Debugf("Enforcing pull policy to %q to support custom platform (arch: %q, os: %q, variant: %q)", "always", options.Architecture, options.OS, options.Variant)
+				pullPolicy = config.PullPolicyAlways
+			}
 		}
 	}
 

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -158,6 +158,13 @@ type ContainersConfig struct {
 	// PidNS indicates how to create a pid namespace for the container
 	PidNS string `toml:"pidns,omitempty"`
 
+	// Copy the content from the underlying image into the newly created
+	// volume when the container is created instead of when it is started.
+	// If false, the container engine will not copy the content until
+	// the container is started. Setting it to true may have negative
+	// performance implications.
+	PrepareVolumeOnCreate bool `toml:"prepare_volume_on_create,omitempty"`
+
 	// RootlessNetworking depicts the "kind" of networking for rootless
 	// containers.  Valid options are `slirp4netns` and `cni`. Default is
 	// `slirp4netns`
@@ -384,6 +391,10 @@ type EngineConfig struct {
 	// will refer to the plugin as) mapped to a path, which must point to a
 	// Unix socket that conforms to the Volume Plugin specification.
 	VolumePlugins map[string]string `toml:"volume_plugins,omitempty"`
+
+	// ChownCopiedFiles tells the container engine whether to chown files copied
+	// into a container to the container's primary uid/gid.
+	ChownCopiedFiles bool `toml:"chown_copied_files"`
 }
 
 // SetOptions contains a subset of options in a Config. It's used to indicate if

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -189,6 +189,13 @@ default_sysctls = [
 #
 # pids_limit = 2048
 
+# Copy the content from the underlying image into the newly created volume
+# when the container is created instead of when it is started. If false,
+# the container engine will not copy the content until the container is started.
+# Setting it to true may have negative performance implications.
+#
+# prepare_volume_on_create = false
+
 # Indicates the networking to be used for rootless containers
 # rootless_networking = "slirp4netns"
 

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -340,6 +340,8 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	c.LockType = "shm"
 	c.MachineEnabled = false
 
+	c.ChownCopiedFiles = true
+
 	return c, nil
 }
 

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.40.2-dev"
+const Version = "0.41.1-dev"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
-# github.com/containers/common v0.40.2-0.20210707094508-0a4a1906d4b2
+# github.com/containers/common v0.41.1-0.20210721112610-c95d2f794edf
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
 github.com/containers/common/pkg/apparmor


### PR DESCRIPTION
By proxy by vendoring containers/common.  Previously, a "dangling" image
was an untagged image; just a described in the Docker docs.  The
definition of dangling has now been refined to an untagged image without
children to be compatible with Docker.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

WIP since I am currently vendoring in my fork of c/common for testing purposes.