### PR TITLE
buildah build: add --all-platforms

### DIFF
--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -329,6 +329,7 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 	options := define.BuildOptions{
 		AddCapabilities:         iopts.CapAdd,
 		AdditionalTags:          tags,
+		AllPlatforms:            iopts.AllPlatforms,
 		Annotations:             iopts.Annotation,
 		Architecture:            systemContext.ArchitectureChoice,
 		Args:                    args,

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -378,6 +378,7 @@ return 1
 
  _buildah_bud() {
      local boolean_options="
+     --all-platforms
      --help
      -h
      --layers

--- a/define/build.go
+++ b/define/build.go
@@ -234,4 +234,8 @@ type BuildOptions struct {
 	// to build the image for.  If this slice has items in it, the OS and
 	// Architecture fields above are ignored.
 	Platforms []struct{ OS, Arch, Variant string }
+	// AllPlatforms tells the builder to set the list of target platforms
+	// to match the set of platforms for which all of the build's base
+	// images are available.  If this field is set, Platforms is ignored.
+	AllPlatforms bool
 }

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -38,6 +38,10 @@ Add a custom host-to-IP mapping (host:ip)
 
 Add a line to /etc/hosts. The format is hostname:ip. The **--add-host** option can be set multiple times.
 
+**--all-platforms**
+
+Instead of building for a set of platforms specified using the **--platform** option, inspect the build's base images, and build for all of the platforms for which they are all available.  Stages that use *scratch* as a starting point can not be inspected, so at least one non-*scratch* stage must be present for detection to work usefully.
+
 **--annotation** *annotation*
 
 Add an image *annotation* (e.g. annotation=*value*) to the image metadata. Can be used multiple times.
@@ -808,6 +812,8 @@ buildah build --arch s390x --manifest myimage /tmp/mysrc
 buildah bud --platform linux/s390x,linux/ppc64le,linux/amd64 --manifest myimage /tmp/mysrc
 
 buildah bud --platform linux/arm64 --platform linux/amd64 --manifest myimage /tmp/mysrc
+
+buildah bud --all-platforms --manifest myimage /tmp/mysrc
 
 ### Building an image using a URL
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -48,6 +48,7 @@ type NameSpaceResults struct {
 
 // BudResults represents the results for Build flags
 type BudResults struct {
+	AllPlatforms        bool
 	Annotation          []string
 	Authfile            string
 	BuildArg            []string
@@ -175,6 +176,7 @@ func GetLayerFlags(flags *LayerResults) pflag.FlagSet {
 // GetBudFlags returns common build flags
 func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs := pflag.FlagSet{}
+	fs.BoolVar(&flags.AllPlatforms, "all-platforms", false, "attempt to build for all base image platforms")
 	fs.String("arch", runtime.GOARCH, "set the ARCH of the image to the provided value instead of the architecture of the host")
 	fs.StringArrayVar(&flags.Annotation, "annotation", []string{}, "Set metadata for an image (default [])")
 	fs.StringVar(&flags.Authfile, "authfile", "", "path of the authentication file.")

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -9,11 +9,11 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"unicode"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/pkg/sshagent"
 	"github.com/containers/common/pkg/parse"
@@ -669,7 +669,7 @@ const platformSep = "/"
 
 // DefaultPlatform returns the standard platform for the current system
 func DefaultPlatform() string {
-	return runtime.GOOS + platformSep + runtime.GOARCH
+	return platforms.DefaultString()
 }
 
 // Platform separates the platform string into os, arch and variant,

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3366,8 +3366,19 @@ _EOF
   if test $status -ne 0 ; then
     skip "unable to run arm container, assuming emulation is not available"
   fi
+  outputlist=localhost/testlist
   run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json --jobs=0 --platform=linux/arm64,linux/amd64 --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.fail-multistage ${TESTSDIR}/bud/multiarch
   expect_output --substring 'error building at STEP "RUN false"'
+}
+
+@test "bud-multiple-platform-no-run" {
+  outputlist=localhost/testlist
+  run_buildah build --signature-policy ${TESTSDIR}/policy.json --jobs=0 --all-platforms --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.no-run ${TESTSDIR}/bud/multiarch
+  run_buildah manifest inspect $outputlist
+  echo "$output"
+  run jq '.manifests | length' <<< "$output"
+  echo "$output"
+  [[ "$output" -gt 1 ]] # should at least be more than one entry in there, right?
 }
 
 # * Performs multi-stage build with label1=value1 and verifies

--- a/tests/bud/multiarch/Dockerfile.no-run
+++ b/tests/bud/multiarch/Dockerfile.no-run
@@ -1,0 +1,7 @@
+# A base image that is known to be a manifest list.
+FROM docker.io/library/alpine
+COPY Dockerfile.no-run /root/
+# A different base image that is known to be a manifest list, supporting a
+# different but partially-overlapping set of platforms.
+FROM registry.access.redhat.com/ubi8-micro
+COPY --from=0 /root/Dockerfile.no-run /root/


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a `--all-platforms` that instructs the builder to build for the intersection of all platforms for which the build's base images are available.  Returns an error if any of them aren't references to manifest lists.  We've learned that we can't really trust architecture and OS information stored in image config blobs, so we don't try to salvage that case.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The bits where we populate and prune the list of platforms that all of our base images support use versions both with and without variant information in order to avoid dropping 64-bit ARM when one base image is for variant "v8" and one doesn't specify a variant.  It's not ideal, but I think it's within the bounds of for how variant information is meant to be treated.

#### Does this PR introduce a user-facing change?

```release-note
Added the --all-platforms option to "buildah build".
```