### PR TITLE
Report ignorefile location when no content added

### DIFF
--- a/add.go
+++ b/add.go
@@ -47,8 +47,10 @@ type AddAndCopyOptions struct {
 	// If the sources include directory trees, Hasher will be passed
 	// tar-format archives of the directory trees.
 	Hasher io.Writer
-	// Excludes is the contents of the .dockerignore file.
+	// Excludes is the contents of the .containerignore file.
 	Excludes []string
+	// IgnoreFile is the path to the .containerignore file.
+	IgnoreFile string
 	// ContextDir is the base directory for content being copied and
 	// Excludes patterns.
 	ContextDir string
@@ -564,7 +566,11 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			}
 		}
 		if itemsCopied == 0 {
-			return errors.Wrapf(syscall.ENOENT, "no items matching glob %q copied (%d filtered out)", localSourceStat.Glob, len(localSourceStat.Globbed))
+			excludesFile := ""
+			if options.IgnoreFile != "" {
+				excludesFile = " using " + options.IgnoreFile
+			}
+			return errors.Wrapf(syscall.ENOENT, "no items matching glob %q copied (%d filtered out%s)", localSourceStat.Glob, len(localSourceStat.Globbed), excludesFile)
 		}
 	}
 	return nil

--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -317,7 +317,7 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 
 	var excludes []string
 	if iopts.IgnoreFile != "" {
-		if excludes, err = parseIgnore(iopts.IgnoreFile); err != nil {
+		if excludes, _, err = parse.ContainerIgnoreFile(contextDir, iopts.IgnoreFile); err != nil {
 			return err
 		}
 	}
@@ -350,6 +350,7 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 		IIDFile:                 iopts.Iidfile,
 		In:                      stdin,
 		Isolation:               isolation,
+		IgnoreFile:              iopts.IgnoreFile,
 		Labels:                  iopts.Label,
 		Layers:                  layers,
 		LogRusage:               iopts.LogRusage,

--- a/define/build.go
+++ b/define/build.go
@@ -227,6 +227,8 @@ type BuildOptions struct {
 	RusageLogFile string
 	// Excludes is a list of excludes to be used instead of the .dockerignore file.
 	Excludes []string
+	// IgnoreFile is a name of the .containerignore file
+	IgnoreFile string
 	// From is the image name to use to replace the value specified in the first
 	// FROM instruction in the Containerfile
 	From string

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -101,6 +101,7 @@ type Executor struct {
 	rootfsMap                      map[string]bool             // Holds the names of every stage whose rootfs is referenced in a COPY or ADD instruction.
 	blobDirectory                  string
 	excludes                       []string
+	ignoreFile                     string
 	unusedArgs                     map[string]struct{}
 	capabilities                   []string
 	devices                        define.ContainerDevices
@@ -143,7 +144,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 
 	excludes := options.Excludes
 	if len(excludes) == 0 {
-		excludes, err = imagebuilder.ParseDockerignore(options.ContextDirectory)
+		excludes, options.IgnoreFile, err = parse.ContainerIgnoreFile(options.ContextDirectory, options.IgnoreFile)
 		if err != nil {
 			return nil, err
 		}
@@ -208,6 +209,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		store:                          store,
 		contextDir:                     options.ContextDirectory,
 		excludes:                       excludes,
+		ignoreFile:                     options.IgnoreFile,
 		pullPolicy:                     options.PullPolicy,
 		registry:                       options.Registry,
 		ignoreUnrecognizedInstructions: options.IgnoreUnrecognizedInstructions,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -401,6 +401,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 			PreserveOwnership: preserveOwnership,
 			ContextDir:        contextDir,
 			Excludes:          copyExcludes,
+			IgnoreFile:        s.executor.ignoreFile,
 			IDMappingOptions:  idMappingOptions,
 			StripSetuidBit:    stripSetuid,
 			StripSetgidBit:    stripSetgid,

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containers/storage/pkg/unshare"
 	units "github.com/docker/go-units"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/openshift/imagebuilder"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -1230,4 +1231,21 @@ func SSH(sshSources []string) (map[string]*sshagent.Source, error) {
 		parsed[parts[0]] = source
 	}
 	return parsed, nil
+}
+
+func ContainerIgnoreFile(contextDir, path string) ([]string, string, error) {
+	if path != "" {
+		excludes, err := imagebuilder.ParseIgnore(path)
+		return excludes, path, err
+	}
+	path = filepath.Join(contextDir, ".containerignore")
+	excludes, err := imagebuilder.ParseIgnore(path)
+	if os.IsNotExist(err) {
+		path = filepath.Join(contextDir, ".dockerignore")
+		excludes, err = imagebuilder.ParseIgnore(path)
+	}
+	if os.IsNotExist(err) {
+		return excludes, "", nil
+	}
+	return excludes, path, err
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -110,6 +110,7 @@ symlink(subdir)"
 @test "bud with .dockerignore #2" {
   run_buildah 125 build -t testbud3 --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/dockerignore3
   expect_output --substring 'error building.*"COPY test1.txt /upload/test1.txt".*no such file or directory'
+  expect_output --substring $(realpath "${TESTSDIR}/bud/dockerignore3/.dockerignore")
 }
 
 @test "bud-flags-order-verification" {


### PR DESCRIPTION
Users have accidently had a .containerignore or .dockerignore
file in their context directly which blocked all content.
Currently we report that no globs matched, but do not
identify where the globs came from.

This change is an attempt to add this data to the error.
Example: https://github.com/containers/buildah/issues/3318

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

