### PR TITLE
buildah: increase rootless test coverage with `rootless + unshare`

### DIFF
--- a/tests/add.bats
+++ b/tests/add.bats
@@ -14,7 +14,6 @@ load helpers
 }
 
 @test "add-local-plain" {
-  skip_if_rootless_environment
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
@@ -60,7 +59,6 @@ load helpers
 }
 
 @test "add-local-archive" {
-  skip_if_rootless_environment
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
@@ -203,7 +201,6 @@ load helpers
 }
 
 @test "add --ignorefile" {
-  skip_if_rootless_environment
   mytest=${TESTDIR}/mytest
   mkdir -p ${mytest}
   touch ${mytest}/mystuff
@@ -237,7 +234,6 @@ stuff/mystuff"
 }
 
 @test "add quietly" {
-  skip_if_rootless_environment
   _prefetch busybox
   createrandom ${TESTDIR}/randomfile
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
@@ -250,7 +246,6 @@ stuff/mystuff"
 }
 
 @test "add from container" {
-  skip_if_rootless_environment
   _prefetch busybox
   createrandom ${TESTDIR}/randomfile
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
@@ -270,7 +265,6 @@ stuff/mystuff"
 }
 
 @test "add from image" {
-  skip_if_rootless_environment
   _prefetch busybox
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
   cid=$output

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -36,7 +36,6 @@ load helpers
 }
 
 @test "mount" {
-  skip_if_rootless_environment
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
   cid=$output
   run_buildah mount $cid
@@ -50,7 +49,6 @@ load helpers
 }
 
 @test "by-name" {
-  skip_if_rootless_environment
   run_buildah from --signature-policy ${TESTSDIR}/policy.json --name scratch-working-image-for-test scratch
   cid=$output
   run_buildah mount scratch-working-image-for-test
@@ -60,7 +58,6 @@ load helpers
 }
 
 @test "commit" {
-  skip_if_rootless_environment
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -60,7 +60,6 @@ load helpers
 }
 
 @test "bud with .dockerignore - unmatched" {
-  skip_if_rootless_environment
   # Here .dockerignore contains 'unmatched', which will not match anything.
   # Therefore everything in the subdirectory should be copied into the image.
   #
@@ -261,7 +260,6 @@ _EOF
 }
 
 @test "bud with --layers, multistage, and COPY with --from" {
-  skip_if_rootless_environment
   _prefetch alpine
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
 
@@ -351,7 +349,6 @@ _EOF
 }
 
 @test "bud-multistage-cache" {
-   skip_if_rootless_environment
   _prefetch alpine busybox
   target=foo
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.extended ${TESTSDIR}/bud/multi-stage-builds
@@ -636,7 +633,6 @@ _EOF
 }
 
 @test "bud-from-multiple-files-one-from" {
-  skip_if_rootless_environment
   target=scratch-image
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files
   run_buildah from --quiet ${target}
@@ -662,7 +658,6 @@ _EOF
 }
 
 @test "bud-from-multiple-files-two-froms" {
-  skip_if_rootless_environment
   _prefetch alpine
   target=scratch-image
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1.scratch -f Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files
@@ -689,7 +684,6 @@ _EOF
 }
 
 @test "bud-multi-stage-builds" {
-  skip_if_rootless_environment
   _prefetch alpine
   target=multi-stage-index
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds
@@ -726,7 +720,6 @@ _EOF
 }
 
 @test "bud-multi-stage-builds-small-as" {
-  skip_if_rootless_environment
   _prefetch alpine
   target=multi-stage-index
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as
@@ -763,7 +756,6 @@ _EOF
 }
 
 @test "bud-preserve-subvolumes" {
-  skip_if_rootless_environment
   # This Dockerfile needs us to be able to handle a working RUN instruction.
   skip_if_no_runtime
 
@@ -906,7 +898,6 @@ function _test_http() {
 }
 
 @test "bud-volume-perms" {
-  skip_if_rootless_environment
   # This Dockerfile needs us to be able to handle a working RUN instruction.
   skip_if_no_runtime
 
@@ -957,7 +948,6 @@ function _test_http() {
 }
 
 @test "bud-from-glob" {
-  skip_if_rootless_environment
   _prefetch alpine
   target=alpine-image
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile2.glob ${TESTSDIR}/bud/from-multiple-files
@@ -1028,7 +1018,6 @@ function _test_http() {
 }
 
 @test "bud with symlinks" {
-  skip_if_rootless_environment
   _prefetch alpine
   target=alpine-image
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/symlink
@@ -1048,7 +1037,6 @@ function _test_http() {
 }
 
 @test "bud with symlinks to relative path" {
-  skip_if_rootless_environment
   _prefetch alpine
   target=alpine-image
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.relative-symlink ${TESTSDIR}/bud/symlink
@@ -1067,7 +1055,6 @@ function _test_http() {
 }
 
 @test "bud with multiple symlinks in a path" {
-  skip_if_rootless_environment
   _prefetch alpine
   target=alpine-image
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.multiple-symlinks ${TESTSDIR}/bud/symlink
@@ -1100,7 +1087,6 @@ function _test_http() {
 }
 
 @test "bud multi-stage with symlink to absolute path" {
-  skip_if_rootless_environment
   _prefetch ubuntu
   target=ubuntu-image
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.absolute-symlink ${TESTSDIR}/bud/symlink
@@ -1118,7 +1104,6 @@ function _test_http() {
 }
 
 @test "bud multi-stage with dir symlink to absolute path" {
-  skip_if_rootless_environment
   _prefetch ubuntu
   target=ubuntu-image
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.absolute-dir-symlink ${TESTSDIR}/bud/symlink
@@ -1276,7 +1261,6 @@ function _test_http() {
 }
 
 @test "bud-onbuild" {
-  skip_if_rootless_environment
   _prefetch alpine
   target=onbuild
   run_buildah build --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/onbuild
@@ -1359,7 +1343,6 @@ function _test_http() {
 }
 
 @test "bud-from-stdin" {
-  skip_if_rootless_environment
   target=scratch-image
   cat ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch | run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f - ${TESTSDIR}/bud/from-multiple-files
   run_buildah from --quiet ${target}
@@ -1630,7 +1613,6 @@ function _test_http() {
 }
 
 @test "bud with FROM AS skip FROM construct" {
-  skip_if_rootless_environment
   _prefetch alpine
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t test1 -f ${TESTSDIR}/bud/from-as/Dockerfile.skip ${TESTSDIR}/bud/from-as
   expect_output --substring "LOCAL=/1"
@@ -1719,7 +1701,6 @@ function _test_http() {
 }
 
 @test "bud with copy-from in Dockerfile no prior FROM" {
-  skip_if_rootless_environment
   _prefetch busybox quay.io/libpod/testimage:20210610
   target=no-prior-from
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy-from ${TESTSDIR}/bud/copy-from
@@ -1742,7 +1723,6 @@ function _test_http() {
 }
 
 @test "bud with copy-from referencing the base image" {
-  skip_if_rootless_environment
   _prefetch busybox
   target=busybox-derived
   target_mt=busybox-mt-derived
@@ -1774,7 +1754,6 @@ function _test_http() {
 }
 
 @test "bud-target" {
-  skip_if_rootless_environment
   _prefetch alpine ubuntu
   target=target
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --target mytarget ${TESTSDIR}/bud/target
@@ -2029,7 +2008,6 @@ _EOF
 }
 
 @test "bud-copy-workdir" {
-  skip_if_rootless_environment
   target=testimage
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/copy-workdir
   run_buildah from ${target}
@@ -2043,7 +2021,6 @@ _EOF
 
 # regression test for https://github.com/containers/podman/issues/10671
 @test "bud-copy-workdir --layers" {
-  skip_if_rootless_environment
   _prefetch alpine
 
   target=testimage
@@ -2125,7 +2102,6 @@ _EOF
 }
 
 @test "bud-copy-dockerignore-hardlinks" {
-  skip_if_rootless_environment
   target=image
   mkdir -p ${TESTDIR}/hardlinks/subdir
   cp ${TESTSDIR}/bud/recurse/Dockerfile ${TESTDIR}/hardlinks
@@ -2303,7 +2279,6 @@ _EOF
 }
 
 @test "bud with Dockerfile from stdin" {
-  skip_if_rootless_environment
   _prefetch alpine
   target=df-stdin
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} - < ${TESTSDIR}/bud/context-from-stdin/Dockerfile
@@ -2321,7 +2296,6 @@ _EOF
 }
 
 @test "bud with Dockerfile from stdin tar" {
-  skip_if_rootless_environment
   _prefetch alpine
   target=df-stdin
   # 'cmd1 < <(cmd2)' == 'cmd2 | cmd1' but runs cmd1 in this shell, not sub.

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -14,7 +14,6 @@ load helpers
 }
 
 @test "copy-local-multiple" {
-  skip_if_rootless_environment
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
   createrandom ${TESTDIR}/third-randomfile
@@ -54,7 +53,6 @@ load helpers
 }
 
 @test "copy-local-plain" {
-  skip_if_rootless_environment
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
   createrandom ${TESTDIR}/third-randomfile
@@ -81,7 +79,6 @@ load helpers
 }
 
 @test "copy-local-subdirectory" {
-  skip_if_rootless_environment
   mkdir -p ${TESTDIR}/subdir
   createrandom ${TESTDIR}/subdir/randomfile
   createrandom ${TESTDIR}/subdir/other-randomfile
@@ -104,7 +101,6 @@ load helpers
 }
 
 @test "copy-local-force-directory" {
-  skip_if_rootless_environment
   createrandom ${TESTDIR}/randomfile
 
   run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
@@ -128,7 +124,6 @@ load helpers
 }
 
 @test "copy-url-mtime" {
-  skip_if_rootless_environment
   # Create a file with random content and a non-now timestamp (so we can
   # can trust that buildah correctly set mtime on copy)
   createrandom ${TESTDIR}/randomfile
@@ -242,7 +237,6 @@ load helpers
 }
 
 @test "copy-symlink" {
-  skip_if_rootless_environment
   createrandom ${TESTDIR}/randomfile
   ln -s ${TESTDIR}/randomfile ${TESTDIR}/link-randomfile
 
@@ -266,7 +260,6 @@ load helpers
 }
 
 @test "ignore-socket" {
-  skip_if_rootless_environment
   createrandom ${TESTDIR}/randomfile
   # This seems to be the least-worst way to create a socket: run and kill nc
   nc -lkU ${TESTDIR}/test.socket &
@@ -300,7 +293,6 @@ load helpers
 }
 
 @test "copy-symlink-archive-suffix" {
-  skip_if_rootless_environment
   createrandom ${TESTDIR}/randomfile.tar.gz
   ln -s ${TESTDIR}/randomfile.tar.gz ${TESTDIR}/link-randomfile.tar.gz
 
@@ -335,7 +327,6 @@ load helpers
 }
 
 @test "copy --ignorefile" {
-  skip_if_rootless_environment
   mytest=${TESTDIR}/mytest
   mkdir -p ${mytest}
   touch ${mytest}/mystuff
@@ -369,7 +360,6 @@ stuff/mystuff"
 }
 
 @test "copy-quiet" {
-  skip_if_rootless_environment
   createrandom ${TESTDIR}/randomfile
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
@@ -384,7 +374,6 @@ stuff/mystuff"
 }
 
 @test "copy-from-container" {
-  skip_if_rootless_environment
   _prefetch busybox
   createrandom ${TESTDIR}/randomfile
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
@@ -404,7 +393,6 @@ stuff/mystuff"
 }
 
 @test "copy-container-root" {
-  skip_if_rootless_environment
   _prefetch busybox
   createrandom ${TESTDIR}/randomfile
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
@@ -422,7 +410,6 @@ stuff/mystuff"
 }
 
 @test "add-from-image" {
-  skip_if_rootless_environment
   _prefetch busybox
   run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
   cid=$output

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -3,7 +3,6 @@
 load helpers
 
 @test "mount-flags-order-verification" {
-  skip_if_rootless_environment
   run_buildah 125 mount cnt1 --notruncate path1
   check_options_flag_err "--notruncate"
 
@@ -15,7 +14,6 @@ load helpers
 }
 
 @test "mount one container" {
-  skip_if_rootless_environment
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
@@ -23,12 +21,10 @@ load helpers
 }
 
 @test "mount bad container" {
-  skip_if_rootless_environment
   run_buildah 125 mount badcontainer
 }
 
 @test "mount multi images" {
-  skip_if_rootless_environment
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
@@ -40,7 +36,6 @@ load helpers
 }
 
 @test "mount multi images one bad" {
-  skip_if_rootless_environment
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
@@ -52,7 +47,6 @@ load helpers
 }
 
 @test "list currently mounted containers" {
-  skip_if_rootless_environment
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -408,7 +408,6 @@ _EOF
 @test "combination-namespaces" {
   skip_if_chroot
   skip_if_rootless
-  skip_if_rootless_environment
 
   _prefetch alpine
   # mnt is always per-container, cgroup isn't a thing OCI runtime lets us configure
@@ -464,7 +463,6 @@ _EOF
 }
 
 @test "invalid userns-uid-map userns-gid-map" {
-	skip_if_rootless_environment
 	run_buildah 125 from --userns-uid-map 16  --userns-gid-map 0:48:16 scratch
 	expect_output 'error initializing ID mappings: userns-uid-map setting is malformed expected ["uint32:uint32:uint32"]: ["16"]'
 

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -74,7 +74,6 @@ load helpers
 }
 
 @test "use prune to remove dangling images" {
-  skip_if_rootless_environment
   _prefetch busybox
 
   createrandom ${TESTDIR}/randomfile
@@ -115,7 +114,6 @@ load helpers
 }
 
 @test "use prune to remove dangling images with parent" {
-  skip_if_rootless_environment
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -3,7 +3,6 @@
 load helpers
 
 @test "run" {
-        skip_if_rootless_environment
 	skip_if_no_runtime
 
 	_prefetch alpine
@@ -182,7 +181,6 @@ function configure_and_check_user() {
 }
 
 @test "run-user" {
-        skip_if_rootless_environment
 	skip_if_no_runtime
 
 	eval $(go env)
@@ -490,7 +488,6 @@ function configure_and_check_user() {
 }
 
 @test "run-builtin-volume-omitted" {
-        skip_if_rootless_environment
 	# This image is known to include a volume, but not include the mountpoint
 	# in the image.
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/registry:volume_omitted

--- a/tests/squash.bats
+++ b/tests/squash.bats
@@ -17,7 +17,6 @@ function check_lengths() {
 }
 
 @test "squash" {
-        skip_if_rootless_environment
 	createrandom ${TESTDIR}/randomfile
 	run_buildah from scratch
 	cid=$output
@@ -57,7 +56,6 @@ function check_lengths() {
 }
 
 @test "squash-using-dockerfile" {
-        skip_if_rootless_environment
 	createrandom ${TESTDIR}/randomfile
 	image=stage0
 	from=scratch

--- a/tests/umount.bats
+++ b/tests/umount.bats
@@ -14,7 +14,6 @@ load helpers
 }
 
 @test "umount one image" {
-  skip_if_rootless_environment
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid=$output
@@ -27,7 +26,6 @@ load helpers
 }
 
 @test "umount multi images" {
-  skip_if_rootless_environment
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
@@ -42,7 +40,6 @@ load helpers
 }
 
 @test "umount all images" {
-  skip_if_rootless_environment
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output
@@ -57,7 +54,6 @@ load helpers
 }
 
 @test "umount multi images one bad" {
-  skip_if_rootless_environment
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
   cid1=$output


### PR DESCRIPTION
Tests for `rootless` added here https://github.com/containers/buildah/pull/3804 skipped some of the cases. 

Almost all of the skipped test cases can be covered under an environment of `rootless + unshare`. 
Following PR attempts to solve that by modifying test infrastructure and adding a `cirrus` task dedicated to `rootless+unshare` testing.