### PR TITLE
Cirrus: Workaround defunct package metadata

### DIFF
--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -37,7 +37,11 @@ EOF
             # Need to re-build lists (removed during image production)
             lilto apt-get -qq -y update
             msg "Installing previously downloaded/cached packages"
-            $SHORT_APTGET install --no-download --ignore-missing containerd.io docker-ce docker-ce-cli
+            # TODO: Workaround metadata update (above) ruining usefulness
+            # of pre-populated package cache.
+            # Ref: https://github.com/containers/automation_images/issues/95
+            # i.e. this should at least specify --no-download
+            $SHORT_APTGET install containerd.io docker-ce docker-ce-cli
 
             # At the time of this comment, Ubuntu is using systemd-resolved
             # which interfears badly with conformance testing.  Some tests


### PR DESCRIPTION
#### What type of PR is this?

> /kind flake

#### What this PR does / why we need it:

During VM image build, a number of packages are downloaded but not
installed, since they may interfere with some testing.  Then at runtime,
where required, the packages are installed from cache and used.  This
mechanism broke, and is being investigated in
https://github.com/containers/automation_images/issues/95

#### How to verify it

The setup stage for the conformance tests will pass without error.

#### Which issue(s) this PR fixes:

Broken CI

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None