### PR TITLE
Allow processing of network options from FlagSet

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -803,11 +803,16 @@ func parseIDMap(spec []string) (m [][3]uint32, err error) {
 
 // NamespaceOptions parses the build options for all namespaces except for user namespace.
 func NamespaceOptions(c *cobra.Command) (namespaceOptions define.NamespaceOptions, networkPolicy define.NetworkConfigurationPolicy, err error) {
+	return NamespaceOptionsFromFlagSet(c.Flags(), c.Flag)
+}
+
+// NamespaceOptionsFromFlagSet parses the build options for all namespaces except for user namespace.
+func NamespaceOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name string) *pflag.Flag) (namespaceOptions define.NamespaceOptions, networkPolicy define.NetworkConfigurationPolicy, err error) {
 	options := make(define.NamespaceOptions, 0, 7)
 	policy := define.NetworkDefault
 	for _, what := range []string{"cgroupns", string(specs.IPCNamespace), "network", string(specs.PIDNamespace), string(specs.UTSNamespace)} {
-		if c.Flags().Lookup(what) != nil && c.Flag(what).Changed {
-			how := c.Flag(what).Value.String()
+		if flags.Lookup(what) != nil && findFlagFunc(what).Changed {
+			how := findFlagFunc(what).Value.String()
 			switch what {
 			case "network":
 				what = string(specs.NetworkNamespace)

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/containers/buildah/define"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 )
@@ -136,6 +138,20 @@ func TestIsolation(t *testing.T) {
 			assert.Error(t, fmt.Errorf("isolation %q not equal to user input %q", isolation.String(), expected))
 		}
 	}
+}
+
+func TestNamespaceOptions(t *testing.T) {
+	fs := pflag.NewFlagSet("testme", pflag.PanicOnError)
+	fs.String("cgroupns", "", "")
+	err := fs.Parse([]string{"--cgroupns", "private"})
+	assert.NoError(t, err)
+	nsos, np, err := NamespaceOptionsFromFlagSet(fs, fs.Lookup)
+	assert.NoError(t, err)
+	assert.Equal(t, np, define.NetworkEnabled)
+	nso := nsos.Find(string(specs.CgroupNamespace))
+	assert.Equal(t, *nso, define.NamespaceOption{
+		Name: string(specs.CgroupNamespace),
+	})
 }
 
 func TestParsePlatform(t *testing.T) {


### PR DESCRIPTION
In situations where you don't want/need Cobra climbing behavior nor
Cobra at all using FlagSet is the easier sell.

Signed-off-by: Andreas Bergmeier <abergmeier@gmx.net>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 

/kind feature

> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

