### PR TITLE
Switch most calls to filepath.Walk to filepath.WalkDir

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"net"
 	"os"
@@ -1179,10 +1180,10 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 				// we don't expand any of the contents that are archives
 				options := req.GetOptions
 				options.ExpandArchives = false
-				walkfn := func(path string, info os.FileInfo, err error) error {
+				walkfn := func(path string, d fs.DirEntry, err error) error {
 					if err != nil {
 						if options.IgnoreUnreadable && errorIsPermission(err) {
-							if info != nil && info.IsDir() {
+							if info != nil && d.IsDir() {
 								return filepath.SkipDir
 							}
 							return nil
@@ -1192,8 +1193,8 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 						}
 						return errors.Wrapf(err, "copier: get: error reading %q", path)
 					}
-					if info.Mode()&os.ModeType == os.ModeSocket {
-						logrus.Warningf("copier: skipping socket %q", info.Name())
+					if d.Type() == os.ModeSocket {
+						logrus.Warningf("copier: skipping socket %q", d.Name())
 						return nil
 					}
 					// compute the path of this item
@@ -1216,7 +1217,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 						return err
 					}
 					if skip {
-						if info.IsDir() {
+						if d.IsDir() {
 							// if there are no "include
 							// this anyway" patterns at
 							// all, we don't need to
@@ -1254,17 +1255,21 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 					}
 					// if it's a symlink, read its target
 					symlinkTarget := ""
-					if info.Mode()&os.ModeType == os.ModeSymlink {
+					if d.Type() == os.ModeSymlink {
 						target, err := os.Readlink(path)
 						if err != nil {
 							return errors.Wrapf(err, "copier: get: readlink(%q(%q))", rel, path)
 						}
 						symlinkTarget = target
 					}
+					info, err := d.Info()
+					if err != nil {
+						return err
+					}
 					// if it's a directory and we're staying on one device, and it's on a
 					// different device than the one we started from, skip its contents
 					var ok error
-					if info.Mode().IsDir() && req.GetOptions.NoCrossDevice {
+					if d.IsDir() && req.GetOptions.NoCrossDevice {
 						if !sameDevice(topInfo, info) {
 							ok = filepath.SkipDir
 						}
@@ -1282,7 +1287,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 					return ok
 				}
 				// walk the directory tree, checking/adding items individually
-				if err := filepath.Walk(item, walkfn); err != nil {
+				if err := filepath.WalkDir(item, walkfn); err != nil {
 					return errors.Wrapf(err, "copier: get: %q(%q)", queue[i], item)
 				}
 				itemsCopied++

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path"
@@ -501,8 +502,8 @@ func testPut(t *testing.T) {
 				require.NoErrorf(t, err, "error extracting archive %q to directory %q", testArchives[i].name, tmp)
 
 				var found []string
-				err = filepath.Walk(tmp, func(path string, info os.FileInfo, err error) error {
-					if info == nil || err != nil {
+				err = filepath.WalkDir(tmp, func(path string, d fs.DirEntry, err error) error {
+					if err != nil {
 						return err
 					}
 					rel, err := filepath.Rel(tmp, path)
@@ -1561,8 +1562,8 @@ func testMkdir(t *testing.T) {
 					root := dir
 					options := MkdirOptions{ChownNew: &idtools.IDPair{UID: os.Getuid(), GID: os.Getgid()}}
 					var beforeNames, afterNames []string
-					err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-						if info == nil || err != nil {
+					err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+						if err != nil {
 							return err
 						}
 						rel, err := filepath.Rel(dir, path)
@@ -1575,8 +1576,8 @@ func testMkdir(t *testing.T) {
 					require.NoErrorf(t, err, "error walking directory to catalog pre-Mkdir contents: %v", err)
 					err = Mkdir(root, testCase.create, options)
 					require.NoErrorf(t, err, "error creating directory %q under %q with Mkdir: %v", testCase.create, root, err)
-					err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-						if info == nil || err != nil {
+					err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+						if err != nil {
 							return err
 						}
 						rel, err := filepath.Rel(dir, path)
@@ -1777,8 +1778,8 @@ func testRemove(t *testing.T) {
 					root := dir
 					options := RemoveOptions{All: testCase.all}
 					beforeNames := make(map[string]struct{})
-					err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-						if info == nil || err != nil {
+					err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+						if err != nil {
 							return err
 						}
 						rel, err := filepath.Rel(dir, path)
@@ -1796,8 +1797,8 @@ func testRemove(t *testing.T) {
 					}
 					require.NoErrorf(t, err, "error removing item %q under %q with Remove: %v", testCase.remove, root, err)
 					afterNames := make(map[string]struct{})
-					err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-						if info == nil || err != nil {
+					err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+						if err != nil {
 							return err
 						}
 						rel, err := filepath.Rel(dir, path)


### PR DESCRIPTION
Should speed up most walks escpecially if they don't need to
stat every directory entry.

[ NO NEW TESTS NEEDED]

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

