### PR TITLE
Accept repositories on login/logout

### DIFF
--- a/cmd/buildah/login.go
+++ b/cmd/buildah/login.go
@@ -19,8 +19,10 @@ func init() {
 	var (
 		opts = loginReply{
 			loginOpts: auth.LoginOptions{
-				Stdin:  os.Stdin,
-				Stdout: os.Stdout},
+				Stdin:              os.Stdin,
+				Stdout:             os.Stdout,
+				AcceptRepositories: true,
+			},
 		}
 		loginDescription = "Login to a container registry on a specified server."
 	)

--- a/cmd/buildah/logout.go
+++ b/cmd/buildah/logout.go
@@ -12,7 +12,8 @@ import (
 func init() {
 	var (
 		opts = auth.LogoutOptions{
-			Stdout: os.Stdout,
+			Stdout:             os.Stdout,
+			AcceptRepositories: true,
 		}
 		logoutDescription = "Remove the cached username and password for the registry."
 	)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now synchronize the behavior with Podman and accept repositories during login and logout per default.
#### How to verify it
Login/logout with a repository and verify `auth.json`. Push and pull should use the credentials in the same way as the Podman integration tests described in https://github.com/containers/podman/pull/11054.
#### Which issue(s) this PR fixes:

Requires https://github.com/containers/buildah/pull/3410

#### Special notes for your reviewer:
Incorporates with https://github.com/containers/podman/pull/11054
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Accept repositories (and registry namespaces) on login/logout and during push/pull.
```

