### PR TITLE
[release-1.11-rhel] CVE-2022-27651: do not set the inheritable capabilities

### DIFF
--- a/chroot/run.go
+++ b/chroot/run.go
@@ -888,7 +888,7 @@ func setCapabilities(spec *specs.Spec, keepCaps ...string) error {
 	capMap := map[capability.CapType][]string{
 		capability.BOUNDING:    spec.Process.Capabilities.Bounding,
 		capability.EFFECTIVE:   spec.Process.Capabilities.Effective,
-		capability.INHERITABLE: spec.Process.Capabilities.Inheritable,
+		capability.INHERITABLE: []string{},
 		capability.PERMITTED:   spec.Process.Capabilities.Permitted,
 		capability.AMBIENT:     spec.Process.Capabilities.Ambient,
 	}

--- a/run_linux.go
+++ b/run_linux.go
@@ -1755,9 +1755,6 @@ func setupCapAdd(g *generate.Generator, caps ...string) error {
 		if err := g.AddProcessCapabilityEffective(cap); err != nil {
 			return errors.Wrapf(err, "error adding %q to the effective capability set", cap)
 		}
-		if err := g.AddProcessCapabilityInheritable(cap); err != nil {
-			return errors.Wrapf(err, "error adding %q to the inheritable capability set", cap)
-		}
 		if err := g.AddProcessCapabilityPermitted(cap); err != nil {
 			return errors.Wrapf(err, "error adding %q to the permitted capability set", cap)
 		}
@@ -1775,9 +1772,6 @@ func setupCapDrop(g *generate.Generator, caps ...string) error {
 		}
 		if err := g.DropProcessCapabilityEffective(cap); err != nil {
 			return errors.Wrapf(err, "error removing %q from the effective capability set", cap)
-		}
-		if err := g.DropProcessCapabilityInheritable(cap); err != nil {
-			return errors.Wrapf(err, "error removing %q from the inheritable capability set", cap)
 		}
 		if err := g.DropProcessCapabilityPermitted(cap); err != nil {
 			return errors.Wrapf(err, "error removing %q from the permitted capability set", cap)

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -389,3 +389,16 @@ function configure_and_check_user() {
 	cid=$(buildah from --pull=false --device /dev/fuse:/dev/fuse1 --signature-policy ${TESTSDIR}/policy.json alpine)
 	run_buildah 0 run ${cid} ls /dev/fuse1
 }
+
+@test "run-inheritable-capabilities" {
+	skip_if_no_runtime
+
+	_prefetch alpine
+
+	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	cid=$output
+	run_buildah run $cid grep ^CapInh: /proc/self/status
+	expect_output "CapInh:	0000000000000000"
+	run_buildah run --cap-add=ALL $cid grep ^CapInh: /proc/self/status
+	expect_output "CapInh:	0000000000000000"
+}


### PR DESCRIPTION
The kernel never sets the inheritable capabilities for a process, they are only set by userspace. Emulate the same behavior.

Closes: CVE-2022-27651

Cherry-picked from https://github.com/containers/buildah/commit/e7e55c988c05dd74005184ceb64f097a0cfe645b for GHSA-c3g4-w6cv-6v7h applied to the main branch.