### PR TITLE
[CI:DOCS] Just restore protections of shadow-utils

### DIFF
--- a/contrib/buildahimage/centos7/Dockerfile
+++ b/contrib/buildahimage/centos7/Dockerfile
@@ -8,7 +8,7 @@ FROM centos:7
 
 # Remove directories used by yum that are just taking
 # up space.
-RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install buildah fuse-overlayfs xz; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
+RUN useradd build; yum -y update; rpm --restore --quiet shadow-utils; yum -y install buildah fuse-overlayfs xz; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
 
 ADD https://raw.githubusercontent.com/containers/buildah/main/contrib/buildahimage/stable/containers.conf /etc/containers/
 

--- a/contrib/buildahimage/stable/Dockerfile
+++ b/contrib/buildahimage/stable/Dockerfile
@@ -11,7 +11,7 @@ FROM registry.fedoraproject.org/fedora:latest
 # Don't include container-selinux and remove
 # directories used by yum that are just taking
 # up space.
-RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install buildah fuse-overlayfs xz --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
+RUN useradd build; yum -y update; rpm --restore --quiet shadow-utils; yum -y install buildah fuse-overlayfs xz --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
 
 ADD https://raw.githubusercontent.com/containers/buildah/main/contrib/buildahimage/stable/containers.conf /etc/containers/
 

--- a/contrib/buildahimage/stablebyhand/Containerfile.buildahstable
+++ b/contrib/buildahimage/stablebyhand/Containerfile.buildahstable
@@ -23,7 +23,7 @@ FROM registry.fedoraproject.org/fedora:latest
 # `podman push quay.io/buildah/stable:v1.14.3 docker://quay.io/buildah/stable:v1.14.3`
 #
 COPY /tmp/buildah-1.14.3-1.fc31.x86_64.rpm /tmp
-RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install /tmp/buildah-1.14.3-1.fc31.x86_64.rpm fuse-overlayfs xz --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.* /tmp/buildah*.rpm
+RUN useradd build; yum -y update; rpm --restore --quiet shadow-utils; yum -y install /tmp/buildah-1.14.3-1.fc31.x86_64.rpm fuse-overlayfs xz --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.* /tmp/buildah*.rpm
 
 ADD https://raw.githubusercontent.com/containers/buildah/main/contrib/buildahimage/stable/containers.conf /etc/containers/
 

--- a/contrib/buildahimage/testing/Dockerfile
+++ b/contrib/buildahimage/testing/Dockerfile
@@ -13,7 +13,7 @@ FROM registry.fedoraproject.org/fedora:latest
 # Don't include container-selinux and remove
 # directories used by yum that are just taking
 # up space.
-RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install buildah fuse-overlayfs xz --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+RUN useradd build; yum -y update; rpm --restore --quiet shadow-utils; yum -y install buildah fuse-overlayfs xz --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 ADD https://raw.githubusercontent.com/containers/buildah/main/contrib/buildahimage/stable/containers.conf /etc/containers/
 

--- a/contrib/buildahimage/upstream/Dockerfile
+++ b/contrib/buildahimage/upstream/Dockerfile
@@ -17,7 +17,7 @@ ENV GOPATH=/root/buildah
 # to the container.
 # Finally remove the buildah directory and a few other packages
 # that are needed for building but not running Buildah
-RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install --enablerepo=updates-testing \
+RUN useradd build; yum -y update; rpm --restore --quiet shadow-utils; yum -y install --enablerepo=updates-testing \
      make \
      golang \
      bats \


### PR DESCRIPTION
Base images don't have shadow-utils permissions set correctly, this
change should speed up the building of images a little bit.

[NO TESTS NEEDED] This does not change buildah in any way, so no need to
tests.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

