### PR TITLE
[1.23] unmarshalConvertedConfig(): handle zstd compression

### DIFF
--- a/tests/from.bats
+++ b/tests/from.bats
@@ -612,3 +612,8 @@ load helpers
   run_buildah inspect --format '{{.CNIPluginPath}}' $cid
   expect_output "${cni_plugin_path}"
 }
+
+@test "from-image-with-zstd-compression" {
+  copy --format oci --dest-compress --dest-compress-format zstd docker://quay.io/libpod/alpine_nginx:latest dir:${TESTDIR}/base-image
+  run_buildah from dir:${TESTDIR}/base-image
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:



The Docker manifest format doesn't currently support listing layers compressed using zstd, so we trigger an error when we try to convert an in-memory OCI manifest to the Docker format as a preliminary step in reading the image's config blob in the Docker format.

Instead, first create a temporary copy of the manifest, and then force the MIME types for all layers in the temporary copy of the manifest to appear to be compressed using gzip. Both OCI and Docker formats will accept the resulting manifest without issue. We throw the copy away after we've read the config blob, so the wackiness should be contained.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

