### PR TITLE
imagebuildah.BuildDockerfiles(): create the jobs semaphore

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -176,8 +176,17 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 		files = append(files, b.Bytes())
 	}
 
-	if options.JobSemaphore == nil && options.Jobs != nil && *options.Jobs != 0 {
-		options.JobSemaphore = semaphore.NewWeighted(int64(*options.Jobs))
+	if options.JobSemaphore == nil {
+		if options.Jobs != nil {
+			if *options.Jobs < 0 {
+				return "", nil, errors.New("error building: invalid value for jobs.  It must be a positive integer")
+			}
+			if *options.Jobs > 0 {
+				options.JobSemaphore = semaphore.NewWeighted(int64(*options.Jobs))
+			}
+		} else {
+			options.JobSemaphore = semaphore.NewWeighted(1)
+		}
 	}
 
 	manifestList := options.Manifest

--- a/run_linux.go
+++ b/run_linux.go
@@ -2727,7 +2727,6 @@ func (b *Builder) getSSHMount(tokens []string, count int, sshsources map[string]
 			gid = uint32(gid64)
 		default:
 			return nil, nil, errInvalidSyntax
-
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Make sure that, if we're given neither a concurrent jobs count nor a semaphore to use, we create a semaphore.  Otherwise, each platform in a multi-platform build will run with maximum concurrency, which isn't the desired default.  Our CLI always passes in a Jobs count, so it hasn't been affected by this problem.

#### How to verify it

The CLI always passes a number of jobs, so it doesn't trigger this.  It can be observed in programs that consume the library and set neither the `Jobs` nor the `JobSemaphore` field of a `define.BuildOptions`.  Podman, which consumes our CLI front-end, also won't stumble over it.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```