### PR TITLE
Cirrus: Fix defunct package metadata breaking cache

### DIFF
--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -34,10 +34,10 @@ EOF
         ;;
     ubuntu)
         if [[ "$1" == "conformance" ]]; then
-            # Need to re-build lists (removed during image production)
-            lilto apt-get -qq -y update
             msg "Installing previously downloaded/cached packages"
-            $SHORT_APTGET install --no-download --ignore-missing containerd.io docker-ce docker-ce-cli
+            ooe.sh dpkg -i \
+                $PACKAGE_DOWNLOAD_DIR/containerd.io*.deb \
+                $PACKAGE_DOWNLOAD_DIR/docker-ce*.deb
 
             # At the time of this comment, Ubuntu is using systemd-resolved
             # which interfears badly with conformance testing.  Some tests


### PR DESCRIPTION
#### What type of PR is this?

> /kind flake

#### What this PR does / why we need it:

During VM image build, a number of packages are downloaded but not
installed, since they may interfere with some testing.  Then at runtime,
where required, the packages are installed from cache and used.
However, between image build and runtime it's possible the repository
contents change, which will invalidate the package cache.  Since the
`--no-download --ignore-missing` options were used, the install will
fail.

Ref: https://github.com/containers/automation_images/issues/95

Fortunately, when it comes to the docker packages, no other dependencies
are required and so `apt-get` isn't required.  Switch to using a simple
dpkg install command on the necessary files.  If this ever breaks due
to new dependencies, the list of files may simply be updated.

#### How to verify it

The setup stage of the conformance tests will pass.

#### Which issue(s) this PR fixes:

Fixes https://github.com/containers/automation_images/issues/95

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None