### PR TITLE
[WIP] imagebuildah: prevent race cause `c/storage` does not persist names with layers.

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1366,7 +1366,7 @@ func (s *StageExecutor) tagExistingImage(ctx context.Context, cacheID, output st
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "error computing digest of manifest for image %q", cacheID)
 	}
-	img, err := is.Transport.GetStoreImage(s.executor.store, dest)
+	_, img, err := util.FindImage(s.executor.store, "", s.executor.systemContext, cacheID)
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "error locating new copy of image %q (i.e., %q)", cacheID, transports.ImageName(dest))
 	}


### PR DESCRIPTION
When running concurrent builds references to layers are changed and
c/storage does not accounts for names so use ID where possible.

Builds fail with `image not known`.

### Reproducer

```bash
#!/bin/bash
x=1
sudo ./podman rmi -af
rm -f log*.*
sudo ./podman build -t first . &> logfirst.log
while [ $x -le 30 ]
do
  echo "$x times"
  sudo ./podman build --log-level debug -t $x . &> log$x.log &
  x=$(( $x + 1 ))
#  sleep 1
done
````
### Dockerfile

```Dockerfile
FROM quay.io/jitesoft/alpine
```

### Note:

This PR is just for discussion to confirm if we can do better solutions or not. I believe underlying problem still persists either in `c/image` or `c/storage`. **See bz 2055487**



