### PR TITLE
[CI:DOCS] Github-workflow: Report both failures and errors.

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -22,8 +22,8 @@ env:
     # Debug-mode can reveal secrets, only enable by a secret value.
     # Ref: https://help.github.com/en/actions/configuring-and-managing-workflows/managing-a-workflow-run#enabling-step-debug-logging
     ACTIONS_STEP_DEBUG: '${{ secrets.ACTIONS_STEP_DEBUG }}'
-    # Use same destination addresses from podman repository
-    FAILMAILCSV: './_podman/contrib/cirrus/cron-fail_addrs.csv'
+    # CSV listing of e-mail addresses for delivery failure or error notices
+    RCPTCSV: rh.container.bot@gmail.com,podman-monitor@lists.podman.io
     # Filename for table of cron-name to build-id data
     # (must be in $GITHUB_WORKSPACE/artifacts/)
     NAME_ID_FILEPATH: './artifacts/name_id.txt'
@@ -69,10 +69,6 @@ jobs:
                 ) > ./artifacts/email_body.txt
 
             - if: steps.cron.outputs.failures > 0
-              id: mailto
-              run: printf "::set-output name=csv::%s\n" $(cat "$FAILMAILCSV")
-
-            - if: steps.mailto.outputs.csv != ''
               name: Send failure notification e-mail
               # Ref: https://github.com/dawidd6/action-send-mail
               uses: dawidd6/action-send-mail@v2.2.2
@@ -82,7 +78,7 @@ jobs:
                 username: ${{secrets.ACTION_MAIL_USERNAME}}
                 password: ${{secrets.ACTION_MAIL_PASSWORD}}
                 subject: Cirrus-CI cron build failures on ${{github.repository}}
-                to: ${{steps.mailto.outputs.csv}}
+                to: ${{env.RCPTCSV}}
                 from: ${{secrets.ACTION_MAIL_SENDER}}
                 body: file://./artifacts/email_body.txt
 
@@ -91,3 +87,16 @@ jobs:
               with:
                   name: ${{ github.job }}_artifacts
                   path: artifacts/*
+
+            - if: failure()
+              name: Send error notification e-mail
+              uses: dawidd6/action-send-mail@v2.2.2
+              with:
+                server_address: ${{secrets.ACTION_MAIL_SERVER}}
+                server_port: 465
+                username: ${{secrets.ACTION_MAIL_USERNAME}}
+                password: ${{secrets.ACTION_MAIL_PASSWORD}}
+                subject: Github workflow error on ${{github.repository}}
+                to: ${{env.RCPTCSV}}
+                from: ${{secrets.ACTION_MAIL_SENDER}}
+                body: "Job failed: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Port of changes from https://github.com/containers/podman/pull/12997 and
https://github.com/containers/podman/pull/13005 to the workflow in this
repository.

#### How to verify it

Impractical to automatically verify, other than stare at it and wonder how it ever worked :rofl: 
TBH, I was able to test/confirm these changes via a similar PR in another repository:
https://github.com/containers/automation_images/runs/4940937282?check_suite_focus=true
(i.e. it correctly sent an error-notice e-mail due to an unrelated/soon-to-be-fixed problem)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

None