### PR TITLE
Ed's periodic test cleanup

### DIFF
--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -492,6 +492,5 @@ stuff/mystuff"
   run_buildah copy --contextdir . $ctr / /opt/
   run_buildah run $ctr ls -1 /opt/
   expect_line_count 1
-  expect_output --substring test_file
-  ! expect_output --substring excluded_test_file
+  assert "$output" = "test_file" "only contents of copied directory"
 }


### PR DESCRIPTION
Primarily and most importantly, check error messages. You will
see this material again.
 - subnote, find and fix actually broken tests

Second, fix an invalid use of $TESTSDIR ('S' meaning 'Source')

And a few other fixes

Signed-off-by: Ed Santiago <santiago@redhat.com>
