### PR TITLE
[1.21] runtime-flag (debug) test: handle old & new runc

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2853,6 +2853,9 @@ _EOF
 
   local found_runtime=
 
+  # runc-1.0.0-70.rc92 and 1.0.1-3 have completely different
+  # debug messages. This is the only string common to both.
+  local flag_accepted_rx="level=debug.*msg=.child process in init"
   if [ -n "$(command -v runc)" ]; then
     found_runtime=y
     if is_cgroupsv2; then
@@ -2860,7 +2863,7 @@ _EOF
       run_buildah ? bud --runtime=runc --runtime-flag=debug \
                         -q -t alpine-bud-runc --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
       if [ "$status" -eq 0 ]; then
-        expect_output --substring "nsexec started"
+        expect_output --substring "$flag_accepted_rx"
       else
         # If it fails, this is because this version of runc doesn't support cgroup v2.
         expect_output --substring "this version of runc doesn't work on cgroups v2" "should fail by unsupportability for cgroupv2"
@@ -2868,7 +2871,7 @@ _EOF
     else
       run_buildah bud --runtime=runc --runtime-flag=debug \
                       -q -t alpine-bud-runc --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
-      expect_output --substring "nsexec started"
+      expect_output --substring "$flag_accepted_rx"
     fi
 
   fi


### PR DESCRIPTION
Between runc-1.0.0-70.rc92 and 1.0.1-3, debug messages changed
entirely. Old runc is a short and sweet list:

   time="..." level=debug msg="nsexec:601 nsexec started"
   time="..." level=debug msg="child process in init()"
   time="..." level=debug msg="logging has already been configured"

New runc is pages and pages of gobbledygook which I'm not going to
paste here but which, basically, is completely different. Better,
because most messages now include "runc", but different.

These buildah tests need to pass in environments with old and
new runc. As best I can determine, the "child process in init"
message is the only string common to both old and new runc.
Use it as our gauge. (Note: I considered using a regex pattern
containing both "nsexec" and "runc". That's less maintainable.
If/when runc changes debug messages again, we may need to go
that route, but for now let's keep things clean).

Signed-off-by: Ed Santiago <santiago@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

