### PR TITLE
[CI:DOCS] Touch up Containerfile man page to show ARG can be 1st

### DIFF
--- a/docs/Containerfile.5.md
+++ b/docs/Containerfile.5.md
@@ -61,8 +61,10 @@ A Containerfile is similar to a Makefile.
   `FROM image@digest`
 
   -- The **FROM** instruction sets the base image for subsequent instructions. A
-  valid Containerfile must have **FROM** as its first instruction. The image can be any
-  valid image. It is easy to start by pulling an image from the public
+  valid Containerfile must have either **ARG** or *FROM** as its first instruction.
+  If **FROM** is not the first instruction in the file, it may only be preceded by
+  one or more ARG instructions, which declare arguments that are used in the next FROM line in the Containerfile.
+  The image can be any valid image. It is easy to start by pulling an image from the public
   repositories.
 
   -- **FROM** must appear at least once in the Containerfile.


### PR DESCRIPTION
The Containerfile man page says FROM must be the first statement
in the file.  However, that is not true as the ARG instruction can proceed it.

Fixes: #3555

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


> /kind bug

#### What this PR does / why we need it:

Fixes the Containerfile man page which stated FROM had to be the first instruction, when it is permissible to have ARG.

#### How to verify it

Read

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

