### PR TITLE
Fix default CNI paths

### DIFF
--- a/contrib/completions/bash/buildah
+++ b/contrib/completions/bash/buildah
@@ -404,8 +404,6 @@ return 1
      --cap-drop
      --cert-dir
      --cgroup-parent
-     --cni-config-dir
-     --cni-plugin-path
      --cpu-period
      --cpu-quota
      --cpu-shares
@@ -490,8 +488,6 @@ return 1
      local options_with_args="
      --cap-add
      --cap-drop
-     --cni-config-dir
-     --cni-plugin-path
      --hostname
      --ipc
      --isolation
@@ -1107,8 +1103,6 @@ esac
      --cert-dir
      --cgroup-parent
      --cidfile
-     --cni-config-dir
-     --cni-plugin-path
      --cpu-period
      --cpu-quota
      --cpu-shares

--- a/define/types.go
+++ b/define/types.go
@@ -34,10 +34,6 @@ const (
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"
 
-	DefaultCNIPluginPath = "/usr/libexec/cni:/opt/cni/bin"
-	// DefaultCNIConfigDir is the default location of CNI configuration files.
-	DefaultCNIConfigDir = "/etc/cni/net.d"
-
 	// OCIv1ImageManifest is the MIME type of an OCIv1 image manifest,
 	// suitable for specifying as a value of the PreferredManifestType
 	// member of a CommitOptions structure.  It is also the default.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -113,18 +113,6 @@ This option is added to be aligned with other containers CLIs.
 Buildah doesn't send a copy of the context directory to a daemon or a remote server.
 Thus, compressing the data before sending it is irrelevant to Buildah.
 
-**--cni-config-dir**=*directory*
-
-Location of CNI configuration files which will dictate which plugins will be
-used to configure network interfaces and routing for containers created for
-handling `RUN` instructions, if those containers will be run in their own
-network namespaces, and networking is not disabled.
-
-**--cni-plugin-path**=*directory[:directory[:directory[...]]]*
-
-List of directories in which the CNI plugins which will be used for configuring
-network namespaces can be found.
-
 **--cpu-period**=*0*
 
 Set the CPU period for the Completely Fair Scheduler (CFS), which is a

--- a/docs/buildah-from.1.md
+++ b/docs/buildah-from.1.md
@@ -103,18 +103,6 @@ that the cgroup namespace in which `buildah` itself is being run should be reuse
 
 Write the container ID to the file.
 
-**--cni-config-dir**=*directory*
-
-Location of CNI configuration files which will dictate which plugins will be
-used to configure network interfaces and routing when the container is
-subsequently used for `buildah run`, if processes to be started will be run in
-their own network namespaces, and networking is not disabled.
-
-**--cni-plugin-path**=*directory[:directory[:directory[...]]]*
-
-List of directories in which the CNI plugins which will be used for configuring
-network namespaces can be found.
-
 **--cpu-period**=*0*
 
 Limit the CPU CFS (Completely Fair Scheduler) period

--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -46,18 +46,6 @@ If a capability is specified to both the **--cap-add** and **--cap-drop**
 options, it will be dropped, regardless of the order in which the options were
 given.
 
-**--cni-config-dir**=*directory*
-
-Location of CNI configuration files which will dictate which plugins will be
-used to configure network interfaces and routing inside the running container,
-if the container will be run in its own network namespace, and networking is
-not disabled.
-
-**--cni-plugin-path**=*directory[:directory[:directory[...]]]*
-
-List of directories in which the CNI plugins which will be used for configuring
-network namespaces can be found.
-
 **--contextdir** *directory*
 
 Allows setting context directory for current RUN invocation. Specifying a context

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -147,8 +147,10 @@ func GetNameSpaceFlags(flags *NameSpaceResults) pflag.FlagSet {
 	fs.StringVar(&flags.Cgroup, "cgroupns", "", "'private', or 'host'")
 	fs.StringVar(&flags.IPC, string(specs.IPCNamespace), "", "'private', `path` of IPC namespace to join, or 'host'")
 	fs.StringVar(&flags.Network, string(specs.NetworkNamespace), "", "'private', 'none', 'ns:path' of network namespace to join, or 'host'")
-	fs.StringVar(&flags.CNIConfigDir, "cni-config-dir", define.DefaultCNIConfigDir, "`directory` of CNI configuration files")
-	fs.StringVar(&flags.CNIPlugInPath, "cni-plugin-path", define.DefaultCNIPluginPath, "`path` of CNI network plugins")
+	fs.StringVar(&flags.CNIConfigDir, "cni-config-dir", "", "`directory` of CNI configuration files")
+	_ = fs.MarkHidden("cni-config-dir")
+	fs.StringVar(&flags.CNIPlugInPath, "cni-plugin-path", "", "`path` of CNI network plugins")
+	_ = fs.MarkHidden("cni-plugin-path")
 	fs.StringVar(&flags.PID, string(specs.PIDNamespace), "", "private, `path` of PID namespace to join, or 'host'")
 	fs.StringVar(&flags.UTS, string(specs.UTSNamespace), "", "private, :`path` of UTS namespace to join, or 'host'")
 	return fs
@@ -160,8 +162,6 @@ func GetNameSpaceFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["cgroupns"] = completion.AutocompleteNamespaceFlag
 	flagCompletion[string(specs.IPCNamespace)] = completion.AutocompleteNamespaceFlag
 	flagCompletion[string(specs.NetworkNamespace)] = completion.AutocompleteNamespaceFlag
-	flagCompletion["cni-config-dir"] = commonComp.AutocompleteDefault
-	flagCompletion["cni-plugin-path"] = commonComp.AutocompleteDefault
 	flagCompletion[string(specs.PIDNamespace)] = completion.AutocompleteNamespaceFlag
 	flagCompletion[string(specs.UTSNamespace)] = completion.AutocompleteNamespaceFlag
 	return flagCompletion

--- a/run_linux.go
+++ b/run_linux.go
@@ -279,19 +279,6 @@ rootless=%d
 
 	defer b.cleanupTempVolumes()
 
-	if options.CNIConfigDir == "" {
-		options.CNIConfigDir = b.CNIConfigDir
-		if b.CNIConfigDir == "" {
-			options.CNIConfigDir = define.DefaultCNIConfigDir
-		}
-	}
-	if options.CNIPluginPath == "" {
-		options.CNIPluginPath = b.CNIPluginPath
-		if b.CNIPluginPath == "" {
-			options.CNIPluginPath = define.DefaultCNIPluginPath
-		}
-	}
-
 	switch isolation {
 	case define.IsolationOCI:
 		var moreCreateArgs []string

--- a/util/types.go
+++ b/util/types.go
@@ -7,10 +7,6 @@ import (
 const (
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = define.DefaultRuntime
-	// DefaultCNIPluginPath is the default location of CNI plugin helpers.
-	DefaultCNIPluginPath = define.DefaultCNIPluginPath
-	// DefaultCNIConfigDir is the default location of CNI configuration files.
-	DefaultCNIConfigDir = define.DefaultCNIConfigDir
 )
 
 var (


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:

We need to use the default from containers.conf and not hardcode them in
buildah. This fixes an issue with the cni network backend since it would
try to access /etc/cni/net.d/ even as rootless user. This regression was
introduced in commit f9cff07b8121.

Also hide the cni flags as we do not expect users to change this. The
recommended way is to change them in containers.conf.

#### How to verify it

run `buildah bud` rootless

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

