### PR TITLE
ssh-agent: Increase timeout before we explicitly close connection

### DIFF
--- a/pkg/sshagent/sshagent.go
+++ b/pkg/sshagent/sshagent.go
@@ -111,8 +111,9 @@ func (a *AgentServer) Serve(processLabel string) (string, error) {
 				a.wg.Done()
 			}()
 			// the only way to get agent.ServeAgent is to close the connection it's serving on
+			// TODO: ideally we should use some sort of forwarding mechanism for output instead of manually closing connection.
 			go func() {
-				time.Sleep(500 * time.Millisecond)
+				time.Sleep(2000 * time.Millisecond)
 				c.Close()
 			}()
 		}


### PR DESCRIPTION
There are cases where remote will close connection by itself with a message
make sure we give connection enough time instead of closing explictly
early.

**Future improvement:** Relay output and perform close instead of relying on  `ServeAgent` to flush
buffer by closing connection.

Output after this:
```console
STEP 4/4: RUN --mount=type=ssh,required=true ssh git@github.com
Pseudo-terminal will not be allocated because stdin is not a terminal.
Warning: Permanently added the ECDSA host key for IP address '<>' to the list of known hosts.
agent key .. returned incorrect signature type
Hi flouthoc! You've successfully authenticated, but GitHub does not provide shell access.
```
[NO TESTS NEEDED]
There is no convenient way to test this in CI. 

Closes: https://github.com/containers/buildah/issues/3587
