### PR TITLE
fix hang when oci runtime fails

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3157,6 +3157,23 @@ _EOF
 
 }
 
+@test "bud - invalid runtime flags test" {
+  skip_if_no_runtime
+  skip_if_chroot
+
+  _prefetch alpine
+
+  mytmpdir=${TESTDIR}/my-dir
+  mkdir -p ${mytmpdir}
+  cat > $mytmpdir/Containerfile << _EOF
+from alpine
+run echo hello
+_EOF
+
+    run_buildah 1 build --signature-policy ${TESTSDIR}/policy.json --runtime-flag invalidflag -t build_test $mytmpdir .
+    assert "$output" =~ ".*invalidflag" "failed when passing undefined flags to the runtime"
+}
+
 @test "bud with --add-host" {
   skip_if_no_runtime
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
 /kind bug


#### What this PR does / why we need it:

When the run child process exits early the parent still tries to read
from the ready pipe. Reading from the pipe should end when all writers
are closed. The problem is that the parent kept the writer open as well.
To fix the hang we just need to close the writer before we try to read
and after we gave it to the child.

To prevent closing the fd twice with defer I added a new fileCloser type
to store if the file was already closed.

This problem was noticed in the podman CI:
https://storage.googleapis.com/cirrus-ci-6707778565701632-fcae48/artifacts/containers/podman/6624611893772288/html/sys-podman-fedora-35-root-host-netavark.log.html


#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

