### PR TITLE
run: set parent-death signals and forward SIGHUP/SIGINT/SIGTERM

### DIFF
--- a/chroot/run.go
+++ b/chroot/run.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -159,9 +160,23 @@ func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reade
 
 	// Start the grandparent subprocess.
 	cmd := unshare.Command(runUsingChrootCommand)
+	setPdeathsig(cmd.Cmd)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdin, stdout, stderr
 	cmd.Dir = "/"
 	cmd.Env = []string{fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel())}
+
+	interrupted := make(chan os.Signal, 100)
+	cmd.Hook = func(int) error {
+		signal.Notify(interrupted, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			for receivedSignal := range interrupted {
+				if err := cmd.Process.Signal(receivedSignal); err != nil {
+					logrus.Infof("%v while attempting to forward %v to child process", err, receivedSignal)
+				}
+			}
+		}()
+		return nil
+	}
 
 	logrus.Debugf("Running %#v in %#v", cmd.Cmd, cmd)
 	confwg.Add(1)
@@ -173,6 +188,8 @@ func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reade
 	cmd.ExtraFiles = append([]*os.File{preader}, cmd.ExtraFiles...)
 	err = cmd.Run()
 	confwg.Wait()
+	signal.Stop(interrupted)
+	close(interrupted)
 	if err == nil {
 		return conferr
 	}
@@ -571,6 +588,7 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 
 	// Start the parent subprocess.
 	cmd := unshare.Command(append([]string{runUsingChrootExecCommand}, spec.Process.Args...)...)
+	setPdeathsig(cmd.Cmd)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdin, stdout, stderr
 	cmd.Dir = "/"
 	cmd.Env = []string{fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel())}
@@ -593,10 +611,19 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 	}
 	cmd.OOMScoreAdj = spec.Process.OOMScoreAdj
 	cmd.ExtraFiles = append([]*os.File{preader}, cmd.ExtraFiles...)
+	interrupted := make(chan os.Signal, 100)
 	cmd.Hook = func(int) error {
 		for _, f := range closeOnceRunning {
 			f.Close()
 		}
+		signal.Notify(interrupted, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			for receivedSignal := range interrupted {
+				if err := cmd.Process.Signal(receivedSignal); err != nil {
+					logrus.Infof("%v while attempting to forward %v to child process", err, receivedSignal)
+				}
+			}
+		}()
 		return nil
 	}
 
@@ -609,6 +636,8 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 	}()
 	err = cmd.Run()
 	confwg.Wait()
+	signal.Stop(interrupted)
+	close(interrupted)
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			if waitStatus, ok := exitError.ProcessState.Sys().(syscall.WaitStatus); ok {
@@ -792,11 +821,27 @@ func runUsingChrootExecMain() {
 
 	// Actually run the specified command.
 	cmd := exec.Command(args[0], args[1:]...)
+	setPdeathsig(cmd)
 	cmd.Env = options.Spec.Process.Env
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	cmd.Dir = cwd
 	logrus.Debugf("Running %#v (PATH = %q)", cmd, os.Getenv("PATH"))
-	if err = cmd.Run(); err != nil {
+	interrupted := make(chan os.Signal, 100)
+	if err = cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "process failed to start with error: %v", err)
+	}
+	go func() {
+		for range interrupted {
+			if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
+				logrus.Infof("%v while attempting to send SIGKILL to child process", err)
+			}
+		}
+	}()
+	signal.Notify(interrupted, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+	err = cmd.Wait()
+	signal.Stop(interrupted)
+	close(interrupted)
+	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			if waitStatus, ok := exitError.ProcessState.Sys().(syscall.WaitStatus); ok {
 				if waitStatus.Exited() {
@@ -1418,4 +1463,12 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 		}
 	}
 	return undoBinds, nil
+}
+
+// setPdeathsig sets a parent-death signal for the process
+func setPdeathsig(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4011,3 +4011,28 @@ _EOF
   run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/workdir-user
   expect_output --substring "1000:1000 /home/http/public"
 }
+
+@test "build interruption" {
+  skip_if_no_runtime
+
+  _prefetch alpine
+
+  mkfifo ${TESTDIR}/pipe
+  # start the build running in the background - don't use the function wrapper because that sets '$!' to a value that's not what we want
+  ${BUILDAH_BINARY} ${BUILDAH_REGISTRY_OPTS} ${ROOTDIR_OPTS} --signature-policy ${TESTSDIR}/policy.json build ${TESTSDIR}/bud/long-sleep > ${TESTDIR}/pipe 2>&1 &
+  buildah_pid="${!}"
+  echo buildah is pid ${buildah_pid}
+  # save what's written to the fifo to a plain file
+  coproc cat ${TESTDIR}/pipe > ${TESTDIR}/log
+  cat_pid="${COPROC_PID}"
+  echo cat is pid ${cat_pid}
+  # kill the buildah process early
+  sleep 30
+  kill -s SIGINT "${buildah_pid}"
+  # wait for output to stop getting written from anywhere
+  wait "${buildah_pid}" "${cat_pid}"
+  echo log:
+  cat ${TESTDIR}/log
+  echo checking:
+  ! grep 'not fully killed' ${TESTDIR}/log
+}

--- a/tests/bud/long-sleep/Dockerfile
+++ b/tests/bud/long-sleep/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+# this can be a long long time, since the test should kill it long before this has elapsed
+RUN sleep 300
+RUN echo not fully killed


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Restore setting of the parent-death signal when we're running subprocesses in Run(), so that if we get killed, the child processes will also get killed.

While a child process is running, if we receive SIGHUP, SIGINT, or SIGTERM, forward the signal to our child process unless it's ~~a container~~ the command we're executing, which we SIGKILL without mercy, and finish the current routine, which will then notice that the child process has exited and return an error to its caller.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes #3544.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```