### PR TITLE
Bump openshift/imagebuilder to v1.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/runtime-tools v0.9.0
 	github.com/opencontainers/selinux v1.10.0
-	github.com/openshift/imagebuilder v1.2.2
+	github.com/openshift/imagebuilder v1.2.3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.1 // indirect
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921

--- a/go.sum
+++ b/go.sum
@@ -878,8 +878,8 @@ github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xA
 github.com/opencontainers/selinux v1.8.5/go.mod h1:HTvjPFoGMbpQsG886e3lQwnsRWtE4TC1OF3OUvG9FAo=
 github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK99DRLDhyU=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/openshift/imagebuilder v1.2.2 h1:++jWWMkTVJKP2MIjTPaTk2MqwWIOYYlDaQbZyLlLBh0=
-github.com/openshift/imagebuilder v1.2.2/go.mod h1:TRYHe4CH9U6nkDjxjBNM5klrLbJBrRbpJE5SaRwUBsQ=
+github.com/openshift/imagebuilder v1.2.3 h1:jvA7mESJdclRKkTe3Yl6UWlliFNVW6mLY8RI+Rrfhfo=
+github.com/openshift/imagebuilder v1.2.3/go.mod h1:TRYHe4CH9U6nkDjxjBNM5klrLbJBrRbpJE5SaRwUBsQ=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1572,3 +1572,12 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 func (s *StageExecutor) EnsureContainerPath(path string) error {
 	return copier.Mkdir(s.mountPoint, filepath.Join(s.mountPoint, path), copier.MkdirOptions{})
 }
+
+// TODO: Stub for v1.25.1 build
+func (s *StageExecutor) EnsureContainerPathAs(path string, user string, mode *os.FileMode) error {
+        coptions := copier.MkdirOptions{
+                ChmodNew: mode,
+        }
+
+	return copier.Mkdir(s.mountPoint, filepath.Join(s.mountPoint, path), coptions)
+}

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/client.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/client.go
@@ -682,10 +682,26 @@ func (e *ClientExecutor) Preserve(path string) error {
 }
 
 func (e *ClientExecutor) EnsureContainerPath(path string) error {
-	return e.createOrReplaceContainerPathWithOwner(path, 0, 0)
+	return e.createOrReplaceContainerPathWithOwner(path, 0, 0, nil)
 }
 
