### PR TITLE
integration tests: learn to start a dummy registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ LIBSECCOMP_COMMIT := release-2.3
 
 EXTRA_LDFLAGS ?=
 BUILDAH_LDFLAGS := $(GO_LDFLAGS) '-X main.GitCommit=$(GIT_COMMIT) -X main.buildInfo=$(SOURCE_DATE_EPOCH) -X main.cniVersion=$(CNI_COMMIT) $(EXTRA_LDFLAGS)'
-SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go define/*.go docker/*.go manifests/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go pkg/util/*.go util/*.go
+SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go define/*.go docker/*.go internal/parse/*.go internal/source/*.go internal/util/*.go manifests/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go pkg/util/*.go util/*.go
 
 LINTFLAGS ?=
 

--- a/cmd/buildah/passwd.go
+++ b/cmd/buildah/passwd.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/bcrypt"
+)
+
+var (
+	passwdDescription = `Generate a password hash using golang.org/x/crypto/bcrypt.`
+	passwdCommand     = &cobra.Command{
+		Use:     "passwd",
+		Short:   "Generate a password hash",
+		Long:    passwdDescription,
+		RunE:    passwdCmd,
+		Example: `buildah passwd testpassword`,
+		Args:    cobra.ExactArgs(1),
+		Hidden:  true,
+	}
+)
+
+func passwdCmd(c *cobra.Command, args []string) error {
+	passwd, err := bcrypt.GenerateFromPassword([]byte(args[0]), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(passwd))
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(passwdCommand)
+}

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -38,7 +38,7 @@ var (
 	errBadOptionArg  = errors.New("must provide an argument for option")
 	errBadVolDest    = errors.New("must set volume destination")
 	errBadVolSrc     = errors.New("must set volume source")
-	errDuplicateDest = errors.Errorf("duplicate mount destination")
+	errDuplicateDest = errors.New("duplicate mount destination")
 )
 
 // GetBindMount parses a single bind mount entry from the --mount flag.

--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -3,58 +3,67 @@
 load helpers
 
 @test "authenticate: login/logout" {
-  run_buildah 0 login --username testuserfoo --password testpassword docker.io
+  start_registry testuserfoo testpassword
 
-  run_buildah 0 logout docker.io
+  run_buildah 0 login --cert-dir $REGISTRY_DIR --username testuserfoo --password testpassword localhost:$REGISTRY_PORT
+
+  run_buildah 0 logout localhost:$REGISTRY_PORT
 }
 
 @test "authenticate: login/logout should succeed with XDG_RUNTIME_DIR unset" {
   unset XDG_RUNTIME_DIR
-  run_buildah 0 login --username testuserfoo --password testpassword docker.io
 
-  run_buildah 0 logout docker.io
+  start_registry testuserfoo testpassword
+
+  run_buildah 0 login --cert-dir $REGISTRY_DIR --username testuserfoo --password testpassword localhost:$REGISTRY_PORT
+
+  run_buildah 0 logout localhost:$REGISTRY_PORT
 }
 
 @test "authenticate: logout should fail with nonexistent authfile" {
-  run_buildah 0 login --username testuserfoo --password testpassword docker.io
+  start_registry testuserfoo testpassword
 
-  run_buildah 125 logout --authfile /tmp/nonexistent docker.io
+  run_buildah 0 login --cert-dir $REGISTRY_DIR --username testuserfoo --password testpassword localhost:$REGISTRY_PORT
+
+  run_buildah 125 logout --authfile /tmp/nonexistent localhost:$REGISTRY_PORT
   expect_output "checking authfile: stat /tmp/nonexistent: no such file or directory"
 
-  run_buildah 0 logout docker.io
+  run_buildah 0 logout localhost:$REGISTRY_PORT
 }
 
 @test "authenticate: cert and credentials" {
-
   _prefetch alpine
 
+  testuser="testuser$RANDOM"
+  testpassword="testpassword$RANDOM"
+  start_registry "$testuser" "$testpassword"
+
   # Basic test: should pass
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword alpine localhost:5000/my-alpine
+  run_buildah push --cert-dir $REGISTRY_DIR --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds "$testuser":"$testpassword" alpine localhost:$REGISTRY_PORT/my-alpine
   expect_output --substring "Writing manifest to image destination"
 
   # With tls-verify=true, should fail due to self-signed cert
-  # The magic GODEBUG is needed for RHEL on 2021-01-20. Without it,
-  # we get the following error instead of 'unknown authority':
-  #   x509: certificate relies on legacy Common Name field, use SANs or [...]
-  # It is possible that this is a temporary workaround, and Go
-  # may remove it without notice. We'll deal with that then.
-  GODEBUG=x509ignoreCN=0 run_buildah 125 push  --signature-policy ${TESTSDIR}/policy.json --tls-verify=true alpine localhost:5000/my-alpine
+  run_buildah 125 push --signature-policy ${TESTSDIR}/policy.json --tls-verify=true alpine localhost:$REGISTRY_PORT/my-alpine
   expect_output --substring " x509: certificate signed by unknown authority" \
                 "push with --tls-verify=true"
 
   # wrong credentials: should fail
-  run_buildah 125 from --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds baduser:badpassword localhost:5000/my-alpine
+  run_buildah 125 from --cert-dir $REGISTRY_DIR --signature-policy ${TESTSDIR}/policy.json --creds baduser:badpassword localhost:$REGISTRY_PORT/my-alpine
+  expect_output --substring "unauthorized: authentication required"
+  run_buildah 125 from --cert-dir $REGISTRY_DIR --signature-policy ${TESTSDIR}/policy.json --creds "$testuser":badpassword localhost:$REGISTRY_PORT/my-alpine
+  expect_output --substring "unauthorized: authentication required"
+  run_buildah 125 from --cert-dir $REGISTRY_DIR --signature-policy ${TESTSDIR}/policy.json --creds baduser:"$testpassword" localhost:$REGISTRY_PORT/my-alpine
   expect_output --substring "unauthorized: authentication required"
 
   # This should work
-  run_buildah from --name "my-alpine-work-ctr" --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword localhost:5000/my-alpine
+  run_buildah from --cert-dir $REGISTRY_DIR --name "my-alpine-work-ctr" --signature-policy ${TESTSDIR}/policy.json --creds "$testuser":"$testpassword" localhost:$REGISTRY_PORT/my-alpine
   expect_output --from="${lines[-1]}" "my-alpine-work-ctr"
 
   # Create Dockerfile for bud tests
   mkdir -p ${TESTDIR}/dockerdir
   DOCKERFILE=${TESTDIR}/dockerdir/Dockerfile
   /bin/cat <<EOM >$DOCKERFILE
-FROM localhost:5000/my-alpine
+FROM localhost:$REGISTRY_PORT/my-alpine
 EOM
 
   # Remove containers and images before bud tests
@@ -62,51 +71,44 @@ EOM
   run_buildah rmi -f --all
 
   # bud test bad password should fail
-  run_buildah 125 bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds=testuser:badpassword
+  run_buildah 125 bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds="$testuser":badpassword
   expect_output --substring "unauthorized: authentication required" \
                 "buildah bud with wrong credentials"
 
   # bud test this should work
-  run_buildah bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds=testuser:testpassword .
-  expect_output --from="${lines[0]}" "STEP 1/1: FROM localhost:5000/my-alpine"
+  run_buildah bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds="$testuser":"$testpassword" .
+  expect_output --from="${lines[0]}" "STEP 1/1: FROM localhost:$REGISTRY_PORT/my-alpine"
   expect_output --substring "Writing manifest to image destination"
 }
 
 
 @test "authenticate: with --tls-verify=true" {
-  if [ -z "$BUILDAH_AUTHDIR" ]; then
-    # Special case: in Cirrus, the registry auth dir is hardcoded
-    if [ -n "$CIRRUS_CI" -a -e "$HOME/auth/domain.cert" ]; then
-      BUILDAH_AUTHDIR="$HOME/auth"
-    else
-      skip "\$BUILDAH_AUTHDIR undefined"
-    fi
-  fi
-
   _prefetch alpine
 
+  start_registry
+
   # Push with correct credentials: should pass
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=true --cert-dir=$BUILDAH_AUTHDIR --creds testuser:testpassword alpine localhost:5000/my-alpine
+  run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=true --cert-dir=$REGISTRY_DIR --creds testuser:testpassword alpine localhost:$REGISTRY_PORT/my-alpine
   expect_output --substring "Writing manifest to image destination"
 
   # Push with wrong credentials: should fail
-  run_buildah 125 push --signature-policy ${TESTSDIR}/policy.json --tls-verify=true --cert-dir=$BUILDAH_AUTHDIR --creds testuser:WRONGPASSWORD alpine localhost:5000/my-alpine
+  run_buildah 125 push --signature-policy ${TESTSDIR}/policy.json --tls-verify=true --cert-dir=$REGISTRY_DIR --creds testuser:WRONGPASSWORD alpine localhost:$REGISTRY_PORT/my-alpine
   expect_output --substring "unauthorized: authentication required"
 
   # Make sure we can fetch it
-  run_buildah from --pull-always --cert-dir=$BUILDAH_AUTHDIR --tls-verify=true --creds=testuser:testpassword localhost:5000/my-alpine
+  run_buildah from --pull-always --cert-dir=$REGISTRY_DIR --tls-verify=true --creds=testuser:testpassword localhost:$REGISTRY_PORT/my-alpine
   expect_output --from="${lines[-1]}" "localhost-working-container"
   cid="${lines[-1]}"
 
   # Commit with correct credentials
   run_buildah run $cid touch testfile
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --cert-dir=$BUILDAH_AUTHDIR --tls-verify=true --creds=testuser:testpassword $cid docker://localhost:5000/my-alpine
+  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --cert-dir=$REGISTRY_DIR --tls-verify=true --creds=testuser:testpassword $cid docker://localhost:$REGISTRY_PORT/my-alpine
 
   # Create Dockerfile for bud tests
   mkdir -p ${TESTDIR}/dockerdir
   DOCKERFILE=${TESTDIR}/dockerdir/Dockerfile
   /bin/cat <<EOM >$DOCKERFILE
-FROM localhost:5000/my-alpine
+FROM localhost:$REGISTRY_PORT/my-alpine
 RUN rm testfile
 EOM
 
@@ -115,8 +117,8 @@ EOM
   run_buildah rmi -f --all
 
   # bud with correct credentials
-  run_buildah bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --cert-dir=$BUILDAH_AUTHDIR --tls-verify=true --creds=testuser:testpassword .
-  expect_output --from="${lines[0]}" "STEP 1/2: FROM localhost:5000/my-alpine"
+  run_buildah bud -f $DOCKERFILE --signature-policy ${TESTSDIR}/policy.json --cert-dir=$REGISTRY_DIR --tls-verify=true --creds=testuser:testpassword .
+  expect_output --from="${lines[0]}" "STEP 1/2: FROM localhost:$REGISTRY_PORT/my-alpine"
   expect_output --substring "Writing manifest to image destination"
 }
 
@@ -124,21 +126,23 @@ EOM
 @test "authenticate: with cached (not command-line) credentials" {
   _prefetch alpine
 
-  run_buildah 0 login --tls-verify=false --username testuser --password testpassword localhost:5000
+  start_registry
+
+  run_buildah 0 login --tls-verify=false --username testuser --password testpassword localhost:$REGISTRY_PORT
   expect_output "Login Succeeded!"
 
   # After login, push should pass
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false alpine localhost:5000/my-alpine
+  run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false alpine localhost:$REGISTRY_PORT/my-alpine
   expect_output --substring "Storing signatures"
 
-  run_buildah 125 login --tls-verify=false --username testuser --password WRONGPASSWORD localhost:5000
-  expect_output 'error logging into "localhost:5000": invalid username/password' \
+  run_buildah 125 login --tls-verify=false --username testuser --password WRONGPASSWORD localhost:$REGISTRY_PORT
+  expect_output 'error logging into "localhost:'"$REGISTRY_PORT"'": invalid username/password' \
                 "buildah login, wrong credentials"
 
-  run_buildah 0 logout localhost:5000
-  expect_output "Removed login credentials for localhost:5000"
+  run_buildah 0 logout localhost:$REGISTRY_PORT
+  expect_output "Removed login credentials for localhost:$REGISTRY_PORT"
 
-  run_buildah 125 push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false alpine localhost:5000/my-alpine
+  run_buildah 125 push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false alpine localhost:$REGISTRY_PORT/my-alpine
   expect_output --substring "unauthorized: authentication required" \
                 "buildah push after buildah logout"
 }

--- a/tests/bud/from-encrypted-image/Dockerfile
+++ b/tests/bud/from-encrypted-image/Dockerfile
@@ -1,1 +1,0 @@
-FROM localhost:5000/buildah/busybox_encrypted:latest

--- a/tests/containers.bats
+++ b/tests/containers.bats
@@ -70,14 +70,11 @@ load helpers
 
 @test "containers all test" {
   skip_if_in_container
-  run which podman
-  if [[ $status -ne 0 ]]; then
-    skip "podman is not installed"
-  fi
+  skip_if_no_podman
 
   _prefetch alpine busybox
   run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
-  podman create --root ${TESTDIR}/root --storage-driver ${STORAGE_DRIVER} busybox ls
+  podman create --root ${TESTDIR}/root --storage-driver ${STORAGE_DRIVER} --net=host busybox ls
   run_buildah containers
   expect_line_count 2
   run_buildah containers -a

--- a/tests/containers_conf.bats
+++ b/tests/containers_conf.bats
@@ -4,76 +4,74 @@ load helpers
 
 @test "containers.conf selinux test" {
     if ! which selinuxenabled > /dev/null 2> /dev/null ; then
-	skip "No selinuxenabled executable"
+        skip "No selinuxenabled executable"
     elif ! selinuxenabled ; then
-	skip "selinux is disabled"
+        skip "selinux is disabled"
     fi
 
-
-    export CONTAINERS_CONF=${TESTSDIR}/containers.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    _prefetch alpine
+    cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
     run_buildah --log-level=error run $cid sh -c "cat /proc/self/attr/current | grep container_t"
 
-    buildah rm $cid
+    run_buildah rm $cid
 
-    export CONTAINERS_CONF=${TESTSDIR}/containers1.conf
-    sed "s/^label = true/label = false/g" ${TESTSDIR}/containers.conf > ${TESTSDIR}/containers1.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
-    run_buildah 1 --log-level=error run $cid sh -c "cat /proc/self/attr/current | grep container_t"
-    rm ${TESTSDIR}/containers1.conf
+    sed "s/^label = true/label = false/g" ${TESTSDIR}/containers.conf > ${TESTDIR}/containers.conf
+    cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah 1 --log-level=error run $cid sh -c "cat /proc/self/attr/current | grep container_t"
 }
 
 @test "containers.conf ulimit test" {
     if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
-    skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION"
-  fi
+        skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION"
+    fi
 
-    export CONTAINERS_CONF=${TESTSDIR}/containers.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    _prefetch alpine
+    cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
     run_buildah --log-level=error run $cid  awk '/open files/{print $4}' /proc/self/limits
-	expect_output "500" "limits: open files (w/file limit)"
+    expect_output "500" "limits: open files (w/file limit)"
 
-    cid=$(buildah from --pull --ulimit nofile=300:400 --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
-	run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
-	expect_output "300" "limits: open files (w/file limit)"
+    cid=$(buildah from --ulimit nofile=300:400 --signature-policy ${TESTSDIR}/policy.json alpine)
+    run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
+    expect_output "300" "limits: open files (w/file limit)"
 }
 
 @test "containers.conf additional devices test" {
     skip_if_rootless_environment
     if test "$BUILDAH_ISOLATION" = "chroot" -o "$BUILDAH_ISOLATION" = "rootless" ; then
-	skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION"
+        skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION"
     fi
-    export CONTAINERS_CONF=${TESTSDIR}/containers.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
-    run_buildah 1 --log-level=error run $cid ls /dev/foo1
-    buildah rm $cid
 
-    sed '/^devices.*/a "/dev/foo:\/dev\/foo1:rmw",' ${TESTSDIR}/containers.conf > ${TESTSDIR}/containers1.conf
+    _prefetch alpine
+    cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+    CONTAINERS_CONF=$CONTAINERS_CONF run_buildah 1 --log-level=error run $cid ls /dev/foo1
+    run_buildah rm $cid
+
+    sed '/^devices.*/a "\/dev\/foo:\/dev\/foo1:rmw",' ${TESTSDIR}/containers.conf > ${TESTDIR}/containers.conf
     rm -f /dev/foo; mknod /dev/foo c 1 1
