### PR TITLE
[CI:DOCS] man pages: sort flags, and keep them that way

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -271,7 +271,7 @@ environment variable.  `export BUILDAH_FORMAT=docker`
 Overrides the first `FROM` instruction within the Containerfile.  If there are multiple
 FROM instructions in a Containerfile, only the first is changed.
 
-**-h**, **--help**
+**--help**, **-h**
 
 Print usage statement
 
@@ -283,14 +283,14 @@ option to `false`.  The environment variables passed in include `http_proxy`,
 `https_proxy`, `ftp_proxy`, `no_proxy`, and also the upper case versions of
 those.
 
+**--ignorefile** *file*
+
+Path to an alternative .containerignore (.dockerignore) file.
+
 **--iidfile** *ImageIDfile*
 
 Write the built image's ID to the file.  When `--platform` is specified more
 than once, attempting to use this option will trigger an error.
-
-**--ignorefile** *file*
-
-Path to an alternative .containerignore (.dockerignore) file.
 
 **--ipc** *how*
 
@@ -602,21 +602,6 @@ the user namespace in which `buildah` itself is being run should be reused, or
 it can be the path to an user namespace which is already in use by another
 process.
 
-**--userns-uid-map-user** *user*
-
-Specifies that a UID mapping which should be used to set ownership, at the
-filesystem level, on the working container's contents, can be found in entries
-in the `/etc/subuid` file which correspond to the specified user.
-Commands run when handling `RUN` instructions will default to being run in
-their own user namespaces, configured using the UID and GID maps.
-If --userns-gid-map-group is specified, but --userns-uid-map-user is not
-specified, `buildah` will assume that the specified group name is also a
-suitable user name to use as the default setting for this option.
-
-Users can specify the maps directly using `--userns-uid-map` described in the buildah(1) man page.
-
-**NOTE:** When this option is specified by a rootless user, the specified mappings are relative to the rootless usernamespace in the container, rather than being relative to the host as it would be when run rootful.
-
 **--userns-gid-map-group** *group*
 
 Specifies that a GID mapping which should be used to set ownership, at the
@@ -629,6 +614,21 @@ specified, `buildah` will assume that the specified user name is also a
 suitable group name to use as the default setting for this option.
 
 Users can specify the maps directly using `--userns-gid-map` described in the buildah(1) man page.
+
+**NOTE:** When this option is specified by a rootless user, the specified mappings are relative to the rootless usernamespace in the container, rather than being relative to the host as it would be when run rootful.
+
+**--userns-uid-map-user** *user*
+
+Specifies that a UID mapping which should be used to set ownership, at the
+filesystem level, on the working container's contents, can be found in entries
+in the `/etc/subuid` file which correspond to the specified user.
+Commands run when handling `RUN` instructions will default to being run in
+their own user namespaces, configured using the UID and GID maps.
+If --userns-gid-map-group is specified, but --userns-uid-map-user is not
+specified, `buildah` will assume that the specified group name is also a
+suitable user name to use as the default setting for this option.
+
+Users can specify the maps directly using `--userns-uid-map` described in the buildah(1) man page.
 
 **NOTE:** When this option is specified by a rootless user, the specified mappings are relative to the rootless usernamespace in the container, rather than being relative to the host as it would be when run rootful.
 

--- a/docs/buildah-commit.1.md
+++ b/docs/buildah-commit.1.md
@@ -48,13 +48,13 @@ registries, and images being written to local storage would only need to be
 decompressed again to be stored.  Compression can be forced in all cases by
 specifying **--disable-compression=false**.
 
-**--encryption-key** *key*
-
-The [protocol:keyfile] specifies the encryption protocol, which can be JWE (RFC7516), PGP (RFC4880), and PKCS7 (RFC2315) and the key material required for image encryption. For instance, jwe:/path/to/key.pem or pgp:admin@example.com or pkcs7:/path/to/x509-file.
-
 **--encrypt-layer** *layer(s)*
 
 Layer(s) to encrypt: 0-indexed layer indices with support for negative indexing (e.g. 0 is the first layer, -1 is the last layer). If not defined, will encrypt all layers if encryption-key flag is specified.
+
+**--encryption-key** *key*
+
+The [protocol:keyfile] specifies the encryption protocol, which can be JWE (RFC7516), PGP (RFC4880), and PKCS7 (RFC2315) and the key material required for image encryption. For instance, jwe:/path/to/key.pem or pgp:admin@example.com or pkcs7:/path/to/x509-file.
 
 **--format**, **-f** *[oci | docker]*
 

