### PR TITLE
manifest: Make sure manifest `rm` only removes manifests not referenced images.

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -459,7 +459,8 @@ func manifestRmCmd(c *cobra.Command, args []string) error {
 	}
 
 	options := &libimage.RemoveImagesOptions{
-		Filters: []string{"readonly=false"},
+		Filters:        []string{"readonly=false"},
+		LookupManifest: true,
 	}
 	rmiReports, rmiErrors := runtime.RemoveImages(context.Background(), args, options)
 	for _, r := range rmiReports {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/containerd/containerd v1.5.5
 	github.com/containernetworking/cni v0.8.1
-	github.com/containers/common v0.43.3-0.20210830085322-6143ffe54e5f
+	github.com/containers/common v0.43.3-0.20210902095222-a7acc160fb25
 	github.com/containers/image/v5 v5.16.0
 	github.com/containers/ocicrypt v1.1.2
 	github.com/containers/storage v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/containernetworking/cni v0.8.1 h1:7zpDnQ3T3s4ucOuJ/ZCLrYBxzkg0AELFfII
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
-github.com/containers/common v0.43.3-0.20210830085322-6143ffe54e5f h1:aK7C516naCNpgksPPM9qAs5wgfmeeKtp1NlLREvMy7A=
-github.com/containers/common v0.43.3-0.20210830085322-6143ffe54e5f/go.mod h1:NIymxA8e3mUVnLoeGFoDgIrJeUmVA/djOqgMmO112Qw=
+github.com/containers/common v0.43.3-0.20210902095222-a7acc160fb25 h1:zcFtn+MuCwpywchrRtZjFQxTJIcNb9vjlIeZktYgSzQ=
+github.com/containers/common v0.43.3-0.20210902095222-a7acc160fb25/go.mod h1:NIymxA8e3mUVnLoeGFoDgIrJeUmVA/djOqgMmO112Qw=
 github.com/containers/image/v5 v5.16.0 h1:WQcNSzb7+ngS2cfynx0vUwhk+scpgiKlldVcsF8GPbI=
 github.com/containers/image/v5 v5.16.0/go.mod h1:XgTpfAPLRGOd1XYyCU5cISFr777bLmOerCSpt/v7+Q4=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=

--- a/tests/rm.bats
+++ b/tests/rm.bats
@@ -52,3 +52,20 @@ load helpers
   run_buildah 125 rm -a "$cid"
   expect_output --substring "when using the --all switch, you may not pass any containers names or IDs"
 }
+
+@test "remove a single tagged manifest list" {
+  _prefetch busybox
+  run_buildah manifest create manifestsample
+  run_buildah manifest add manifestsample busybox
+  run_buildah tag manifestsample manifestsample2
+  run_buildah manifest rm manifestsample2
+  # Output should only untag the listed manifest nothing else
+  expect_output "untagged: localhost/manifestsample2:latest"
+  run_buildah manifest rm manifestsample
+  # Since actual list is getting removed it will also print the image id of list
+  # So check for substring instead of exact match
+  expect_output --substring "untagged: localhost/manifestsample:latest"
+  # Check if busybox is still there
+  run_buildah images
+  expect_output --substring "busybox"
+}

--- a/vendor/github.com/containers/common/libimage/disk_usage.go
+++ b/vendor/github.com/containers/common/libimage/disk_usage.go
@@ -52,6 +52,10 @@ func (r *Runtime) DiskUsage(ctx context.Context) ([]ImageDiskUsage, error) {
 
 // diskUsageForImage returns the disk-usage baseistics for the specified image.
 func diskUsageForImage(ctx context.Context, image *Image, tree *layerTree) ([]ImageDiskUsage, error) {
+	if err := image.isCorrupted(""); err != nil {
+		return nil, err
+	}
+
 	base := ImageDiskUsage{
 		ID:         image.ID(),
 		Created:    image.Created(),

--- a/vendor/github.com/containers/common/libimage/image.go
+++ b/vendor/github.com/containers/common/libimage/image.go
@@ -74,7 +74,10 @@ func (i *Image) isCorrupted(name string) error {
 	}
 
 	if _, err := ref.NewImage(context.Background(), nil); err != nil {
-		return errors.Errorf("Image %s exists in local storage but may be corrupted: %v", name, err)
+		if name == "" {
+			name = i.ID()[:12]
+		}
+		return errors.Errorf("Image %s exists in local storage but may be corrupted (remove the image to resolve the issue): %v", name, err)
 	}
 	return nil
 }

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -778,7 +778,7 @@ func (c *NetworkConfig) Validate() error {
 		}
 	}
 
-	if stringsEq(c.CNIPluginDirs, cniBinDir) {
+	if stringsEq(c.CNIPluginDirs, DefaultCNIPluginDirs) {
 		return nil
 	}
 

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -262,7 +262,13 @@ default_sysctls = [
 
 # Path to directory where CNI plugin binaries are located.
 #
-#cni_plugin_dirs = ["/usr/libexec/cni"]
+#cni_plugin_dirs = [
+#  "/usr/local/libexec/cni",
+#  "/usr/libexec/cni",
+#  "/usr/local/lib/cni",
+#  "/usr/lib/cni",
+#  "/opt/cni/bin",
+#]
 
 # The network name of the default CNI network to attach pods to.
 #

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -76,10 +76,12 @@ var (
 		"CAP_SYS_CHROOT",
 	}
 
-	cniBinDir = []string{
+	// It may seem a bit unconventional, but it is necessary to do so
+	DefaultCNIPluginDirs = []string{
+		"/usr/local/libexec/cni",
 		"/usr/libexec/cni",
-		"/usr/lib/cni",
 		"/usr/local/lib/cni",
+		"/usr/lib/cni",
 		"/opt/cni/bin",
 	}
 
@@ -207,7 +209,7 @@ func DefaultConfig() (*Config, error) {
 			DefaultNetwork:   "podman",
 			DefaultSubnet:    DefaultSubnet,
 			NetworkConfigDir: cniConfig,
-			CNIPluginDirs:    cniBinDir,
+			CNIPluginDirs:    DefaultCNIPluginDirs,
 		},
 		Engine:  *defaultEngineConfig,
 		Secrets: defaultSecretConfig(),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,7 +61,7 @@ github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
-# github.com/containers/common v0.43.3-0.20210830085322-6143ffe54e5f
+# github.com/containers/common v0.43.3-0.20210902095222-a7acc160fb25
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
 github.com/containers/common/pkg/apparmor


### PR DESCRIPTION
Following PR makes sure that `buildah manifest rm <list>` only removes
the manifest list not referenced images.

Depends on: https://github.com/containers/common/pull/753
