### PR TITLE
[1.17] Cirrus: Disable conformance test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -124,25 +124,12 @@ gce_instance:
         - './hack/tree_status.sh'
 
 
-'cirrus-ci/only_prs/conformance_task':
-    depends_on:
-        - 'cirrus-ci/only_prs/vendor'
-    gce_instance:  # Only need to specify differences from defaults (above)
-        image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
-
-    timeout_in: 20m
-
-    setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
-    conformance_test_script: '${SCRIPT_BASE}/test.sh conformance |& ${_TIMESTAMP}'
-
-
 'cirrus-ci/success_task':
 
     depends_on:
         - 'cirrus-ci/only_prs/meta'
         - 'cirrus-ci/only_prs/gate'
         - 'cirrus-ci/only_prs/vendor'
-        - 'cirrus-ci/only_prs/conformance'
 
     env:
         CIRRUS_SHELL: direct  # execute command directly


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Unfortunately do to a problem in the scripts that produced these
VM images, and my own misunderstanding of how `apt-get` works,
conformance testing will no longer pass reliably.  Since the upstream
docker package repository deletes old packages, there is no reasonable
way to recover without extensive efforts updating/fixing the tests and
environment.

#### How to verify it

The remaining CI tests will pass

#### Which issue(s) this PR fixes:

Daily cron-jobs and all PRs against this branch will fail 'conformance' test.

#### Special notes for your reviewer:

This is a CI-only change with zero impact on buildah-code.

#### Does this PR introduce a user-facing change?

None