### PR TITLE
Fix resolv.conf content with run --net=private

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -381,6 +381,13 @@ function check_options_flag_err() {
     [[ $output = *"No options ($flag) can be specified after"* ]]
 }
 
+#################
+#  is_rootless  #  Check if we run as normal user
+#################
+function is_rootless() {
+    [ "$(id -u)" -ne 0 ]
+}
+
 ####################
 #  skip_if_chroot  #
 ####################


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?
Make sure to use the correct resolv.conf in case of systemd-resolved.
Also filter out 127... nameserver when run in private netns.
<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
Dns resolution which --net=private does not work correct.

#### How to verify it
see test

#### Which issue(s) this PR fixes:
Fixes #2780
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

