### PR TITLE
Cirrus: Run int. tests in parallel with unit

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -202,7 +202,8 @@ integration_task:
     alias: integration
     only_if: *not_docs
     depends_on:
-      - unit
+      - smoke
+      - vendor
 
     matrix:
         # VFS
@@ -259,7 +260,8 @@ in_podman_task:
     alias: in_podman
     only_if: *not_docs
     depends_on:
-        - unit
+      - smoke
+      - vendor
 
     env:
         # This is key, cause the scripts to re-execute themselves inside a container.


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

This is somewhat of a band-aid since these two tasks take 45+ minutes
each.  Running them in parallel improves the overall runtime when
tests are otherwise/generally passing.  If/when unit tests fail, the
status won't update until integration tasks complete, but the failure
will be immediately observable in a PR.  So it's a minor price to pay
for improved runtime in the general case.

#### How to verify it

CI will pass

#### Which issue(s) this PR fixes:

None - by team request.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None