### PR TITLE
Create shorter names for containers based on image IDs

### DIFF
--- a/new.go
+++ b/new.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/stringid"
 	digest "github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/openshift/imagebuilder"
@@ -48,6 +49,15 @@ func getImageName(name string, img *storage.Image) string {
 
 func imageNamePrefix(imageName string) string {
 	prefix := imageName
+	if d, err := digest.Parse(imageName); err == nil {
+		prefix = d.Encoded()
+		if len(prefix) > 12 {
+			prefix = prefix[:12]
+		}
+	}
+	if stringid.ValidateID(prefix) == nil {
+		prefix = stringid.TruncateID(prefix)
+	}
 	s := strings.Split(prefix, ":")
 	if len(s) > 0 {
 		prefix = s[0]

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -648,3 +648,19 @@ load helpers
   expect_output "$tmp"
   BOGUS_PROXY=$tmp run_buildah 1 run $cid printenv BOGUS_PROXY
 }
+
+@test "from-image-by-id" {
+  _prefetch busybox
+  run_buildah from --cidfile ${TESTDIR}/cid busybox
+  cid=$(cat ${TESTDIR}/cid)
+  createrandom ${TESTDIR}/randomfile
+  run_buildah copy ${cid} ${TESTDIR}/randomfile /
+  run_buildah commit --iidfile ${TESTDIR}/iid ${cid}
+  iid=$(cat ${TESTDIR}/iid)
+  run_buildah from --cidfile ${TESTDIR}/cid2 ${iid}
+  cid2=$(cat ${TESTDIR}/cid2)
+  run_buildah run ${cid2} hostname -f
+  truncated=${iid##*:}
+  truncated=$(echo ${truncated} | cut -c-12)
+  expect_output ${truncated}-working-container
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When we specify the image name to use for creating a container by using its ID, truncate the ID before appending the naming suffix.  An untruncated ID is already as long as the static HOST_NAME_MAX value used by some applications, and we started making the container's name the FQDN of the container in f8c152694c1edce4b9b1d80d926f94226caab90c, which would have created problems for those applications.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes #3892.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Containers created by running "buildah from" and specifying the base image using its full ID, or during a "buildah build", will be given shorter auto-generated names.
```