### PR TITLE
rootless: do not bind mount /sys if not needed

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -2164,6 +2164,13 @@ func setupRootlessSpecChanges(spec *specs.Spec, bundleDir string, shmSize string
 		return err
 	}
 
+	// If the container has a network namespace, we can create a fresh /sys mount
+	for _, ns := range spec.Linux.Namespaces {
+		if ns.Type == specs.NetworkNamespace {
+			return nil
+		}
+	}
+
 	// Replace /sys with a read-only bind mount.
 	mounts := []specs.Mount{
 		{

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -50,6 +50,11 @@ load helpers
   run_buildah run $RUNOPTS --net=host "$ctr" readlink /proc/self/ns/net
   expect_output "$mynetns"
 
+  # Check that we are not bind mounting /sys from the host with --net=container
+  host_sys=$(grep "/sys " /proc/self/mountinfo | cut -d ' ' -f 3)
+  run_buildah run $RUNOPTS --net=container "$ctr" sh -c 'grep "/sys " /proc/self/mountinfo | cut -d " " -f 3'
+  assert "$output" != "$host_sys"
+
   # Create a container that doesn't use that mapping.
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet alpine
   ctr="$output"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

> /kind api-change
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

allow to mount a fresh sysfs in the container

#### How to verify it

there is a new test

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

