### PR TITLE
Adds overlay.GenerateStructure in-order generate a permanent overlayfs dir structure.

### DIFF
--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -30,20 +30,38 @@ func TempDir(containerDir string, rootUID, rootGID int) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create the overlay tmpdir in %s directory", contentDir)
 	}
-	upperDir := filepath.Join(contentDir, "upper")
-	workDir := filepath.Join(contentDir, "work")
+
+	return generateOverlayStructure(contentDir, rootUID, rootGID)
+}
+
+// GenerateStructure generates an overlay directory structure for container content
+func GenerateStructure(containerDir, containerID, name string, rootUID, rootGID int) (string, error) {
+
+	contentDir := filepath.Join(containerDir, "overlay-containers", containerID, name)
+	if err := idtools.MkdirAllAs(contentDir, 0700, rootUID, rootGID); err != nil {
+		return "", errors.Wrapf(err, "failed to create the overlay %s directory", contentDir)
+	}
+
+	return generateOverlayStructure(contentDir, rootUID, rootGID)
+}
+
+// generateOverlayStructure generates upper, work and merge directory structure for overlay directory
+func generateOverlayStructure(containerDir string, rootUID, rootGID int) (string, error) {
+
+	upperDir := filepath.Join(containerDir, "upper")
+	workDir := filepath.Join(containerDir, "work")
 	if err := idtools.MkdirAllAs(upperDir, 0700, rootUID, rootGID); err != nil {
 		return "", errors.Wrapf(err, "failed to create the overlay %s directory", upperDir)
 	}
 	if err := idtools.MkdirAllAs(workDir, 0700, rootUID, rootGID); err != nil {
 		return "", errors.Wrapf(err, "failed to create the overlay %s directory", workDir)
 	}
-	mergeDir := filepath.Join(contentDir, "merge")
+	mergeDir := filepath.Join(containerDir, "merge")
 	if err := idtools.MkdirAllAs(mergeDir, 0700, rootUID, rootGID); err != nil {
 		return "", errors.Wrapf(err, "failed to create the overlay %s directory", mergeDir)
 	}
 
-	return contentDir, nil
+	return containerDir, nil
 }
 
 // Mount creates a subdir of the contentDir based on the source directory


### PR DESCRIPTION
Following PR is being used by a downstream PR ( https://github.com/containers/podman/pull/11170 ) on  (podman). 
Idea is to remove redundant code so that we can serve the use-cases for adding rootfs-overlay to podman.