### PR TITLE
buildkit: add support for persistent caching across builds with `--mount=type=cache`

### DIFF
--- a/docs/Containerfile.5.md
+++ b/docs/Containerfile.5.md
@@ -102,13 +102,15 @@ A Containerfile is similar to a Makefile.
 
 Attach a filesystem mount to the container
 
-Current supported mount TYPES are bind, and tmpfs.
+Current supported mount TYPES are bind, cache, secret and tmpfs.
 
        e.g.
 
        mount=type=bind,source=/path/on/host,destination=/path/in/container
 
        mount=type=tmpfs,tmpfs-size=512M,destination=/path/in/container
+
+       mount=type=secret,id=mysecret cat /run/secrets/mysecret
 
        Common Options:
 
@@ -131,6 +133,19 @@ Current supported mount TYPES are bind, and tmpfs.
               · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
 
               · tmpcopyup: Path that is shadowed by the tmpfs mount is recursively copied up to the tmpfs itself.
+
+	Options specific to cache:
+
+              · id: Create a separate cache directory for a particular id.
+
+              · mode: File mode for new cache directory in octal. Default 0755.
+
+              · ro, readonly: read only cache if set.
+
+              · uid: uid for cache directory.
+
+              · gid: gid for cache directory.
+
 
 **RUN Secrets**
 

--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -103,13 +103,15 @@ BUILDAH\_ISOLATION environment variable.  `export BUILDAH_ISOLATION=oci`
 
 Attach a filesystem mount to the container
 
-Current supported mount TYPES are bind, and tmpfs. <sup>[[1]](#Footnote1)</sup>
+Current supported mount TYPES are bind, cache, secret and tmpfs. <sup>[[1]](#Footnote1)</sup>
 
        e.g.
 
        type=bind,source=/path/on/host,destination=/path/in/container
 
        type=tmpfs,tmpfs-size=512M,destination=/path/in/container
+
+       type=cache,target=/path/in/container
 
        Common Options:
 
@@ -132,6 +134,22 @@ Current supported mount TYPES are bind, and tmpfs. <sup>[[1]](#Footnote1)</sup>
               · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
 
               · tmpcopyup: Path that is shadowed by the tmpfs mount is recursively copied up to the tmpfs itself.
+
+       Options specific to secret:
+
+              · id: the identifier for the secret passed into the `buildah bud --secret` or `podman build --secret` command.
+
+       Options specific to cache:
+
+              · id: Create a separate cache directory for a particular id.
+
+              · mode: File mode for new cache directory in octal. Default 0755.
+
+              · ro, readonly: read only cache if set.
+
+              · uid: uid for cache directory.
+
+              · gid: gid for cache directory.
 
 **--network**, **--net**=*mode*
 

--- a/run_linux.go
+++ b/run_linux.go
@@ -2407,6 +2407,13 @@ func (b *Builder) runSetupRunMounts(mounts []string, secrets map[string]string, 
 			}
 			finalMounts = append(finalMounts, *mount)
 			mountTargets = append(mountTargets, mount.Destination)
+		case "cache":
+			mount, err := b.getCacheMount(tokens, rootUID, rootGID, processUID, processGID)
+			if err != nil {
+				return nil, nil, err
+			}
+			finalMounts = append(finalMounts, *mount)
+			mountTargets = append(mountTargets, mount.Destination)
 		default:
 			return nil, nil, errors.Errorf("invalid mount type %q", kv[1])
 		}
@@ -2439,6 +2446,20 @@ func (b *Builder) getBindMount(tokens []string, contextDir string, rootUID, root
 func (b *Builder) getTmpfsMount(tokens []string, rootUID, rootGID, processUID, processGID int) (*spec.Mount, error) {
 	var optionMounts []specs.Mount
 	mount, err := parse.GetTmpfsMount(tokens)
+	if err != nil {
+		return nil, err
+	}
+	optionMounts = append(optionMounts, mount)
+	volumes, err := b.runSetupVolumeMounts(b.MountLabel, nil, optionMounts, rootUID, rootGID, processUID, processGID)
+	if err != nil {
+		return nil, err
+	}
+	return &volumes[0], nil
+}
+
+func (b *Builder) getCacheMount(tokens []string, rootUID, rootGID, processUID, processGID int) (*spec.Mount, error) {
+	var optionMounts []specs.Mount
+	mount, err := parse.GetCacheMount(tokens)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3579,3 +3579,15 @@ _EOF
   expect_output --substring "certs"
   run_buildah rmi -f testbud
 }
+
+@test "bud-with-mount-cache-like-buildkit" {
+  skip_if_no_runtime
+  skip_if_in_container
+  # try writing something to persistant cache
+  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/buildkit-mount/Dockerfilecachewrite
+  # try reading something from persistant cache in a different build
+  run_buildah build -t testbud2 --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/buildkit-mount/Dockerfilecacheread
+  expect_output --substring "hello"
+  run_buildah rmi -f testbud
+  run_buildah rmi -f testbud2
+}

--- a/tests/bud/buildkit-mount/Dockerfilecacheread
+++ b/tests/bud/buildkit-mount/Dockerfilecacheread
@@ -1,0 +1,4 @@
+FROM alpine
+RUN mkdir /test
+# use option z if selinux is enabled
+RUN --mount=type=cache,target=/test,z cat /test/world

--- a/tests/bud/buildkit-mount/Dockerfilecachewrite
+++ b/tests/bud/buildkit-mount/Dockerfilecachewrite
@@ -1,0 +1,4 @@
+FROM alpine
+RUN mkdir /test
+# use option z if selinux is enabled
+RUN --mount=type=cache,target=/test,z echo hello > /test/world


### PR DESCRIPTION
Following PR introduces a new mount `type=cache` in parity to buildkit
which allows users to share persistent cache between different builds.

Allowing users to cache content generated by business logic or enhance
build performance by caching components across various builds.

Closes: https://github.com/containers/buildah/issues/3452