### PR TITLE
Default secret mode to 400

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -2459,7 +2459,7 @@ func getSecretMount(tokens []string, secrets map[string]string, mountlabel strin
 	var id, target string
 	var required bool
 	var uid, gid uint32
-	var mode uint32 = 400
+	var mode uint32 = 0400
 	for _, val := range tokens {
 		kv := strings.SplitN(val, "=", 2)
 		switch kv[0] {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3289,6 +3289,18 @@ _EOF
   expect_output --substring "cat: can't open '/mysecret': No such file or directory"
 }
 
+@test "bud with default mode perms" {
+  _prefetch alpine
+  mytmpdir=${TESTDIR}/my-dir1
+  mkdir -p ${mytmpdir}
+  cat > $mytmpdir/mysecret << _EOF
+SOMESECRETDATA
+_EOF
+
+  run_buildah bud --secret=id=mysecret,src=${mytmpdir}/mysecret --signature-policy ${TESTSDIR}/policy.json  -t secretmode -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-mode ${TESTSDIR}/bud/run-mounts
+  expect_output --substring "400"
+}
+
 @test "bud with containerfile secret options" {
   _prefetch alpine
   mytmpdir=${TESTDIR}/my-dir1

--- a/tests/bud/run-mounts/Dockerfile.secret-mode
+++ b/tests/bud/run-mounts/Dockerfile.secret-mode
@@ -1,0 +1,2 @@
+FROM alpine
+RUN --mount=type=secret,id=mysecret stat -c "%a" /run/secrets/mysecret


### PR DESCRIPTION
Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:

Fixed a bug where buildah bud mounted secrets permissions were incorrect due to a decimal/octal conversion error. buildah bud mounted secrets now have a default permission of 400.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

Fixes #3557

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