--- a/docs/buildah-from.1.md
+++ b/docs/buildah-from.1.md
@@ -266,8 +266,7 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
 A *name* for the working container
 
-**--net** *how*
-**--network** *how*
+**--network** *how*, **--net** *how*
 
 Sets the configuration for network namespaces when the container is subsequently
 used for `buildah run`.
@@ -394,29 +393,6 @@ the user namespace in which `Buildah` itself is being run should be reused, or
 it can be the path to an user namespace which is already in use by another
 process.
 
-**--userns-uid-map-user** *mapping*
-
-Directly specifies a UID mapping which should be used to set ownership, at the
-filesystem level, on the container's contents.
-Commands run using `buildah run` will default to being run in their own user
-namespaces, configured using the UID and GID maps.
-
-Entries in this map take the form of one or more triples of a starting
-in-container UID, a corresponding starting host-level UID, and the number of
-consecutive IDs which the map entry represents.
-
-This option overrides the *remap-uids* setting in the *options* section of
-/etc/containers/storage.conf.
-
-If this option is not specified, but a global --userns-uid-map setting is
-supplied, settings from the global option will be used.
-
-If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-uid-map
-are specified, but --userns-gid-map is specified, the UID map will be set to
-use the same numeric values as the GID map.
-
-**NOTE:** When this option is specified by a rootless user, the specified mappings are relative to the rootless usernamespace in the container, rather than being relative to the host as it would be when run rootful.
-
 **--userns-gid-map-group** *mapping*
 
 Directly specifies a GID mapping which should be used to set ownership, at the
@@ -440,17 +416,6 @@ use the same numeric values as the UID map.
 
 **NOTE:** When this option is specified by a rootless user, the specified mappings are relative to the rootless usernamespace in the container, rather than being relative to the host as it would be when run rootful.
 
-**--userns-uid-map-user** *user*
-
-Specifies that a UID mapping which should be used to set ownership, at the
-filesystem level, on the container's contents, can be found in entries in the
-`/etc/subuid` file which correspond to the specified user.
-Commands run using `buildah run` will default to being run in their own user
-namespaces, configured using the UID and GID maps.
-If --userns-gid-map-group is specified, but --userns-uid-map-user is not
-specified, `Buildah` will assume that the specified group name is also a
-suitable user name to use as the default setting for this option.
-
 **--userns-gid-map-group** *group*
 
 Specifies that a GID mapping which should be used to set ownership, at the
@@ -461,6 +426,40 @@ namespaces, configured using the UID and GID maps.
 If --userns-uid-map-user is specified, but --userns-gid-map-group is not
 specified, `Buildah` will assume that the specified user name is also a
 suitable group name to use as the default setting for this option.
+
+**--userns-uid-map-user** *mapping*
+
+Directly specifies a UID mapping which should be used to set ownership, at the
+filesystem level, on the container's contents.
+Commands run using `buildah run` will default to being run in their own user
+namespaces, configured using the UID and GID maps.
+
+Entries in this map take the form of one or more triples of a starting
+in-container UID, a corresponding starting host-level UID, and the number of
+consecutive IDs which the map entry represents.
+
+This option overrides the *remap-uids* setting in the *options* section of
+/etc/containers/storage.conf.
+
+If this option is not specified, but a global --userns-uid-map setting is
+supplied, settings from the global option will be used.
+
+If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-uid-map
+are specified, but --userns-gid-map is specified, the UID map will be set to
+use the same numeric values as the GID map.
+
+**NOTE:** When this option is specified by a rootless user, the specified mappings are relative to the rootless usernamespace in the container, rather than being relative to the host as it would be when run rootful.
+
+**--userns-uid-map-user** *user*
+
+Specifies that a UID mapping which should be used to set ownership, at the
+filesystem level, on the container's contents, can be found in entries in the
+`/etc/subuid` file which correspond to the specified user.
+Commands run using `buildah run` will default to being run in their own user
+namespaces, configured using the UID and GID maps.
+If --userns-gid-map-group is specified, but --userns-uid-map-user is not
+specified, `Buildah` will assume that the specified group name is also a
+suitable user name to use as the default setting for this option.
 
 **--uts** *how*
 

