### PR TITLE
conformance: allow test cases to specify dockerUseBuildKit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/containers/ocicrypt v1.1.2
 	github.com/containers/storage v1.36.0
 	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/docker v20.10.8+incompatible
 	github.com/docker/go-units v0.4.0
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20190625141545-5a177b73e316
 	github.com/fsouza/go-dockerclient v1.7.4

--- a/tests/conformance/testdata/Dockerfile.margs
+++ b/tests/conformance/testdata/Dockerfile.margs
@@ -1,0 +1,39 @@
+FROM alpine
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN mkdir first
+RUN echo ${BUILDPLATFORM}  > first/buildplatform=`echo ${BUILDPLATFORM} | sed s,/,_,g`
+RUN echo ${BUILDOS}        > first/buildos=`echo ${BUILDOS} | sed s,/,_,g`
+RUN echo ${BUILDARCH}      > first/buildarch=`echo ${BUILDARCH} | sed s,/,_,g`
+RUN echo ${BUILDVARIANT}   > first/buildvariant=`echo ${BUILDVARIANT} | sed s,/,_,g`
+RUN echo ${TARGETPLATFORM} > first/targetplatform=`echo ${TARGETPLATFORM} | sed s,/,_,g`
+RUN echo ${TARGETOS}       > first/targetos=`echo ${TARGETOS} | sed s,/,_,g`
+RUN echo ${TARGETARCH}     > first/targetarch=`echo ${TARGETARCH} | sed s,/,_,g`
+RUN echo ${TARGETVARIANT}  > first/targetvariant=`echo ${TARGETVARIANT} | sed s,/,_,g`
+
+FROM alpine
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN mkdir second
+RUN echo ${BUILDPLATFORM}  > second/buildplatform=`echo ${BUILDPLATFORM} | sed s,/,_,g`
+RUN echo ${BUILDOS}        > second/buildos=`echo ${BUILDOS} | sed s,/,_,g`
+RUN echo ${BUILDARCH}      > second/buildarch=`echo ${BUILDARCH} | sed s,/,_,g`
+RUN echo ${BUILDVARIANT}   > second/buildvariant=`echo ${BUILDVARIANT} | sed s,/,_,g`
+RUN echo ${TARGETPLATFORM} > second/targetplatform=`echo ${TARGETPLATFORM} | sed s,/,_,g`
+RUN echo ${TARGETOS}       > second/targetos=`echo ${TARGETOS} | sed s,/,_,g`
+RUN echo ${TARGETARCH}     > second/targetarch=`echo ${TARGETARCH} | sed s,/,_,g`
+RUN echo ${TARGETVARIANT}  > second/targetvariant=`echo ${TARGETVARIANT} | sed s,/,_,g`
+COPY --from=0 first/* ./first/
+RUN touch -r /etc/os-release first first/* second second/*


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

The API flag that we'd need to set to in a build request to get dockerd use BuildKit instead of the classic docker builder isn't available in go-dockerclient, so add a second docker-based path that uses the API types and client library, which the conformance tests were already pulling in as indirect dependencies, but skip tests that set the flag if we're not on the current client version.

This is mainly groundwork for testing compatibility, in the future, with features that aren't in the docker classic builder.

#### How to verify it

New conformance test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```