### PR TITLE
linux: fix lookup for runtime

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -800,11 +800,10 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 	runtime := options.Runtime
 	if runtime == "" {
 		runtime = util.Runtime()
-
-		localRuntime := util.FindLocalRuntime(runtime)
-		if localRuntime != "" {
-			runtime = localRuntime
-		}
+	}
+	localRuntime := util.FindLocalRuntime(runtime)
+	if localRuntime != "" {
+		runtime = localRuntime
 	}
 
 	// Default to just passing down our stdio.


### PR DESCRIPTION
lookup the full runtime path instead of using its name.

Closes: https://github.com/containers/buildah/issues/3721

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


