### PR TITLE
Allow processing of id options from FlagSet

### DIFF
--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -112,6 +112,25 @@ func TestDeviceFromPath(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestIDMappingOptions(t *testing.T) {
+	fs := pflag.NewFlagSet("testme", pflag.PanicOnError)
+	pfs := pflag.NewFlagSet("persist", pflag.PanicOnError)
+	fs.String("userns-uid-map-user", "", "")
+	fs.String("userns-gid-map-group", "", "")
+	fs.String("userns-uid-map", "", "")
+	fs.String("userns-gid-map", "", "")
+	fs.String("userns", "", "")
+	err := fs.Parse([]string{})
+	assert.NoError(t, err)
+	uos, _, err := IDMappingOptionsFromFlagSet(fs, pfs, fs.Lookup)
+	assert.NoError(t, err)
+	nso := uos.Find(string(specs.UserNamespace))
+	assert.Equal(t, *nso, define.NamespaceOption{
+		Host: true,
+		Name: string(specs.UserNamespace),
+	})
+}
+
 func TestIsolation(t *testing.T) {
 	def, err := defaultIsolation()
 	if err != nil {


### PR DESCRIPTION
In situations where you don't want/need Cobra climbing behavior nor
Cobra at all using FlagSet is the easier sell.

Signed-off-by: Andreas Bergmeier <abergmeier@gmx.net>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 

/kind feature

> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

