### PR TITLE
[CI:DOCS] Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -28,6 +28,9 @@ env:
     # (must be in $GITHUB_WORKSPACE/artifacts/)
     NAME_ID_FILEPATH: './artifacts/name_id.txt'
 
+permissions:
+  contents: read
+
 jobs:
     cron_failures:
         runs-on: ubuntu-latest

--- a/.github/workflows/multi-arch-build.yaml
+++ b/.github/workflows/multi-arch-build.yaml
@@ -18,6 +18,9 @@ on:
   # allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   multi:
     name: multi-arch image build

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,9 +7,15 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
 
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?


 /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:


None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None

```

