### PR TITLE
imagebuildah.stageExecutor.prepare(): remove pseudonym check

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -39,7 +39,7 @@ const (
 )
 
 // Mount is a mountpoint for the build container.
-type Mount specs.Mount
+type Mount = specs.Mount
 
 type BuildOptions = define.BuildOptions
 

--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -2,26 +2,11 @@ package imagebuildah
 
 import (
 	"github.com/containers/buildah"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // InitReexec is a wrapper for buildah.InitReexec().  It should be called at
 // the start of main(), and if it returns true, main() should return
-// immediately.
+// successfully immediately.
 func InitReexec() bool {
 	return buildah.InitReexec()
-}
-
-func convertMounts(mounts []Mount) []specs.Mount {
-	specmounts := []specs.Mount{}
-	for _, m := range mounts {
-		s := specs.Mount{
-			Destination: m.Destination,
-			Type:        m.Type,
-			Source:      m.Source,
-			Options:     m.Options,
-		}
-		specmounts = append(specmounts, s)
-	}
-	return specmounts
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -280,6 +280,11 @@ symlink(subdir)"
   ! test -r "$root"/tmp/postCommit
 }
 
+@test "bud-multistage-pull-always" {
+  _prefetch busybox
+  run_buildah bud --pull-always --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.extended ${TESTSDIR}/bud/multi-stage-builds
+}
+
 @test "bud with --layers and symlink file" {
   _prefetch alpine
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In `prepare()`, don't check if the image name that it's passed is a pseudonym for the result of a stage in the Dockerfile.  Its callers already did that.

When `execute()` knows that the image it's told to use as a base is a pseudonym for the result of another stage in the Dockerfile, force the pull policy to "never" to prevent an error when `--pull-always=true`.

Make `imagebuildah.Mount` a type alias instead of its own type, since we never needed it to be a distinct type, but we didn't make it an alias when we started using them.

#### How to verify it

New integration test (for that second one)!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
None
```