### PR TITLE
network setup: increase timeout to 4 minutes

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -2333,9 +2333,9 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 	return err
 }
 
-// waitForSync waits for a maximum of 5 seconds to read something from the file
+// waitForSync waits for a maximum of 4 minutes to read something from the file
 func waitForSync(pipeR *os.File) error {
-	if err := pipeR.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+	if err := pipeR.SetDeadline(time.Now().Add(4 * time.Minute)); err != nil {
 		return err
 	}
 	b := make([]byte, 16)


### PR DESCRIPTION




<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

 /kind bug


#### What this PR does / why we need it:

Podman waits for 4 minutes to wait for conmon/oci runtime to create the
container[1]. Since this value seems to work we should use the same one
here.

[1] https://github.com/containers/podman/blob/b4b8b8b5374967f9a98aef6c9793c51342d54b9d/libpod/define/runtime.go#L27


#### How to verify it

#### Which issue(s) this PR fixes:
Fixes containers/podman#13327

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

