### PR TITLE
unmarshalConvertedConfig(): handle zstd compression

### DIFF
--- a/tests/from.bats
+++ b/tests/from.bats
@@ -612,3 +612,8 @@ load helpers
   run_buildah inspect --format '{{.CNIPluginPath}}' $cid
   expect_output "${cni_plugin_path}"
 }
+
+@test "from-image-with-zstd-compression" {
+  copy --format oci --dest-compress --dest-compress-format zstd docker://quay.io/libpod/alpine_nginx:latest dir:${TESTDIR}/base-image
+  run_buildah from dir:${TESTDIR}/base-image
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Docker manifest format doesn't currently support listing layers compressed using zstd, so we trigger an error when we try to convert an in-memory OCI manifest to the Docker format as a preliminary step in reading the image's config blob in the Docker format.
    
Instead, first create a temporary copy of the manifest, and then force the MIME types for all layers in the temporary copy of the manifest to appear to be compressed using gzip.  Both OCI and Docker formats will accept the resulting manifest without issue.  We throw the copy away after we've read the config blob, so the wackiness should be contained.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```