### PR TITLE
Allow callers to replace the ContainerPrefix

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -257,6 +257,8 @@ type BuilderOptions struct {
 	// or "scratch" to indicate that the container should not be based on
 	// an image.
 	FromImage string
+	// ContainerSuffix is the suffix to add for generated container names
+	ContainerSuffix string
 	// Container is a desired name for the build container.
 	Container string
 	// PullPolicy decides whether or not we should pull the image that

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -36,6 +36,8 @@ type fromReply struct {
 	*buildahcli.NameSpaceResults
 }
 
+var suffix string
+
 func init() {
 	var (
 		fromDescription = "\n  Creates a new working container, either from scratch or using a specified\n  image as a starting point."
@@ -74,6 +76,11 @@ func init() {
 	flags.BoolVar(&opts.pullNever, "pull-never", false, "do not pull the image, use the image present in store if available")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "don't output progress information when pulling images")
 	flags.StringVar(&opts.signaturePolicy, "signature-policy", "", "`pathname` of signature policy file (not usually used)")
+	flags.StringVar(&suffix, "suffix", "", "suffix to add to intermediate containers")
+	if err := flags.MarkHidden("suffix"); err != nil {
+		panic(fmt.Sprintf("error marking the suffix flag as hidden: %v", err))
+	}
+
 	if err := flags.MarkHidden("signature-policy"); err != nil {
 		panic(fmt.Sprintf("error marking signature-policy as hidden: %v", err))
 	}
@@ -284,6 +291,7 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 	options := buildah.BuilderOptions{
 		FromImage:             args[0],
 		Container:             iopts.name,
+		ContainerSuffix:       suffix,
 		PullPolicy:            pullPolicy,
 		SignaturePolicyPath:   signaturePolicy,
 		SystemContext:         systemContext,

--- a/define/build.go
+++ b/define/build.go
@@ -80,6 +80,8 @@ type CommonBuildOptions struct {
 
 // BuildOptions can be used to alter how an image is built.
 type BuildOptions struct {
+	// ContainerSuffix it the name to suffix containers with
+	ContainerSuffix string
 	// ContextDirectory is the default source location for COPY and ADD
 	// commands.
 	ContextDirectory string

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -57,6 +57,7 @@ var builtinAllowedBuildArgs = map[string]bool{
 // interface.  It coordinates the entire build by using one or more
 // StageExecutors to handle each stage of the build.
 type Executor struct {
+	containerSuffix                string
 	logger                         *logrus.Logger
 	stages                         map[string]*StageExecutor
 	store                          storage.Store
@@ -205,6 +206,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 	}
 
 	exec := Executor{
+		containerSuffix:                options.ContainerSuffix,
 		logger:                         logger,
 		stages:                         make(map[string]*StageExecutor),
 		store:                          store,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -539,6 +539,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		Args:                  ib.Args,
 		FromImage:             from,
 		PullPolicy:            pullPolicy,
+		ContainerSuffix:       s.executor.containerSuffix,
 		Registry:              s.executor.registry,
 		BlobDirectory:         s.executor.blobDirectory,
 		SignaturePolicyPath:   s.executor.signaturePolicyPath,

--- a/new.go
+++ b/new.go
@@ -197,6 +197,9 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 	}
 
 	name := "working-container"
+	if options.ContainerSuffix != "" {
+		name = options.ContainerSuffix
+	}
 	if options.Container != "" {
 		name = options.Container
 	} else {

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -92,6 +92,10 @@ load helpers
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json localhost/alpine2
   expect_output "alpine2-working-container"
   run_buildah rm $output
+  tmp=$RANDOM
+  run_buildah from --suffix $tmp --quiet --signature-policy ${TESTSDIR}/policy.json localhost/alpine2
+  expect_output "alpine2-$tmp"
+  run_buildah rm $output
   run_buildah rmi alpine alpine2
 
   run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/alpine


### PR DESCRIPTION
This idea of this PR is to allow Podman to add a Podman
prefix to containers. This would allow it to keep track
of containers created by Podman and make it easier to remove
them when it wants to remove all.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

