### PR TITLE
build: allow `--no-cache` and `--layers` so build cache can be overrided

### DIFF
--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -280,10 +280,6 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 		return errors.Errorf("can only set one of 'pull' or 'pull-always' or 'pull-never'")
 	}
 
-	if c.Flag("layers").Changed && c.Flag("no-cache").Changed {
-		return errors.Errorf("can only set one of 'layers' or 'no-cache'")
-	}
-
 	if (c.Flag("rm").Changed || c.Flag("force-rm").Changed) && (!c.Flag("layers").Changed && !c.Flag("no-cache").Changed) {
 		return errors.Errorf("'rm' and 'force-rm' can only be set with either 'layers' or 'no-cache'")
 	}


### PR DESCRIPTION
Buildah should allow users to override build cache by using `--no-cache`
and `--layers` togather, this is already functional but there is a top
level check which must be removed

Closes: https://github.com/containers/buildah/issues/3861