-    export CONTAINERS_CONF=${TESTSDIR}/containers1.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
-    run_buildah  --log-level=error run $cid ls /dev/foo1
+    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+    cid="$output"
+    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah  --log-level=error run $cid ls /dev/foo1
     rm -f /dev/foo
-    rm ${TESTSDIR}/containers1.conf
 }
 
 @test "containers.conf capabilities test" {
-    export CONTAINERS_CONF=${TESTSDIR}/containers.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    _prefetch alpine
+
+    run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+    cid="$output"
     run_buildah --log-level=error run $cid sh -c 'grep  CapEff /proc/self/status | cut -f2'
-    CapEff=$output
+    CapEff="$output"
     expect_output "00000000a80425fb"
-    buildah rm $cid
+    run_buildah rm $cid
 
-    sed "/AUDIT_WRITE/d" ${TESTSDIR}/containers.conf > ${TESTSDIR}/containers1.conf
-    export CONTAINERS_CONF=${TESTSDIR}/containers1.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    sed "/AUDIT_WRITE/d" ${TESTSDIR}/containers.conf > ${TESTDIR}/containers.conf
+    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+    cid="$output"
 
-    run_buildah --log-level=error run $cid sh -c 'grep  CapEff /proc/self/status | cut -f2'
-    buildah rm $cid
+    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah --log-level=error run $cid sh -c 'grep  CapEff /proc/self/status | cut -f2'
+    run_buildah rm $cid
 
     test "$output" != "$CapEff"
-    rm ${TESTSDIR}/containers1.conf
 }
 
 @test "containers.conf /dev/shm test" {
@@ -81,8 +79,9 @@ load helpers
         skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION"
     fi
 
-    export CONTAINERS_CONF=${TESTSDIR}/containers.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
+    _prefetch alpine
+    run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+    cid="$output"
     run_buildah --log-level=error run $cid sh -c 'df /dev/shm | awk '\''/shm/{print $4}'\'''
     expect_output "200"
 }
