### PR TITLE
[release-1.22] Bump to v1.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ![buildah logo](https://cdn.rawgit.com/containers/buildah/main/logos/buildah-logo_large.png)
 
 # Changelog
+## v1.22.3 (2021-08-20)
+  * [release-1.22] bump to v1.22.3
+
 ## v1.22.2 (2021-08-19)
   * [release-1.22] bump c/image to v5.15.2
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+- Changelog for v1.22.3 (2021-08-20)
+  * [release-1.22] bump to v1.22.3
+
 - Changelog for v1.22.2 (2021-08-19)
   * [release-1.22] bump c/image to v5.15.2
 

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in define/types.go too
-Version:        1.22.3
+Version:        1.22.4-dev
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,6 +100,8 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Fri Aug 20, 2021 Tom Sweeney <tsweeney@redhat.com> 1.22.4-dev-1
+
 * Fri Aug 20, 2021 Tom Sweeney <tsweeney@redhat.com> 1.22.3-1
 - [release-1.22] bump to v1.22.3
 

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in define/types.go too
-Version:        1.22.3-dev
+Version:        1.22.3
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,7 +100,8 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
-* Thu Aug 19, 2021 Tom Sweeney <tsweeney@redhat.com> 1.22.3-dev-1
+* Fri Aug 20, 2021 Tom Sweeney <tsweeney@redhat.com> 1.22.3-1
+- [release-1.22] bump to v1.22.3
 
 * Thu Aug 19, 2021 Tom Sweeney <tsweeney@redhat.com> 1.22.2-1
 - [release-1.22] bump c/image to v5.15.2

--- a/define/types.go
+++ b/define/types.go
@@ -28,7 +28,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.22.3-dev"
+	Version = "1.22.3"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/define/types.go
+++ b/define/types.go
@@ -28,7 +28,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.22.3"
+	Version = "1.22.4-dev"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
Bumping to v1.22.3.  The v1.22.2 tag/release that was created for v1.22.2 was
created badly and is messing up go modules.  Per @vrothberg, the
only fix is to bump the version and create a new release.

[NO TESTS NEEDED]
[NO NEW TESTS NEEDED]
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

