### PR TITLE
Initialize network backend before first pull

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -75,6 +75,14 @@ func Pull(ctx context.Context, imageName string, options PullOptions) (imageID s
 		return "", err
 	}
 
+	// Note: It is important to do this before we pull any images/create containers.
+	// The default backend detection logic needs an empty store to correctly detect
+	// that we can use netavark, if the store was not empty it will use CNI to not break existing installs.
+	_, err = getNetworkInterface(options.Store, "", "")
+	if err != nil {
+		return "", err
+	}
+
 	runtime, err := libimage.RuntimeFromStore(options.Store, &libimage.RuntimeOptions{SystemContext: options.SystemContext})
 	if err != nil {
 		return "", err

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -41,6 +41,8 @@ load helpers
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "busybox:glibc"
   expect_output --substring "busybox:latest"
+  # We need to see if this file is created after first pull in at least one test
+  [ -f ${TESTDIR}/root/defaultNetworkBackend ]
 
   run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/alpine_nginx:latest
   run_buildah images --format "{{.Name}}:{{.Tag}}"


### PR DESCRIPTION
Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
After clean install, it is necessary to decide the network backend before any image is pulled so that `netavark` is chosen correctly. Without this change, if `buildah pull` is executed at first, the network backend is not determined and an image is pulled. This results in choosing `cni` at a next command because an image already exists while `netavark` is chosen if `buildah from` or `buildah bud` is called at first.

#### How to verify it

Run the added test.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

