### PR TITLE
build, commit: allow removing default identity labels using `--identity-labels=false`

### DIFF
--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -39,6 +39,7 @@ type commitInputOptions struct {
 	signBy             string
 	squash             bool
 	tlsVerify          bool
+	identityLabel      bool
 	encryptionKeys     []string
 	encryptLayers      []int
 	unsetenvs          []string
@@ -107,6 +108,7 @@ func commitListFlagSet(cmd *cobra.Command, opts *commitInputOptions) {
 		panic(fmt.Sprintf("error marking reference-time as hidden: %v", err))
 	}
 
+	flags.BoolVar(&opts.identityLabel, "identity-label", true, "add default builder label (default true)")
 	flags.BoolVar(&opts.rm, "rm", false, "remove the container and its content after committing it to an image. Default leaves the container and its content in place.")
 	flags.StringVar(&opts.signaturePolicy, "signature-policy", "", "`pathname` of signature policy file (not usually used)")
 	_ = cmd.RegisterFlagCompletionFunc("signature-policy", completion.AutocompleteDefault)
@@ -189,7 +191,9 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 	}
 
 	// Add builder identity information.
-	builder.SetLabel(buildah.BuilderIdentityAnnotation, define.Version)
+	if iopts.identityLabel {
+		builder.SetLabel(buildah.BuilderIdentityAnnotation, define.Version)
+	}
 
 	encConfig, encLayers, err := getEncryptConfig(iopts.encryptionKeys, iopts.encryptLayers)
 	if err != nil {

--- a/define/build.go
+++ b/define/build.go
@@ -29,6 +29,8 @@ type CommonBuildOptions struct {
 	CPUSetMems string
 	// HTTPProxy determines whether *_proxy env vars from the build host are passed into the container.
 	HTTPProxy bool
+	// IdentityLabel if set ensures that default `io.buildah.version` label is not applied to build image.
+	IdentityLabel types.OptionalBool
 	// Memory is the upper limit (in bytes) on how much memory running containers can use.
 	Memory int64
 	// DNSSearch is the list of DNS search domains to add to the build container's /etc/resolv.conf

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -283,6 +283,10 @@ option to `false`.  The environment variables passed in include `http_proxy`,
 `https_proxy`, `ftp_proxy`, `no_proxy`, and also the upper case versions of
 those.
 
+**--identity-label** *bool-value*
+
+Adds default identity label `io.buildah.version` if set. (default true).
+
 **--ignorefile** *file*
 
 Path to an alternative .containerignore (.dockerignore) file.

--- a/docs/buildah-commit.1.md
+++ b/docs/buildah-commit.1.md
@@ -65,6 +65,10 @@ formats include *oci* (OCI image-spec v1.0, the default) and *docker* (version
 Note: You can also override the default format by setting the BUILDAH\_FORMAT
 environment variable.  `export BUILDAH\_FORMAT=docker`
 
+**--identity-label** *bool-value*
+
+Adds default identity label `io.buildah.version` if set. (default true).
+
 **--iidfile** *ImageIDfile*
 
 Write the image ID to the file.

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1519,7 +1519,9 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 			s.builder.SetLabel(label[0], "")
 		}
 	}
-	s.builder.SetLabel(buildah.BuilderIdentityAnnotation, define.Version)
+	if s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolUndefined || s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolTrue {
+		s.builder.SetLabel(buildah.BuilderIdentityAnnotation, define.Version)
+	}
 	for _, annotationSpec := range s.executor.annotations {
 		annotation := strings.SplitN(annotationSpec, "=", 2)
 		if len(annotation) > 1 {

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -74,6 +74,7 @@ type BudResults struct {
 	PullAlways          bool
 	PullNever           bool
 	Quiet               bool
+	IdentityLabel       bool
 	Rm                  bool
 	Runtime             string
 	RuntimeFlags        []string
@@ -227,6 +228,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 		panic(fmt.Sprintf("error marking the pull-never flag as hidden: %v", err))
 	}
 	fs.BoolVarP(&flags.Quiet, "quiet", "q", false, "refrain from announcing build instructions and image read/write progress")
+	fs.BoolVar(&flags.IdentityLabel, "identity-label", true, "add default identity label (default true)")
 	fs.BoolVar(&flags.Rm, "rm", true, "Remove intermediate containers after a successful build")
 	// "runtime" definition moved to avoid name collision in podman build.  Defined in cmd/buildah/build.go.
 	fs.StringSliceVar(&flags.RuntimeFlags, "runtime-flag", []string{}, "add global flags for the container runtime")

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -136,6 +136,7 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 	cpuQuota, _ := flags.GetInt64("cpu-quota")
 	cpuShares, _ := flags.GetUint64("cpu-shares")
 	httpProxy, _ := flags.GetBool("http-proxy")
+	identityLabel, _ := flags.GetBool("identity-label")
 
 	ulimit := []string{}
 	if flags.Changed("ulimit") {
@@ -146,25 +147,26 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 	sshsources, _ := flags.GetStringArray("ssh")
 
 	commonOpts := &define.CommonBuildOptions{
-		AddHost:      addHost,
-		CPUPeriod:    cpuPeriod,
-		CPUQuota:     cpuQuota,
-		CPUSetCPUs:   findFlagFunc("cpuset-cpus").Value.String(),
-		CPUSetMems:   findFlagFunc("cpuset-mems").Value.String(),
-		CPUShares:    cpuShares,
-		CgroupParent: findFlagFunc("cgroup-parent").Value.String(),
-		DNSOptions:   dnsOptions,
-		DNSSearch:    dnsSearch,
-		DNSServers:   dnsServers,
-		HTTPProxy:    httpProxy,
-		Memory:       memoryLimit,
-		MemorySwap:   memorySwap,
-		NoHosts:      noHosts,
-		ShmSize:      findFlagFunc("shm-size").Value.String(),
-		Ulimit:       ulimit,
-		Volumes:      volumes,
-		Secrets:      secrets,
-		SSHSources:   sshsources,
+		AddHost:       addHost,
+		CPUPeriod:     cpuPeriod,
+		CPUQuota:      cpuQuota,
+		CPUSetCPUs:    findFlagFunc("cpuset-cpus").Value.String(),
+		CPUSetMems:    findFlagFunc("cpuset-mems").Value.String(),
+		CPUShares:     cpuShares,
+		CgroupParent:  findFlagFunc("cgroup-parent").Value.String(),
+		DNSOptions:    dnsOptions,
+		DNSSearch:     dnsSearch,
+		DNSServers:    dnsServers,
+		HTTPProxy:     httpProxy,
+		IdentityLabel: types.NewOptionalBool(identityLabel),
+		Memory:        memoryLimit,
+		MemorySwap:    memorySwap,
+		NoHosts:       noHosts,
+		ShmSize:       findFlagFunc("shm-size").Value.String(),
+		Ulimit:        ulimit,
+		Volumes:       volumes,
+		Secrets:       secrets,
+		SSHSources:    sshsources,
 	}
 	securityOpts, _ := flags.GetStringArray("security-opt")
 	if err := parseSecurityOpts(securityOpts, commonOpts); err != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -633,6 +633,13 @@ _EOF
   expect_output "$want_output"
 }
 
+@test "bud-from-scratch-remove-identity-label" {
+  target=scratch-image
+  run_buildah build --identity-label=false --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
+  expect_output "map[]"
+}
+
 @test "bud-from-scratch-annotation" {
   target=scratch-image
   run_buildah build --annotation "test=annotation1,annotation2=z" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -24,6 +24,16 @@ load helpers
   run_buildah images alpine-image
 }
 
+@test "commit-with-remove-identity-label" {
+  _prefetch alpine
+  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$output
+  run_buildah commit --identity-label=false --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
+  run_buildah images alpine-image
+  run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' alpine-image
+  expect_output "map[]"
+}
+
 @test "commit format test" {
   _prefetch alpine
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine


### PR DESCRIPTION
Allow end users to remove default identity labels if they want to.
Since there are instances where images can be reproduced across version
hence users must have option to suppress default labels.

Closes: https://github.com/containers/buildah/issues/3826