@@ -92,18 +91,18 @@ load helpers
         skip "BUILDAH_ISOLATION = $BUILDAH_ISOLATION"
     fi
 
-    test -e /usr/bin/crun || skip "/usr/bin/crun doesn't exist"
+    test -x /usr/bin/crun || skip "/usr/bin/crun doesn't exist"
 
     ln -s /usr/bin/crun ${TESTDIR}/runtime
 
-    cat >${TESTDIR}/containers_non_standard_runtime.conf << EOF
+    cat >${TESTDIR}/containers.conf << EOF
 [engine]
 runtime = "nonstandard_runtime_name"
 [engine.runtimes]
 nonstandard_runtime_name = ["${TESTDIR}/runtime"]
 EOF
 
-    export CONTAINERS_CONF=${TESTDIR}/containers_non_standard_runtime.conf
-    cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine)
-    run_buildah --log-level=error run $cid true
+    _prefetch alpine
+    cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah --log-level=error run $cid true
 }

--- a/tests/registries.conf
+++ b/tests/registries.conf
@@ -13,8 +13,8 @@ location="mirror.gcr.io"
 # barfs spectacularly when trying to fetch them. We've hand-copied
 # those to quay, using skopeo copy --all ...
 [[registry]]
-prefix="docker.io/library"
-location="quay.io/libpod"
+location="docker.io/library"
+mirror=[{location="quay.io/libpod"}]
 
 # 2021-03-23 these are used in buildah system tests, but not (yet?)
 # listed in the global shortnames.conf.

