### PR TITLE
speed up combination-namespaces test

### DIFF
--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -403,14 +403,14 @@ _EOF
 
   _prefetch alpine
   # mnt is always per-container, cgroup isn't a thing OCI runtime lets us configure
-  for ipc in host container private ; do
-    for net in host container private; do
-      for pid in host container private; do
-        for userns in host container private; do
-          for uts in host container private; do
-	    for cgroupns in host container private; do
+  for ipc in host private; do
+    for net in host private; do
+      for pid in host private; do
+        for userns in host private; do
+          for uts in host private; do
+            for cgroupns in host private; do
 
-              if test $userns == private -o $userns == container -a $pid == host ; then
+              if test $userns == private -a $pid == host ; then
                 # We can't mount a fresh /proc, and OCI runtime won't let us bind mount the host's.
                 continue
               fi
@@ -425,7 +425,7 @@ _EOF
               [ "$output" != "" ]
               run_buildah run --terminal=false $ctr pwd
               [ "$output" != "" ]
-	    done
+            done
           done
         done
       done


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


/kind cleanup


#### What this PR does / why we need it:

Commit d05957a6f6de added the private value for namespace flags and kept
container as alias for backwards compat. Commit b480ce832f3e added the
cgroup falg so the test has 3^6 combinations to test. This takes way to
long. Since container is the same as private we only test private. The
container value is already covered in the other namespace tests, see
general_namespace() function.

With this commit the test time went down from 23 min to 3 min on my
laptop.

#### How to verify it

Run the test and compare the time.

#### Which issue(s) this PR fixes:

Fixes #3768


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