--- a/docs/buildah-images.1.md
+++ b/docs/buildah-images.1.md
@@ -76,13 +76,13 @@ Display the image name history.
 
 Display the output in JSON format.
 
-**--noheading**, **-n**
-
-Omit the table headings from the listing of images.
-
 **--no-trunc**
 
 Do not truncate output.
+
+**--noheading**, **-n**
+
+Omit the table headings from the listing of images.
 
 **--quiet**, **-q**
 

--- a/docs/buildah-pull.1.md
+++ b/docs/buildah-pull.1.md
@@ -52,10 +52,6 @@ value can be entered.  The password is entered without echo.
 
 The [key[:passphrase]] to be used for decryption of images. Key can point to keys and/or certificates. Decryption will be tried with all keys. If the key is protected by a passphrase, it is required to be passed in the argument and omitted otherwise.
 
-**--quiet**, **-q**
-
-If an image needs to be pulled from the registry, suppress progress output.
-
 **--os**="OS"
 
 Set the OS of the image to be pulled instead of using the current operating system of the host.
@@ -81,6 +77,10 @@ Pull image policy. The default is **missing**.
 - **missing**: attempt to pull the latest image from the registries listed in registries.conf if a local image does not exist. Raise an error if the image is not in any listed registry and is not present locally.
 - **always**: Pull the image from the first registry it is found in as listed in  registries.conf. Raise an error if not found in the registries, even if the image is present locally.
 - **never**: do not pull the image from the registry, use only the local version. Raise an error if the image is not present locally.
+
+**--quiet**, **-q**
+
+If an image needs to be pulled from the registry, suppress progress output.
 
 **--remove-signatures**
 

--- a/docs/buildah-push.1.md
+++ b/docs/buildah-push.1.md
@@ -62,13 +62,13 @@ After copying the image, write the digest of the resulting image to the file.
 
 Don't compress copies of filesystem layers which will be pushed.
 
-**--encryption-key** *key*
-
-The [protocol:keyfile] specifies the encryption protocol, which can be JWE (RFC7516), PGP (RFC4880), and PKCS7 (RFC2315) and the key material required for image encryption. For instance, jwe:/path/to/key.pem or pgp:admin@example.com or pkcs7:/path/to/x509-file.
-
 **--encrypt-layer** *layer(s)*
 
 Layer(s) to encrypt: 0-indexed layer indices with support for negative indexing (e.g. 0 is the first layer, -1 is the last layer). If not defined, will encrypt all layers if encryption-key flag is specified.
+
+**--encryption-key** *key*
+
+The [protocol:keyfile] specifies the encryption protocol, which can be JWE (RFC7516), PGP (RFC4880), and PKCS7 (RFC2315) and the key material required for image encryption. For instance, jwe:/path/to/key.pem or pgp:admin@example.com or pkcs7:/path/to/x509-file.
 
 **--format**, **-f**
 

