### PR TITLE
[WIP] Skip frequently flaking bud-multiple-platform-no-run

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3607,6 +3607,7 @@ _EOF
 }
 
 @test "bud-multiple-platform-no-run" {
+  skip "Frequently flakes: https://github.com/containers/buildah/issues/3710"
   outputlist=localhost/testlist
   run_buildah build --signature-policy ${TESTSDIR}/policy.json --jobs=0 --all-platforms --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.no-run ${TESTSDIR}/bud/multiarch
   run_buildah manifest inspect $outputlist


### PR DESCRIPTION
#### What type of PR is this?

> /kind flake

#### What this PR does / why we need it:

The `bud-multiple-platform-no-run` test seems to be flaking more and more frequently, disable it temporarily while
https://github.com/containers/buildah/issues/3710 is researched.

#### How to verify it

CI will pass and not run `bud-multiple-platform-no-run` test

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Opening this PR preemptively, in case flake-rate becomes intolerable.   See also https://github.com/containers/podman/pull/13718 for podman.

#### Does this PR introduce a user-facing change?

None