### PR TITLE
Update VM Images + Drop prior-ubuntu testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,13 +28,11 @@ env:
     FEDORA_NAME: "fedora-34"
     PRIOR_FEDORA_NAME: "fedora-33"
     UBUNTU_NAME: "ubuntu-2104"
-    PRIOR_UBUNTU_NAME: "ubuntu-2010"
 
-    IMAGE_SUFFIX: "c6248193773010944"
+    IMAGE_SUFFIX: "c6431352024203264"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
-    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "prior-ubuntu-${IMAGE_SUFFIX}"
 
     IN_PODMAN_IMAGE: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
 
@@ -76,7 +74,6 @@ meta_task:
             ${FEDORA_CACHE_IMAGE_NAME}
             ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
             ${UBUNTU_CACHE_IMAGE_NAME}
-            ${PRIOR_UBUNTU_CACHE_IMAGE_NAME}
         BUILDID: "${CIRRUS_BUILD_ID}"
         REPOREF: "${CIRRUS_CHANGE_IN_REPO}"
         GCPJSON: ENCRYPTED[d3614d6f5cc0e66be89d4252b3365fd84f14eee0259d4eb47e25fc0bc2842c7937f5ee8c882b7e547b4c5ec4b6733b14]
@@ -271,10 +268,6 @@ integration_task:
             DISTRO_NV: "${UBUNTU_NAME}"
             IMAGE_NAME: "${UBUNTU_CACHE_IMAGE_NAME}"
             STORAGE_DRIVER: 'vfs'
-        - env:
-            DISTRO_NV: "${PRIOR_UBUNTU_NAME}"
-            IMAGE_NAME: "${PRIOR_UBUNTU_CACHE_IMAGE_NAME}"
-            STORAGE_DRIVER: 'vfs'
         # OVERLAY
         - env:
             DISTRO_NV: "${FEDORA_NAME}"
@@ -287,10 +280,6 @@ integration_task:
         - env:
             DISTRO_NV: "${UBUNTU_NAME}"
             IMAGE_NAME: "${UBUNTU_CACHE_IMAGE_NAME}"
-            STORAGE_DRIVER: 'overlay'
-        - env:
-            DISTRO_NV: "${PRIOR_UBUNTU_NAME}"
-            IMAGE_NAME: "${PRIOR_UBUNTU_CACHE_IMAGE_NAME}"
             STORAGE_DRIVER: 'overlay'
 
     gce_instance:


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:

These images contain a workaround for:
     https://github.com/containers/podman/issues/11123

This mainly affects the system-tests, a small number of which make calls to podman.

Ref: https://github.com/containers/podman/issues/11070 and https://github.com/containers/automation_images/pull/88

#### How to verify it

All CI Testing will pass

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

None