### PR TITLE
imagebuildah: fix an attempt to write to a nil map

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -168,7 +168,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 		files = append(files, b.Bytes())
 	}
 
-	if options.Jobs != nil && *options.Jobs != 0 {
+	if options.JobSemaphore == nil && options.Jobs != nil && *options.Jobs != 0 {
 		options.JobSemaphore = semaphore.NewWeighted(int64(*options.Jobs))
 	}
 
@@ -201,6 +201,8 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 		platformContext.VariantChoice = platform.Variant
 		platformOptions := options
 		platformOptions.SystemContext = &platformContext
+		platformOptions.OS = platform.OS
+		platformOptions.Architecture = platform.Arch
 		logPrefix := ""
 		if len(options.Platforms) > 1 {
 			logPrefix = "[" + platform.OS + "/" + platform.Arch

--- a/tests/bud/multiarch/Dockerfile.fail-multistage
+++ b/tests/bud/multiarch/Dockerfile.fail-multistage
@@ -1,0 +1,18 @@
+FROM registry.access.redhat.com/ubi8-micro
+RUN touch -r /etc/os-release /timestamped
+RUN sleep 0
+FROM registry.access.redhat.com/ubi8-micro
+COPY --from=0 /timestamped /timestamped
+RUN sleep 0
+FROM registry.access.redhat.com/ubi8-micro
+COPY --from=1 /timestamped /timestamped
+RUN sleep 0
+FROM registry.access.redhat.com/ubi8-micro
+COPY --from=2 /timestamped /timestamped
+RUN false
+FROM registry.access.redhat.com/ubi8-micro
+COPY --from=3 /timestamped /timestamped
+RUN sleep 0
+FROM registry.access.redhat.com/ubi8-micro
+COPY --from=4 /timestamped /timestamped
+RUN sleep 0


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If the build for a single stage fails, we break out of the loop that's iterating through all of the stages over in its own goroutine, and start cleaning up after the stages that were already completed.

Because the function that launched that goroutine also calls its cleanup function in non-error cases, the cleanup function sets the map that's used to keep track of what needs to be cleaned up to `nil` after the function finishes iterating through the map, so that we won't try to clean up (a given thing that needs to be cleaned up) more than once.

Because the loop that's iterating through all of the stages is running in its own goroutine, it doesn't stop when the function that started it returns in error cases, so it would still attempt to build subsequent stages.  Have it check for cases where the map variable has already been cleared, or if one of the stages that it's already run returned an error.  If the function that it calls to build the stage, using the map variable as a parameter, is already running at that point, it'll have a non-`nil` map, so it won't crash, but it might not be cleaned up correctly, either.

If such a stage finishes, either successfully or with an error, the goroutine would try to pass the result back to its parent(?) goroutine over a channel that was no longer being read from, and it would stall, never releasing the jobs semaphore.  Because we started sharing that semaphore across multiple-platform builds, builds for other platforms would stall completely, and the whole build would stall.  Make the results channel into a buffered channel to allow it to not stall there.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
```