### PR TITLE
buildah build --network add support for custom networks 

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -389,7 +389,8 @@ Valid _mode_ values are:
 - **none**: no networking;
 - **host**: use the host network stack. Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure;
 - **ns:**_path_: path to a network namespace to join;
-- `private`: create a new namespace for the container (default)
+- **private**: create a new namespace for the container (default)
+- **\<network name|ID\>**: Join the network with the given name or ID, e.g. use `--network mynet` to join the network with the name mynet. Only supported for rootful users.
 
 **--no-cache**
 
@@ -797,6 +798,8 @@ buildah build --no-cache --rm=false -t imageName .
 buildah build --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc .
 
 buildah build -f Containerfile.in -t imageName .
+
+buildah build --network mynet .
 
 ### Building an multi-architecture image using the --manifest option (requires emulation software)
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2823,9 +2823,6 @@ EOF
   run_buildah build --network=container --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
-
-  run_buildah 125 build --network=bogus --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
-
 }
 
 @test "bud-replace-from-in-containerfile" {
@@ -3901,4 +3898,20 @@ _EOF
   expect_output --substring "hello"
   expect_output --substring "hello2"
   run_buildah rmi -f testbud
+}
+
+@test "bud with network names" {
+  skip_if_no_runtime
+  skip_if_in_container
+
+  _prefetch alpine
+
+  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json --network notexists ${TESTSDIR}/bud/network
+  expect_output --substring "network not found"
+
+  if test "$BUILDAH_ISOLATION" = "oci"; then
+    run_buildah bud --signature-policy ${TESTSDIR}/policy.json --network podman ${TESTSDIR}/bud/network
+    # default subnet is 10.88.0.0/16
+    expect_output --substring "10.88."
+  fi
 }

--- a/tests/bud/network/Containerfile
+++ b/tests/bud/network/Containerfile
@@ -1,0 +1,2 @@
+FROM alpine
+RUN ip addr

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -582,6 +582,7 @@ function configure_and_check_user() {
 
 @test "run check /etc/hosts" {
 	skip_if_no_runtime
+	skip_if_in_container
 
 	${OCI} --version
 	_prefetch debian
@@ -589,7 +590,7 @@ function configure_and_check_user() {
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json debian
 	cid=$output
 	run_buildah 125 run --network=bogus $cid cat /etc/hosts
-	expect_output "checking network namespace: stat bogus: no such file or directory"
+    expect_output --substring "unable to find network with name or ID bogus: network not found"
 
 	run_buildah run $cid cat /etc/hosts
 	expect_output --substring "127.0.0.1.*$cid"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


 /kind feature


#### What this PR does / why we need it:
The backend logic already supports specifying custom network names. This
only adds the support for the frontend parsing.



#### How to verify it

buildah bud --network name1,name2 ...

#### Which issue(s) this PR fixes:


Fixes containers/podman#12282

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

