### PR TITLE
copier: RemoveAll possibly-directories

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -1681,7 +1681,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 							break
 						}
 					}
-					if err = os.Remove(path); err == nil {
+					if err = os.RemoveAll(path); err == nil {
 						err = os.Link(linkTarget, path)
 					}
 				}
@@ -1696,7 +1696,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 							break
 						}
 					}
-					if err = os.Remove(path); err == nil {
+					if err = os.RemoveAll(path); err == nil {
 						err = os.Symlink(filepath.FromSlash(hdr.Linkname), filepath.FromSlash(path))
 					}
 				}
@@ -1711,7 +1711,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 							break
 						}
 					}
-					if err = os.Remove(path); err == nil {
+					if err = os.RemoveAll(path); err == nil {
 						err = mknod(path, chrMode(0600), int(mkdev(devMajor, devMinor)))
 					}
 				}
@@ -1726,7 +1726,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 							break
 						}
 					}
-					if err = os.Remove(path); err == nil {
+					if err = os.RemoveAll(path); err == nil {
 						err = mknod(path, blkMode(0600), int(mkdev(devMajor, devMinor)))
 					}
 				}
@@ -1758,7 +1758,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 							break
 						}
 					}
-					if err = os.Remove(path); err == nil {
+					if err = os.RemoveAll(path); err == nil {
 						err = mkfifo(path, 0600)
 					}
 				}

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -531,6 +531,7 @@ func testPut(t *testing.T) {
 				archive := makeArchiveSlice([]tar.Header{
 					{Name: "target", Typeflag: tar.TypeReg, Size: 123, Mode: 0755, ModTime: testDate},
 					{Name: "test", Typeflag: tar.TypeDir, Size: 0, Mode: 0755, ModTime: testDate},
+					{Name: "test/content", Typeflag: tar.TypeReg, Size: 0, Mode: 0755, ModTime: testDate},
 					{Name: "test", Typeflag: typeFlag, Size: 0, Mode: 0755, Linkname: "target", ModTime: testDate},
 				})
 				tmp, err := ioutil.TempDir("", "copier-test-")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When we attempt to remove a directory to make way for a non-directory as part of extracting content, use RemoveAll() instead of Remove().

#### How to verify it

Added to a unit test!

#### Which issue(s) this PR fixes:

Fixes #3655 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```