-func (e *ClientExecutor) createOrReplaceContainerPathWithOwner(path string, uid, gid int) error {
+func (e *ClientExecutor) EnsureContainerPathAs(path, user string, mode *os.FileMode) error {
+	uid, gid := 0, 0
+
+	u, g, err := e.getUser(user)
+	if err == nil {
+		uid = u
+		gid = g
+	}
+
+	return e.createOrReplaceContainerPathWithOwner(path, uid, gid, mode)
+}
+
+func (e *ClientExecutor) createOrReplaceContainerPathWithOwner(path string, uid, gid int, mode *os.FileMode) error {
+	if mode == nil {
+		m := os.FileMode(0755)
+		mode = &m
+	}
 	createPath := func(dest string) error {
 		var writerErr error
 		if !strings.HasSuffix(dest, "/") {
@@ -704,7 +720,7 @@ func (e *ClientExecutor) createOrReplaceContainerPathWithOwner(path string, uid,
 			writerErr = tarball.WriteHeader(&tar.Header{
 				Name:     dest,
 				Typeflag: tar.TypeDir,
-				Mode:     0755,
+				Mode:     int64(*mode),
 				Uid:      uid,
 				Gid:      gid,
 			})
@@ -848,21 +864,22 @@ func (e *ClientExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) er
 	return e.CopyContainer(e.Container, excludes, copies...)
 }
 
-// CopyContainer copies the provided content into a destination container.
-func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []string, copies ...imagebuilder.Copy) error {
-	chownUid, chownGid := -1, -1
-	chown := func(h *tar.Header, r io.Reader) (data []byte, update bool, skip bool, err error) {
-		if chownUid != -1 {
-			h.Uid = chownUid
+func (e *ClientExecutor) findMissingParents(container *docker.Container, dest string) (parents []string, err error) {
+	destParent := filepath.Clean(dest)
+	for filepath.Dir(destParent) != destParent {
+		exists, err := isContainerPathDirectory(e.Client, container.ID, destParent)
+		if err != nil {
+			return nil, err
 		}
-		if chownGid != -1 {
-			h.Gid = chownGid
+		if !exists {
+			parents = append(parents, destParent)
 		}
-		if (h.Uid > 0x1fffff || h.Gid > 0x1fffff) && h.Format == tar.FormatUSTAR {
-			h.Format = tar.FormatPAX
-		}
-		return nil, false, false, nil
+		destParent = filepath.Dir(destParent)
 	}
+	return parents, nil
+}
+
+func (e *ClientExecutor) getUser(userspec string) (int, int, error) {
 	readFile := func(path string) ([]byte, error) {
 		var buffer, contents bytes.Buffer
 		if err := e.Client.DownloadFromContainer(e.Container.ID, docker.DownloadFromContainerOptions{
@@ -922,89 +939,96 @@ func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []s
 		}
 		return *value, nil
 	}
-	findMissingParents := func(dest string) (parents []string, err error) {
-		destParent := filepath.Clean(dest)
-		for filepath.Dir(destParent) != destParent {
-			exists, err := isContainerPathDirectory(e.Client, container.ID, destParent)
+
+	spec := strings.SplitN(userspec, ":", 2)
+	if len(spec) == 2 {
+		parsedUid, err := strconv.ParseUint(spec[0], 10, 32)
+		if err != nil {
+			// maybe it's a user name? look up the UID
+			passwdFile, err := readFile("/etc/passwd")
 			if err != nil {
-				return nil, err
+				return -1, -1, err
 			}
-			if !exists {
-				parents = append(parents, destParent)
+			uid, err := parse(passwdFile, 0, spec[0], 7, 2)
+			if err != nil {
+				return -1, -1, fmt.Errorf("error reading UID value from passwd file for --chown=%s: %v", spec[0], err)
 			}
-			destParent = filepath.Dir(destParent)
+			parsedUid, err = strconv.ParseUint(uid, 10, 32)
+			if err != nil {
+				return -1, -1, fmt.Errorf("error parsing UID value %q from passwd file for --chown=%s", uid, userspec)
+			}
 		}
-		return parents, nil
+		parsedGid, err := strconv.ParseUint(spec[1], 10, 32)
+		if err != nil {
+			// maybe it's a group name? look up the GID
+			groupFile, err := readFile("/etc/group")
+			if err != nil {
+				return -1, -1, err
+			}
+			gid, err := parse(groupFile, 0, spec[1], 4, 2)
+			if err != nil {
+				return -1, -1, err
+			}
+			parsedGid, err = strconv.ParseUint(gid, 10, 32)
+			if err != nil {
+				return -1, -1, fmt.Errorf("error parsing GID value %q from group file for --chown=%s", gid, userspec)
+			}
+		}
+		return int(parsedUid), int(parsedGid), nil
+	}
+
+	var parsedUid, parsedGid uint64
+	if id, err := strconv.ParseUint(spec[0], 10, 32); err == nil {
+		// it's an ID. use it as both the UID and the GID
+		parsedUid = id
+		parsedGid = id
+	} else {
+		// it's a user name, we'll need to look up their UID and primary GID
+		passwdFile, err := readFile("/etc/passwd")
+		if err != nil {
+			return -1, -1, err
+		}
+		// read the UID and primary GID
+		uid, err := parse(passwdFile, 0, spec[0], 7, 2)
+		if err != nil {
+			return -1, -1, fmt.Errorf("error reading UID value from /etc/passwd for --chown=%s", userspec)
+		}
+		gid, err := parse(passwdFile, 0, spec[0], 7, 3)
+		if err != nil {
+			return -1, -1, fmt.Errorf("error reading GID value from /etc/passwd for --chown=%s", userspec)
+		}
+		if parsedUid, err = strconv.ParseUint(uid, 10, 32); err != nil {
+			return -1, -1, fmt.Errorf("error parsing UID value %q from /etc/passwd for --chown=%s", uid, userspec)
+		}
+		if parsedGid, err = strconv.ParseUint(gid, 10, 32); err != nil {
+			return -1, -1, fmt.Errorf("error parsing GID value %q from /etc/passwd for --chown=%s", gid, userspec)
+		}
+	}
+	return int(parsedUid), int(parsedGid), nil
+}
+
+// CopyContainer copies the provided content into a destination container.
+func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []string, copies ...imagebuilder.Copy) error {
+	chownUid, chownGid := -1, -1
+	chown := func(h *tar.Header, r io.Reader) (data []byte, update bool, skip bool, err error) {
+		if chownUid != -1 {
+			h.Uid = chownUid
+		}
+		if chownGid != -1 {
+			h.Gid = chownGid
+		}
+		if (h.Uid > 0x1fffff || h.Gid > 0x1fffff) && h.Format == tar.FormatUSTAR {
+			h.Format = tar.FormatPAX
+		}
+		return nil, false, false, nil
 	}
 	for _, c := range copies {
 		chownUid, chownGid = -1, -1
 		if c.Chown != "" {
-			spec := strings.SplitN(c.Chown, ":", 2)
-			if len(spec) == 2 {
-				parsedUid, err := strconv.ParseUint(spec[0], 10, 32)
-				if err != nil {
-					// maybe it's a user name? look up the UID
-					passwdFile, err := readFile("/etc/passwd")
-					if err != nil {
-						return err
-					}
-					uid, err := parse(passwdFile, 0, spec[0], 7, 2)
-					if err != nil {
-						return fmt.Errorf("error reading UID value from passwd file for --chown=%s: %v", spec[0], err)
-					}
-					parsedUid, err = strconv.ParseUint(uid, 10, 32)
-					if err != nil {
-						return fmt.Errorf("error parsing UID value %q from passwd file for --chown=%s", uid, c.Chown)
-					}
-				}
-				parsedGid, err := strconv.ParseUint(spec[1], 10, 32)
-				if err != nil {
-					// maybe it's a group name? look up the GID
-					groupFile, err := readFile("/etc/group")
-					if err != nil {
-						return err
-					}
-					gid, err := parse(groupFile, 0, spec[1], 4, 2)
-					if err != nil {
-						return err
-					}
-					parsedGid, err = strconv.ParseUint(gid, 10, 32)
-					if err != nil {
-						return fmt.Errorf("error parsing GID value %q from group file for --chown=%s", gid, c.Chown)
-					}
-				}
-				chownUid = int(parsedUid)
-				chownGid = int(parsedGid)
-			} else {
-				var parsedUid, parsedGid uint64
-				if id, err := strconv.ParseUint(spec[0], 10, 32); err == nil {
-					// it's an ID. use it as both the UID and the GID
-					parsedUid = id
-					parsedGid = id
-				} else {
-					// it's a user name, we'll need to look up their UID and primary GID
-					passwdFile, err := readFile("/etc/passwd")
-					if err != nil {
-						return err
-					}
-					// read the UID and primary GID
-					uid, err := parse(passwdFile, 0, spec[0], 7, 2)
-					if err != nil {
-						return fmt.Errorf("error reading UID value from /etc/passwd for --chown=%s", c.Chown)
-					}
-					gid, err := parse(passwdFile, 0, spec[0], 7, 3)
-					if err != nil {
-						return fmt.Errorf("error reading GID value from /etc/passwd for --chown=%s", c.Chown)
-					}
-					if parsedUid, err = strconv.ParseUint(uid, 10, 32); err != nil {
-						return fmt.Errorf("error parsing UID value %q from /etc/passwd for --chown=%s", uid, c.Chown)
-					}
-					if parsedGid, err = strconv.ParseUint(gid, 10, 32); err != nil {
-						return fmt.Errorf("error parsing GID value %q from /etc/passwd for --chown=%s", gid, c.Chown)
-					}
-				}
-				chownUid = int(parsedUid)
-				chownGid = int(parsedGid)
+			var err error
+			chownUid, chownGid, err = e.getUser(c.Chown)
+			if err != nil {
+				return err
 			}
 		}
 		// TODO: reuse source
@@ -1012,12 +1036,20 @@ func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []s
 			if src == "" {
 				src = "*"
 			}
+			assumeDstIsDirectory := len(c.Src) > 1
+		repeatThisSrc:
 			klog.V(4).Infof("Archiving %s download=%t fromFS=%t from=%s", src, c.Download, c.FromFS, c.From)
 			var r io.Reader
 			var closer io.Closer
 			var err error
 			if len(c.From) > 0 {
-				r, closer, err = e.archiveFromContainer(c.From, src, c.Dest)
+				if !assumeDstIsDirectory {
+					var err error
+					if assumeDstIsDirectory, err = e.isContainerGlobMultiple(e.Client, c.From, src); err != nil {
+						return err
+					}
+				}
+				r, closer, err = e.archiveFromContainer(c.From, src, c.Dest, assumeDstIsDirectory)
 			} else {
 				r, closer, err = e.Archive(c.FromFS, src, c.Dest, c.Download, excludes)
 			}
@@ -1027,7 +1059,11 @@ func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []s
 			asOwner := ""
 			if c.Chown != "" {
 				asOwner = fmt.Sprintf(" as %d:%d", chownUid, chownGid)
-				missingParents, err := findMissingParents(c.Dest)
+				// the daemon would implicitly create missing
+				// directories with the wrong ownership, so
+				// check for any that don't exist and create
+				// them ourselves
+				missingParents, err := e.findMissingParents(container, c.Dest)
 				if err != nil {
 					return err
 				}
@@ -1035,7 +1071,7 @@ func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []s
 					sort.Strings(missingParents)
 					klog.V(5).Infof("Uploading directories %v to %s%s", missingParents, container.ID, asOwner)
 					for _, missingParent := range missingParents {
-						if err := e.createOrReplaceContainerPathWithOwner(missingParent, chownUid, chownGid); err != nil {
+						if err := e.createOrReplaceContainerPathWithOwner(missingParent, chownUid, chownGid, nil); err != nil {
 							return err
 						}
 					}
@@ -1050,6 +1086,13 @@ func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []s
 			if klog.V(6) {
 				logArchiveOutput(r, "Archive file for %s")
 			}
+			// add a workaround allow us to notice if a
+			// dstNeedsToBeDirectoryError was returned while
+			// attempting to read the data we're uploading,
+			// indicating that we thought the content would be just
+			// one item, but it actually isn't
+			reader := &readErrorWrapper{Reader: r}
+			r = reader
 			err = e.Client.UploadToContainer(container.ID, docker.UploadToContainerOptions{
 				InputStream: r,
 				Path:        "/",
@@ -1058,11 +1101,28 @@ func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []s
 				klog.Errorf("Error while closing stream container copy stream %s: %v", container.ID, err)
 			}
 			if err != nil {
+				if errors.Is(reader.err, dstNeedsToBeDirectoryError) && !assumeDstIsDirectory {
+					assumeDstIsDirectory = true
+					goto repeatThisSrc
+				}
+				if apiErr, ok := err.(*docker.Error); ok && apiErr.Status == 404 {
+					klog.V(4).Infof("path %s did not exist in container %s: %v", src, container.ID, err)
+				}
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+type readErrorWrapper struct {
+	io.Reader
+	err error
+}
+
+func (r *readErrorWrapper) Read(p []byte) (n int, err error) {
+	n, r.err = r.Reader.Read(p)
+	return n, r.err
 }
 
 type closers []func() error
@@ -1077,7 +1137,7 @@ func (c closers) Close() error {
 	return lastErr
 }
 
-func (e *ClientExecutor) archiveFromContainer(from string, src, dst string) (io.Reader, io.Closer, error) {
+func (e *ClientExecutor) archiveFromContainer(from string, src, dst string, multipleSources bool) (io.Reader, io.Closer, error) {
 	var containerID string
 	if other, ok := e.Named[from]; ok {
 		if other.Container == nil {
@@ -1114,7 +1174,7 @@ func (e *ClientExecutor) archiveFromContainer(from string, src, dst string) (io.
 		})
 		pw.CloseWithError(err)
 	}
-	ar, archiveRoot, err := archiveFromContainer(pr, src, dst, nil, check, fetch)
+	ar, archiveRoot, err := archiveFromContainer(pr, src, dst, nil, check, fetch, multipleSources)
 	if err != nil {
 		pr.Close()
 		pw.Close()
@@ -1130,6 +1190,51 @@ func (e *ClientExecutor) archiveFromContainer(from string, src, dst string) (io.
 	})
 	go fetch(pw)
 	return &readCloser{Reader: ar, Closer: closer}, pr, nil
+}
+
+func (e *ClientExecutor) isContainerGlobMultiple(client *docker.Client, from, glob string) (bool, error) {
+	reader, closer, err := e.archiveFromContainer(from, glob, "/ignored", true)
+	if err != nil {
+		return false, nil
+	}
+
+	defer closer.Close()
+	tr := tar.NewReader(reader)
+
+	h, err := tr.Next()
+	if err != nil {
+		if err == io.EOF {
+			err = nil
+		} else {
+			if apiErr, ok := err.(*docker.Error); ok && apiErr.Status == 404 {
+				klog.V(4).Infof("path %s did not exist in container %s: %v", glob, e.Container.ID, err)
+				err = nil
+			}
+		}
+		return false, err
+	}
+
+	klog.V(4).Infof("Retrieved first header from %s using glob %s: %#v", from, glob, h)
+
+	h, err = tr.Next()
+	if err != nil {
+		if err == io.EOF {
+			err = nil
+		}
+		return false, err
+	}
+
+	klog.V(4).Infof("Retrieved second header from %s using glob %s: %#v", from, glob, h)
+
+	// take the remainder of the input and discard it
+	go func() {
+		n, err := io.Copy(ioutil.Discard, reader)
+		if n > 0 || err != nil {
+			klog.V(6).Infof("Discarded %d bytes from end of from glob check, and got error: %v", n, err)
+		}
+	}()
+
+	return true, nil
 }
 
 func (e *ClientExecutor) Archive(fromFS bool, src, dst string, allowDownload bool, excludes []string) (io.Reader, io.Closer, error) {

--- a/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
+++ b/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
@@ -12,7 +12,7 @@
 #
 
 %global golang_version 1.8.1
-%{!?version: %global version 1.2.2-dev}
+%{!?version: %global version 1.2.3}
 %{!?release: %global release 1}
 %global package_name imagebuilder
 %global product_name Container Image Builder

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -420,7 +420,7 @@ github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift/imagebuilder v1.2.2
+# github.com/openshift/imagebuilder v1.2.3
 github.com/openshift/imagebuilder
 github.com/openshift/imagebuilder/dockerclient
 github.com/openshift/imagebuilder/dockerfile/command


### PR DESCRIPTION
Bump openshift/imagebuilder to v1.2.3.  Adds a stub for the
new IB.EnsureContainerPathAs() function which is not yet used
but is present.

@giuseppe, PTAL

This is a required update to get Buildah imported into Podman
for the v4.0.2 release.

[NO NEW TESTS NEEDED]

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

