### PR TITLE
Remove a stray `\` from .containerenv

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -255,7 +255,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 			rootless = 1
 		}
 		// Populate the .containerenv with container information
-		containerenv := fmt.Sprintf(`\
+		containerenv := fmt.Sprintf(`
 engine="buildah-%s"
 name=%q
 id=%q


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Start `.containerenv` with a blank line rather than a stray backslash.

#### How to verify it

Visual inspection.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
.containerenv files in containers will no longer start with a backslash character on a line by itself.  Instead, they will start with an empty line.
```