### PR TITLE
copier.Get(): try to avoid descending into directories

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -152,7 +152,7 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 	var idMappingOptions *buildah.IDMappingOptions
 	contextdir := iopts.contextdir
 	if iopts.ignoreFile != "" && contextdir == "" {
-		return errors.Errorf("--ignore options requires that you specify a context dir using --contextdir")
+		return errors.Errorf("--ignorefile option requires that you specify a context dir using --contextdir")
 	}
 
 	if iopts.from != "" {

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -947,7 +947,7 @@ func testGetMultiple(t *testing.T) {
 						"file-b",
 						"link-c",
 						"hlink-0",
-						"subdir-a/file-c",
+						// "subdir-a/file-c", // strings.HasPrefix("**/*-c", "subdir-a/") is false
 						"subdir-b",
 						"subdir-b/file-n",
 						"subdir-b/file-o",
@@ -1060,7 +1060,7 @@ func testGetMultiple(t *testing.T) {
 					pattern: ".",
 					exclude: []string{"*", "!**/*-c"},
 					items: []string{
-						"subdir-a/file-c",
+						// "subdir-a/file-c", // strings.HasPrefix("**/*-c", "subdir-a/") is false
 						"link-c",
 						"subdir-c",
 						"subdir-c/file-p",

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -200,7 +200,7 @@ load helpers
   run_buildah run $cid ls /Makefile
 }
 
-@test "add --ignore" {
+@test "add --ignorefile" {
   mytest=${TESTDIR}/mytest
   mkdir -p ${mytest}
   touch ${mytest}/mystuff
@@ -221,7 +221,7 @@ stuff/mystuff"
   cid=$output
 
   run_buildah 125 copy --ignorefile ${mytest}/.ignore $cid ${mytest} /stuff
-  expect_output -- "--ignore options requires that you specify a context dir using --contextdir" "container file list"
+  expect_output -- "--ignorefile option requires that you specify a context dir using --contextdir" "container file list"
 
   run_buildah add --contextdir=${mytest} --ignorefile ${mytest}/.ignore $cid ${mytest} /stuff
 

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -2864,4 +2864,10 @@ var internalTestCases = []testCase{
 		withoutDocker: true,
 		fsSkip:        []string{"(dir):tmp:mtime"},
 	},
+
+	{
+		name:       "dockerignore-exceptions-skip",
+		contextDir: "dockerignore/exceptions-skip",
+		fsSkip:     []string{"(dir):volume:mtime"},
+	},
 }

--- a/tests/conformance/testdata/dockerignore/exceptions-skip/.dockerignore
+++ b/tests/conformance/testdata/dockerignore/exceptions-skip/.dockerignore
@@ -1,0 +1,2 @@
+volume/
+!**/oneline.txt

--- a/tests/conformance/testdata/dockerignore/exceptions-skip/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/exceptions-skip/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine
+COPY ./ ./

--- a/tests/conformance/testdata/dockerignore/exceptions-skip/volume/data/oneline.txt
+++ b/tests/conformance/testdata/dockerignore/exceptions-skip/volume/data/oneline.txt
@@ -1,0 +1,1 @@
+one line of text

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -326,7 +326,7 @@ load helpers
   expect_output --substring "no such file or directory"
 }
 
-@test "copy --ignore" {
+@test "copy --ignorefile" {
   mytest=${TESTDIR}/mytest
   mkdir -p ${mytest}
   touch ${mytest}/mystuff
@@ -347,7 +347,7 @@ stuff/mystuff"
   cid=$output
 
   run_buildah 125 copy --ignorefile ${mytest}/.ignore $cid ${mytest} /stuff
-  expect_output -- "--ignore options requires that you specify a context dir using --contextdir" "container file list"
+  expect_output -- "--ignorefile option requires that you specify a context dir using --contextdir" "container file list"
 
   run_buildah copy --contextdir=${mytest} --ignorefile ${mytest}/.ignore $cid ${mytest} /stuff
 
@@ -441,9 +441,7 @@ stuff/mystuff"
 
   run_buildah 1 run $from ls -l sub2.txt
 
-  run_buildah run $from ls -l subdir/sub1.txt
-
-  run_buildah 1 run $from ls -l subdir/sub2.txt
+  run_buildah 1 run $from ls -l subdir/
 }
 
 @test "copy-preserving-extended-attributes" {

--- a/tests/copy/copy.go
+++ b/tests/copy/copy.go
@@ -21,6 +21,7 @@ func main() {
 	var storeOptions storage.StoreOptions
 	var systemContext types.SystemContext
 	var logLevel string
+	var maxParallelDownloads uint
 
 	if buildah.InitReexec() {
 		return
@@ -78,9 +79,10 @@ func main() {
 			}()
 
 			options := cp.Options{
-				ReportWriter:   os.Stdout,
-				SourceCtx:      &systemContext,
-				DestinationCtx: &systemContext,
+				ReportWriter:         os.Stdout,
+				SourceCtx:            &systemContext,
+				DestinationCtx:       &systemContext,
+				MaxParallelDownloads: maxParallelDownloads,
 			}
 			if _, err = cp.Image(context.TODO(), policyContext, dest, src, &options); err != nil {
 				return err
@@ -105,6 +107,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&systemContext.SignaturePolicyPath, "signature-policy", "", "`pathname` of signature policy file")
 	rootCmd.PersistentFlags().StringVar(&systemContext.UserShortNameAliasConfPath, "short-name-alias-conf", "", "`pathname` of short name alias cache file (not usually used)")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "warn", "logging level")
+	rootCmd.PersistentFlags().UintVar(&maxParallelDownloads, "max-parallel-downloads", 0, "maximum `number` of blobs to copy at once")
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -152,7 +152,7 @@ function imgtype() {
 }
 
 function copy() {
-    ${COPY_BINARY} ${ROOTDIR_OPTS} ${BUILDAH_REGISTRY_OPTS} "$@"
+    ${COPY_BINARY} --max-parallel-downloads=1 ${ROOTDIR_OPTS} ${BUILDAH_REGISTRY_OPTS} "$@"
 }
 
 function podman() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When processing a directory tree, only descend into a directory that is marked for exclusion if its path is literally a prefix of an exception pattern.

Subtly, but in a way that's compatible with docker, this means that if we exclude directory "subdir", but we've been told to also include `**/file` (with an exclusion pattern of `!**/file`), we won't descend into "subdir" and find a file named "subdir/file", because "**/file" doesn't start with "subdir/".

More generally, exclusion patterns that start with "!" which include any wildcards before their final component technically won't be treated correctly.

#### How to verify it

It's rather difficult to create the permissions-based error that we can encounter when we attempt to descend into a directory that we can't read, but which wouldn't contain anything we'd include if we could read it, as described in #3427, when the tests are running as root, but there's a new conformance test that confirms that we at least don't do the technically-correct-but-incompatible thing.

#### Which issue(s) this PR fixes:

Should fix #3427.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```