### PR TITLE
Add --unsetenv option to buildah commit and build

### DIFF
--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -381,6 +381,7 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 		Excludes:                excludes,
 		Timestamp:               timestamp,
 		Platforms:               platforms,
+		UnsetEnvs:               iopts.UnsetEnvs,
 	}
 	if iopts.Quiet {
 		options.ReportWriter = ioutil.Discard

--- a/commit.go
+++ b/commit.go
@@ -101,6 +101,8 @@ type CommitOptions struct {
 	// integers in the slice represent 0-indexed layer indices, with support for negative
 	// indexing. i.e. 0 is the first layer, -1 is the last (top-most) layer.
 	OciEncryptLayers *[]int
+	// UnsetEnvs is a list of environments to not add to final image.
+	UnsetEnvs []string
 }
 
 var (

--- a/define/build.go
+++ b/define/build.go
@@ -240,4 +240,6 @@ type BuildOptions struct {
 	// to match the set of platforms for which all of the build's base
 	// images are available.  If this field is set, Platforms is ignored.
 	AllPlatforms bool
+	// UnsetEnvs is a list of environments to not add to final image.
+	UnsetEnvs []string
 }

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -586,6 +586,10 @@ include:
   "sigpending": maximum number of pending signals (ulimit -i)
   "stack": maximum stack size (ulimit -s)
 
+**--unsetenv** *env*
+
+Unset environment variables from the final image.
+
 **--userns** *how*
 
 Sets the configuration for user namespaces when handling `RUN` instructions.

--- a/docs/buildah-commit.1.md
+++ b/docs/buildah-commit.1.md
@@ -101,6 +101,10 @@ When --timestamp is set, the created timestamp is always set to the time specifi
 
 Require HTTPS and verification of certificates when talking to container registries (defaults to true).  TLS verification cannot be used when talking to an insecure registry.
 
+**--unsetenv** *env*
+
+Unset environment variables from the final image.
+
 ## EXAMPLE
 
 This example saves an image based on the container.

--- a/image.go
+++ b/image.go
@@ -752,11 +752,31 @@ func (b *Builder) makeImageRef(options CommitOptions) (types.ImageReference, err
 	if manifestType == "" {
 		manifestType = define.OCIv1ImageManifest
 	}
-	oconfig, err := json.Marshal(&b.OCIv1)
+	oci1 := b.OCIv1
+	docker := b.Docker
+	for _, u := range options.UnsetEnvs {
+		var env []string
+		for _, e := range oci1.Config.Env {
+			if strings.HasPrefix(e, u+"=") {
+				continue
+			}
+			env = append(env, e)
+		}
+		oci1.Config.Env = env
+		env = []string{}
+		for _, e := range docker.Config.Env {
+			if strings.HasPrefix(e, u+"=") {
+				continue
+			}
+			env = append(env, e)
+		}
+		docker.Config.Env = env
+	}
+	oconfig, err := json.Marshal(&oci1)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error encoding OCI-format image configuration %#v", b.OCIv1)
 	}
-	dconfig, err := json.Marshal(&b.Docker)
+	dconfig, err := json.Marshal(&docker)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error encoding docker-format image configuration %#v", b.Docker)
 	}

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -126,6 +126,7 @@ type Executor struct {
 	secrets                        map[string]define.Secret
 	sshsources                     map[string]*sshagent.Source
 	logPrefix                      string
+	unsetEnvs                      []string
 }
 
 type imageTypeAndHistoryAndDiffIDs struct {
@@ -270,6 +271,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		secrets:                        secrets,
 		sshsources:                     sshsources,
 		logPrefix:                      logPrefix,
+		unsetEnvs:                      options.UnsetEnvs,
 	}
 	if exec.err == nil {
 		exec.err = os.Stderr

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1403,6 +1403,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		RetryDelay:            s.executor.retryPullPushDelay,
 		HistoryTimestamp:      s.executor.timestamp,
 		Manifest:              s.executor.manifest,
+		UnsetEnvs:             s.executor.unsetEnvs,
 	}
 	imgID, _, manifestDigest, err := s.builder.Commit(ctx, imageRef, options)
 	if err != nil {

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -87,6 +87,7 @@ type BudResults struct {
 	Jobs                int
 	LogRusage           bool
 	RusageLogFile       string
+	UnsetEnvs           []string
 }
 
 // FromAndBugResults represents the results for common flags
@@ -231,6 +232,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.Int64Var(&flags.Timestamp, "timestamp", 0, "set created timestamp to the specified epoch seconds to allow for deterministic builds, defaults to current time")
 	fs.BoolVar(&flags.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	fs.String("variant", "", "override the `variant` of the specified image")
+	fs.StringSliceVar(&flags.UnsetEnvs, "unsetenv", nil, "Unset environment variable from final image")
 	return fs
 }
 
@@ -263,6 +265,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["target"] = commonComp.AutocompleteNone
 	flagCompletion["timestamp"] = commonComp.AutocompleteNone
 	flagCompletion["variant"] = commonComp.AutocompleteNone
+	flagCompletion["unsetenv"] = commonComp.AutocompleteNone
 	return flagCompletion
 }
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -454,6 +454,17 @@ symlink(subdir)"
   expect_output "${target}-working-container"
 }
 
+@test "build --unsetenv PATH" {
+  _prefetch alpine
+  target=scratch-image
+  run_buildah build --unsetenv PATH --signature-policy ${TESTSDIR}/policy.json -t oci-${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah inspect --type=image --format '{{.OCIv1.Config.Env}}' oci-${target}
+  expect_output "[]" "No Path should be defined"
+  run_buildah build --unsetenv PATH --signature-policy ${TESTSDIR}/policy.json --format docker -t docker-${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah inspect --type=image --format '{{.OCIv1.Config.Env}}' docker-${target}
+  expect_output "[]" "No Path should be defined"
+}
+
 @test "bud-from-scratch-untagged" {
   run_buildah build --iidfile ${TESTDIR}/output.iid --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/from-scratch
   iid=$(cat ${TESTDIR}/output.iid)

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -39,6 +39,19 @@ load helpers
   expect_output --from="$mediatype" "application/vnd.docker.image.rootfs.diff.tar.gzip"
 }
 
+@test "commit --unsetenv PATH" {
+  _prefetch alpine
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
+  run_buildah commit --unsetenv PATH --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-oci
+  run_buildah commit --unsetenv PATH --format docker --disable-compression=false --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-docker
+
+  run_buildah inspect --type=image --format '{{.OCIv1.Config.Env}}' alpine-image-oci
+  expect_output "[]" "No Path should be defined"
+  run_buildah inspect --type=image --format '{{.Docker.Config.Env}}' alpine-image-docker
+  expect_output "[]" "No Path should be defined"
+}
+
 @test "commit quiet test" {
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine


### PR DESCRIPTION
This option will allow users to remove environment variables from the
final image.

Fixes: https://github.com/containers/buildah/issues/3512

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

