### PR TITLE
Fix platform handling for empty os/arch values

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -216,8 +216,12 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 			Architecture: platform.Arch,
 			Variant:      platform.Variant,
 		})
-		if platformSpec.OS != "" && platformSpec.Architecture != "" {
+		// platforms.Normalize converts an empty os value to GOOS
+		// so we have to check the original value here to not overwrite the default for no reason
+		if platform.OS != "" {
 			platformContext.OSChoice = platformSpec.OS
+		}
+		if platform.Arch != "" {
 			platformContext.ArchitectureChoice = platformSpec.Architecture
 			platformContext.VariantChoice = platformSpec.Variant
 		}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2429,6 +2429,30 @@ EOM
   expect_output arm
 }
 
+@test "bud with custom platform and empty os or arch" {
+  run_buildah build --signature-policy ${TESTSDIR}/policy.json \
+    -f ${TESTSDIR}/bud/from-scratch/Containerfile \
+    -t platform-test \
+    --platform=windows/
+
+  run_buildah inspect --format "{{ .Docker.OS }}" platform-test
+  expect_output windows
+
+  run_buildah inspect --format "{{ .OCIv1.OS }}" platform-test
+  expect_output windows
+
+  run_buildah build --signature-policy ${TESTSDIR}/policy.json \
+    -f ${TESTSDIR}/bud/from-scratch/Containerfile \
+    -t platform-test2 \
+    --platform=/arm
+
+  run_buildah inspect --format "{{ .Docker.Architecture }}" platform-test2
+  expect_output arm
+
+  run_buildah inspect --format "{{ .OCIv1.Architecture }}" platform-test2
+  expect_output arm
+}
+
 @test "bud Add with linked tarball" {
   _prefetch alpine
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/symlink/Containerfile.add-tar-with-link -t testctr ${TESTSDIR}/bud/symlink


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


/kind bug


#### What this PR does / why we need it:

If you run `buildah bud --platform windows/` the os is ignored at the
moment and it uses the host os. We should still use the os from the
platform in this case. This fixes an issue with podman-remote build
where it is possible that only the os is set in the platform string.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

