### PR TITLE
Add epoch time field to buildah images

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -25,6 +25,7 @@ type jsonImage struct {
 	Digest       string    `json:"digest"`
 	CreatedAt    string    `json:"createdat"`
 	Size         string    `json:"size"`
+	Created      int64     `json:"created"`
 	CreatedAtRaw time.Time `json:"createdatraw"`
 	ReadOnly     bool      `json:"readonly"`
 	History      []string  `json:"history"`
@@ -35,6 +36,7 @@ type imageOutputParams struct {
 	ID           string
 	Name         string
 	Digest       string
+	Created      int64
 	CreatedAt    string
 	Size         string
 	CreatedAtRaw time.Time
@@ -204,6 +206,7 @@ func formatImagesJSON(images []*libimage.Image, opts imageOptions) error {
 		jsonImages = append(jsonImages,
 			jsonImage{
 				CreatedAtRaw: created,
+				Created:      created.Unix(),
 				CreatedAt:    units.HumanDuration(time.Since(created)) + " ago",
 				Digest:       image.Digest().String(),
 				ID:           truncateID(image.ID(), opts.truncate),
@@ -246,6 +249,7 @@ func formatImages(images []*libimage.Image, opts imageOptions) error {
 		}
 		created := image.Created()
 		outputParam.CreatedAtRaw = created
+		outputParam.Created = created.Unix()
 		outputParam.CreatedAt = units.HumanDuration(time.Since(created)) + " ago"
 		outputParam.Digest = image.Digest().String()
 		outputParam.ID = truncateID(image.ID(), opts.truncate)

--- a/docs/buildah-images.md
+++ b/docs/buildah-images.md
@@ -58,14 +58,15 @@ Valid placeholders for the Go template are listed below:
 
 | **Placeholder** | **Description**                          |
 | --------------- | -----------------------------------------|
-| .Tag            | Image Tag                                |
+| .Created        | Creation date in epoch time              |
+| .CreatedAt      | Creation date Pretty Formatted           |
+| .CreatedAtRaw   | Creation date in raw format              |
+| .Digest         | Image Digest                             |
 | .ID             | Image ID                                 |
 | .Name           | Image Name                               |
-| .Digest         | Image Digest                             |
-| .CreatedAt      | Creation date Pretty Formatted           |
-| .Size           | Image Size                               |
-| .CreatedAtRaw   | Creation date in raw format              |
 | .ReadOnly       | Indicates if image came from a R/O store |
+| .Size           | Image Size                               |
+| .Tag            | Image Tag                                |
 
 **--history**
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2453,19 +2453,23 @@ EOM
 
 @test "bud timestamp" {
   _prefetch alpine
-  run_buildah build --timestamp=0 --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
+  timestamp=40
+  run_buildah build --timestamp=${timestamp} --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
   cid=$output
   run_buildah inspect --format '{{ .Docker.Created }}' timestamp
   expect_output --substring "1970-01-01"
   run_buildah inspect --format '{{ .OCIv1.Created }}' timestamp
   expect_output --substring "1970-01-01"
   run_buildah inspect --format '{{ .History }}' timestamp
-  expect_output --substring '1970-01-01 00:00:00'
+  expect_output --substring "1970-01-01 00:00:${timestamp}"
 
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json timestamp
   cid=$output
   run_buildah run $cid ls -l /tmpfile
   expect_output --substring "1970"
+
+  run_buildah images --format "{{.Created}}" timestamp
+  expect_output ${timestamp}
 
   rm -rf ${TESTDIR}/tmp
 }
@@ -2475,6 +2479,9 @@ EOM
   TIMESTAMP=$(date '+%s')
   run_buildah build --timestamp=${TIMESTAMP} --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
   cid=$output
+
+  run_buildah images --format "{{.Created}}" timestamp
+  expect_output ${timestamp}
 
   run_buildah build --timestamp=${TIMESTAMP} --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
   expect_output "$cid"


### PR DESCRIPTION
Currently buildah images does not have an easy way to get the epoch
creation time. This field is available in `podman images` as the
Created field. Adding to buildah images to make it consistent.

Fixes: https://github.com/containers/buildah/issues/3478

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

