### PR TITLE
Make pull commands be consistent

### DIFF
--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -124,14 +124,17 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 		defer os.Remove(iopts.BudResults.Authfile)
 	}
 
+	// Allow for --pull, --pull=true, --pull=false, --pull=never, --pull=always
+	// --pull-always and --pull-never.  The --pull-never and --pull-always options
+	// will not be documented.
 	pullPolicy := define.PullIfMissing
-	if iopts.Pull {
+	if strings.EqualFold(strings.TrimSpace(iopts.Pull), "true") {
 		pullPolicy = define.PullIfNewer
 	}
-	if iopts.PullAlways {
+	if iopts.PullAlways || strings.EqualFold(strings.TrimSpace(iopts.Pull), "always") {
 		pullPolicy = define.PullAlways
 	}
-	if iopts.PullNever {
+	if iopts.PullNever || strings.EqualFold(strings.TrimSpace(iopts.Pull), "never") {
 		pullPolicy = define.PullNever
 	}
 	logrus.Debugf("Pull Policy for pull [%v]", pullPolicy)

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -433,26 +433,24 @@ the help of emulation provided by packages like `qemu-user-static`.
 
 **--pull**
 
-When the flag is enabled, attempt to pull the latest image from the registries
+When the flag is enabled or set explicitly to `true` (with *--pull=true*), attempt to pull the latest image from the registries
 listed in registries.conf if a local image does not exist or the image is newer
 than the one in storage. Raise an error if the image is not in any listed
 registry and is not present locally.
 
 If the flag is disabled (with *--pull=false*), do not pull the image from the
-registry, unless there is no local image. Raise an error if the image is not
-in any registry and is not present locally.
+registry, use only the local version. Raise an error if the image is not
+present locally.
 
-Defaults to *true*.
-
-**--pull-always**
-
-Pull the image from the first registry it is found in as listed in registries.conf.
+If the pull flag is set to `always` (with *--pull=always*),
+pull the image from the first registry it is found in as listed in registries.conf.
 Raise an error if not found in the registries, even if the image is present locally.
 
-**--pull-never**
-
+If the pull flag is set to `never` (with *--pull=never*),
 Do not pull the image from the registry, use only the local version. Raise an error
 if the image is not present locally.
+
+Defaults to *true*.
 
 **--quiet**, **-q**
 

--- a/docs/buildah-from.1.md
+++ b/docs/buildah-from.1.md
@@ -311,7 +311,7 @@ the help of emulation provided by packages like `qemu-user-static`.
 
 **--pull**
 
-When the flag is enabled, attempt to pull the latest image from the registries
+When the flag is enabled or set explicitly to `true` (with *--pull=true*), attempt to pull the latest image from the registries
 listed in registries.conf if a local image does not exist or the image is newer
 than the one in storage. Raise an error if the image is not in any listed
 registry and is not present locally.
@@ -320,17 +320,15 @@ If the flag is disabled (with *--pull=false*), do not pull the image from the
 registry, use only the local version. Raise an error if the image is not
 present locally.
 
-Defaults to *true*.
-
-**--pull-always**
-
-Pull the image from the first registry it is found in as listed in registries.conf.
+If the pull flag is set to `always` (with *--pull=always*),
+pull the image from the first registry it is found in as listed in registries.conf.
 Raise an error if not found in the registries, even if the image is present locally.
 
-**--pull-never**
-
+If the pull flag is set to `never` (with *--pull=never*),
 Do not pull the image from the registry, use only the local version. Raise an error
 if the image is not present locally.
+
+Defaults to *true*.
 
 **--quiet**, **-q**
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -69,7 +69,7 @@ type BudResults struct {
 	Manifest            string
 	NoCache             bool
 	Timestamp           int64
-	Pull                bool
+	Pull                string
 	PullAlways          bool
 	PullNever           bool
 	Quiet               bool
@@ -214,9 +214,16 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.Manifest, "manifest", "", "add the image to the specified manifest list. Creates manifest list if it does not exist")
 	fs.BoolVar(&flags.NoCache, "no-cache", false, "Do not use existing cached images for the container build. Build from the start with a new set of cached layers.")
 	fs.String("os", runtime.GOOS, "set the OS to the provided value instead of the current operating system of the host")
-	fs.BoolVar(&flags.Pull, "pull", true, "pull the image from the registry if newer or not present in store, if false, only pull the image if not present")
+	fs.StringVar(&flags.Pull, "pull", "true", "pull the image from the registry if newer or not present in store, if false, only pull the image if not present, if always, pull the image even if the named image is present in store, if never, only use the image present in store if available")
+	fs.Lookup("pull").NoOptDefVal = "true" //allow `--pull ` to be set to `true` as expected.
 	fs.BoolVar(&flags.PullAlways, "pull-always", false, "pull the image even if the named image is present in store")
+	if err := fs.MarkHidden("pull-always"); err != nil {
+		panic(fmt.Sprintf("error marking the pull-always flag as hidden: %v", err))
+	}
 	fs.BoolVar(&flags.PullNever, "pull-never", false, "do not pull the image, use the image present in store if available")
+	if err := fs.MarkHidden("pull-never"); err != nil {
+		panic(fmt.Sprintf("error marking the pull-never flag as hidden: %v", err))
+	}
 	fs.BoolVarP(&flags.Quiet, "quiet", "q", false, "refrain from announcing build instructions and image read/write progress")
 	fs.BoolVar(&flags.Rm, "rm", true, "Remove intermediate containers after a successful build")
 	// "runtime" definition moved to avoid name collision in podman build.  Defined in cmd/buildah/build.go.
@@ -259,6 +266,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["logfile"] = commonComp.AutocompleteDefault
 	flagCompletion["manifest"] = commonComp.AutocompleteDefault
 	flagCompletion["os"] = commonComp.AutocompleteNone
+	flagCompletion["pull"] = commonComp.AutocompleteDefault
 	flagCompletion["runtime-flag"] = commonComp.AutocompleteNone
 	flagCompletion["secret"] = commonComp.AutocompleteNone
 	flagCompletion["ssh"] = commonComp.AutocompleteNone

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2329,7 +2329,7 @@ _EOF
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull ${TESTSDIR}/bud/pull
   expect_output --substring "COMMIT pull"
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull-never ${TESTSDIR}/bud/pull
+  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull=never ${TESTSDIR}/bud/pull
   expect_output --substring "COMMIT pull"
 }
 
@@ -3302,6 +3302,8 @@ _EOF
 @test "bud with --pull-always" {
   _prefetch docker.io/library/alpine
   run_buildah build --pull-always --signature-policy ${TESTSDIR}/policy.json -t testpull ${TESTSDIR}/bud/containerfile
+  expect_output --from="${lines[1]}" "Trying to pull docker.io/library/alpine:latest..."
+  run_buildah build --pull=always --signature-policy ${TESTSDIR}/policy.json -t testpull ${TESTSDIR}/bud/containerfile
   expect_output --from="${lines[1]}" "Trying to pull docker.io/library/alpine:latest..."
 }
 

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -368,7 +368,7 @@ load helpers
   echo "$output"
   expect_output --substring "busybox-working-container"
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --pull-never busybox
+  run_buildah from --signature-policy ${TESTSDIR}/policy.json --pull=never busybox
   echo "$output"
   expect_output --substring "busybox-working-container"
 }
@@ -394,7 +394,7 @@ load helpers
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc --pull-always docker.io/busybox
   expect_output --substring "Getting"
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json busyboxc fakename-img
-  run_buildah 125 from --signature-policy ${TESTSDIR}/policy.json --pull-always fakename-img
+  run_buildah 125 from --signature-policy ${TESTSDIR}/policy.json --pull=always fakename-img
 
   # Also check for base-image annotations.
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' fakename-img


### PR DESCRIPTION
Per @edsantiago 's suggestion, make the pull commands consistent, always
accepting a value.  Currently we have:

--pull
--pull=true
--pull=false
--pull-never
--pull-always

With this changes, we will only have pull with a variety of options,
ala:

--pull
--pull=true
--pull=false
--pull=never
--pull=always

For backward compatibility, the --pull-never and --pull-always
options will remain operational, however they are not documented
and are conisdered deprecated.

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

