### PR TITLE
Tests should rely only on static/unchanging images

### DIFF
--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -446,7 +446,7 @@ stuff/mystuff"
 
 @test "copy-preserving-extended-attributes" {
   createrandom ${TESTDIR}/randomfile
-  image="registry.fedoraproject.org/fedora-minimal"
+  image="quay.io/libpod/fedora-minimal:34"
   _prefetch $image
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json $image
   first="$output"

--- a/tests/e2e/buildah_suite_test.go
+++ b/tests/e2e/buildah_suite_test.go
@@ -33,7 +33,7 @@ const (
 
 var (
 	integrationRoot    string
-	cacheImages        = []string{"alpine", "busybox", "quay.io/libpod/fedora-minimal:latest"}
+	cacheImages        = []string{"alpine", "busybox", "quay.io/libpod/fedora-minimal:34"}
 	restoreImages      = []string{"alpine", "busybox"}
 	defaultWaitTimeout = 90
 )


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Around 18th of Nov. 2021, a new/incompatible
`quay.io/libpod/fedora-minimal:latest` was pushed by the quay
auto-builder servicing the podman repo.  This caused a number of
problems across several branches.  To address this, the auto-builder was
disabled and a fixed F34 based image was tagged and pushed as both
`latest` and `34`.  However, all repositories which use this test image
need to be individually updated to reference it.

See https://github.com/containers/podman/pull/12343

#### How to verify it

CI will pass

#### Which issue(s) this PR fixes:

None filed

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

None