### PR TITLE
buildkit: Add support for `--mount=type=tmpfs` to allow mounting volatile memory instead of persistent storage.

### DIFF
--- a/docs/Containerfile.5.md
+++ b/docs/Containerfile.5.md
@@ -94,14 +94,49 @@ A Containerfile is similar to a Makefile.
   # Executable form
   RUN ["executable", "param1", "param2"]
   ```
+**RUN mounts**
 
-**RUN Secrets*
+**--mount**=*type=TYPE,TYPE-SPECIFIC-OPTION[,...]*
+
+Attach a filesystem mount to the container
+
+Current supported mount TYPES are bind, and tmpfs.
+
+       e.g.
+
+       mount=type=bind,source=/path/on/host,destination=/path/in/container
+
+       mount=type=tmpfs,tmpfs-size=512M,destination=/path/in/container
+
+       Common Options:
+
+              · src, source: mount source spec for bind and volume. Mandatory for bind.
+
+              · dst, destination, target: mount destination spec.
+
+              · ro, read-only: true or false (default).
+
+       Options specific to bind:
+
+              · bind-propagation: shared, slave, private, rshared, rslave, or rprivate(default). See also mount(2).
+
+              . bind-nonrecursive: do not setup a recursive bind mount.  By default it is recursive.
+
+       Options specific to tmpfs:
+
+              · tmpfs-size: Size of the tmpfs mount in bytes. Unlimited by default in Linux.
+
+              · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
+
+              · tmpcopyup: Path that is shadowed by the tmpfs mount is recursively copied up to the tmpfs itself.
+
+**RUN Secrets**
 
 The RUN command has a feature to allow the passing of secret information into the image build. These secrets files can be used during the RUN command but are not committed to the final image. The `RUN` command supports the `--mount` option to identify the secret file. A secret file from the host is mounted into the container while the image is being built.
 
 Container engines pass secret the secret file into the build using the `--secret` flag.
 
-**RUN --mount* options:
+**--mount**=*type=secret,TYPE-SPECIFIC-OPTION[,...]*
 
 - `id` is the identifier to for the secret passed into the `buildah bud --secret` or `podman build --secret`. This identifier is associated with the RUN --mount identifier to use in the Containerfile.
 

--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -131,6 +131,8 @@ Current supported mount TYPES are bind, and tmpfs. <sup>[[1]](#Footnote1)</sup>
 
               · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
 
+              · tmpcopyup: Path that is shadowed by the tmpfs mount is recursively copied up to the tmpfs itself.
+
 **--network**, **--net**=*mode*
 
 Sets the configuration for the network namespace for the container.

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -431,6 +431,9 @@ func GetTmpfsMount(args []string) (specs.Mount, error) {
 		case "readonly":
 			// Alias for "ro"
 			newMount.Options = append(newMount.Options, "ro")
+		case "tmpcopyup":
+			//the path that is shadowed by the tmpfs mount is recursively copied up to the tmpfs itself.
+			newMount.Options = append(newMount.Options, kv[0])
 		case "tmpfs-mode":
 			if len(kv) == 1 {
 				return newMount, errors.Wrapf(optionArgError, kv[0])

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3550,3 +3550,12 @@ _EOF
   expect_output --substring "world"
   run_buildah rmi -f testbud
 }
+
+@test "bud-with-mount-with-tmpfs-like-buildkit" {
+  skip_if_no_runtime
+  skip_if_in_container
+  # tmpfs mount: target should be available on container without creating any special directory on container
+  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/buildkit-mount/Dockerfiletmpfs
+  [ "$status" -eq 0 ]
+  run_buildah rmi -f testbud
+}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3559,3 +3559,11 @@ _EOF
   [ "$status" -eq 0 ]
   run_buildah rmi -f testbud
 }
+
+@test "bud-with-mount-with-tmpfs-with-copyup-like-buildkit" {
+  skip_if_no_runtime
+  skip_if_in_container
+  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/buildkit-mount/Dockerfiletmpfscopyup
+  expect_output --substring "certs"
+  run_buildah rmi -f testbud
+}

--- a/tests/bud/buildkit-mount/Dockerfiletmpfs
+++ b/tests/bud/buildkit-mount/Dockerfiletmpfs
@@ -1,0 +1,4 @@
+FROM alpine
+
+# As a baseline, this should succeed without creating any directory on container
+RUN --mount=type=tmpfs,target=/var/tmpfs-not-empty touch /var/tmpfs-not-empty/hello

--- a/tests/bud/buildkit-mount/Dockerfiletmpfscopyup
+++ b/tests/bud/buildkit-mount/Dockerfiletmpfscopyup
@@ -1,0 +1,4 @@
+FROM alpine
+
+# As a baseline, this should succeed without creating any directory on container
+RUN --mount=type=tmpfs,target=/etc/ssl,tmpcopyup ls /etc/ssl


### PR DESCRIPTION
Following PR adds supports for buildkit like `--mount=type=tmpfs` which
allows end users to mount a chunk of volatile memory instead of a persistent storage device within container.

Usage
```Dockerfile
RUN --mount=type=tmpfs,target=/sometarget
```