### PR TITLE
conformance: tighten up exception specifications

### DIFF
--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -2,7 +2,7 @@
 
 # Buildah/Docker Conformance Test Suite
 
-The conformance test for buildah is used to verify the images built with Buildah are equivalent to those built by Docker.  It does this by building an image using the version of buildah library that's being tested, building what should be the same image using `docker build`, and comparing them.
+The conformance test for buildah is used to verify the images built with Buildah are equivalent to those built by Docker.  It does this by building an image using the version of buildah library that's being tested, building what should be the same image using the docker engine's build API, and comparing them.
 
 ## Installing dependencies
 
@@ -15,17 +15,17 @@ Conformance tests use Docker CE to build images to be compared with images built
 
 ## Run conformance tests
 
-You can run the test with go test:
+You can run all of the tests with go test:
 ```
 go test -v -tags "$(./btrfs_tag.sh) $(./btrfs_installed_tag.sh) $(./libdm_tag.sh)" ./tests/conformance
 ```
 
-If you want to run one of the test cases you can use flag "-run":
+If you want to run one of the test cases you can use the "-run" flag:
 ```
 go test -v -tags "$(./btrfs_tag.sh) $(./btrfs_installed_tag.sh) $(./libdm_tag.sh)" -run TestConformance/shell ./tests/conformance
 ```
 
 If you also want to build and compare on a line-by-line basis, run:
 ```
-go test -v -tags "$(./btrfs_tag.sh) $(./btrfs_installed_tag.sh) $(./libdm_tag.sh)" ./tests/conformance -compare-layers
+go test -v -timeout=60m -tags "$(./btrfs_tag.sh) $(./btrfs_installed_tag.sh) $(./libdm_tag.sh)" ./tests/conformance -compare-layers
 ```

--- a/tests/conformance/testdata/Dockerfile.copyfrom_1
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_1
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN touch /a /b
+RUN touch -t @1485449953 /a /b
 FROM busybox
 COPY --from=base /a /
 RUN ls -al /a

--- a/tests/conformance/testdata/Dockerfile.copyfrom_10
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_10
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN mkdir -p /a && touch /a/1
+RUN mkdir -p /a && touch -t @1485449953 /a/1
 FROM busybox
 COPY --from=base /a/1 /a/b/c
 RUN ls -al /a/b/c && ! ls -al /a/b/1

--- a/tests/conformance/testdata/Dockerfile.copyfrom_11
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_11
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN mkdir -p /a && touch /a/1
+RUN mkdir -p /a && touch -t @1485449953 /a/1
 FROM busybox
 COPY --from=base /a /a/b/c
 RUN ls -al /a/b/c/1 && ! ls -al /a/b/1

--- a/tests/conformance/testdata/Dockerfile.copyfrom_12
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_12
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN mkdir -p /a && touch /a/1
+RUN mkdir -p /a && touch -t @1485449953 /a/1
 FROM busybox
 COPY --from=base a /a
 RUN ls -al /a/1 && ! ls -al /a/a

--- a/tests/conformance/testdata/Dockerfile.copyfrom_13
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_13
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN mkdir -p /a && touch /a/1
+RUN mkdir -p /a && touch -t @1485449953 /a/1
 FROM busybox
 COPY --from=base a/. /a
 RUN ls -al /a/1 && ! ls -al /a/a

--- a/tests/conformance/testdata/Dockerfile.copyfrom_2
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_2
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN touch /a
+RUN touch -t @1485449953 /a
 FROM busybox
 COPY --from=base /a /a
 RUN ls -al /a

--- a/tests/conformance/testdata/Dockerfile.copyfrom_3
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_3
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN touch /a
+RUN touch -t @1485449953 /a
 FROM busybox
 WORKDIR /b
 COPY --from=base /a .

--- a/tests/conformance/testdata/Dockerfile.copyfrom_3_1
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_3_1
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN touch /a
+RUN touch -t @1485449953 /a
 FROM busybox
 WORKDIR /b
 COPY --from=base /a ./b

