### PR TITLE
stage_executor: re-use all the layers from `cache` for `squashed` case and `commit` as late as possible.

### DIFF
--- a/tests/bud/layers-squash/Dockerfile.multi-stage
+++ b/tests/bud/layers-squash/Dockerfile.multi-stage
@@ -1,0 +1,9 @@
+# Following stage must be picked from cache
+FROM busybox as one
+RUN echo hello
+RUN echo hello > world
+
+# Following stage must be picked from cache except last instruction
+FROM busybox as two
+RUN echo hello1
+RUN echo helloworld


### PR DESCRIPTION
Current implementation of marking for re-use of cache `commits` on every
`stage` when used with `--squashed` however we should try to re-use as
many layers are possible if `--layers` is specified and `commit` only on
`last instruction` of `last stage` to perform final squash.

Closes: https://github.com/containers/buildah/issues/3665