### PR TITLE
Wire logger through to config

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -271,6 +271,8 @@ type BuilderOptions struct {
 	// to store copies of layer blobs that we pull down, if any.  It should
 	// already exist.
 	BlobDirectory string
+	// Logger is the logrus logger to write log messages with
+	Logger *logrus.Logger `json:"-"`
 	// Mount signals to NewBuilder() that the container should be mounted
 	// immediately.
 	Mount bool

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -558,6 +558,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		MaxPullRetries:        s.executor.maxPullPushRetries,
 		PullRetryDelay:        s.executor.retryPullPushDelay,
 		OciDecryptConfig:      s.executor.ociDecryptConfig,
+		Logger:                s.executor.logger,
 	}
 
 	builder, err = buildah.NewBuilder(ctx, s.executor.store, builderOptions)

--- a/new.go
+++ b/new.go
@@ -290,6 +290,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		Format:          options.Format,
 		TempVolumes:     map[string]bool{},
 		Devices:         options.Devices,
+		Logger:          options.Logger,
 	}
 
 	if options.Mount {


### PR DESCRIPTION
Currently we are only wiring the logger into run_linux.go
Not into the Config section.

This PR is needed in order to update vendor in Podman.
https://github.com/containers/podman/pull/12375

[NO NEW TESTS NEEDED] Tests will be done in Podman.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

