### PR TITLE
docs/buildah-build.1.md: don't imply that -v isn't just a RUN thing

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,9 +12,8 @@ docs: $(patsubst %.md,%,$(wildcard *.md))
 %.1: %.1.md
 ### sed is used to filter http/s links as well as relative links
 ### replaces "\" at the end of a line with two spaces
-### this ensures that manpages are renderd correctly
-
-	@sed -e 's/\((buildah[^)]*\.md\(#.*\)\?)\)//g' \
+### this ensures that manpages are rendered correctly
+	sed -e 's/\((buildah[^)]*\.md\(#.*\)\?)\)//g' \
 	 -e 's/\[\(buildah[^]]*\)\]/\1/g' \
 	 -e 's/\[\([^]]*\)](http[^)]\+)/\1/g' \
 	 -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g' \

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -641,9 +641,9 @@ Set the architecture variant of the image to be pulled.
 
 **--volume**, **-v**[=*[HOST-DIR:CONTAINER-DIR[:OPTIONS]]*]
 
-   Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Buildah
-   bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the Buildah
-   container. The `OPTIONS` are a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
+Mount a host directory into containers when executing *RUN* instructions during
+the build.  The `OPTIONS` are a comma delimited list and can be:
+<sup>[[1]](#Footnote1)</sup>
 
    * [rw|ro]
    * [U]


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The current wording doesn't clearly state that volumes specified using -v are only a factor when executing RUN instructions.

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```