### PR TITLE
buildkit, executor: Add support for inline `FROM --platform=` within Containerfile/Dockerfile

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -598,6 +598,25 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 			for _, child := range node.Children { // tokens on this line, though we only care about the first
 				switch strings.ToUpper(child.Value) { // first token - instruction
 				case "FROM":
+					for _, flag := range child.Flags {
+						if strings.HasPrefix(flag, "--platform=") {
+							platformString := strings.TrimPrefix(flag, "--platform=")
+							os, arch, variant, err := parse.Platform(platformString)
+							if err != nil {
+								return "", nil, errors.Wrapf(err, "unable to parse platform %q", platformString)
+							}
+							// configure executor's system context for pull's being perform for base images
+							if arch != "" {
+								b.systemContext.ArchitectureChoice = arch
+							}
+							if os != "" {
+								b.systemContext.OSChoice = os
+							}
+							if variant != "" {
+								b.systemContext.VariantChoice = variant
+							}
+						}
+					}
 					if child.Next != nil { // second token on this line
 						// If we have a fromOverride, replace the value of
 						// image name for the first FROM in the Containerfile.

--- a/tests/bud/platform/Dockerfile
+++ b/tests/bud/platform/Dockerfile
@@ -1,0 +1,2 @@
+FROM --platform=linux/arm64 busybox
+RUN uname -m

--- a/tests/bud/platform/Dockerfileamd
+++ b/tests/bud/platform/Dockerfileamd
@@ -1,0 +1,2 @@
+FROM --platform=linux/amd64 busybox
+RUN uname -m

--- a/tests/test_runner.sh
+++ b/tests/test_runner.sh
@@ -19,4 +19,4 @@ function execute() {
 TESTS=${@:-.}
 
 # Run the tests.
-execute time bats --tap $TESTS
+execute time bats --tap $TESTS --filter


### PR DESCRIPTION
Allows end users to configure executor's `OS`, `ARCH`,`VARIANT` via inline
`--platform`. See: https://github.com/containers/buildah/issues/3712

Usage

```Dockerfile
FROM --platform=linux/arm64 alpine
RUN uname -a
```

------

While this allows executor to pull base images with custom
`OS`, `ARCH`, `VARIANT` it still allows end-users to tag images with
different format if they need to. As discussed here: https://github.com/containers/buildah/issues/3261

For example

Doing a `buildah build --platform linux/amd64 -t test .` on below
containerfile.

```Dockerfile
FROM --platform=linux/arm64 alpine
RUN uname -a
```

Would result in tagging image as `linux/amd64` while `base` layer would
be pulled for `linux/arm64`.



Closes: https://github.com/containers/buildah/issues/3712
Should Closes this as well: #3261