### PR TITLE
build: history should not contain `ARG` values. OTOH `RUN` history should contain final values.

### DIFF
--- a/tests/bud/with-arg/Dockerfile
+++ b/tests/bud/with-arg/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+ARG FOO
+ENV FOO=bat
+RUN echo $FOO

--- a/tests/bud/with-arg/Dockerfile2
+++ b/tests/bud/with-arg/Dockerfile2
@@ -1,0 +1,4 @@
+FROM alpine
+ARG FOO
+ENV FOO=${FOO}
+RUN echo $FOO


### PR DESCRIPTION
It seems docker never writes ARG values to build history and only writes
values with RUN statements. As a result it can utilize caching better if
assgnment of an ARG value is never used.

Instance
```Dockerfile
FROM alpine
ARG FOO
ENV FOO=bat
RUN echo $FOO
```

In above example --build-arg FOO=value has no significance as value
is always overriden by ENV.

Following PR makes sure buildah mimics a similar behaviour.

Closes: https://github.com/containers/buildah/issues/1936
