### PR TITLE
Support overlayfs path contains colon

### DIFF
--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -88,7 +88,7 @@ func mountHelper(contentDir, source, dest string, _, _ int, graphOptions []strin
 		if err := os.Mkdir(lowerTwo, 0755); err != nil {
 			return mount, err
 		}
-		overlayOptions = fmt.Sprintf("lowerdir=%s:%s,private", source, lowerTwo)
+		overlayOptions = fmt.Sprintf("lowerdir=%s:%s,private", escapeColon(source), lowerTwo)
 	} else {
 		// Read-write overlay mounts want a lower, upper and a work layer.
 		workDir := filepath.Join(contentDir, "work")
@@ -105,8 +105,7 @@ func mountHelper(contentDir, source, dest string, _, _ int, graphOptions []strin
 				return mount, err
 			}
 		}
-
-		overlayOptions = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,private", source, upperDir, workDir)
+		overlayOptions = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,private", escapeColon(source), upperDir, workDir)
 	}
 
 	if unshare.IsRootless() {
@@ -153,6 +152,11 @@ func mountHelper(contentDir, source, dest string, _, _ int, graphOptions []strin
 	mount.Options = strings.Split(overlayOptions, ",")
 
 	return mount, nil
+}
+
+// Convert ":" to "\:", the path which will be overlay mounted need to be escaped
+func escapeColon(source string) string {
+	return strings.ReplaceAll(source, ":", "\\:")
 }
 
 // RemoveTemp removes temporary mountpoint and all content from its parent

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -141,3 +141,19 @@ func TestParsePlatform(t *testing.T) {
 	_, _, _, err = Platform("a")
 	assert.Error(t, err)
 }
+
+func TestSplitStringWithColonEscape(t *testing.T) {
+	tests := []struct {
+		volume         string
+		expectedResult []string
+	}{
+		{"/root/a:/root/test:O", []string{"/root/a", "/root/test", "O"}},
+		{"/root/a\\:b/c:/root/test:O", []string{"/root/a:b/c", "/root/test", "O"}},
+		{"/root/a:/root/test\\:test1/a:O", []string{"/root/a", "/root/test:test1/a", "O"}},
+		{"/root/a\\:b/c:/root/test\\:test1/a:O", []string{"/root/a:b/c", "/root/test:test1/a", "O"}},
+	}
+	for _, args := range tests {
+		val := SplitStringWithColonEscape(args.volume)
+		assert.Equal(t, val, args.expectedResult)
+	}
+}

--- a/run_linux.go
+++ b/run_linux.go
@@ -1925,7 +1925,7 @@ func (b *Builder) runSetupVolumeMounts(mountLabel string, volumeMounts []string,
 	// Bind mount volumes given by the user when the container was created
 	for _, i := range volumeMounts {
 		var options []string
-		spliti := strings.Split(i, ":")
+		spliti := parse.SplitStringWithColonEscape(i)
 		if len(spliti) > 2 {
 			options = strings.Split(spliti[2], ",")
 		}


### PR DESCRIPTION
Signed-off-by: chenk008 <kongchen28@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind bug


#### What this PR does / why we need it:

After patched this PR https://github.com/containers/podman/pull/11912,  `podman run --rootfs /root/a:b:O echo hello` failed with error message
```
Error: rootfs-overlay: creating overlay failed "/root/a:b" from native overlay: mount overlay:/var/lib/containers/storage/overlay-containers/6f8b0d6252f15175c8006235ad246a9b163ed293ba4dcc8886a65d7d5673fd21/rootfs/merge, flags: 0x4, data: lowerdir=/root/a:b,upperdir=/var/lib/containers/storage/overlay-containers/6f8b0d6252f15175c8006235ad246a9b163ed293ba4dcc8886a65d7d5673fd21/rootfs/upper,workdir=/var/lib/containers/storage/overlay-containers/6f8b0d6252f15175c8006235ad246a9b163ed293ba4dcc8886a65d7d5673fd21/rootfs/work,context="system_u:object_r:container_file_t:s0:c364,c880": no such file or directory
```

But overlayfs mount support path which contains colon, the below command works.
```
mount -t overlay overlay -o lowerdir='/root/a\:b',upperdir=/var/lib/containers/storage/overlay-containers/4eb7c0ede19c7a837b7d790d5d2bc7c3ad95cd47fbedc056a96a45e8c371201e/rootfs/upper,workdir=/var/lib/containers/storage/overlay-containers/4eb7c0ede19c7a837b7d790d5d2bc7c3ad95cd47fbedc056a96a45e8c371201e/rootfs/work /var/lib/containers/storage/overlay-containers/4eb7c0ede19c7a837b7d790d5d2bc7c3ad95cd47fbedc056a96a45e8c371201e/rootfs/merge
```


#### How to verify it

`podman run --rootfs /root/a:b:O echo hello` succeeded to echo hello.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->


It is related to  https://github.com/containers/podman/issues/11913


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->