--- a/tests/source.bats
+++ b/tests/source.bats
@@ -124,10 +124,12 @@ load helpers
   echo 222... > ${TESTDIR}/file2
   run_buildah source add $srcdir ${TESTDIR}/file2
 
-  run_buildah source push --tls-verify=false --creds testuser:testpassword $srcdir localhost:5000/source:test
+  start_registry
+
+  run_buildah source push --tls-verify=false --creds testuser:testpassword $srcdir localhost:${REGISTRY_PORT}/source:test
 
   pulldir=${TESTDIR}/pulledsource
-  run_buildah source pull --tls-verify=false --creds testuser:testpassword localhost:5000/source:test $pulldir
+  run_buildah source pull --tls-verify=false --creds testuser:testpassword localhost:${REGISTRY_PORT}/source:test $pulldir
 
   run diff -r $srcdir $pulldir
   [ "$status" -eq 0 ]

--- a/vendor/golang.org/x/crypto/bcrypt/base64.go
+++ b/vendor/golang.org/x/crypto/bcrypt/base64.go
@@ -1,0 +1,35 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bcrypt
+
+import "encoding/base64"
+
+const alphabet = "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
+var bcEncoding = base64.NewEncoding(alphabet)
+
+func base64Encode(src []byte) []byte {
+	n := bcEncoding.EncodedLen(len(src))
+	dst := make([]byte, n)
+	bcEncoding.Encode(dst, src)
+	for dst[n-1] == '=' {
+		n--
+	}
+	return dst[:n]
+}
+
+func base64Decode(src []byte) ([]byte, error) {
+	numOfEquals := 4 - (len(src) % 4)
+	for i := 0; i < numOfEquals; i++ {
+		src = append(src, '=')
+	}
+
+	dst := make([]byte, bcEncoding.DecodedLen(len(src)))
+	n, err := bcEncoding.Decode(dst, src)
+	if err != nil {
+		return nil, err
+	}
+	return dst[:n], nil
+}

