### PR TITLE
Fix build with .git url with branch

### DIFF
--- a/define/types.go
+++ b/define/types.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	urlpkg "net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -111,7 +112,11 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 	if err != nil {
 		return "", "", errors.Wrapf(err, "error creating temporary directory for %q", url)
 	}
-	if strings.HasPrefix(url, "git://") || strings.HasSuffix(url, ".git") {
+	urlParsed, err := urlpkg.Parse(url)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "error parsing url %q", url)
+	}
+	if strings.HasPrefix(url, "git://") || strings.HasSuffix(urlParsed.Path, ".git") {
 		err = cloneToDirectory(url, name)
 		if err != nil {
 			if err2 := os.RemoveAll(name); err2 != nil {
@@ -156,9 +161,6 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 }
 
 func cloneToDirectory(url, dir string) error {
-	if !strings.HasPrefix(url, "git://") && !strings.HasSuffix(url, ".git") {
-		url = "git://" + url
-	}
 	gitBranch := strings.Split(url, "#")
 	var cmd *exec.Cmd
 	if len(gitBranch) < 2 {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2208,6 +2208,10 @@ _EOF
   run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t gittarget -f tests/bud/shell/Dockerfile git://github.com/containers/buildah#release-1.11-rhel
 }
 
+@test "bud using gitrepo with .git and branch" {
+  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t gittarget -f tests/bud/shell/Dockerfile https://github.com/containers/buildah.git#release-1.11-rhel
+}
+
 # Fixes #1906: buildah was not detecting changed tarfile
 @test "bud containerfile with tar archive in copy" {
   _prefetch busybox


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

Fix builds with a URL that has a non-`git://` prefix, a `.git` suffix on its path, and contains a branch in the URL fragment (the portion of the URL after the `#`).

The build with git URL recognizes git URLs by either a `git://` scheme prefix, or any other scheme such as `https://` and a `.git` suffix.

The build with git URL and branch recognizes the branch name as the fragment part of the URL, the part after the `#`.

The `.git` suffix check is performed by checking that the suffix of the full URL is `.git`, however this causes URLs that begin with scheme `https://`, and have a `.git` path suffix, to not be recognized as git URLs when a branch name is appended.

The logic for checking if the URL path is suffixed with `.git` should parse the URL first and consider only the path when looking for the suffix.

#### How to verify it

Run buildah (or podman using this version of buildah) to build the following git URL:

```
podman build -t test https://github.com/leighmcculloch/stellar--docker-stellar-core-horizon.git#cap21and40
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

Fixes containers/podman#11450

#### Special notes for your reviewer:

This is my first contribution.

This commit also removes the guard within the `cloneToDirectory` function because it is unnecessary since every location the function is called the check has already been carried out.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed build from git URL's with branch. 
```

