### PR TITLE
Move DiscoverContainerfile to define directory, so podman can use it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ LIBSECCOMP_COMMIT := release-2.3
 
 EXTRA_LDFLAGS ?=
 BUILDAH_LDFLAGS := -ldflags '-X main.GitCommit=$(GIT_COMMIT) -X main.buildInfo=$(SOURCE_DATE_EPOCH) -X main.cniVersion=$(CNI_COMMIT) $(EXTRA_LDFLAGS)'
-SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go docker/*.go manifests/*.go pkg/blobcache/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go util/*.go
+SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go docker/*.go manifests/*.go pkg/blobcache/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go pkg/util/*.go util/*.go
 
 LINTFLAGS ?=
 

--- a/pkg/util/test/test1/Containerfile
+++ b/pkg/util/test/test1/Containerfile
@@ -1,0 +1,1 @@
+from scratch

--- a/pkg/util/test/test1/Dockerfile
+++ b/pkg/util/test/test1/Dockerfile
@@ -1,0 +1,1 @@
+from scratch

--- a/pkg/util/test/test2/Dockerfile
+++ b/pkg/util/test/test2/Dockerfile
@@ -1,0 +1,1 @@
+from scratch

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// DiscoverContainerfile tries to find a Containerfile or a Dockerfile within the provided `path`.
+func DiscoverContainerfile(path string) (foundCtrFile string, err error) {
+	// Test for existence of the file
+	target, err := os.Stat(path)
+	if err != nil {
+		return "", errors.Wrap(err, "discovering Containerfile")
+	}
+
+	switch mode := target.Mode(); {
+	case mode.IsDir():
+		// If the path is a real directory, we assume a Containerfile or a Dockerfile within it
+		ctrfile := filepath.Join(path, "Containerfile")
+
+		// Test for existence of the Containerfile file
+		file, err := os.Stat(ctrfile)
+		if err != nil {
+			// See if we have a Dockerfile within it
+			ctrfile = filepath.Join(path, "Dockerfile")
+
+			// Test for existence of the Dockerfile file
+			file, err = os.Stat(ctrfile)
+			if err != nil {
+				return "", errors.Wrap(err, "cannot find Containerfile or Dockerfile in context directory")
+			}
+		}
+
+		// The file exists, now verify the correct mode
+		if mode := file.Mode(); mode.IsRegular() {
+			foundCtrFile = ctrfile
+		} else {
+			return "", errors.Errorf("assumed Containerfile %q is not a file", ctrfile)
+		}
+
+	case mode.IsRegular():
+		// If the context dir is a file, we assume this as Containerfile
+		foundCtrFile = path
+	}
+
+	return foundCtrFile, nil
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiscoverContainerfile(t *testing.T) {
+	_, err := DiscoverContainerfile("./bogus")
+	assert.NotNil(t, err)
+
+	_, err = DiscoverContainerfile("./")
+	assert.NotNil(t, err)
+
+	name, err := DiscoverContainerfile("test/test1/Dockerfile")
+	assert.Nil(t, err)
+	assert.Equal(t, name, "test/test1/Dockerfile")
+
+	name, err = DiscoverContainerfile("test/test1/Containerfile")
+	assert.Nil(t, err)
+	assert.Equal(t, name, "test/test1/Containerfile")
+
+	name, err = DiscoverContainerfile("test/test1")
+	assert.Nil(t, err)
+	assert.Equal(t, name, "test/test1/Containerfile")
+
+	name, err = DiscoverContainerfile("test/test2")
+	assert.Nil(t, err)
+	assert.Equal(t, name, "test/test2/Dockerfile")
+
+}


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

