### PR TITLE
Makefile: update cross targets

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -177,7 +177,7 @@ conformance_task:
     conformance_test_script: '${SCRIPT_BASE}/test.sh conformance |& ${_TIMESTAMP}'
 
 
-# Confirm cross-compile ALL archetectures on a Mac OS-X VM.
+# Confirm cross-compile ALL architectures on a Mac OS-X VM.
 cross_build_task:
     name: "Cross Compile"
     alias: cross_build
@@ -186,13 +186,14 @@ cross_build_task:
       - unit
 
     osx_instance:
-        image: 'catalina-base'
+        image: 'big-sur-base'
 
     script:
         - brew update
         - brew install go
         - brew install go-md2man
         - brew install gpgme
+        - go version
         - make cross CGO_ENABLED=0
 
     binary_artifacts:

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,11 @@ bin/buildah: $(SOURCES) cmd/buildah/*.go
 .PHONY: buildah
 buildah: bin/buildah
 
+LINUX_CROSS_TARGETS = $(addprefix bin/buildah.,$(subst /,.,$(shell $(GO) tool dist list | grep ^linux/)))
+DARWIN_CROSS_TARGETS = $(addprefix bin/buildah.,$(subst /,.,$(shell $(GO) tool dist list | grep ^darwin/)))
+WINDOWS_CROSS_TARGETS = $(addsuffix .exe,$(addprefix bin/buildah.,$(subst /,.,$(shell $(GO) tool dist list | grep ^windows/))))
 .PHONY: cross
-cross: bin/buildah.darwin.amd64 bin/buildah.linux.386 bin/buildah.linux.amd64 bin/buildah.linux.arm64 bin/buildah.linux.arm bin/buildah.linux.mips64 bin/buildah.linux.mips64le bin/buildah.linux.mips bin/buildah.linux.mipsle bin/buildah.linux.ppc64 bin/buildah.linux.ppc64le bin/buildah.linux.riscv64 bin/buildah.linux.s390x bin/buildah.windows.amd64.exe
+cross: $(LINUX_CROSS_TARGETS) $(DARWIN_CROSS_TARGETS) $(WINDOWS_CROSS_TARGETS)
 
 bin/buildah.%:
 	mkdir -p ./bin


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Update the "cross" makefile target to just try building on every Linux, Darwin, or Windows architecture that the current version of Go supports.

That way, the next time we upgrade Go to a version that supports more architectures, we won't have to remember to update the list of cross-compile targets that we try to build in CI to catch cross-compilation problems.

#### How to verify it

`make cross`, then look in ./bin

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```