### PR TITLE
push: support to specify the compression format

### DIFF
--- a/docs/buildah-push.md
+++ b/docs/buildah-push.md
@@ -38,6 +38,16 @@ environment variable. `export REGISTRY_AUTH_FILE=path`
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
 The default certificates directory is _/etc/containers/certs.d_.
 
+**--compression-format** *format*
+
+Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.
+
+**--compression-level** *level*
+
+Specify the compression level used with the compression.
+
+Specifies the compression level to use.  The value is specific to the compression algorithm used, e.g. for zstd the accepted values are in the range 1-20 (inclusive), while for gzip it is 1-9 (inclusive).
+
 **--creds** *creds*
 
 The [username[:password]] to use to authenticate with the registry if required.

--- a/push.go
+++ b/push.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/common/libimage"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	encconfig "github.com/containers/ocicrypt/config"
@@ -25,6 +26,7 @@ type PushOptions struct {
 	// Compression specifies the type of compression which is applied to
 	// layer blobs.  The default is to not use compression, but
 	// archive.Gzip is recommended.
+	// OBSOLETE: Use CompressionFormat instead.
 	Compression archive.Compression
 	// SignaturePolicyPath specifies an override location for the signature
 	// policy which should be used for verifying the new image as it is
@@ -71,6 +73,11 @@ type PushOptions struct {
 	// integers in the slice represent 0-indexed layer indices, with support for negative
 	// indexing. i.e. 0 is the first layer, -1 is the last (top-most) layer.
 	OciEncryptLayers *[]int
+
+	// CompressionFormat is the format to use for the compression of the blobs
+	CompressionFormat *compression.Algorithm
+	// CompressionLevel specifies what compression level is used
+	CompressionLevel *int
 }
 
 // Push copies the contents of the image to a new location.
@@ -84,6 +91,8 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 	libimageOptions.RetryDelay = &options.RetryDelay
 	libimageOptions.OciEncryptConfig = options.OciEncryptConfig
 	libimageOptions.OciEncryptLayers = options.OciEncryptLayers
+	libimageOptions.CompressionFormat = options.CompressionFormat
+	libimageOptions.CompressionLevel = options.CompressionLevel
 	libimageOptions.PolicyAllowStorage = true
 
 	if options.Quiet {

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -203,3 +203,14 @@ load helpers
   run_buildah push --quiet --signature-policy ${TESTSDIR}/policy.json alpine dir:$mytmpdir
   expect_output ""
 }
+
+@test "push with --compression-format" {
+  _prefetch alpine
+  run_buildah from --quiet --pull alpine
+  cid=$output
+  run_buildah images -q
+  imageid=$output
+  run_buildah push --format oci --compression-format zstd:chunked $imageid dir:${TESTDIR}/zstd
+  # Verify there is some zstd compressed layer.
+  grep application/vnd.oci.image.layer.v1.tar+zstd ${TESTDIR}/zstd/manifest.json
+}


### PR DESCRIPTION
add two new flags to "buildah push" to allow tweaking the compression
format for the data layers.

The flag --compression-format allows users to specify the compression
algorithm to use.

With --compression-level it is possible to tweak the compression
level.

An image usage for partial pulls can be pushed with:

$ buildah push --compression-format zstd:chunked FOO

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

It allows users to specify the compression for the image data layers.

#### How to verify it

buildah push --compression-format zstd:chunked FOO dir:/tmp/foo

The files under /tmp/foo are compressed with zstd.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--

-->

```release-note
push has two new flags to allow tweaking the compression format for the data layers.
The flag --compression-format allows users to specify the compression algorithm to use, while with --compression-level it is possible to tweak the compression level.
```

