### PR TITLE
[CI:DOCS] Clarify rmi w/ manifest/index use

### DIFF
--- a/docs/buildah-rmi.md
+++ b/docs/buildah-rmi.md
@@ -15,10 +15,20 @@ Passing an argument _image_ deletes it, along with any of its dangling (untagged
 
 ## LIMITATIONS
 
-If the image was pushed to a directory path using the 'dir:' transport
-the rmi command can not remove the image. Instead standard file system
-commands should be used.
-If _imageID_ is a name, but does not include a registry name, buildah will attempt to find and remove an image named using the registry name _localhost_, if no such image is found, it will search for the intended image by attempting to expand the given name using the names of registries provided in the system's registries configuration file, registries.conf.
+* If the image was pushed to a directory path using the 'dir:' transport,
+  the rmi command can not remove the image. Instead, standard file system
+  commands should be used.
+
+* If _imageID_ is a name, but does not include a registry name, buildah will
+  attempt to find and remove the named image using the registry name _localhost_,
+  if no such image is found, it will search for the intended image by attempting
+  to expand the given name using the names of registries provided in the system's
+  registries configuration file, registries.conf.
+
+* If the _imageID_ refers to a *manifest list* or *image index*, this command
+  will ***not*** do what you expect!  This command will remove the images
+  associated with the *manifest list* or *index* (not the manifest list/image index
+  itself). To remove that, use the `buildah manifest rm` subcommand instead.
 
 ## OPTIONS
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

[The `rmi` command isn't intended to remove an image index or manifest.](https://github.com/containers/buildah/issues/3490#issuecomment-910033675)  However, this is the subcommand which many users may intuitively reach for.  Clarify this situation in the `rmi` documentation.

#### How to verify it

RTFM (with special consideration given to the man-page conversion)

#### Which issue(s) this PR fixes:

Related to #3490 3490

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

None