### PR TITLE
image: set MediaType in OCI manifests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.0.2-0.20210819154149-5ad6f50d6283
+	github.com/opencontainers/image-spec v1.0.2-0.20211123152302-43a7dee1ec31
 	github.com/opencontainers/runc v1.0.2
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/runtime-tools v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -684,8 +684,9 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.2-0.20210819154149-5ad6f50d6283 h1:TVzvdjOalkJBNkbpPVMAr4KV9QRf2IjfxdyxwAK78Gs=
 github.com/opencontainers/image-spec v1.0.2-0.20210819154149-5ad6f50d6283/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.0.2-0.20211123152302-43a7dee1ec31 h1:Wh4aR2I6JFwySre9m3iHJYuMnvUFE/HT6qAXozRWi/E=
+github.com/opencontainers/image-spec v1.0.2-0.20211123152302-43a7dee1ec31/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=

--- a/image.go
+++ b/image.go
@@ -239,6 +239,7 @@ func (i *containerImageRef) createConfigsAndManifests() (v1.Image, v1.Manifest, 
 		Versioned: specs.Versioned{
 			SchemaVersion: 2,
 		},
+		MediaType: v1.MediaTypeImageManifest,
 		Config: v1.Descriptor{
 			MediaType: v1.MediaTypeImageConfig,
 		},

--- a/internal/source/create.go
+++ b/internal/source/create.go
@@ -54,6 +54,7 @@ func Create(ctx context.Context, sourcePath string, options CreateOptions) error
 	// Create and write the manifest.
 	manifest := specV1.Manifest{
 		Versioned: spec.Versioned{SchemaVersion: 2},
+		MediaType: specV1.MediaTypeImageManifest,
 		Config: specV1.Descriptor{
 			MediaType: MediaTypeSourceImageConfig,
 			Digest:    configBlob.Digest,

--- a/pkg/blobcache/blobcache_test.go
+++ b/pkg/blobcache/blobcache_test.go
@@ -102,6 +102,7 @@ func TestBlobCache(t *testing.T) {
 					Versioned: specs.Versioned{
 						SchemaVersion: 2,
 					},
+					MediaType: v1.MediaTypeImageManifest,
 					Config: v1.Descriptor{
 						MediaType: v1.MediaTypeImageConfig,
 						Digest:    configInfo.Digest,

--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -159,7 +159,7 @@ func main() {
 				errors = true
 				continue
 			}
-			manifestType = v1.MediaTypeImageManifest
+			manifestType = oManifest.MediaType
 			configType = oManifest.Config.MediaType
 		case define.Dockerv2ImageManifest:
 			err = json.Unmarshal(manifest, &dManifest)

--- a/tests/source.bats
+++ b/tests/source.bats
@@ -10,8 +10,8 @@ load helpers
   # Inspect the index.json
   run jq -r .manifests[0].mediaType $srcdir/index.json
   expect_output "application/vnd.oci.image.manifest.v1+json"
-  run jq -r .manifests[0].size $srcdir/index.json
-  expect_output "199"
+  run jq -r .mediaType $srcdir/index.json
+  expect_output null # TODO: common#839 will change this to "application/vnd.oci.image.index.v1+json"
   # Digest of manifest
   run jq -r .manifests[0].digest $srcdir/index.json
   manifestDigest=${output//sha256:/} # strip off the sha256 prefix
@@ -25,6 +25,8 @@ load helpers
   expect_output "null"
   run jq -r .config.mediaType $srcdir/blobs/sha256/$manifestDigest
   expect_output "application/vnd.oci.source.image.config.v1+json"
+  run jq -r .mediaType $srcdir/blobs/sha256/$manifestDigest
+  expect_output "application/vnd.oci.image.manifest.v1+json"
   run jq -r .config.size $srcdir/blobs/sha256/$manifestDigest
   [ "$status" -eq 0 ] # let's not check the size (afraid of time-stamp impacts)
   # Digest of config

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/index.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/index.go
@@ -21,6 +21,9 @@ import "github.com/opencontainers/image-spec/specs-go"
 type Index struct {
 	specs.Versioned
 
+	// MediaType specificies the type of this document data structure e.g. `application/vnd.oci.image.index.v1+json`
+	MediaType string `json:"mediaType,omitempty"`
+
 	// Manifests references platform specific manifests.
 	Manifests []Descriptor `json:"manifests"`
 

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
@@ -20,6 +20,9 @@ import "github.com/opencontainers/image-spec/specs-go"
 type Manifest struct {
 	specs.Versioned
 
+	// MediaType specificies the type of this document data structure e.g. `application/vnd.oci.image.manifest.v1+json`
+	MediaType string `json:"mediaType,omitempty"`
+
 	// Config references a configuration object for a container, by digest.
 	// The referenced configuration object is a JSON blob that the runtime uses to set up the container.
 	Config Descriptor `json:"config"`

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -22,7 +22,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = "-dev"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -384,7 +384,7 @@ github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
 # github.com/opencontainers/go-digest v1.0.0
 github.com/opencontainers/go-digest
-# github.com/opencontainers/image-spec v1.0.2-0.20210819154149-5ad6f50d6283
+# github.com/opencontainers/image-spec v1.0.2-0.20211123152302-43a7dee1ec31
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v1.0.2


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

In image-spec 1.0.2, the `MediaType` field is now available in OCI manifests and indexes, so set it.

Update the `imgtype` helper to output the `MediaType` field as-is from OCI image manifests instead of just always supplying the expected value.

#### How to verify it

Updated test helper!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```