### PR TITLE
config: support the variant field

### DIFF
--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -43,6 +43,7 @@ type configResults struct {
 	shell                  string
 	stopSignal             string
 	user                   string
+	variant                string
 	volume                 []string
 	workingDir             string
 }
@@ -91,6 +92,7 @@ func init() {
 	flags.StringVar(&opts.shell, "shell", "", "add `shell` to run in containers")
 	flags.StringVar(&opts.stopSignal, "stop-signal", "", "set `stop signal` for containers based on image")
 	flags.StringVarP(&opts.user, "user", "u", "", "set default `user` to run inside containers based on image")
+	flags.StringVar(&opts.variant, "variant", "", "set architecture `variant` of the target image")
 	flags.StringSliceVarP(&opts.volume, "volume", "v", []string{}, "add default `volume` path to be created for containers based on image (default [])")
 	flags.StringVar(&opts.workingDir, "workingdir", "", "set working `directory` for containers based on image")
 
@@ -168,6 +170,9 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 	}
 	if c.Flag("arch").Changed {
 		builder.SetArchitecture(iopts.arch)
+	}
+	if c.Flag("variant").Changed {
+		builder.SetVariant(iopts.variant)
 	}
 	if c.Flag("os").Changed {
 		builder.SetOS(iopts.os)

--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -301,6 +301,7 @@ return 1
        --stop-signal
        --user
        -u
+       --variant
        --volume
        -v
        --workingdir
@@ -435,7 +436,6 @@ return 1
      --os
      --pid
      --platform
-     --platforms
      --runtime
      --runtime-flag
      --security-opt
@@ -451,6 +451,7 @@ return 1
      --userns-uid-map-user
      --userns-gid-map-group
      --uts
+     --variant
      --volume
      -v
   "
@@ -1099,6 +1100,7 @@ esac
 
      local options_with_args="
      --add-host
+     --arch
      --authfile
      --cap-add
      --cap-drop
@@ -1123,7 +1125,9 @@ esac
      --name
      --net
      --network
+     --os
      --pid
+     --platform
      --security-opt
      --shm-size
      --ulimit
@@ -1133,6 +1137,7 @@ esac
      --userns-uid-map-user
      --userns-gid-map-group
      --uts
+     --variant
      --volume
   "
 

--- a/docker/types.go
+++ b/docker/types.go
@@ -151,6 +151,8 @@ type V1Image struct {
 	Config *Config `json:"config,omitempty"`
 	// Architecture is the hardware that the image is build and runs on
 	Architecture string `json:"architecture,omitempty"`
+	// Variant is a variant of the CPU that the image is built and runs on
+	Variant string `json:"variant,omitempty"`
 	// OS is the operating system used to build and run the image
 	OS string `json:"os,omitempty"`
 	// Size is the total size of the image including all layers it is composed of

--- a/docs/buildah-config.1.md
+++ b/docs/buildah-config.1.md
@@ -186,6 +186,13 @@ or UID, optionally followed by a group name or GID, separated by a colon (':').
 If names are used, the container should include entries for those names in its
 */etc/passwd* and */etc/group* files.
 
+**--variant** *variant*
+
+Set the target architecture *variant* for any images which will be built using
+the specified container.  By default, if the container was based on an image,
+that image's target architecture and variant information is kept, otherwise the
+host's architecture and variant are recorded.
+
 **--volume**, **-v** *volume*
 
 Add a location in the directory tree which should be marked as a *volume* in any images which will be built using the specified container. Can be used multiple times. If *volume* has a trailing `-`, and is already set, then the *volume* is removed from the config.

--- a/info.go
+++ b/info.go
@@ -11,10 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/containers/buildah/util"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/system"
 	"github.com/containers/storage/pkg/unshare"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -43,8 +45,10 @@ func Info(store storage.Store) ([]InfoData, error) {
 
 func hostInfo() map[string]interface{} {
 	info := map[string]interface{}{}
-	info["os"] = runtime.GOOS
-	info["arch"] = runtime.GOARCH
+	ps := platforms.Normalize(v1.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH})
+	info["os"] = ps.OS
+	info["arch"] = ps.Architecture
+	info["variant"] = ps.Variant
 	info["cpus"] = runtime.NumCPU()
 	info["rootless"] = unshare.IsRootless()
 

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -198,6 +198,7 @@ function check_matrix() {
    --created-by COINCIDENCE \
    --arch amd64 \
    --os linux \
+   --variant abc \
    --user likes:things \
    --port 12345 \
    --env VARIABLE=VALUE1,VALUE2 \
@@ -228,6 +229,7 @@ function check_matrix() {
   check_matrix 'Author'       'TESTAUTHOR'
   check_matrix 'Architecture' 'amd64'
   check_matrix 'OS'           'linux'
+  check_matrix 'Variant'      'abc'
 
   run_buildah inspect --format '{{.ImageCreatedBy}}' $cid
   expect_output "COINCIDENCE"

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -113,3 +113,14 @@ load helpers
 	run_buildah inspect --format "{{.Docker}}" alpine
         expect_output --substring '\{'
 }
+
+@test "inspect-format-docker-variant" {
+	# github.com/containerd/containerd/platforms.Normalize() converts Arch:"armhf" to Arch:"arm"+Variant:"v7",
+	# so check that platform normalization happens at least for that one
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json --arch=armhf scratch
+	cid=$output
+	run_buildah inspect --format "{{.Docker.Architecture}}" $cid
+	[[ "$output" == "arm" ]]
+	run_buildah inspect --format "{{.Docker.Variant}}" $cid
+	[[ "$output" == "v7" ]]
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add the `variant` field, along with methods for setting and querying it, and expose them in the `buildah config` and `buildah inspect` commands.

When setting an initial architecture for a container based on an image which doesn't contain an architecture, or from "scratch", normalize the architecture name we've been given, and set both it and the variant field at the same time.

Provide normalized architecture+variant values in `buildah info`.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```