### PR TITLE
set base-image annotations

### DIFF
--- a/config.go
+++ b/config.go
@@ -82,7 +82,15 @@ func (b *Builder) initConfig(ctx context.Context, img types.Image) error {
 			if err := json.Unmarshal(b.Manifest, &v1Manifest); err != nil {
 				return errors.Wrapf(err, "error parsing OCI manifest %q", string(b.Manifest))
 			}
-			b.ImageAnnotations = v1Manifest.Annotations
+			for k, v := range v1Manifest.Annotations {
+				// NOTE: do not override annotations that are
+				// already set. Otherwise, we may erase
+				// annotations such as the digest of the base
+				// image.
+				if value := b.ImageAnnotations[k]; value == "" {
+					b.ImageAnnotations[k] = v
+				}
+			}
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
+	github.com/opencontainers/image-spec v1.0.2-0.20210730191737-8e42a01fb1b7
 	github.com/opencontainers/runc v1.0.1
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/runtime-tools v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -627,8 +627,9 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6 h1:yN8BPXVwMBAm3Cuvh1L5XE8XpvYRMdsVLd82ILprhUU=
 github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.0.2-0.20210730191737-8e42a01fb1b7 h1:axgApq2XShTLwQii2zAnIkMPlhGVHbAXHUcHezu5G/k=
+github.com/opencontainers/image-spec v1.0.2-0.20210730191737-8e42a01fb1b7/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=

--- a/new.go
+++ b/new.go
@@ -12,10 +12,12 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/shortnames"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	digest "github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/openshift/imagebuilder"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -248,6 +250,15 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 	namespaceOptions := defaultNamespaceOptions
 	namespaceOptions.AddOrReplace(options.NamespaceOptions...)
 
+	// Set the base-image annotations as suggested by the OCI image spec.
+	imageAnnotations := map[string]string{}
+	imageAnnotations[v1.AnnotationBaseImageDigest] = imageDigest
+	if !shortnames.IsShortName(imageSpec) {
+		// If the base image could be resolved to a fully-qualified
+		// image name, let's set it.
+		imageAnnotations[v1.AnnotationBaseImageName] = imageSpec
+	}
+
 	builder := &Builder{
 		store:                 store,
 		Type:                  containerType,
@@ -256,7 +267,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		FromImageDigest:       imageDigest,
 		Container:             name,
 		ContainerID:           container.ID,
-		ImageAnnotations:      map[string]string{},
+		ImageAnnotations:      imageAnnotations,
 		ImageCreatedBy:        "",
 		ProcessLabel:          container.ProcessLabel(),
 		MountLabel:            container.MountLabel(),

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -160,10 +160,10 @@ function check_matrix() {
   run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
   run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
 
-  run_buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci
-  expect_output "map[ANNOTATION:VALUE1,VALUE2]"
-  run_buildah inspect              --format '{{.ImageAnnotations}}'                      $cid
-  expect_output "map[ANNOTATION:VALUE1,VALUE2]"
+  run_buildah inspect --type=image --format '{{index .ImageAnnotations "ANNOTATION"}}' scratch-image-oci
+  expect_output "VALUE1,VALUE2"
+  run_buildah inspect              --format '{{index .ImageAnnotations "ANNOTATION"}}' $cid
+  expect_output "VALUE1,VALUE2"
   check_matrix 'Config.ExposedPorts' 'map[12345:{}]'
   check_matrix 'Config.Env'          '[VARIABLE=VALUE1,VALUE2]'
   check_matrix 'Config.Labels.LABEL' 'VALUE'
@@ -253,10 +253,10 @@ function check_matrix() {
   expect_output "PROBABLY-EMPTY"
 
   # The following aren't part of the Docker v2 spec, so they're discarded when we save to Docker format.
-  run_buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci
-  expect_output "map[ANNOTATION:VALUE1,VALUE2]"
-  run_buildah inspect              --format '{{.ImageAnnotations}}'                      $cid
-  expect_output "map[ANNOTATION:VALUE1,VALUE2]"
+  run_buildah inspect --type=image --format '{{index .ImageAnnotations "ANNOTATION"}}'   scratch-image-oci
+  expect_output "VALUE1,VALUE2"
+  run_buildah inspect              --format '{{index .ImageAnnotations "ANNOTATION"}}'   $cid
+  expect_output "VALUE1,VALUE2"
   run_buildah inspect --type=image --format '{{.Docker.Comment}}'                        scratch-image-docker
   expect_output "INFORMATIVE"
   run_buildah inspect --type=image --format '{{.Docker.Config.Domainname}}'              scratch-image-docker
@@ -348,10 +348,10 @@ function check_matrix() {
   check_matrix 'Config.Env'          '[VARIABLE=VALUE1,VALUE2]'
   check_matrix 'Config.Labels.LABEL' 'VALUE'
   check_matrix 'Config.ExposedPorts' 'map[12345:{}]'
-  run_buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci
-  expect_output "map[ANNOTATION:VALUE1,VALUE2]"
-  run_buildah inspect              --format '{{.ImageAnnotations}}'                      $cid
-  expect_output "map[ANNOTATION:VALUE1,VALUE2]"
+  run_buildah inspect --type=image --format '{{index .ImageAnnotations "ANNOTATION"}}' scratch-image-oci
+  expect_output "VALUE1,VALUE2"
+  run_buildah inspect              --format '{{index .ImageAnnotations "ANNOTATION"}}' $cid
+  expect_output "VALUE1,VALUE2"
 
   run_buildah config \
    --created-by COINCIDENCE \
@@ -370,10 +370,10 @@ function check_matrix() {
   check_matrix 'Config.Env'          '[]'
   check_matrix 'Config.Labels.LABEL' '<no value>'
   check_matrix 'Config.ExposedPorts' 'map[]'
-  run_buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci
-  expect_output "map[]"
-  run_buildah inspect              --format '{{.ImageAnnotations}}'                      $cid
-  expect_output "map[]"
+  run_buildah inspect --type=image --format '{{index .ImageAnnotations "ANNOTATION"}}' scratch-image-oci
+  expect_output ""
+  run_buildah inspect              --format '{{index .ImageAnnotations "ANNOTATION"}}' $cid
+  expect_output ""
 
   run_buildah config \
    --created-by COINCIDENCE \

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/annotations.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/annotations.go
@@ -53,4 +53,10 @@ const (
 
 	// AnnotationDescription is the annotation key for the human-readable description of the software packaged in the image.
 	AnnotationDescription = "org.opencontainers.image.description"
+
+	// AnnotationBaseImageDigest is the annotation key for the digest of the image's base image.
+	AnnotationBaseImageDigest = "org.opencontainers.image.base.digest"
+
+	// AnnotationBaseImageName is the annotation key for the image reference of the image's base image.
+	AnnotationBaseImageName = "org.opencontainers.image.base.name"
 )

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
@@ -89,8 +89,19 @@ type Image struct {
 	// Architecture is the CPU architecture which the binaries in this image are built to run on.
 	Architecture string `json:"architecture"`
 
+	// Variant is the variant of the specified CPU architecture which image binaries are intended to run on.
+	Variant string `json:"variant,omitempty"`
+
 	// OS is the name of the operating system which the image is built to run on.
 	OS string `json:"os"`
+
+	// OSVersion is an optional field specifying the operating system
+	// version, for example on Windows `10.0.14393.1066`.
+	OSVersion string `json:"os.version,omitempty"`
+
+	// OSFeatures is an optional field specifying an array of strings,
+	// each listing a required OS feature (for example on Windows `win32k`).
+	OSFeatures []string `json:"os.features,omitempty"`
 
 	// Config defines the execution parameters which should be used as a base when running a container using the image.
 	Config ImageConfig `json:"config,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -387,7 +387,7 @@ github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
 # github.com/opencontainers/go-digest v1.0.0
 github.com/opencontainers/go-digest
-# github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
+# github.com/opencontainers/image-spec v1.0.2-0.20210730191737-8e42a01fb1b7
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v1.0.1


### PR DESCRIPTION
Since opencontainers/image-spec/pull/822/ the OCI spec supports two new
annotations to set the fully-qualified name and the digest of the base
image.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @nalind @TomSweeneyRedHat @imjasonh PTAL