### PR TITLE
Cirrus: Increase unit-test timeout

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -139,7 +139,7 @@ unit_task:
       - smoke
       - vendor
 
-    timeout_in: 50m
+    timeout_in: 1h
 
     matrix:
         - env:


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Observed a unit-test typical runtime is around 45m, so a 50m timeout is
cutting things closely given variability in networking and shared vCPU
performance.  Increase the timeout to 1-hour to provide an additional
buffer.

#### How to verify it

Unit-tests will pass.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

None