### PR TITLE
selinux: don't use `lsetxattr` on `/proc/self/fd/%d` and bump selinux to `v1.10.1`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/opencontainers/runc v1.1.1
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/runtime-tools v0.9.0
-	github.com/opencontainers/selinux v1.10.0
+	github.com/opencontainers/selinux v1.10.1
 	github.com/openshift/imagebuilder v1.2.3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -877,8 +877,9 @@ github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqi
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opencontainers/selinux v1.8.5/go.mod h1:HTvjPFoGMbpQsG886e3lQwnsRWtE4TC1OF3OUvG9FAo=
-github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK99DRLDhyU=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
+github.com/opencontainers/selinux v1.10.1 h1:09LIPVRP3uuZGQvgR+SgMSNBd1Eb3vlRbGqQpoHsF8w=
+github.com/opencontainers/selinux v1.10.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/openshift/imagebuilder v1.2.3 h1:jvA7mESJdclRKkTe3Yl6UWlliFNVW6mLY8RI+Rrfhfo=
 github.com/openshift/imagebuilder v1.2.3/go.mod h1:TRYHe4CH9U6nkDjxjBNM5klrLbJBrRbpJE5SaRwUBsQ=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/selinux.go
+++ b/selinux.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/opencontainers/runtime-tools/generate"
 	selinux "github.com/opencontainers/selinux/go-selinux"
-	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 )
 
@@ -33,7 +32,7 @@ func runLabelStdioPipes(stdioPipe [][]int, processLabel, mountLabel string) erro
 	}
 	for i := range stdioPipe {
 		pipeFdName := fmt.Sprintf("/proc/self/fd/%d", stdioPipe[i][0])
-		if err := label.Relabel(pipeFdName, pipeContext, false); err != nil {
+		if err := selinux.Chcon(pipeFdName, pipeContext, false); err != nil {
 			return errors.Wrapf(err, "setting file label on %q", pipeFdName)
 		}
 	}

--- a/vendor/github.com/opencontainers/selinux/go-selinux/rchcon.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/rchcon.go
@@ -12,7 +12,7 @@ import (
 
 func rchcon(fpath, label string) error {
 	return pwalkdir.Walk(fpath, func(p string, _ fs.DirEntry, _ error) error {
-		e := setFileLabel(p, label)
+		e := lSetFileLabel(p, label)
 		// Walk a file tree can race with removal, so ignore ENOENT.
 		if errors.Is(e, os.ErrNotExist) {
 			return nil

--- a/vendor/github.com/opencontainers/selinux/go-selinux/rchcon_go115.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/rchcon_go115.go
@@ -11,7 +11,7 @@ import (
 
 func rchcon(fpath, label string) error {
 	return pwalk.Walk(fpath, func(p string, _ os.FileInfo, _ error) error {
-		e := setFileLabel(p, label)
+		e := lSetFileLabel(p, label)
 		// Walk a file tree can race with removal, so ignore ENOENT.
 		if errors.Is(e, os.ErrNotExist) {
 			return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -415,7 +415,7 @@ github.com/opencontainers/runtime-tools/generate
 github.com/opencontainers/runtime-tools/generate/seccomp
 github.com/opencontainers/runtime-tools/specerror
 github.com/opencontainers/runtime-tools/validate
-# github.com/opencontainers/selinux v1.10.0
+# github.com/opencontainers/selinux v1.10.1
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk


### PR DESCRIPTION
* Syscall `lsetxattr` always fails with `ENOTSUP` when it tries to relabel
`/proc/self/fd/%d` but in this case we are acutally interested in the
actual file pointed by the `/proc/self/fd/%d` not in the `symlink` 
( since that was the behavior before ) so  use `Chcon` instead of `Relabel` 
since `Relabel` was configured  here https://github.com/opencontainers/selinux/pull/173 
to use `lsetxattr` instead of `setxattr`.

* Bump selinux to `v1.10.1` to verify if it works

Fixes and replaces: https://github.com/containers/buildah/pull/3875
See: https://github.com/containers/common/pull/994

[NO NEW TESTS NEEDED]: This does not adds new functionality but all existing tests must pass with selinux `v.1.10.1` as of now they all break when selinux is bumped to `v.1.10.1`