### PR TITLE
buildkit: add support for exporting build output with `--output` or `-o`

### DIFF
--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -328,6 +328,15 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 		t := time.Unix(iopts.Timestamp, 0).UTC()
 		timestamp = &t
 	}
+	if c.Flag("output").Changed {
+		buildOption, err := parse.GetBuildOutput(iopts.BuildOutput)
+		if err != nil {
+			return err
+		}
+		if buildOption.IsStdout {
+			iopts.Quiet = true
+		}
+	}
 	options := define.BuildOptions{
 		AddCapabilities:         iopts.CapAdd,
 		AdditionalTags:          tags,
@@ -363,6 +372,7 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 		OS:                      systemContext.OSChoice,
 		Out:                     stdout,
 		Output:                  output,
+		BuildOutput:             iopts.BuildOutput,
 		OutputFormat:            format,
 		PullPolicy:              pullPolicy,
 		PullPushRetryDelay:      pullPushRetryDelay,

--- a/commit.go
+++ b/commit.go
@@ -229,6 +229,7 @@ func (b *Builder) addManifest(ctx context.Context, manifestName string, imageSpe
 func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options CommitOptions) (string, reference.Canonical, digest.Digest, error) {
 	var (
 		imgID string
+		src   types.ImageReference
 	)
 
 	// If we weren't given a name, build a destination reference using a
@@ -300,7 +301,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 	logrus.Debugf("committing image with reference %q is allowed by policy", transports.ImageName(dest))
 
 	// Build an image reference from which we can copy the finished image.
-	src, err := b.makeImageRef(options)
+	src, err = b.makeContainerImageRef(options)
 	if err != nil {
 		return imgID, nil, "", errors.Wrapf(err, "error computing layer digests and building metadata for container %q", b.ContainerID)
 	}

--- a/define/build.go
+++ b/define/build.go
@@ -123,6 +123,10 @@ type BuildOptions struct {
 	Args map[string]string
 	// Name of the image to write to.
 	Output string
+	// BuildOutput specifies if any custom build output is selected for following build.
+	// It allows end user to export recently built rootfs into a directory or tar.
+	// See the documentation of 'buildah build --output' for the details of the format.
+	BuildOutput string
 	// Additional tags to add to the image that we write, if we know of a
 	// way to add them.
 	AdditionalTags []string

--- a/define/types.go
+++ b/define/types.go
@@ -96,6 +96,13 @@ type Secret struct {
 	SourceType string
 }
 
+// BuildOutputOptions contains the the outcome of parsing the value of a build --output flag
+type BuildOutputOption struct {
+	Path     string // Only valid if !IsStdout
+	IsDir    bool
+	IsStdout bool
+}
+
 // TempDirForURL checks if the passed-in string looks like a URL or -.  If it is,
 // TempDirForURL creates a temporary directory, arranges for its contents to be
 // the contents of that URL, and returns the temporary directory's path, along

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -411,6 +411,25 @@ By default, Buildah manages _/etc/hosts_, adding the container's own IP address.
 
 Set the OS of the image to be built, and that of the base image to be pulled, if the build uses one, instead of using the current operating system of the host.
 
+**--output**, **-o**=""
+
+Output destination (format: type=local,dest=path)
+
+The --output (or -o) option extends the default behavior of building a container image by allowing users to export the contents of the image as files on the local filesystem, which can be useful for generating local binaries, code generation, etc.
+
+The value for --output is a comma-separated sequence of key=value pairs, defining the output type and options.
+
+Supported _keys_ are:
+- **dest**: Destination path for exported output. Valid value is absolute or relative path, `-` means the standard output.
+- **type**: Defines the type of output to be used. Valid values is documented below.
+
+Valid _type_ values are:
+- **local**: write the resulting build files to a directory on the client-side.
+- **tar**: write the resulting files as a single tarball (.tar).
+
+If no type is specified, the value defaults to **local**.
+Alternatively, instead of a comma-separated sequence, the value of **--output** can be just a destination (in the `**dest** format) (e.g. `--output some-path`, `--output -`) where `--output some-path` is treated as if **type=local** and `--output -` is treated as if **type=tar**.
+
 **--pid** *how*
 
 Sets the configuration for PID namespaces when handling `RUN` instructions.
@@ -823,6 +842,16 @@ buildah bud --platform linux/s390x,linux/ppc64le,linux/amd64 --manifest myimage 
 buildah bud --platform linux/arm64 --platform linux/amd64 --manifest myimage /tmp/mysrc
 
 buildah bud --all-platforms --manifest myimage /tmp/mysrc
+
+### Building an image using (--output) custom build output
+
+buildah build -o out .
+
+buildah build --output type=local,dest=out .
+
+buildah build --output type=tar,dest=out.tar .
+
+buildah build -o - . > out.tar
 
 ### Building an image using a URL
 

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -133,6 +133,7 @@ type Executor struct {
 	unsetEnvs               []string
 	processLabel            string // Shares processLabel of first stage container with containers of other stages in same build
 	mountLabel              string // Shares mountLabel of first stage container with containers of other stages in same build
+	buildOutput             string // Specifies instructions for any custom build output
 }
 
 type imageTypeAndHistoryAndDiffIDs struct {
@@ -276,6 +277,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		sshsources:                     sshsources,
 		logPrefix:                      logPrefix,
 		unsetEnvs:                      options.UnsetEnvs,
+		buildOutput:                    options.BuildOutput,
 	}
 	if exec.err == nil {
 		exec.err = os.Stderr

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/buildah/define"
 	buildahdocker "github.com/containers/buildah/docker"
 	"github.com/containers/buildah/internal"
+	internalUtil "github.com/containers/buildah/internal/util"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/pkg/rusage"
 	"github.com/containers/buildah/util"
@@ -28,6 +29,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/chrootarchive"
+	"github.com/containers/storage/pkg/unshare"
 	docker "github.com/fsouza/go-dockerclient"
 	digest "github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -1447,8 +1449,18 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 
 // commit writes the container's contents to an image, using a passed-in tag as
 // the name if there is one, generating a unique ID-based one otherwise.
+// or commit via any custom exporter if specified.
 func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer bool, output string) (string, reference.Canonical, error) {
 	ib := s.stage.Builder
+	var buildOutputOption define.BuildOutputOption
+	if s.executor.buildOutput != "" {
+		var err error
+		logrus.Debugf("Generating custom build output with options %q", s.executor.buildOutput)
+		buildOutputOption, err = parse.GetBuildOutput(s.executor.buildOutput)
+		if err != nil {
+			return "", nil, errors.Wrapf(err, "failed to parse build output")
+		}
+	}
 	var imageRef types.ImageReference
 	if output != "" {
 		imageRef2, err := s.executor.resolveNameToImageRef(output)
@@ -1555,6 +1567,39 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		HistoryTimestamp:      s.executor.timestamp,
 		Manifest:              s.executor.manifest,
 		UnsetEnvs:             s.executor.unsetEnvs,
+	}
+	// generate build output
+	if s.executor.buildOutput != "" {
+		extractRootfsOpts := buildah.ExtractRootfsOptions{}
+		if unshare.IsRootless() {
+			// In order to maintain as much parity as possible
+			// with buildkit's version of --output and to avoid
+			// unsafe invocation of exported executables it was
+			// decided to strip setuid,setgid and extended attributes.
+			// Since modes like setuid,setgid leaves room for executable
+			// to get invoked with different file-system permission its safer
+			// to strip them off for unpriviledged invocation.
+			// See: https://github.com/containers/buildah/pull/3823#discussion_r829376633
+			extractRootfsOpts.StripSetuidBit = true
+			extractRootfsOpts.StripSetgidBit = true
+			extractRootfsOpts.StripXattrs = true
+		}
+		rc, errChan, err := s.builder.ExtractRootfs(options, extractRootfsOpts)
+		if err != nil {
+			return "", nil, errors.Wrapf(err, "failed to extract rootfs from given container image")
+		}
+		defer rc.Close()
+		err = internalUtil.ExportFromReader(rc, buildOutputOption)
+		if err != nil {
+			return "", nil, errors.Wrapf(err, "failed to export build output")
+		}
+		if errChan != nil {
+			err = <-errChan
+			if err != nil {
+				return "", nil, err
+			}
+		}
+
 	}
 	imgID, _, manifestDigest, err := s.builder.Commit(ctx, imageRef, options)
 	if err != nil {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,9 +1,18 @@
 package util
 
 import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/containers/buildah/define"
 	"github.com/containers/common/libimage"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/chrootarchive"
+	"github.com/containers/storage/pkg/unshare"
+	"github.com/pkg/errors"
 )
 
 // LookupImage returns *Image to corresponding imagename or id
@@ -21,4 +30,52 @@ func LookupImage(ctx *types.SystemContext, store storage.Store, image string) (*
 		return nil, err
 	}
 	return localImage, nil
+}
+
+// ExportFromReader reads bytes from given reader and exports to external tar, directory or stdout.
+func ExportFromReader(input io.Reader, opts define.BuildOutputOption) error {
+	var err error
+	if !filepath.IsAbs(opts.Path) {
+		opts.Path, err = filepath.Abs(opts.Path)
+		if err != nil {
+			return err
+		}
+	}
+	if opts.IsDir {
+		// In order to keep this feature as close as possible to
+		// buildkit it was decided to preserve ownership when
+		// invoked as root since caller already has access to artifacts
+		// therefore we can preserve ownership as is, however for rootless users
+		// ownership has to be changed so exported artifacts can still
+		// be accessible by unpriviledged users.
+		// See: https://github.com/containers/buildah/pull/3823#discussion_r829376633
+		noLChown := false
+		if unshare.IsRootless() {
+			noLChown = true
+		}
+
+		err = os.MkdirAll(opts.Path, 0700)
+		if err != nil {
+			return errors.Wrapf(err, "failed while creating the destination path %q", opts.Path)
+		}
+
+		err = chrootarchive.Untar(input, opts.Path, &archive.TarOptions{NoLchown: noLChown})
+		if err != nil {
+			return errors.Wrapf(err, "failed while performing untar at %q", opts.Path)
+		}
+	} else {
+		outFile := os.Stdout
+		if !opts.IsStdout {
+			outFile, err = os.Create(opts.Path)
+			if err != nil {
+				return errors.Wrapf(err, "failed while creating destination tar at %q", opts.Path)
+			}
+			defer outFile.Close()
+		}
+		_, err = io.Copy(outFile, input)
+		if err != nil {
+			return errors.Wrapf(err, "failed while performing copy to %q", opts.Path)
+		}
+	}
+	return nil
 }

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -85,6 +85,7 @@ type BudResults struct {
 	Squash              bool
 	Stdin               bool
 	Tag                 []string
+	BuildOutput         string
 	Target              string
 	TLSVerify           bool
 	Jobs                int
@@ -242,6 +243,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringArrayVar(&flags.SSH, "ssh", []string{}, "SSH agent socket or keys to expose to the build. (format: default|<id>[=<socket>|<key>[,<key>]])")
 	fs.BoolVar(&flags.Stdin, "stdin", false, "pass stdin into containers")
 	fs.StringArrayVarP(&flags.Tag, "tag", "t", []string{}, "tagged `name` to apply to the built image")
+	fs.StringVarP(&flags.BuildOutput, "output", "o", "", "output destination (format: type=local,dest=path)")
 	fs.StringVar(&flags.Target, "target", "", "set the target build stage to build")
 	fs.Int64Var(&flags.Timestamp, "timestamp", 0, "set created timestamp to the specified epoch seconds to allow for deterministic builds, defaults to current time")
 	fs.BoolVar(&flags.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
@@ -281,6 +283,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["timestamp"] = commonComp.AutocompleteNone
 	flagCompletion["variant"] = commonComp.AutocompleteNone
 	flagCompletion["unsetenv"] = commonComp.AutocompleteNone
+	flagCompletion["output"] = commonComp.AutocompleteNone
 	return flagCompletion
 }
 


### PR DESCRIPTION
Allows end-users to export final build content or rootfs to external formats.

By default, a local container image is created from the build result. The --output (or -o) flag allows you to override this behavior, and a specify a custom exporter. For example, custom exporters allow you to export the build artifacts as files on the local filesystem instead of a Container image, which can be useful for generating local binaries, code generation etc.

The value for --output is a CSV-formatted string defining the exporter type and options. Currently, local and tar exporters are supported. The local exporter writes the resulting build files to a directory on the client side. The tar exporter is similar but writes the files as a single tarball (.tar).

```console
buildah build --output type=local,dest=dir-rootfs .
buildah build --output type=tar,dest=rootfs.tar .
buildah build -o dir .
```
Reference: https://docs.docker.com/engine/reference/commandline/build/#custom-build-outputs

Closes: https://github.com/containers/buildah/issues/3789