### PR TITLE
Update 05-openshift-rootless-build.md

### DIFF
--- a/docs/tutorials/05-openshift-rootless-build.md
+++ b/docs/tutorials/05-openshift-rootless-build.md
@@ -284,7 +284,7 @@ sh-5.0$ mkdir output
 And finally build the image, testing that everything works as expected:
 
 ````console
-sh-5.0$ buildah -v /home/build/output:/output:rw -v /home/build/test-script.sh:/test-script.sh:ro build -t myimage -f Containerfile.test
+sh-5.0$ buildah -v /home/build/output:/output:rw -v /home/build/test-script.sh:/test-script.sh:ro build-using-dockerfile -t myimage -f Containerfile.test
 STEP 1: FROM fedora:33
 Getting image source signatures
 Copying blob 453ed60def9c done


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

When I tried to run "Buildah Tutorial 5" last step I got the following error:

```bash
$ buildah -v /home/build/output:/output:rw -v /home/build/test-script.sh:/test-script.sh:ro build -t myimage -f Containerfile.test
unknown command "build" for "buildah"

Did you mean this?
	build-using-dockerfile
```

To fix it I have replaced buildah "build" command with "build-using-dockerfile".