### PR TITLE
using consistent lowercase 'invalid' word in returned err msg

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -182,7 +182,7 @@ func parseSecurityOpts(securityOpts []string, commonOpts *define.CommonBuildOpti
 		}
 		con := strings.SplitN(opt, "=", 2)
 		if len(con) != 2 {
-			return errors.Errorf("Invalid --security-opt name=value pair: %q", opt)
+			return errors.Errorf("invalid --security-opt name=value pair: %q", opt)
 		}
 
 		switch con[0] {
@@ -193,7 +193,7 @@ func parseSecurityOpts(securityOpts []string, commonOpts *define.CommonBuildOpti
 		case "seccomp":
 			commonOpts.SeccompProfilePath = con[1]
 		default:
-			return errors.Errorf("Invalid --security-opt 2: %q", opt)
+			return errors.Errorf("invalid --security-opt 2: %q", opt)
 		}
 
 	}


### PR DESCRIPTION
Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind other

#### What this PR does / why we need it:
Using consistent lowercase "invalid" word in pkg/parse returned error messages.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

