### PR TITLE
Rootless containers users should use additional groups

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -2148,7 +2148,6 @@ func (b *Builder) configureEnvironment(g *generate.Generator, options RunOptions
 }
 
 func setupRootlessSpecChanges(spec *specs.Spec, bundleDir string, shmSize string) error {
-	spec.Process.User.AdditionalGids = nil
 	spec.Linux.Resources = nil
 
 	emptyDir := filepath.Join(bundleDir, "empty")

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3592,3 +3592,8 @@ _EOF
   run_buildah rmi -f testbud
   run_buildah rmi -f testbud2
 }
+
+@test "bud with user in groups" {
+  target=bud-group
+  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/group
+}

--- a/tests/bud/group/Containerfile
+++ b/tests/bud/group/Containerfile
@@ -1,0 +1,11 @@
+FROM alpine
+
+RUN adduser -D -g 'Susan' susan \
+  && addgroup cool_kids \
+  && addgroup susan cool_kids \
+  && addgroup good_kids \
+  && addgroup susan good_kids
+
+USER susan
+
+RUN groups  | grep cool_kids


### PR DESCRIPTION
Fixes https://github.com/containers/buildah/issues/3592

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

