### PR TITLE
executor: Share `selinux` (`process and mount`) `label` of first stage with other stages in same build

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -340,6 +340,10 @@ type BuilderOptions struct {
 	// OciDecryptConfig contains the config that can be used to decrypt an image if it is
 	// encrypted if non-nil. If nil, it does not attempt to decrypt an image.
 	OciDecryptConfig *encconfig.DecryptConfig
+	// ProcessLabel is the SELinux process label associated with the container
+	ProcessLabel string
+	// MountLabel is the SELinux mount label associated with the container
+	MountLabel string
 }
 
 // ImportOptions are used to initialize a Builder from an existing container

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -131,6 +131,8 @@ type Executor struct {
 	sshsources              map[string]*sshagent.Source
 	logPrefix               string
 	unsetEnvs               []string
+	processLabel            string // Shares processLabel of first stage container with containers of other stages in same build
+	mountLabel              string // Shares mountLabel of first stage container with containers of other stages in same build
 }
 
 type imageTypeAndHistoryAndDiffIDs struct {

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	selinux "github.com/opencontainers/selinux/go-selinux"
 	"github.com/pkg/errors"
 )
 
@@ -113,8 +112,7 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
 	isImageMounted := false
 	if fromImage != "" {
 		mountPoint := ""
-		//TODO: remove this selinux check when comment is resolved. https://github.com/containers/buildah/pull/3590#issuecomment-956349109
-		if additionalMountPoints != nil && (selinux.EnforceMode() != 1) {
+		if additionalMountPoints != nil {
 			if val, ok := additionalMountPoints[fromImage]; ok {
 				mountPoint = val.MountPoint
 			}
@@ -280,8 +278,7 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		// do not create cache on host
 		// instead use read-only mounted stage as cache
 		mountPoint := ""
-		//TODO: remove this selinux check when comment is resolved. https://github.com/containers/buildah/pull/3590#issuecomment-956349109
-		if additionalMountPoints != nil && (selinux.EnforceMode() != 1) {
+		if additionalMountPoints != nil {
 			if val, ok := additionalMountPoints[fromStage]; ok {
 				if val.IsStage {
 					mountPoint = val.MountPoint

--- a/new.go
+++ b/new.go
@@ -230,9 +230,20 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 
 	conflict := 100
 	for {
+
+		var flags map[string]interface{}
+		// check if we have predefined ProcessLabel and MountLabel
+		// this could be true if this is another stage in a build
+		if options.ProcessLabel != "" && options.MountLabel != "" {
+			flags = map[string]interface{}{
+				"ProcessLabel": options.ProcessLabel,
+				"MountLabel":   options.MountLabel,
+			}
+		}
 		coptions := storage.ContainerOptions{
 			LabelOpts:        options.CommonBuildOpts.LabelOpts,
 			IDMappingOptions: newContainerIDMappingOptions(options.IDMappingOptions),
+			Flags:            flags,
 			Volatile:         true,
 		}
 		container, err = store.CreateContainer("", []string{tmpName}, imageID, "", "", &coptions)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3759,13 +3759,6 @@ _EOF
 }
 
 @test "bud-with-writeable-mount-bind-from-like-buildkit" {
-  if which selinuxenabled > /dev/null 2> /dev/null ; then
-	if selinuxenabled ; then
-                #TODO: Once pending commit from https://github.com/containers/buildah/pull/3590 is merged
-                #See comment: https://github.com/containers/buildah/pull/3590#issuecomment-956349109
-		skip "skip if selinux enabled, since stages have different selinux label"
-	fi
-  fi
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
@@ -3807,13 +3800,6 @@ _EOF
 }
 
 @test "bud-with-mount-cache-from-like-buildkit" {
-  if which selinuxenabled > /dev/null 2> /dev/null ; then
-	if selinuxenabled ; then
-                #TODO: Once pending commit from https://github.com/containers/buildah/pull/3590 is merged
-                #See comment: https://github.com/containers/buildah/pull/3590#issuecomment-956349109
-		skip "skip if selinux enabled, since stages have different selinux label"
-	fi
-  fi
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
@@ -3826,13 +3812,6 @@ _EOF
 
 # following test must fail
 @test "bud-with-mount-cache-image-from-like-buildkit" {
-  if which selinuxenabled > /dev/null 2> /dev/null ; then
-	if selinuxenabled ; then
-                #TODO: Once pending commit from https://github.com/containers/buildah/pull/3590 is merged
-                #See comment: https://github.com/containers/buildah/pull/3590#issuecomment-956349109
-		skip "skip if selinux enabled, since stages have different selinux label"
-	fi
-  fi
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
@@ -3846,13 +3825,6 @@ _EOF
 }
 
 @test "bud-with-mount-cache-multiple-from-like-buildkit" {
-  if which selinuxenabled > /dev/null 2> /dev/null ; then
-	if selinuxenabled ; then
-                #TODO: Once pending commit from https://github.com/containers/buildah/pull/3590 is merged
-                #See comment: https://github.com/containers/buildah/pull/3590#issuecomment-956349109
-		skip "skip if selinux enabled, since stages have different selinux label"
-	fi
-  fi
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
@@ -3879,14 +3851,6 @@ _EOF
 }
 
 @test "bud-with-mount-bind-from-multistage-relative-like-buildkit" {
-  if which selinuxenabled > /dev/null 2> /dev/null ; then
-	if selinuxenabled ; then
-                #TODO: Once pending commit from https://github.com/containers/buildah/pull/3590 is merged
-                #See comment: https://github.com/containers/buildah/pull/3590#issuecomment-956349109
-		skip "skip if selinux enabled, since stages have different selinux label"
-	fi
-  fi
-
   mkdir ${TESTDIR}/bud
   cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   skip_if_no_runtime
@@ -3898,14 +3862,6 @@ _EOF
 }
 
 @test "bud-with-mount-bind-from-cache-multistage-relative-like-buildkit" {
-  if which selinuxenabled > /dev/null 2> /dev/null ; then
-	if selinuxenabled ; then
-                #TODO: Once pending commit from https://github.com/containers/buildah/pull/3590 is merged
-                #See comment: https://github.com/containers/buildah/pull/3590#issuecomment-956349109
-		skip "skip if selinux enabled, since stages have different selinux label"
-	fi
-  fi
-
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud


### PR DESCRIPTION
### Why do we need this ?

Buildah `builds` are composed of various `stages`. That is each `stage` in a build is a `container`.

As of now buildah does not provides any `processLabel` and `mountLabel` to the stage container which
results in `c/storage` assigning random generated `selinux` labels to each stage.

As a result this PR also enables following feature on systems with `selinux` enabled: https://github.com/containers/buildah/pull/3590

### Problem
If each stage has its own unqiue `processLabel` and `mountLabel` stages cannot be mounted across each other
in the same build. `selinux` prevents that.

### Solution

We get the `processLabel` and `mountLabel` of the first stage created by the container i.e assigned by `c/stoage`
and share it with all the other subsequent stages of the same build.

