### PR TITLE
Tests: disable three gating-test failures

### DIFF
--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -38,9 +38,13 @@ load helpers
   #   x509: certificate relies on legacy Common Name field, use SANs or [...]
   # It is possible that this is a temporary workaround, and Go
   # may remove it without notice. We'll deal with that then.
-  GODEBUG=x509ignoreCN=0 run_buildah 125 push  --signature-policy ${TESTSDIR}/policy.json --tls-verify=true alpine localhost:5000/my-alpine
-  expect_output --substring " x509: certificate signed by unknown authority" \
-                "push with --tls-verify=true"
+  #
+  # 2022-04-04 disable test entirely, it now hard-fails in RHEL 8.6 gating
+  # and it's just not worth figuring out why.
+  #
+  # GODEBUG=x509ignoreCN=0 run_buildah 125 push  --signature-policy ${TESTSDIR}/policy.json --tls-verify=true alpine localhost:5000/my-alpine
+  # expect_output --substring " x509: certificate signed by unknown authority" \
+  #              "push with --tls-verify=true"
 
   # wrong credentials: should fail
   run_buildah 125 from --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds baduser:badpassword localhost:5000/my-alpine

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -595,6 +595,7 @@ function _test_http() {
 }
 
 @test "bud-git-context" {
+  skip "2022-04-04 no longer tested on 1.19"
   # We need git and ssh to be around to handle cloning a repository.
   if ! which git ; then
     skip "no git in PATH"
@@ -1993,6 +1994,7 @@ _EOF
 }
 
 @test "bud using gitrepo and branch" {
+  skip "2022-04-04 no longer tested on 1.19"
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t gittarget -f tests/bud/shell/Dockerfile git://github.com/containers/buildah#release-1.11-rhel
 }
 


### PR DESCRIPTION
One is a certificate error:

    $ buildah push --tls-verify=true alpine localhost:5000/my-alpine
    Get "https://localhost:5000/v2/": x509: certificate relies on legacy Common Name field, use SANs instead

This was addressed in #3014, but back then it failed with "use
SANs or set a magic DEBUG envariable"; that envariable no longer
works.

The other two errors are due to github no longer supporting git:// URLs.
This was addressed in #3701, but that's too hard to backport, so let's
just skip the failing tests.

Signed-off-by: Ed Santiago <santiago@redhat.com>
