### PR TITLE
images: accept multiple filter with logical `AND` between them.

### DIFF
--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -58,7 +58,7 @@ type imageOptions struct {
 
 type imageResults struct {
 	imageOptions
-	filter string
+	filter []string
 }
 
 var imagesHeader = map[string]string{
@@ -93,7 +93,7 @@ func init() {
 	flags.SetInterspersed(false)
 	flags.BoolVarP(&opts.all, "all", "a", false, "show all images, including intermediate images from a build")
 	flags.BoolVar(&opts.digests, "digests", false, "show digests")
-	flags.StringVarP(&opts.filter, "filter", "f", "", "filter output based on conditions provided")
+	flags.StringSliceVarP(&opts.filter, "filter", "f", []string{}, "filter output based on conditions provided")
 	flags.StringVar(&opts.format, "format", "", "pretty-print images using a Go template")
 	flags.BoolVar(&opts.json, "json", false, "output in JSON format")
 	flags.BoolVarP(&opts.noHeading, "noheading", "n", false, "do not print column headings")
@@ -135,8 +135,8 @@ func imagesCmd(c *cobra.Command, args []string, iopts *imageResults) error {
 	ctx := context.Background()
 
 	options := &libimage.ListImagesOptions{}
-	if iopts.filter != "" {
-		options.Filters = []string{iopts.filter}
+	if len(iopts.filter) > 0 {
+		options.Filters = iopts.filter
 	}
 	if !iopts.all {
 		options.Filters = append(options.Filters, "intermediate=false")

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -53,6 +53,11 @@ load helpers
 
   run_buildah images --noheading --filter since=k8s.gcr.io/pause
   expect_line_count 1
+
+  # pause* and u* should only give us pause image not busybox since its a AND between
+  # two filters
+  run_buildah images --noheading --filter "reference=pause*" --filter "reference=u*"
+  expect_line_count 1
 }
 
 @test "images format test" {


### PR DESCRIPTION
Already documented but a `NOOP` currently `buildah images` accepts a
single filter however it should accept multiple filters and perform a
logical `AND` between them while fetching images.

`buildah images --filter <1> --filter <2>`

Closes: https://github.com/containers/buildah/issues/3649