### PR TITLE
manifest-add: allow overriding `--arch` and `--variant` while adding custom image to manifest list

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -328,12 +328,15 @@ func manifestAddCmd(c *cobra.Command, args []string, opts manifestAddOpts) error
 	digest, err := list.Add(getContext(), systemContext, ref, opts.all)
 	if err != nil {
 		var storeErr error
-		// check if the local image exists
-		if ref, _, storeErr = util.FindImage(store, "", systemContext, imageSpec); storeErr != nil {
+		// Retry without a custom system context.  A user may want to add
+		// a custom platform (see #3511).
+		if ref, _, storeErr = util.FindImage(store, "", nil, imageSpec); storeErr != nil {
+			logrus.Errorf("Error while trying to find image on local storage: %v", storeErr)
 			return err
 		}
 		digest, storeErr = list.Add(getContext(), systemContext, ref, opts.all)
 		if storeErr != nil {
+			logrus.Errorf("Error while trying to add on manifest list: %v", storeErr)
 			return err
 		}
 	}

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -180,3 +180,20 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     # Make sure we can add the new image to the list.
     run_buildah manifest add test-list $(< ${TESTDIR}/image-id.txt)
 }
+
+@test "manifest-add-to-list-from-storage" {
+    run_buildah pull --arch=amd64 busybox
+    run_buildah tag busybox test:amd64
+    run_buildah pull --arch=arm64 busybox
+    run_buildah tag busybox test:arm64
+    run_buildah manifest create test
+    run_buildah manifest add test test:amd64
+    run_buildah manifest add --variant=variant-something test test:arm64
+    run_buildah manifest inspect test
+    # must contain amd64
+    expect_output --substring "amd64"
+    # must contain arm64
+    expect_output --substring "arm64"
+    # must contain variant v8
+    expect_output --substring "variant-something"
+}


### PR DESCRIPTION
While adding image to manifest list if we ever fallback to scenario
where we are looking for image in local storage then do not override
system context with the one generated from parsing options, instead pass `nil`
and let `libimage` decide.

Closes: https://github.com/containers/buildah/issues/3511
