### PR TITLE
buildah image: install cpp

### DIFF
--- a/contrib/buildahimage/centos7/Dockerfile
+++ b/contrib/buildahimage/centos7/Dockerfile
@@ -8,7 +8,7 @@ FROM centos:7
 
 # Remove directories used by yum that are just taking
 # up space.
-RUN useradd build; yum -y update; rpm --restore shadow-utils 2>/dev/null; yum -y install buildah fuse-overlayfs xz; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
+RUN useradd build; yum -y update; rpm --restore shadow-utils 2>/dev/null; yum -y install cpp buildah fuse-overlayfs xz; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
 
 ADD https://raw.githubusercontent.com/containers/buildah/main/contrib/buildahimage/stable/containers.conf /etc/containers/
 

--- a/contrib/buildahimage/stable/Dockerfile
+++ b/contrib/buildahimage/stable/Dockerfile
@@ -11,7 +11,7 @@ FROM registry.fedoraproject.org/fedora:latest
 # Don't include container-selinux and remove
 # directories used by yum that are just taking
 # up space.
-RUN useradd build; yum -y update; rpm --restore shadow-utils 2>/dev/null; yum -y install buildah fuse-overlayfs xz --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
+RUN useradd build; yum -y update; rpm --restore shadow-utils 2>/dev/null; yum -y install cpp buildah fuse-overlayfs xz --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
 
 ADD https://raw.githubusercontent.com/containers/buildah/main/contrib/buildahimage/stable/containers.conf /etc/containers/
 

--- a/contrib/buildahimage/stablebyhand/Containerfile.buildahstable
+++ b/contrib/buildahimage/stablebyhand/Containerfile.buildahstable
@@ -23,7 +23,7 @@ FROM registry.fedoraproject.org/fedora:latest
 # `podman push quay.io/buildah/stable:v1.14.3 docker://quay.io/buildah/stable:v1.14.3`
 #
 COPY /tmp/buildah-1.14.3-1.fc31.x86_64.rpm /tmp
-RUN useradd build; yum -y update;  rpm --restore shadow-utils 2>/dev/null; yum -y install /tmp/buildah-1.14.3-1.fc31.x86_64.rpm fuse-overlayfs xz --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.* /tmp/buildah*.rpm
+RUN useradd build; yum -y update;  rpm --restore shadow-utils 2>/dev/null; yum -y install cpp /tmp/buildah-1.14.3-1.fc31.x86_64.rpm fuse-overlayfs xz --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.* /tmp/buildah*.rpm
 
 ADD https://raw.githubusercontent.com/containers/buildah/main/contrib/buildahimage/stable/containers.conf /etc/containers/
 

--- a/contrib/buildahimage/testing/Dockerfile
+++ b/contrib/buildahimage/testing/Dockerfile
@@ -13,7 +13,7 @@ FROM registry.fedoraproject.org/fedora:latest
 # Don't include container-selinux and remove
 # directories used by yum that are just taking
 # up space.
-RUN useradd build; yum -y update;  rpm --restore shadow-utils 2>/dev/null; yum -y install buildah fuse-overlayfs xz --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+RUN useradd build; yum -y update;  rpm --restore shadow-utils 2>/dev/null; yum -y install cpp buildah fuse-overlayfs xz --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 ADD https://raw.githubusercontent.com/containers/buildah/main/contrib/buildahimage/stable/containers.conf /etc/containers/
 

--- a/contrib/buildahimage/upstream/Dockerfile
+++ b/contrib/buildahimage/upstream/Dockerfile
@@ -19,6 +19,7 @@ ENV GOPATH=/root/buildah
 # that are needed for building but not running Buildah
 RUN useradd build; yum -y update;  rpm --restore shadow-utils 2>/dev/null; yum -y install --enablerepo=updates-testing \
      make \
+     cpp \
      golang \
      bats \
      btrfs-progs-devel \

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -431,8 +431,8 @@ func preprocessContainerfileContents(logger *logrus.Logger, containerfile string
 	cppCommand := "cpp"
 	cppPath, err := exec.LookPath(cppCommand)
 	if err != nil {
-		if os.IsNotExist(err) {
-			err = errors.Errorf("error: %s support requires %s to be installed", containerfile, cppPath)
+		if errors.Is(err, exec.ErrNotFound) {
+			err = fmt.Errorf("error: %v: .in support requires %s to be installed", err, cppCommand)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Ship `cpp` with the Buildah container images to make sure that
preprocessing .in files works as expected and documented.

Also improve the error message when cpp isn't installed.

Fixes: #3822