### PR TITLE
build: mirror --authfile to filesystem if pointing to FD instead of file

### DIFF
--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -100,6 +100,7 @@ func getContainerfiles(files []string) []string {
 
 func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 	output := ""
+	cleanTmpFile := false
 	tags := []string{}
 	if c.Flag("tag").Changed {
 		tags = iopts.Tag
@@ -110,6 +111,10 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 	}
 	if err := auth.CheckAuthFile(iopts.BudResults.Authfile); err != nil {
 		return err
+	}
+	iopts.BudResults.Authfile, cleanTmpFile = buildahutil.MirrorToTempFileIfPathIsDescriptor(iopts.BudResults.Authfile)
+	if cleanTmpFile {
+		defer os.Remove(iopts.BudResults.Authfile)
 	}
 
 	pullPolicy := define.PullIfMissing

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2261,6 +2261,14 @@ _EOF
   run_buildah 125 build --authfile /tmp/nonexistent --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
 }
 
+
+@test "bud for multi-stage Containerfile with invalid registry and --authfile as a fd, should fail with no such host" {
+  target=alpine-multi-stage-image
+  run_buildah 125 build --authfile=<(echo "{ \"auths\": { \"myrepository.example\": { \"auth\": \"$(echo 'username:password' | base64 --wrap=0)\" } } }") -t ${target} --file ${TESTSDIR}/bud/from-invalid-registry/Containerfile
+  # Should fail with `no such host` instead of: error reading JSON file "/dev/fd/x"
+  expect_output --substring "no such host"
+}
+
 @test "bud COPY with URL should fail" {
   mkdir ${TESTSDIR}/bud/copy
   FILE=${TESTSDIR}/bud/copy/Dockerfile.url

--- a/tests/bud/from-invalid-registry/Containerfile
+++ b/tests/bud/from-invalid-registry/Containerfile
@@ -1,0 +1,3 @@
+FROM alpine as build
+# Invalid registry and image
+FROM myrepository.example/image:tag


### PR DESCRIPTION
Following PR makes sure that buildah mirrors --authfile to a temporary
file in filesystem if arg is pointing to an FD instead of actual file
as FD can be only consumed once.

Fixes: https://github.com/containers/buildah/issues/3070