--- a/tests/conformance/testdata/Dockerfile.copyfrom_4
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_4
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN mkdir -p /a/b && touch /a/b/1 /a/b/2
+RUN mkdir -p /a/b && touch -t @1485449953 /a/b/1 /a/b/2
 FROM busybox
 COPY --from=base /a/b/ /b/
 RUN ls -al /b/1 /b/2 /b && ! ls -al /a

--- a/tests/conformance/testdata/Dockerfile.copyfrom_5
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_5
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN mkdir -p /a/b && touch /a/b/1 /a/b/2
+RUN mkdir -p /a/b && touch -t @1485449953 /a/b/1 /a/b/2
 FROM busybox
 COPY --from=base /a/b/* /b/
 RUN ls -al /b/1 /b/2 /b && ! ls -al /a /b/a /b/b

--- a/tests/conformance/testdata/Dockerfile.copyfrom_6
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_6
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN mkdir -p /a/b && touch /a/b/1 /a/b/2
+RUN mkdir -p /a/b && touch -t @1485449953 /a/b/1 /a/b/2
 FROM busybox
 COPY --from=base /a/b/. /b/
 RUN ls -al /b/1 /b/2 /b && ! ls -al /a /b/a /b/b

--- a/tests/conformance/testdata/Dockerfile.copyfrom_7
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_7
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN touch /b
+RUN touch -t @1485449953 /b
 FROM busybox
 COPY --from=base /b /a
 RUN ls -al /a && ! ls -al /b

--- a/tests/conformance/testdata/Dockerfile.copyfrom_8
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_8
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN mkdir -p /a && touch /a/b
+RUN mkdir -p /a && touch -t @1485449953 /a/b
 FROM busybox
 COPY --from=base /a/b /a
 RUN ls -al /a && ! ls -al /b

--- a/tests/conformance/testdata/Dockerfile.copyfrom_9
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_9
@@ -1,5 +1,5 @@
 FROM busybox as base
-RUN mkdir -p /a && touch /a/1
+RUN mkdir -p /a && touch -t @1485449953 /a/1
 FROM busybox
 COPY --from=base /a/1 /a/b/c/
 RUN ls -al /a/b/c/1 && ! ls -al /a/b/1

--- a/tests/conformance/testdata/Dockerfile.reusebase
+++ b/tests/conformance/testdata/Dockerfile.reusebase
@@ -1,5 +1,5 @@
 FROM registry.centos.org/centos/centos:centos7 AS base
-RUN touch /1
+RUN touch -t 201701261659.13 /1
 ENV LOCAL=/1
 
 FROM base

--- a/tests/conformance/testdata/dockerignore/allowlist/nothing-dot/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/allowlist/nothing-dot/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-RUN touch /file
+RUN touch -t @1485449953 /file
 FROM scratch
 COPY --from=0 /file /
 ADD . .

--- a/tests/conformance/testdata/dockerignore/allowlist/nothing-slash/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/allowlist/nothing-slash/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-RUN touch /file
+RUN touch -t @1485449953 /file
 FROM scratch
 COPY --from=0 /file /
 ADD / /

--- a/tests/conformance/testdata/dockerignore/allowlist/subsubdir-file/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/allowlist/subsubdir-file/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-RUN touch /file
+RUN touch -t @1485449953 /file
 FROM scratch
 COPY --from=0 /file /
 ADD . .

--- a/tests/conformance/testdata/dockerignore/allowlist/subsubdir-nofile/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/allowlist/subsubdir-nofile/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-RUN touch /file
+RUN touch -t @1485449953 /file
 FROM scratch
 COPY --from=0 /file /
 ADD . .

--- a/tests/conformance/testdata/dockerignore/allowlist/subsubdir-nosubdir/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/allowlist/subsubdir-nosubdir/Dockerfile
@@ -1,5 +1,5 @@
 FROM busybox
-RUN touch /file
+RUN touch -t @1485449953 /file
 FROM scratch
 COPY --from=0 /file /
 ADD . .


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Modify how we process exceptions in conformance tests so that we don't unintentionally disable an attribute comparison (such as "mtime") on items below a directory when we try to skip that attribute comparison on the directory itself.

Fix some incorrect specifications for filesystem differences that we're supposed to ignore, and use the -t flag in more places where we RUN the `touch` command to create files that end up in the final image.

#### How to verify it

Updated conformance tests!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```