### PR TITLE
manifest-create: allow creating manifest list from image in `local-storage`

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -257,7 +257,13 @@ func manifestCreateCmd(c *cobra.Command, args []string, opts manifestCreateOpts)
 				}
 			}
 		}
-		if _, err = list.Add(getContext(), systemContext, ref, opts.all); err != nil {
+		refLocal, _, err := util.FindImage(store, "", systemContext, imageSpec)
+		if err == nil {
+			// Found local image so use that.
+			ref = refLocal
+		}
+		_, err = list.Add(getContext(), systemContext, ref, opts.all)
+		if err != nil {
 			return err
 		}
 	}

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -197,3 +197,13 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     # must contain variant v8
     expect_output --substring "variant-something"
 }
+
+@test "manifest-create-list-from-storage" {
+    run_buildah from --quiet --arch amd64 busybox
+    cid=$output
+    run_buildah commit $cid "$cid-committed:latest"
+    run_buildah manifest create test:latest "$cid-committed:latest"
+    run_buildah manifest inspect test
+    # must contain amd64
+    expect_output --substring "amd64"
+}


### PR DESCRIPTION
`manifest create` must perform a final lookup on local storage while
user adds image while creating a manifest list because there can be
scenarios when image is not pushed to remote reistry and it only exists
on local storage.

A change similar to this was added here: https://github.com/containers/buildah/pull/3877
Also see: https://github.com/containers/buildah/blob/main/cmd/buildah/manifest.go#L328

Closes: https://github.com/containers/buildah/issues/3915