### PR TITLE
helpers.bash: Use correct syntax

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -433,9 +433,9 @@ function skip_if_rootless() {
 ##################################
 function skip_if_rootless_and_cgroupv1() {
     if test "$BUILDAH_ISOLATION" = "rootless"; then
-	if !is_cgroupsv2; then
-		skip "${1:-test does not work when \$BUILDAH_ISOLATION = rootless} and not cgroupv2"
-	fi
+        if ! is_cgroupsv2; then
+            skip "${1:-test does not work when \$BUILDAH_ISOLATION = rootless} and not cgroupv2"
+        fi
     fi
 }
 
@@ -471,7 +471,7 @@ function skip_if_cgroupsv2() {
 #  skip_if_cgroupsv1  #  Some tests don't work with cgroupsv1
 #######################
 function skip_if_cgroupsv1() {
-    if !is_cgroupsv2; then
+    if ! is_cgroupsv2; then
         skip "${1:-test does not work with cgroups v1}"
     fi
 }


### PR DESCRIPTION
Fixes gating test failure:
```
 /usr/share/buildah/test/system/./helpers.bash: line 474: !is_cgroupsv2: command not found
 ```

From: Yiqiao Pu <ypu@redhat.com>

I'm just the committer.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind failing-test

#### What this PR does / why we need it:

Fixes gating tests

#### How to verify it

Gating tests should not show that error.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```


@edsantiago @nalind @rhatdan PTAL.
