### PR TITLE
[CI:DOCS] Include manifest example usage

### DIFF
--- a/docs/buildah-manifest.1.md
+++ b/docs/buildah-manifest.1.md
@@ -27,5 +27,49 @@ The `buildah manifest` command provides subcommands which can be used to:
 | remove   | [buildah-manifest-remove(1)](buildah-manifest-remove.1.md)     | Remove an image from a manifest list or image index.                        |
 | rm       | [buildah-manifest-rm(1)](buildah-manifest-rm.1.md)             | Remove manifest list from local storage.                                    |
 
+
+## EXAMPLES
+
+### Building a multi-arch manifest list from a Containerfile
+
+Assuming the `Containerfile` uses `RUN` instructions, the host needs
+a way to execute non-native binaries.  Configuring this is beyond
+the scope of this example.  Building a multi-arch manifest list
+`shazam` in parallel across 4-threads can be done like this:
+
+        $ platarch=linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+        $ buildah build --jobs=4 --platform=$platarch --manifest shazam .
+
+**Note:** The `--jobs` argument is optional, and the `-t` or `--tag`
+option should *not* be used.
+
+### Assembling a multi-arch manifest from separately built images
+
+Assuming `example.com/example/shazam:$arch` images are built separately
+on other hosts and pushed to the `example.com` registry.  They may
+be combined into a manifest list, and pushed using a simple loop:
+
+        $ REPO=example.com/example/shazam
+        $ buildah manifest create $REPO:latest
+        $ for IMGTAG in amd64 s390x ppc64le arm64; do \
+                  buildah manifest add $REPO:latest docker://$REPO:IMGTAG; \
+              done
+        $ buildah manifest push --all $REPO:latest
+
+**Note:** The `add` instruction argument order is `<manifest>` then `<image>`.
+Also, the `--all` push option is required to ensure all contents are
+pushed, not just the native platform/arch.
+
+### Removing and tagging a manifest list before pushing
+
+Special care is needed when removing and pushing manifest lists, as opposed
+to the contents.  You almost always want to use the `manifest rm` and
+`manifest push --all` subcommands.  For example, a rename and push could
+be performed like this:
+
+        $ buildah tag localhost/shazam example.com/example/shazam
+        $ buildah manifest rm localhost/shazam
+        $ buildah manifest push --all example.com/example/shazam
+
 ## SEE ALSO
 buildah(1), buildah-manifest-create(1), buildah-manifest-add(1), buildah-manifest-remove(1), buildah-manifest-annotate(1), buildah-manifest-inspect(1), buildah-manifest-push(1), buildah-manifest-rm(1)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This duplicates https://github.com/containers/podman/pull/11889 which is
annoying, but there seems no easy way to avoid it.  The
commands/examples have been 'translated' for Buildah.

#### How to verify it

Documentation change must be manually verified.

#### Which issue(s) this PR fixes:

Fixes https://github.com/containers/podman/issues/8872

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

None