### PR TITLE
executor: docker builds must inherit `healthconfig` from baseImage if any and new build does not overrides.

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -678,6 +678,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 			Volumes:      volumes,
 			WorkingDir:   builder.WorkDir(),
 			Entrypoint:   builder.Entrypoint(),
+			Healthcheck:  (*docker.HealthConfig)(builder.Healthcheck()),
 			Labels:       builder.Labels(),
 			Shell:        builder.Shell(),
 			StopSignal:   builder.StopSignal(),


### PR DESCRIPTION
If base image has a healthconfig and child does not overrides it then
docker formatted builds must inherit healthconfig from base image.

Following commit ensures that we are in parity with docker for docker
formatted builds.

Closes: https://github.com/containers/buildah/issues/3796