--- a/docs/buildah-rmi.1.md
+++ b/docs/buildah-rmi.1.md
@@ -37,14 +37,14 @@ Passing an argument _image_ deletes it, along with any of its dangling (untagged
 All local images will be removed from the system that do not have containers using the image as a reference image.
 An image name or id cannot be provided when this option is used. Read/Only images configured by modifying the "additionalimagestores" in the /etc/containers/storage.conf file, can not be removed.
 
+**--force**, **-f**
+
+This option will cause Buildah to remove all containers that are using the image before removing the image from the system.
+
 **--prune**, **-p**
 
 All local images will be removed from the system that do not have a tag and do not have a child image pointing to them.
 An image name or id cannot be provided when this option is used.
-
-**--force**, **-f**
-
-This option will cause Buildah to remove all containers that are using the image before removing the image from the system.
 
 ## EXAMPLE
 

--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -14,6 +14,7 @@ the *buildah config* command.  To execute *buildah run* within an
 interactive shell, specify the --tty option.
 
 ## OPTIONS
+
 **--add-history**
 
 Add an entry to the history which will note what command is being invoked.
@@ -46,18 +47,18 @@ If a capability is specified to both the **--cap-add** and **--cap-drop**
 options, it will be dropped, regardless of the order in which the options were
 given.
 
-**--contextdir** *directory*
-
-Allows setting context directory for current RUN invocation. Specifying a context
-directory causes RUN context to consider context directory as root directory for
-specified source in `--mount` of type 'bind'.
-
 **--cgroupns** *how*
 
 Sets the configuration for the cgroup namespaces for the container.
 The configured value can be "" (the empty string) or "private" to indicate
 that a new cgroup namespace should be created, or it can be "host" to indicate
 that the cgroup namespace in which `buildah` itself is being run should be reused.
+
+**--contextdir** *directory*
+
+Allows setting context directory for current RUN invocation. Specifying a context
+directory causes RUN context to consider context directory as root directory for
+specified source in `--mount` of type 'bind'.
 
 **--env**, **-e** *env=value*
 
@@ -159,6 +160,21 @@ Sets the configuration for the network namespace for the container.
 - **ns:**_path_: path to a network namespace to join;
 - `private`: create a new namespace for the container (default)
 
+**--no-hosts**
+
+Do not create _/etc/hosts_ for the container.
+
+By default, Buildah manages _/etc/hosts_, adding the container's own IP address.
+**--no-hosts** disables this, and the image's _/etc/hosts_ will be preserved unmodified.
+
+**--no-pivot**
+
+Do not use pivot root to jail process inside rootfs. This should be used
+whenever the rootfs is on top of a ramdisk.
+
+Note: You can make this option the default by setting the BUILDAH\_NOPIVOT
+environment variable.  `export BUILDAH_NOPIVOT=true`
+
 **--pid** *how*
 
 Sets the configuration for the PID namespace for the container.
@@ -182,22 +198,7 @@ consult the manpages of the selected container runtime.
 Note: Do not pass the leading `--` to the flag. To pass the runc flag `--log-format json`
 to buildah run, the option given would be `--runtime-flag log-format=json`.
 
-**--no-hosts**
-
-Do not create _/etc/hosts_ for the container.
-
-By default, Buildah manages _/etc/hosts_, adding the container's own IP address.
-**--no-hosts** disables this, and the image's _/etc/hosts_ will be preserved unmodified.
-
-**--no-pivot**
-
-Do not use pivot root to jail process inside rootfs. This should be used
-whenever the rootfs is on top of a ramdisk.
-
-Note: You can make this option the default by setting the BUILDAH\_NOPIVOT
-environment variable.  `export BUILDAH_NOPIVOT=true`
-
-**-t**, **--tty**, **--terminal**
+**--tty**, **--terminal**, **-t**
 
 By default a pseudo-TTY is allocated only when buildah's standard input is
 attached to a pseudo-TTY.  Setting the `--tty` option to `true` will cause a

--- a/docs/buildah-source-create.1.md
+++ b/docs/buildah-source-create.1.md
@@ -14,6 +14,7 @@ Note that the buildah-source command and all its subcommands are experimental
 and may be subject to future changes
 
 ## OPTIONS
+
 **--author** *author*
 
 Set the author of the source image mentioned in the config.  By default, no author is set.

--- a/docs/buildah-umount.1.md
+++ b/docs/buildah-umount.1.md
@@ -10,6 +10,7 @@ buildah\-umount - Unmount the root file system on the specified working containe
 Unmounts the root file system on the specified working containers.
 
 ## OPTIONS
+
 **--all**, **-a**
 
 All of the currently mounted containers will be unmounted.

--- a/docs/buildah-unshare.1.md
+++ b/docs/buildah-unshare.1.md
@@ -20,6 +20,7 @@ It is also useful if you want to use the `buildah mount` command.  If an unprivi
 buildah unshare.  Executing `buildah mount` fails for unprivileged users unless the user is running inside a `buildah unshare` session.
 
 ## OPTIONS
+
 **--mount**, **-m** [*VARIABLE=]containerNameOrID*
 
 Mount the *containerNameOrID* container while running *command*, and set the

--- a/docs/buildah.1.md
+++ b/docs/buildah.1.md
@@ -87,29 +87,6 @@ specify additional options via the `--storage-opt` flag.
 
 Storage driver option, Default storage driver options are configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode). The `STORAGE_OPTS` environment variable overrides the default. The --storage-opt specified options overrides all.
 
