### PR TITLE
define.TempDirForURL(): show CombinedOutput when a command fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ LIBSECCOMP_COMMIT := release-2.3
 
 EXTRA_LDFLAGS ?=
 BUILDAH_LDFLAGS := $(GO_LDFLAGS) '-X main.GitCommit=$(GIT_COMMIT) -X main.buildInfo=$(SOURCE_DATE_EPOCH) -X main.cniVersion=$(CNI_COMMIT) $(EXTRA_LDFLAGS)'
-SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go docker/*.go manifests/*.go pkg/blobcache/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go pkg/util/*.go util/*.go
+SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go define/*.go docker/*.go manifests/*.go pkg/blobcache/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go pkg/util/*.go util/*.go
 
 LINTFLAGS ?=
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -738,6 +738,19 @@ function _test_http() {
   run_buildah from ${target}
 }
 
+@test "bud-git-context-failure" {
+  # We need git to be around to try cloning a repository, even though it'll fail
+  # and exit with return code 128.
+  if ! which git ; then
+    skip "no git in PATH"
+  fi
+  target=giturl-image
+  gitrepo=git:///tmp/no-such-repository
+  run_buildah 128 build --signature-policy ${TESTSDIR}/policy.json -t ${target} "${gitrepo}"
+  # Expect part of what git would have told us... before things went horribly wrong
+  expect_output --substring "Cloning into '"
+}
+
 @test "bud-github-context" {
   target=github-image
   # Any repo should do, but this one is small and is FROM: scratch.


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

When `define.TempDirForURL()` runs an external command, if it fails, include the command's output in the error that's handed back to its caller so that the end-user has some idea of what happened.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Out-of-band error report.

#### Special notes for your reviewer:

We really need to stop adding logic to the `define` package.  It drags additional dependencies in for consumers of the package that only want our type definitions, which directly undermines the stated rationale for creating the `define` package and moving type definitions into it.

#### Does this PR introduce a user-facing change?

```release-note
None
```