### PR TITLE
add: ensure the context directory is an absolute path

### DIFF
--- a/add.go
+++ b/add.go
@@ -201,6 +201,13 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		if err != nil {
 			return errors.Wrapf(err, "error determining current working directory")
 		}
+	} else {
+		if !filepath.IsAbs(options.ContextDir) {
+			contextDir, err = filepath.Abs(options.ContextDir)
+			if err != nil {
+				return errors.Wrapf(err, "error converting context directory path %q to an absolute path", options.ContextDir)
+			}
+		}
 	}
 
 	// Figure out what sorts of sources we have.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When we're processing a context directory, make sure it's an absolute path.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes #3798

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```