### PR TITLE
tests: set `--jobs=1` for flaky `bud-multiple-platform-no-run`

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3625,7 +3625,11 @@ _EOF
 
 @test "bud-multiple-platform-no-run" {
   outputlist=localhost/testlist
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --jobs=0 --all-platforms --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.no-run ${TESTSDIR}/bud/multiarch
+  # Note: [This is a bug] jobs=1 is intentionally set here since --jobs=0 sets
+  # concurrency to maximum which uncovers all sorts of race condition causing
+  # flakes in CI. Please put this back to --jobs=0 when https://github.com/containers/buildah/issues/3710
+  # is resolved.
+  run_buildah build --signature-policy ${TESTSDIR}/policy.json --jobs=1 --all-platforms --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.no-run ${TESTSDIR}/bud/multiarch
   run_buildah manifest inspect $outputlist
   echo "$output"
   run jq '.manifests | length' <<< "$output"


### PR DESCRIPTION
We have a recorded bug here https://github.com/containers/buildah/issues/3710
but complexity of this bug fix is looking high as of now with fixes
going into multiple components.

See dicsussion here: https://github.com/containers/buildah/issues/3710

Reducing jobs for this test will ensure that we process things in serial
order so instead of skipping this test we can still run it in a serial
manner and with no flakes

**Note: This does not fixes the underlying issue but just removes flakes from CI**