### PR TITLE
tests/copy: initialize the network, too

### DIFF
--- a/tests/copy/copy.go
+++ b/tests/copy/copy.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/containers/buildah"
+	"github.com/containers/common/libnetwork/network"
+	"github.com/containers/common/pkg/config"
 	cp "github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/compression"
@@ -71,6 +73,23 @@ func main() {
 				return err
 			}
 			imageStorage.Transport.SetStore(store)
+
+			var conf *config.Config
+			if containersConf, ok := os.LookupEnv("CONTAINERS_CONF"); ok {
+				conf, err = config.NewConfig(containersConf)
+				if err != nil {
+					return err
+				}
+			} else {
+				conf, err = config.DefaultConfig()
+				if err != nil {
+					return err
+				}
+			}
+			_, _, err = network.NetworkBackend(store, conf, false)
+			if err != nil {
+				return err
+			}
 
 			if len(args) < 1 {
 				return errors.Wrapf(err, "no source name provided")


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Force libnetwork to record the network configuration so that its auto-detection logic doesn't get confused by the presence of the image that we're writing to storage, after it's been written.

#### How to verify it

Integration tests should pass.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```