### PR TITLE
run: if `--workingdir` is relative treat it as relative to image's workdir

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -119,7 +119,12 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	}
 
 	if options.WorkingDir != "" {
-		g.SetProcessCwd(options.WorkingDir)
+		if filepath.IsAbs(options.WorkingDir) {
+			g.SetProcessCwd(options.WorkingDir)
+		} else {
+			// assume path is realtive to current working dir
+			g.SetProcessCwd(filepath.Join(b.WorkDir(), filepath.Clean(options.WorkingDir)))
+		}
 	} else if b.WorkDir() != "" {
 		g.SetProcessCwd(b.WorkDir())
 	}

--- a/tests/bud/workingdir/Dockerfile
+++ b/tests/bud/workingdir/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+RUN mkdir -p hello/test
+WORKDIR hello

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -321,6 +321,29 @@ function configure_and_check_user() {
 	expect_output "/"
 }
 
+@test "run --workingdir relative versus absolute" {
+	skip_if_no_runtime
+
+	_prefetch alpine
+
+	run_buildah build -t test-working-dir --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/workingdir/Dockerfile
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json test-working-dir
+	cid=$output
+	run_buildah run $cid pwd
+	expect_output "/hello"
+
+	# ensure relative working dir is treated properly
+	run_buildah run --workingdir ./test $cid pwd
+	expect_output "/hello/test"
+
+	# Ensure absolute working dir is treated properly
+	run_buildah run --workingdir /tmp $cid pwd
+	expect_output "/tmp"
+
+	run_buildah rm $cid
+	run_buildah rmi -a
+}
+
 @test "run --mount" {
 	skip_if_no_runtime
 


### PR DESCRIPTION
When users are specifying `relative` path with `--workingdir` while
performing `buildah run` then buildah should honor relative path by
treating it as relative to image's workdir instead of assuming it as
relative to `root`.

Closes: https://github.com/containers/buildah/issues/3729