### PR TITLE
Replace fmt.Sprintf("%d", x) with strconv.Itoa(x)

### DIFF
--- a/chroot/run_test.go
+++ b/chroot/run_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -193,7 +194,7 @@ func TestProcessEnv(t *testing.T) {
 	testMinimal(t,
 		func(g *generate.Generator, rootDir, bundleDir string) {
 			g.ClearProcessEnv()
-			g.AddProcessEnv("PARENT_TEST_PID", fmt.Sprintf("%d", syscall.Getpid()))
+			g.AddProcessEnv("PARENT_TEST_PID", strconv.Itoa(syscall.Getpid()))
 		},
 		func(t *testing.T, report *types.TestReport) {
 			for _, ev := range report.Spec.Process.Env {

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -1632,7 +1633,7 @@ func TestHandleRename(t *testing.T) {
 		{"c/2", "d/2"},
 	}
 	for i, testCase := range testCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			renamed := handleRename(renames, testCase[0])
 			assert.Equal(t, testCase[1], renamed, "expected to get %q, got %q", testCase[1], renamed)
 		})

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -353,7 +353,7 @@ func (b *Executor) resolveNameToImageRef(output string) (types.ImageReference, e
 func (b *Executor) waitForStage(ctx context.Context, name string, stages imagebuilder.Stages) (bool, error) {
 	found := false
 	for _, otherStage := range stages {
-		if otherStage.Name == name || fmt.Sprintf("%d", otherStage.Position) == name {
+		if otherStage.Name == name || strconv.Itoa(otherStage.Position) == name {
 			found = true
 			break
 		}
@@ -708,7 +708,7 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 
 		b.stagesLock.Lock()
 		b.terminatedStage[stage.Name] = r.Error
-		b.terminatedStage[fmt.Sprintf("%d", stage.Position)] = r.Error
+		b.terminatedStage[strconv.Itoa(stage.Position)] = r.Error
 
 		if r.Error != nil {
 			b.stagesLock.Unlock()

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -673,8 +673,8 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 	checkForLayers := s.executor.layers && s.executor.useCache
 	moreStages := s.index < len(s.stages)-1
 	lastStage := !moreStages
-	imageIsUsedLater := moreStages && (s.executor.baseMap[stage.Name] || s.executor.baseMap[fmt.Sprintf("%d", stage.Position)])
-	rootfsIsUsedLater := moreStages && (s.executor.rootfsMap[stage.Name] || s.executor.rootfsMap[fmt.Sprintf("%d", stage.Position)])
+	imageIsUsedLater := moreStages && (s.executor.baseMap[stage.Name] || s.executor.baseMap[strconv.Itoa(stage.Position)])
+	rootfsIsUsedLater := moreStages && (s.executor.rootfsMap[stage.Name] || s.executor.rootfsMap[strconv.Itoa(stage.Position)])
 
 	// If the base image's name corresponds to the result of an earlier
 	// stage, make sure that stage has finished building an image, and

--- a/imagebuildah/stage_executor_test.go
+++ b/imagebuildah/stage_executor_test.go
@@ -2,7 +2,7 @@ package imagebuildah
 
 import (
 	"encoding/json"
-	"fmt"
+	"strconv"
 	"testing"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -87,7 +87,7 @@ func TestHistoryEntriesEqual(t *testing.T) {
 		},
 	}
 	for i := range testCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var a, b v1.History
 			err := json.Unmarshal([]byte(testCases[i].a), &a)
 			require.Nil(t, err, "error unmarshalling history %q: %v", testCases[i].a, err)

--- a/run_linux.go
+++ b/run_linux.go
@@ -1067,7 +1067,7 @@ func setupRootlessNetwork(pid int) (teardown func(), err error) {
 		unix.CloseOnExec(fd)
 	}
 
-	cmd := exec.Command(slirp4netns, "--mtu", "65520", "-r", "3", "-c", fmt.Sprintf("%d", pid), "tap0")
+	cmd := exec.Command(slirp4netns, "--mtu", "65520", "-r", "3", "-c", strconv.Itoa(pid), "tap0")
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil
 	cmd.ExtraFiles = []*os.File{rootlessSlirpSyncW}
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,8 +1,8 @@
 package util
 
 import (
-	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/containers/common/pkg/config"
@@ -28,7 +28,7 @@ func TestMergeEnv(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			result := MergeEnv(test[0], test[1])
 			if len(result) != len(test[2]) {
 				t.Fatalf("expected %v, got %v", test[2], result)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replace calls to fmt.Sprintf("%d", x) with strconv.Itoa(x), which is slightly faster.

#### How to verify it

The existing tests should be sufficient.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```