-**--userns-uid-map** *mapping*
-
-Directly specifies a UID mapping which should be used to set ownership, at the
-filesystem level, on the working container's contents.
-Commands run when handling `RUN` instructions will default to being run in
-their own user namespaces, configured using the UID and GID maps.
-
-Entries in this map take the form of one or more colon-separated triples of a starting
-in-container UID, a corresponding starting host-level UID, and the number of
-consecutive IDs which the map entry represents.
-
-This option overrides the *remap-uids* setting in the *options* section of
-/etc/containers/storage.conf.
-
-If this option is not specified, but a global --userns-uid-map setting is
-supplied, settings from the global option will be used.
-
-If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-uid-map
-are specified, but --userns-gid-map is specified, the UID map will be set to
-use the same numeric values as the GID map.
-
-**NOTE:** When this option is specified by a rootless user, the specified mappings are relative to the rootless usernamespace in the container, rather than being relative to the host as it would be when run rootful.
-
 **--userns-gid-map** *mapping*
 
 Directly specifies a GID mapping which should be used to set ownership, at the
@@ -130,6 +107,29 @@ supplied, settings from the global option will be used.
 If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-gid-map
 are specified, but --userns-uid-map is specified, the GID map will be set to
 use the same numeric values as the UID map.
+
+**NOTE:** When this option is specified by a rootless user, the specified mappings are relative to the rootless usernamespace in the container, rather than being relative to the host as it would be when run rootful.
+
+**--userns-uid-map** *mapping*
+
+Directly specifies a UID mapping which should be used to set ownership, at the
+filesystem level, on the working container's contents.
+Commands run when handling `RUN` instructions will default to being run in
+their own user namespaces, configured using the UID and GID maps.
+
+Entries in this map take the form of one or more colon-separated triples of a starting
+in-container UID, a corresponding starting host-level UID, and the number of
+consecutive IDs which the map entry represents.
+
+This option overrides the *remap-uids* setting in the *options* section of
+/etc/containers/storage.conf.
+
+If this option is not specified, but a global --userns-uid-map setting is
+supplied, settings from the global option will be used.
+
+If none of --userns-uid-map-user, --userns-gid-map-group, or --userns-uid-map
+are specified, but --userns-gid-map is specified, the UID map will be set to
+use the same numeric values as the GID map.
 
 **NOTE:** When this option is specified by a rootless user, the specified mappings are relative to the rootless usernamespace in the container, rather than being relative to the host as it would be when run rootful.
 

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -243,13 +243,18 @@ sub tool_man {
     my $section = '';
     my @most_recent_flags;
     my $previous_subcmd = '';
+    my $previous_flag = '';
+    my @line_history;                   # Circular buffer of recent lines
     while (my $line = <$fh>) {
         chomp $line;
+        push @line_history, $line;
+        shift @line_history if @line_history > 2;
         next unless $line;		# skip empty lines
 
         # .md files designate sections with leading double hash
         if ($line =~ /^##\s*(GLOBAL\s+)?OPTIONS/) {
             $section = 'flags';
+            $previous_flag = '';
         }
         elsif ($line =~ /^\#\#\s+(SUB)?COMMANDS/) {
             $section = 'commands';
@@ -289,13 +294,31 @@ sub tool_man {
                 delete $man{$_} for @most_recent_flags;
             }
 
+            # AAAAAAAaaaaargh, workaround for buildah-config --add-history
+            # which enumerates a long list of options. Since buildah man pages
+            # (unlike podman) don't use the '####' convention for options,
+            # it's hard to differentiate 'this is an option' from 'this is
+            # a __mention__ of an option'. Workaround: actual options must
+            # be preceded by an empty line.
+            next if $line_history[-2];
+
             @most_recent_flags = ();
             # Handle any variation of '**--foo**, **-f**'
+            my $is_first = 1;
             while ($line =~ s/^\*\*((--[a-z0-9-]+)|(-.))\*\*(,\s+)?//g) {
-                $man{$1} = 1;
-
+                my $flag = $1;
+                $man{$flag} = 1;
+                if ($flag lt $previous_flag && $is_first) {
+                    warn "$ME: $subpath:$.: $flag should precede $previous_flag\n";
+                    ++$Errs;
+                }
+                $previous_flag = $flag if $is_first;
                 # Keep track of them, in case we see 'Not implemented' below
-                push @most_recent_flags, $1;
+                push @most_recent_flags, $flag;
+
+                # Further iterations of /g are allowed to be out of order,
+                # e.g., it's OK for --namespace,-ns to precede --nohead
+                $is_first = 0;
             }
         }
     }


### PR DESCRIPTION
Enforce alphabetical ordering of command-line options in
man pages. Not as simple as with podman, because conventions
are different.

Reference: https://github.com/containers/podman/pull/13625

Signed-off-by: Ed Santiago <santiago@redhat.com>
