### PR TITLE
build: fix libsubid test

### DIFF
--- a/hack/libsubid_tag.sh
+++ b/hack/libsubid_tag.sh
@@ -9,7 +9,11 @@ cc -o "$tmpdir"/libsubid_tag -l subid -x c - > /dev/null 2> /dev/null << EOF
 #include <shadow/subid.h>
 int main() {
 	struct subid_range *ranges = NULL;
+#if SUBID_ABI_MAJOR >= 4j
+	subid_get_uid_ranges("root", &ranges);
+#else
 	get_subuid_ranges("root", &ranges);
+#endif
 	free(ranges);
 	return 0;
 }


### PR DESCRIPTION
libsubid changes its ABI in version 4.  Account for the different name
in the configure script.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
