### PR TITLE
runtime-flag (debug) test: handle old & new runc

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2893,7 +2893,9 @@ _EOF
 
   local found_runtime=
 
-  local flag_accepted_rx="level=debug.*msg=.*/runc"
+  # runc-1.0.0-70.rc92 and 1.0.1-3 have completely different
+  # debug messages. This is the only string common to both.
+  local flag_accepted_rx="level=debug.*msg=.child process in init"
   if [ -n "$(command -v runc)" ]; then
     found_runtime=y
     if is_cgroupsv2; then


### PR DESCRIPTION
Between runc-1.0.0-70.rc92 and 1.0.1-3, debug messages changed
entirely. Old runc is a short and sweet list:

   time="..." level=debug msg="nsexec:601 nsexec started"
   time="..." level=debug msg="child process in init()"
   time="..." level=debug msg="logging has already been configured"

New runc is pages and pages of gobbledygook which I'm not going to
paste here but which, basically, is completely different. Better,
because most messages now include "runc", but different.

These buildah tests need to pass in environments with old and
new runc. As best I can determine, the "child process in init"
message is the only string common to both old and new runc.
Use it as our gauge. (Note: I considered using a regex pattern
containing both "nsexec" and "runc". That's less maintainable.
If/when runc changes debug messages again, we may need to go
that route, but for now let's keep things clean).

Signed-off-by: Ed Santiago <santiago@redhat.com>
