### PR TITLE
buildah build should accept at most one arg

### DIFF
--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -43,7 +43,7 @@ func init() {
 	namespaceResults := buildahcli.NameSpaceResults{}
 
 	buildCommand := &cobra.Command{
-		Use:     "build",
+		Use:     "build [CONTEXT]",
 		Aliases: []string{"build-using-dockerfile", "bud"},
 		Short:   "Build an image using instructions in a Containerfile",
 		Long:    buildDescription,
@@ -57,6 +57,7 @@ func init() {
 			}
 			return buildCmd(cmd, args, br)
 		},
+		Args: cobra.MaximumNArgs(1),
 		Example: `buildah build
   buildah bud -f Containerfile.simple .
   buildah bud --volume /home/test:/myvol:ro,Z -t imageName .
@@ -198,11 +199,6 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 			}
 			contextDir = absDir
 		}
-	}
-	cliArgs = Tail(cliArgs)
-
-	if err := buildahcli.VerifyFlagsArgsOrder(cliArgs); err != nil {
-		return err
 	}
 
 	if len(containerfiles) == 0 {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -171,20 +171,6 @@ _EOF
   expect_output --substring $targetarch
 }
 
-@test "bud-flags-order-verification" {
-  run_buildah 125 build /tmp/tmpdockerfile/ -t blabla
-  check_options_flag_err "-t"
-
-  run_buildah 125 build /tmp/tmpdockerfile/ -q -t blabla
-  check_options_flag_err "-q"
-
-  run_buildah 125 build /tmp/tmpdockerfile/ --force-rm
-  check_options_flag_err "--force-rm"
-
-  run_buildah 125 build /tmp/tmpdockerfile/ --userns=cnt1
-  check_options_flag_err "--userns=cnt1"
-}
-
 @test "bud with --layers and --no-cache flags" {
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
 
@@ -3170,8 +3156,13 @@ from alpine
 run echo hello
 _EOF
 
-    run_buildah 1 build --signature-policy ${TESTSDIR}/policy.json --runtime-flag invalidflag -t build_test $mytmpdir .
+    run_buildah 1 build --signature-policy ${TESTSDIR}/policy.json --runtime-flag invalidflag -t build_test $mytmpdir
     assert "$output" =~ ".*invalidflag" "failed when passing undefined flags to the runtime"
+}
+
+@test "bud - accept at most one arg" {
+    run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/dns extraarg
+    assert "accepts at most 1 arg(s), received 2" "error while parsing arguments"
 }
 
 @test "bud with --add-host" {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug


#### What this PR does / why we need it:

Right now buildah just ignores it when you set more than one argument for
build. Only the first argument is used as context dir. This looks wrong
to me and can lead to users errors.

Fixes test failure in https://github.com/containers/podman/pull/13687

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
buildah build only accepts at most one argument, it errors now when multiple arguments are given instead of ignoring them.
```

