### PR TITLE
Don't pollute

### DIFF
--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -67,9 +67,9 @@ load helpers
   root=$output
   cp ${TESTDIR}/randomfile $root/randomfile
   run_buildah unmount $cid
-  run_buildah commit --iidfile output.iid --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
-  iid=$(cat output.iid)
-  [[ "$iid" == "sha256:"* ]]
+  run_buildah commit --iidfile ${TESTDIR}/output.iid --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  iid=$(< ${TESTDIR}/output.iid)
+  assert "$iid" =~ "sha256:[0-9a-f]{64}"
   run_buildah rmi $iid
   run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
   run_buildah rm $cid

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -361,8 +361,8 @@ load helpers
 
 @test "from cidfile test" {
   _prefetch alpine
-  run_buildah from --cidfile output.cid --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
-  cid=$(cat output.cid)
+  run_buildah from --cidfile ${TESTDIR}/output.cid --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  cid=$(< ${TESTDIR}/output.cid)
   run_buildah containers -f id=${cid}
 }
 

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -176,7 +176,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     echo 'much content, wow.' > ${TESTDIR}/build/content.txt
     echo 'FROM scratch' > ${TESTDIR}/build/Dockerfile
     echo 'ADD content.txt /' >> ${TESTDIR}/build/Dockerfile
-    run_buildah bud --layers --iidfile image-id.txt ${TESTDIR}/build
+    run_buildah bud --layers --iidfile ${TESTDIR}/image-id.txt ${TESTDIR}/build
     # Make sure we can add the new image to the list.
-    run_buildah manifest add test-list $(cat image-id.txt)
+    run_buildah manifest add test-list $(< ${TESTDIR}/image-id.txt)
 }

--- a/tests/sign.bats
+++ b/tests/sign.bats
@@ -18,7 +18,7 @@ function _gpg_setup() {
       GPGOPTS=
   fi
 
-  cat > genkey-answers <<- EOF
+  cat > ${TESTDIR}/genkey-answers <<- EOF
 	%echo Generating a basic OpenPGP key
 	Key-Type: RSA
 	Key-Length: 2048
@@ -28,7 +28,7 @@ function _gpg_setup() {
 	%commit
 	%echo done
 	EOF
-  gpg --batch $GPGOPTS --gen-key --passphrase '' < genkey-answers
+  gpg --batch $GPGOPTS --gen-key --passphrase '' < ${TESTDIR}/genkey-answers
 }
 
 
@@ -79,13 +79,15 @@ function _gpg_setup() {
 @test "build-with-dockerfile-signatures" {
   _gpg_setup
 
-  cat > Dockerfile <<- EOF
+  builddir=${TESTDIR}/builddir
+  mkdir -p $builddir
+  cat > ${builddir}/Dockerfile <<- EOF
 	FROM scratch
 	ADD Dockerfile /
 	EOF
 
   # We should be able to sign at build-time.
-  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --sign-by amanda@localhost -t signed-scratch-image .
+  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --sign-by amanda@localhost -t signed-scratch-image ${builddir}
 
   mkdir -p ${TESTDIR}/signed-image
   # Pushing should preserve the signature.


### PR DESCRIPTION
Several tests were doing '--iidfile x', where 'x' is a filename
with no path. This is super bad: if running as root, it leaves
litter in the current directory. If rootless, it may throw EPERM.
Clean those up, using $TESTDIR for each one.

Tested by running the test suite on my laptop and confirming
there are no more droppings.

And, refactor one particularly hairy set of duplicated build
incantations: make them a series of simple clean loops.

Signed-off-by: Ed Santiago <santiago@redhat.com>
