### PR TITLE
Makefile: only use race detection when it's available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ BINDIR := $(PREFIX)/bin
 BASHINSTALLDIR = $(PREFIX)/share/bash-completion/completions
 BUILDFLAGS := -tags "$(BUILDTAGS)"
 BUILDAH := buildah
+RACEFLAGS := $(shell go test -race ./pkg/rusage > /dev/null 2>&1 && echo -race)
 
 GO := go
 GO110 := 1.10
@@ -168,10 +169,10 @@ tests/testreport/testreport: tests/testreport/testreport.go
 
 .PHONY: test-unit
 test-unit: tests/testreport/testreport
-	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover -race $(shell $(GO) list ./... | grep -v vendor | grep -v tests | grep -v cmd) -timeout 45m
+	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover $(RACEFLAGS) $(shell $(GO) list ./... | grep -v vendor | grep -v tests | grep -v cmd) -timeout 45m
 	tmp=$(shell mktemp -d) ; \
 	mkdir -p $$tmp/root $$tmp/runroot; \
-	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover -race ./cmd/buildah -args --root $$tmp/root --runroot $$tmp/runroot --storage-driver vfs --signature-policy $(shell pwd)/tests/policy.json --registries-conf $(shell pwd)/tests/registries.conf
+	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover $(RACEFLAGS) ./cmd/buildah -args --root $$tmp/root --runroot $$tmp/runroot --storage-driver vfs --signature-policy $(shell pwd)/tests/policy.json --registries-conf $(shell pwd)/tests/registries.conf
 
 vendor-in-container:
 	podman run --privileged --rm --env HOME=/root -v `pwd`:/src -w /src docker.io/library/golang:1.16 make vendor


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Check if `go test` supports the `-race` flag on the build platform, and if so, and only use it for unit tests if it's supported.

Fix a race in `run_linux.go`.

#### How to verify it

`make test-unit` should work correctly on platforms where the `-race` flag is not supported for builds.  `go help build` will list which platforms your installed version of Go supports the flag for.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Marking this as not needing new tests, though it may end up requiring additional changes if the tests we already have start noticing things that need to be fixed.

#### Does this PR introduce a user-facing change?

```release-note
None
```