### PR TITLE
run: fix nil deref using the option's logger

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -702,6 +702,10 @@ func setupTerminal(g *generate.Generator, terminalPolicy TerminalPolicy, termina
 }
 
 func runUsingRuntime(isolation define.Isolation, options RunOptions, configureNetwork bool, configureNetworks, moreCreateArgs []string, spec *specs.Spec, bundlePath, containerName string) (wstatus unix.WaitStatus, err error) {
+	if options.Logger == nil {
+		options.Logger = logrus.StandardLogger()
+	}
+
 	// Lock the caller to a single OS-level thread.
 	runtime.LockOSThread()
 


### PR DESCRIPTION
[NO TESTS NEEDED] since I've no idea how to force it.

Reported-in: containers/podman/issues/11148
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>