### PR TITLE
Add a test for CVE-2022-27651

### DIFF
--- a/tests/run.bats
+++ b/tests/run.bats
@@ -786,9 +786,23 @@ _EOF
 	if test "$DBUS_SESSION_BUS_ADDRESS" = ""; then
 		skip "${1:-test does not work when \$BUILDAH_ISOLATION = chroot}"
 	fi
+	_prefetch alpine
 
 	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
 	cid=$output
 	run_buildah run --cgroupns=host $cid cat /proc/self/cgroup
 	expect_output --substring "/user.slice/"
+}
+
+@test "run-inheritable-capabilities" {
+	skip_if_no_runtime
+
+	_prefetch alpine
+
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	cid=$output
+	run_buildah run $cid grep ^CapInh: /proc/self/status
+	expect_output "CapInh:	0000000000000000"
+	run_buildah run --cap-add=ALL $cid grep ^CapInh: /proc/self/status
+	expect_output "CapInh:	0000000000000000"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Check that the inheritable capabilities are set to 0, even when we explicitly try to add capabilities, so that we won't inadvertently break the fix for CVE-2022-27651 later.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```