### PR TITLE
imagebuildah: move multiple-platform building internal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ LIBSECCOMP_COMMIT := release-2.3
 
 EXTRA_LDFLAGS ?=
 BUILDAH_LDFLAGS := -ldflags '-X main.GitCommit=$(GIT_COMMIT) -X main.buildInfo=$(SOURCE_DATE_EPOCH) -X main.cniVersion=$(CNI_COMMIT) $(EXTRA_LDFLAGS)'
-SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go docker/*.go manifests/*.go pkg/blobcache/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/formats/*.go pkg/manifests/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go util/*.go
+SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go docker/*.go manifests/*.go pkg/blobcache/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go util/*.go
 
 LINTFLAGS ?=
 

--- a/cmd/buildah/bud.go
+++ b/cmd/buildah/bud.go
@@ -13,16 +13,10 @@ import (
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
-	"github.com/containers/common/libimage"
-	"github.com/containers/common/libimage/manifests"
 	"github.com/containers/common/pkg/auth"
-	"github.com/containers/image/v5/manifest"
-	"github.com/containers/storage"
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/semaphore"
 )
 
 type budOptions struct {
@@ -315,32 +309,6 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		return errors.Wrapf(err, "unable to obtain decrypt config")
 	}
 
-	var (
-		jobSemaphore *semaphore.Weighted
-		builds       multierror.Group
-	)
-	if iopts.Jobs > 0 {
-		jobSemaphore = semaphore.NewWeighted(int64(iopts.Jobs))
-		iopts.Jobs = 0
-	}
-	if iopts.Manifest != "" {
-		// Ensure that the list's ID is known before we spawn off any
-		// goroutines that'll want to modify it, so that they don't
-		// race and create two lists, one of which will rapidly become
-		// ignored.
-		rt, err := libimage.RuntimeFromStore(store, nil)
-		if err != nil {
-			return err
-		}
-		_, err = rt.LookupManifestList(iopts.Manifest)
-		if err != nil && errors.Cause(err) == storage.ErrImageUnknown {
-			list := manifests.Create()
-			_, err = list.SaveToImage(store, "", []string{iopts.Manifest}, manifest.DockerV2ListMediaType)
-		}
-		if err != nil {
-			return err
-		}
-	}
 	var excludes []string
 	if iopts.IgnoreFile != "" {
 		if excludes, err = parseDockerignore(iopts.IgnoreFile); err != nil {
@@ -352,82 +320,66 @@ func budCmd(c *cobra.Command, inputArgs []string, iopts budOptions) error {
 		t := time.Unix(iopts.Timestamp, 0).UTC()
 		timestamp = &t
 	}
-	for _, platform := range platforms {
-		platform := platform
-		builds.Go(func() error {
-			platformContext := *systemContext
-			platformContext.OSChoice = platform.OS
-			platformContext.ArchitectureChoice = platform.Arch
-			platformContext.VariantChoice = platform.Variant
-			options := define.BuildOptions{
-				AddCapabilities:         iopts.CapAdd,
-				AdditionalTags:          tags,
-				Annotations:             iopts.Annotation,
-				Architecture:            platform.Arch,
-				Args:                    args,
-				BlobDirectory:           iopts.BlobCache,
-				CNIConfigDir:            iopts.CNIConfigDir,
-				CNIPluginPath:           iopts.CNIPlugInPath,
-				CommonBuildOpts:         commonOpts,
-				Compression:             compression,
-				ConfigureNetwork:        networkPolicy,
-				ContextDirectory:        contextDir,
-				DefaultMountsFilePath:   globalFlagResults.DefaultMountsFile,
-				Devices:                 iopts.Devices,
-				DropCapabilities:        iopts.CapDrop,
-				Err:                     stderr,
-				ForceRmIntermediateCtrs: iopts.ForceRm,
-				From:                    iopts.From,
-				IDMappingOptions:        idmappingOptions,
-				IIDFile:                 iopts.Iidfile,
-				In:                      stdin,
-				Isolation:               isolation,
-				Labels:                  iopts.Label,
-				Layers:                  layers,
-				LogRusage:               iopts.LogRusage,
-				Manifest:                iopts.Manifest,
-				MaxPullPushRetries:      maxPullPushRetries,
-				NamespaceOptions:        namespaceOptions,
-				NoCache:                 iopts.NoCache,
-				OS:                      platform.OS,
-				Out:                     stdout,
-				Output:                  output,
-				OutputFormat:            format,
-				PullPolicy:              pullPolicy,
-				PullPushRetryDelay:      pullPushRetryDelay,
-				Quiet:                   iopts.Quiet,
-				RemoveIntermediateCtrs:  iopts.Rm,
-				ReportWriter:            reporter,
-				Runtime:                 iopts.Runtime,
-				RuntimeArgs:             runtimeFlags,
-				RusageLogFile:           iopts.RusageLogFile,
-				SignBy:                  iopts.SignBy,
-				SignaturePolicyPath:     iopts.SignaturePolicy,
-				Squash:                  iopts.Squash,
-				SystemContext:           &platformContext,
-				Target:                  iopts.Target,
-				TransientMounts:         iopts.Volumes,
-				OciDecryptConfig:        decConfig,
-				Jobs:                    &iopts.Jobs,
-				JobSemaphore:            jobSemaphore,
-				Excludes:                excludes,
-				Timestamp:               timestamp,
-			}
-			if iopts.Quiet {
-				options.ReportWriter = ioutil.Discard
-			}
+	options := define.BuildOptions{
+		AddCapabilities:         iopts.CapAdd,
+		AdditionalTags:          tags,
+		Annotations:             iopts.Annotation,
+		Architecture:            systemContext.ArchitectureChoice,
+		Args:                    args,
+		BlobDirectory:           iopts.BlobCache,
+		CNIConfigDir:            iopts.CNIConfigDir,
+		CNIPluginPath:           iopts.CNIPlugInPath,
+		CommonBuildOpts:         commonOpts,
+		Compression:             compression,
+		ConfigureNetwork:        networkPolicy,
+		ContextDirectory:        contextDir,
+		DefaultMountsFilePath:   globalFlagResults.DefaultMountsFile,
+		Devices:                 iopts.Devices,
+		DropCapabilities:        iopts.CapDrop,
+		Err:                     stderr,
+		ForceRmIntermediateCtrs: iopts.ForceRm,
+		From:                    iopts.From,
+		IDMappingOptions:        idmappingOptions,
+		IIDFile:                 iopts.Iidfile,
+		In:                      stdin,
+		Isolation:               isolation,
+		Labels:                  iopts.Label,
+		Layers:                  layers,
+		LogRusage:               iopts.LogRusage,
+		Manifest:                iopts.Manifest,
+		MaxPullPushRetries:      maxPullPushRetries,
+		NamespaceOptions:        namespaceOptions,
+		NoCache:                 iopts.NoCache,
+		OS:                      systemContext.OSChoice,
+		Out:                     stdout,
+		Output:                  output,
+		OutputFormat:            format,
+		PullPolicy:              pullPolicy,
+		PullPushRetryDelay:      pullPushRetryDelay,
+		Quiet:                   iopts.Quiet,
+		RemoveIntermediateCtrs:  iopts.Rm,
+		ReportWriter:            reporter,
+		Runtime:                 iopts.Runtime,
+		RuntimeArgs:             runtimeFlags,
+		RusageLogFile:           iopts.RusageLogFile,
+		SignBy:                  iopts.SignBy,
+		SignaturePolicyPath:     iopts.SignaturePolicy,
+		Squash:                  iopts.Squash,
+		SystemContext:           systemContext,
+		Target:                  iopts.Target,
+		TransientMounts:         iopts.Volumes,
+		OciDecryptConfig:        decConfig,
+		Jobs:                    &iopts.Jobs,
+		Excludes:                excludes,
+		Timestamp:               timestamp,
+		Platforms:               platforms,
+	}
+	if iopts.Quiet {
+		options.ReportWriter = ioutil.Discard
+	}
 
-			_, _, err = imagebuildah.BuildDockerfiles(getContext(), store, options, dockerfiles...)
-			return err
-		})
-	}
-	if merr := builds.Wait(); merr != nil {
-		if merr.Len() == 1 {
-			return merr.Errors[0]
-		}
-		return merr.ErrorOrNil()
-	}
-	return nil
+	_, _, err = imagebuildah.BuildDockerfiles(getContext(), store, options, dockerfiles...)
+	return err
 }
 
 // discoverContainerfile tries to find a Containerfile or a Dockerfile within the provided `path`.

--- a/commit.go
+++ b/commit.go
@@ -197,7 +197,7 @@ func (b *Builder) addManifest(ctx context.Context, manifestName string, imageSpe
 
 	names, err := util.ExpandNames([]string{manifestName}, systemContext, b.store)
 	if err != nil {
-		return "", errors.Wrapf(err, "error encountered while expanding image name %q", manifestName)
+		return "", errors.Wrapf(err, "error encountered while expanding manifest list name %q", manifestName)
 	}
 
 	ref, err := util.VerifyTagName(imageSpec)

--- a/define/build.go
+++ b/define/build.go
@@ -230,4 +230,8 @@ type BuildOptions struct {
 	// From is the image name to use to replace the value specified in the first
 	// FROM instruction in the Containerfile
 	From string
+	// Platforms is the list of parsed OS/Arch/Variant triples that we want
+	// to build the image for.  If this slice has items in it, the OS and
+	// Architecture fields above are ignored.
+	Platforms []struct{ OS, Arch, Variant string }
 }

--- a/docs/buildah-bud.md
+++ b/docs/buildah-bud.md
@@ -44,7 +44,7 @@ Note: this information is not present in Docker image formats, so it is discarde
 
 **--arch**="ARCH"
 
-Set the ARCH of the image to be pulled to the provided value instead of using the architecture of the host. (Examples: arm, arm64, 386, amd64, ppc64le, s390x)
+Set the ARCH of the image to be built, and that of the base image to be pulled, if the build uses one, to the provided value instead of using the architecture of the host. (Examples: arm, arm64, 386, amd64, ppc64le, s390x)
 
 **--authfile** *path*
 
@@ -214,6 +214,7 @@ from inside a rootless container will fail. The **crun**(1) runtime offers a
 workaround for this by adding the option **--annotation run.oci.keep_original_groups=1**.
 
 **--disable-compression**, **-D**
+
 Don't compress filesystem layers when building the image unless it is required
 by the location where the image is being written.  This is the default setting,
 because image layers are compressed automatically when they are pushed to
@@ -287,7 +288,8 @@ those.
 
 **--iidfile** *ImageIDfile*
 
-Write the image ID to the file.
+Write the built image's ID to the file.  When `--platform` is specified more
+than once, attempting to use this option will trigger an error.
 
 **--ignorefile** *file*
 
@@ -322,7 +324,7 @@ BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`
 
 Run up to N concurrent stages in parallel.  If the number of jobs is greater than 1,
 stdin will be read from /dev/null.  If 0 is specified, then there is
-no limit in the number of jobs that run in parallel.
+no limit on the number of jobs that run in parallel.
 
 **--label** *label*
 
@@ -354,8 +356,9 @@ specified file instead of to standard output and standard error.
 
 **--manifest** "manifest"
 
-Name of the manifest list to which the image will be added. Creates the manifest list
-if it does not exist. This option is useful for building multi architecture images.
+Name of the manifest list to which the built image will be added.  Creates the
+manifest list if it does not exist.  This option is useful for building multi
+architecture images.
 
 **--memory**, **-m**=""
 
@@ -395,7 +398,7 @@ Do not use existing cached images for the container build. Build from the start 
 
 **--os**="OS"
 
-Set the OS of the image to be pulled instead of using the current operating system of the host.
+Set the OS of the image to be built, and that of the base image to be pulled, if the build uses one, instead of using the current operating system of the host.
 
 **--pid** *how*
 
@@ -479,6 +482,7 @@ Note: Do not pass the leading `--` to the flag. To pass the runc flag `--log-for
 to buildah bud, the option given would be `--runtime-flag log-format=json`.
 
 **--secret**=**id=id,src=path**
+
 Pass secret information to be used in the Containerfile for building images
 in a safe way that will not end up stored in the final image, or be seen in other stages.
 The secret will be mounted in the container at the default location of `/run/secrets/id`.
@@ -520,6 +524,7 @@ Squash all of the image's new layers into a single new layer; any preexisting la
 are not squashed.
 
 **--ssh**=**default**|*id[=socket>|<key>[,<key>]*
+
 SSH agent socket or keys to expose to the build.
 The socket path can be left empty to use the value of `default=$SSH_AUTH_SOCK`
 

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -124,6 +124,7 @@ type Executor struct {
 	manifest                       string
 	secrets                        map[string]string
 	sshsources                     map[string]*sshagent.Source
+	logPrefix                      string
 }
 
 type imageTypeAndHistoryAndDiffIDs struct {
@@ -133,8 +134,8 @@ type imageTypeAndHistoryAndDiffIDs struct {
 	err          error
 }
 
-// NewExecutor creates a new instance of the imagebuilder.Executor interface.
-func NewExecutor(logger *logrus.Logger, store storage.Store, options define.BuildOptions, mainNode *parser.Node) (*Executor, error) {
+// newExecutor creates a new instance of the imagebuilder.Executor interface.
+func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, options define.BuildOptions, mainNode *parser.Node) (*Executor, error) {
 	defaultContainerConfig, err := config.Default()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get container config")
@@ -266,6 +267,7 @@ func NewExecutor(logger *logrus.Logger, store storage.Store, options define.Buil
 		manifest:                       options.Manifest,
 		secrets:                        secrets,
 		sshsources:                     sshsources,
+		logPrefix:                      logPrefix,
 	}
 	if exec.err == nil {
 		exec.err = os.Stderr
@@ -442,7 +444,7 @@ func (b *Executor) buildStage(ctx context.Context, cleanupStages map[int]*StageE
 	if stageExecutor.log == nil {
 		stepCounter := 0
 		stageExecutor.log = func(format string, args ...interface{}) {
-			prefix := ""
+			prefix := b.logPrefix
 			if len(stages) > 1 {
 				prefix += fmt.Sprintf("[%d/%d] ", stageIndex+1, len(stages))
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change
/kind cleanup

#### What this PR does / why we need it:

Move multiple-platform build juggling logic from the CLI wrapper directly into the imagebuildah package, to make using it easier for packages that consume us as a library.

This requires reading Dockerfiles into byte slices so that we can re-parse them for each per-platform build, rather than parsing them directly, as we used to, since building modifies the parsed tree.

When building for multiple platforms, prefix progress log messages with the platform description.

#### How to verify it

Visible behavior shouldn't change.
[ NO NEW TESTS NEEDED ]

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This reverts most changes to cmd/buildah/bud.go, so it should look very much like it did before we merged #3402, for example in v1.22.0.
imagebuildah.NewExecutor() should probably have never been an exported function, but it ~is~ was, so this is an API change.

#### Does this PR introduce a user-facing change?

```release-note
None
```