--- a/vendor/golang.org/x/crypto/bcrypt/bcrypt.go
+++ b/vendor/golang.org/x/crypto/bcrypt/bcrypt.go
@@ -1,0 +1,295 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package bcrypt implements Provos and Mazières's bcrypt adaptive hashing
+// algorithm. See http://www.usenix.org/event/usenix99/provos/provos.pdf
+package bcrypt // import "golang.org/x/crypto/bcrypt"
+
+// The code is a port of Provos and Mazières's C implementation.
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"golang.org/x/crypto/blowfish"
+)
+
+const (
+	MinCost     int = 4  // the minimum allowable cost as passed in to GenerateFromPassword
+	MaxCost     int = 31 // the maximum allowable cost as passed in to GenerateFromPassword
+	DefaultCost int = 10 // the cost that will actually be set if a cost below MinCost is passed into GenerateFromPassword
+)
+
+// The error returned from CompareHashAndPassword when a password and hash do
+// not match.
+var ErrMismatchedHashAndPassword = errors.New("crypto/bcrypt: hashedPassword is not the hash of the given password")
+
+// The error returned from CompareHashAndPassword when a hash is too short to
+// be a bcrypt hash.
+var ErrHashTooShort = errors.New("crypto/bcrypt: hashedSecret too short to be a bcrypted password")
+
+// The error returned from CompareHashAndPassword when a hash was created with
+// a bcrypt algorithm newer than this implementation.
+type HashVersionTooNewError byte
+
+func (hv HashVersionTooNewError) Error() string {
+	return fmt.Sprintf("crypto/bcrypt: bcrypt algorithm version '%c' requested is newer than current version '%c'", byte(hv), majorVersion)
+}
+
+// The error returned from CompareHashAndPassword when a hash starts with something other than '$'
+type InvalidHashPrefixError byte
+
+func (ih InvalidHashPrefixError) Error() string {
+	return fmt.Sprintf("crypto/bcrypt: bcrypt hashes must start with '$', but hashedSecret started with '%c'", byte(ih))
+}
+
+type InvalidCostError int
+
+func (ic InvalidCostError) Error() string {
+	return fmt.Sprintf("crypto/bcrypt: cost %d is outside allowed range (%d,%d)", int(ic), int(MinCost), int(MaxCost))
+}
+
+const (
+	majorVersion       = '2'
+	minorVersion       = 'a'
+	maxSaltSize        = 16
+	maxCryptedHashSize = 23
+	encodedSaltSize    = 22
+	encodedHashSize    = 31
+	minHashSize        = 59
+)
+
+// magicCipherData is an IV for the 64 Blowfish encryption calls in
+// bcrypt(). It's the string "OrpheanBeholderScryDoubt" in big-endian bytes.
+var magicCipherData = []byte{
+	0x4f, 0x72, 0x70, 0x68,
+	0x65, 0x61, 0x6e, 0x42,
+	0x65, 0x68, 0x6f, 0x6c,
+	0x64, 0x65, 0x72, 0x53,
+	0x63, 0x72, 0x79, 0x44,
+	0x6f, 0x75, 0x62, 0x74,
+}
+
+type hashed struct {
+	hash  []byte
+	salt  []byte
+	cost  int // allowed range is MinCost to MaxCost
+	major byte
+	minor byte
+}
+
+// GenerateFromPassword returns the bcrypt hash of the password at the given
+// cost. If the cost given is less than MinCost, the cost will be set to
+// DefaultCost, instead. Use CompareHashAndPassword, as defined in this package,
+// to compare the returned hashed password with its cleartext version.
+func GenerateFromPassword(password []byte, cost int) ([]byte, error) {
+	p, err := newFromPassword(password, cost)
+	if err != nil {
+		return nil, err
+	}
+	return p.Hash(), nil
+}
+
+// CompareHashAndPassword compares a bcrypt hashed password with its possible
+// plaintext equivalent. Returns nil on success, or an error on failure.
+func CompareHashAndPassword(hashedPassword, password []byte) error {
+	p, err := newFromHash(hashedPassword)
+	if err != nil {
+		return err
+	}
+
+	otherHash, err := bcrypt(password, p.cost, p.salt)
+	if err != nil {
+		return err
+	}
+
+	otherP := &hashed{otherHash, p.salt, p.cost, p.major, p.minor}
+	if subtle.ConstantTimeCompare(p.Hash(), otherP.Hash()) == 1 {
+		return nil
+	}
+
+	return ErrMismatchedHashAndPassword
+}
+
+// Cost returns the hashing cost used to create the given hashed
+// password. When, in the future, the hashing cost of a password system needs
+// to be increased in order to adjust for greater computational power, this
+// function allows one to establish which passwords need to be updated.
+func Cost(hashedPassword []byte) (int, error) {
+	p, err := newFromHash(hashedPassword)
+	if err != nil {
+		return 0, err
+	}
+	return p.cost, nil
+}
+
+func newFromPassword(password []byte, cost int) (*hashed, error) {
+	if cost < MinCost {
+		cost = DefaultCost
+	}
+	p := new(hashed)
+	p.major = majorVersion
+	p.minor = minorVersion
+
+	err := checkCost(cost)
+	if err != nil {
+		return nil, err
+	}
+	p.cost = cost
+
+	unencodedSalt := make([]byte, maxSaltSize)
+	_, err = io.ReadFull(rand.Reader, unencodedSalt)
+	if err != nil {
+		return nil, err
+	}
+
+	p.salt = base64Encode(unencodedSalt)
+	hash, err := bcrypt(password, p.cost, p.salt)
+	if err != nil {
+		return nil, err
+	}
+	p.hash = hash
+	return p, err
+}
+
+func newFromHash(hashedSecret []byte) (*hashed, error) {
+	if len(hashedSecret) < minHashSize {
+		return nil, ErrHashTooShort
+	}
+	p := new(hashed)
+	n, err := p.decodeVersion(hashedSecret)
+	if err != nil {
+		return nil, err
+	}
+	hashedSecret = hashedSecret[n:]
+	n, err = p.decodeCost(hashedSecret)
+	if err != nil {
+		return nil, err
+	}
+	hashedSecret = hashedSecret[n:]
+
+	// The "+2" is here because we'll have to append at most 2 '=' to the salt
+	// when base64 decoding it in expensiveBlowfishSetup().
+	p.salt = make([]byte, encodedSaltSize, encodedSaltSize+2)
+	copy(p.salt, hashedSecret[:encodedSaltSize])
+
+	hashedSecret = hashedSecret[encodedSaltSize:]
+	p.hash = make([]byte, len(hashedSecret))
+	copy(p.hash, hashedSecret)
+
+	return p, nil
+}
+
+func bcrypt(password []byte, cost int, salt []byte) ([]byte, error) {
+	cipherData := make([]byte, len(magicCipherData))
+	copy(cipherData, magicCipherData)
+
+	c, err := expensiveBlowfishSetup(password, uint32(cost), salt)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < 24; i += 8 {
+		for j := 0; j < 64; j++ {
+			c.Encrypt(cipherData[i:i+8], cipherData[i:i+8])
+		}
+	}
+
+	// Bug compatibility with C bcrypt implementations. We only encode 23 of
+	// the 24 bytes encrypted.
+	hsh := base64Encode(cipherData[:maxCryptedHashSize])
+	return hsh, nil
+}
+
+func expensiveBlowfishSetup(key []byte, cost uint32, salt []byte) (*blowfish.Cipher, error) {
+	csalt, err := base64Decode(salt)
+	if err != nil {
+		return nil, err
+	}
+
+	// Bug compatibility with C bcrypt implementations. They use the trailing
+	// NULL in the key string during expansion.
+	// We copy the key to prevent changing the underlying array.
+	ckey := append(key[:len(key):len(key)], 0)
+
+	c, err := blowfish.NewSaltedCipher(ckey, csalt)
+	if err != nil {
+		return nil, err
+	}
+
+	var i, rounds uint64
+	rounds = 1 << cost
+	for i = 0; i < rounds; i++ {
+		blowfish.ExpandKey(ckey, c)
+		blowfish.ExpandKey(csalt, c)
+	}
+
+	return c, nil
+}
+
+func (p *hashed) Hash() []byte {
+	arr := make([]byte, 60)
+	arr[0] = '$'
+	arr[1] = p.major
+	n := 2
+	if p.minor != 0 {
+		arr[2] = p.minor
+		n = 3
+	}
+	arr[n] = '$'
+	n++
+	copy(arr[n:], []byte(fmt.Sprintf("%02d", p.cost)))
+	n += 2
+	arr[n] = '$'
+	n++
+	copy(arr[n:], p.salt)
+	n += encodedSaltSize
+	copy(arr[n:], p.hash)
+	n += encodedHashSize
+	return arr[:n]
+}
+
+func (p *hashed) decodeVersion(sbytes []byte) (int, error) {
+	if sbytes[0] != '$' {
+		return -1, InvalidHashPrefixError(sbytes[0])
+	}
+	if sbytes[1] > majorVersion {
+		return -1, HashVersionTooNewError(sbytes[1])
+	}
+	p.major = sbytes[1]
+	n := 3
+	if sbytes[2] != '$' {
+		p.minor = sbytes[2]
+		n++
+	}
+	return n, nil
+}
+
+// sbytes should begin where decodeVersion left off.
+func (p *hashed) decodeCost(sbytes []byte) (int, error) {
+	cost, err := strconv.Atoi(string(sbytes[0:2]))
+	if err != nil {
+		return -1, err
+	}
+	err = checkCost(cost)
+	if err != nil {
+		return -1, err
+	}
+	p.cost = cost
+	return 3, nil
+}
+
+func (p *hashed) String() string {
+	return fmt.Sprintf("&{hash: %#v, salt: %#v, cost: %d, major: %c, minor: %c}", string(p.hash), p.salt, p.cost, p.major, p.minor)
+}
+
+func checkCost(cost int) error {
+	if cost < MinCost || cost > MaxCost {
+		return InvalidCostError(cost)
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -508,6 +508,7 @@ go.opencensus.io/trace
 go.opencensus.io/trace/internal
 go.opencensus.io/trace/tracestate
 # golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
+golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/cast5
 golang.org/x/crypto/chacha20


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

When a test needs to talk to a registry server, launch one as part of the test rather than depending on it having been started by someone else.

Use run_buildah where we used to use 'run buildah' without checking the return code, and in a few cases where we did check it.

In the "from with non buildah container" test, use "podman create" with host networking, in an attempt to avoid messing with networking in cases where we're running on a system with a version of podman that will create a bridge with CNI that we'll also create with netavark.  We're not sharing storage between the two invocations, so the logic that tries to detect this problem won't detect it.

#### How to verify it

Updates to tests!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This gets us closer to being able to run integration tests anywhere by pointing `bats` at our `tests` directory.

#### Does this PR introduce a user-facing change?

```release-note
None
```