### PR TITLE
Tests: rename $TESTSDIR and $TESTDIR

### DIFF
--- a/tests/add.bats
+++ b/tests/add.bats
@@ -17,7 +17,7 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
@@ -37,10 +37,10 @@ load helpers
   run_buildah config --workingdir=/cwd $cid
   run_buildah add $cid ${TESTDIR}/randomfile
   run_buildah unmount $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
   run_buildah rm $cid
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json new-image
+  run_buildah from $WITH_POLICY_JSON new-image
   newcid=$output
   run_buildah mount $newcid
   newroot=$output
@@ -62,7 +62,7 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
 
   dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/random1
@@ -86,10 +86,10 @@ load helpers
   run_buildah add $cid ${TESTDIR}/tarball2.tar.gz
   run_buildah add $cid ${TESTDIR}/tarball3.tar.bz2
   run_buildah add $cid ${TESTDIR}/tarball4.tar.bz2
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
   run_buildah rm $cid
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json new-image
+  run_buildah from $WITH_POLICY_JSON new-image
   newcid=$output
   run_buildah mount $newcid
   newroot=$output
@@ -117,15 +117,15 @@ load helpers
   createrandom ${TESTDIR}/distutils.cfg
   permission=$(stat -c "%a" ${TESTDIR}/distutils.cfg)
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ubuntu
+  run_buildah from --quiet $WITH_POLICY_JSON ubuntu
   cid=$output
   run_buildah add $cid ${TESTDIR}/distutils.cfg /usr/lib/python3.7/distutils
   run_buildah run $cid stat -c "%a" /usr/lib/python3.7/distutils
   expect_output $permission
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:${imgName}
+  run_buildah commit $WITH_POLICY_JSON $cid containers-storage:${imgName}
   run_buildah rm $cid
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${imgName}
+  run_buildah from --quiet $WITH_POLICY_JSON ${imgName}
   newcid=$output
   run_buildah run $newcid stat -c "%a" /usr/lib/python3.7/distutils
   expect_output $permission
@@ -137,15 +137,15 @@ load helpers
   createrandom ${TESTDIR}/distutils.cfg
   permission=$(stat -c "%a" ${TESTDIR}/distutils.cfg)
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ubuntu
+  run_buildah from --quiet $WITH_POLICY_JSON ubuntu
   cid=$output
   run_buildah add $cid ${TESTDIR}/distutils.cfg lib/custom
   run_buildah run $cid stat -c "%a" lib/custom
   expect_output $permission
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:${imgName}
+  run_buildah commit $WITH_POLICY_JSON $cid containers-storage:${imgName}
   run_buildah rm $cid
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${imgName}
+  run_buildah from --quiet $WITH_POLICY_JSON ${imgName}
   newcid=$output
   run_buildah run $newcid stat -c "%a" lib/custom
   expect_output $permission
@@ -154,7 +154,7 @@ load helpers
 @test "add with chown" {
   _prefetch busybox
   createrandom ${TESTDIR}/randomfile
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
   run_buildah add --chown bin:bin $cid ${TESTDIR}/randomfile /tmp/random
   run_buildah run $cid ls -l /tmp/random
@@ -165,7 +165,7 @@ load helpers
 @test "add with chmod" {
   _prefetch busybox
   createrandom ${TESTDIR}/randomfile
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
   run_buildah add --chmod 777 $cid ${TESTDIR}/randomfile /tmp/random
   run_buildah run $cid ls -l /tmp/random
@@ -175,7 +175,7 @@ load helpers
 
 @test "add url" {
   _prefetch busybox
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
   run_buildah add $cid https://github.com/containers/buildah/raw/main/README.md
   run_buildah run $cid ls /README.md
@@ -187,7 +187,7 @@ load helpers
 @test "add relative" {
   # make sure we don't get thrown by relative source locations
   _prefetch busybox
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
 
   run_buildah add $cid deny.json /
@@ -217,7 +217,7 @@ expect="
 stuff
 stuff/mystuff"
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
 
   run_buildah 125 copy --ignorefile ${mytest}/.ignore $cid ${mytest} /stuff
@@ -236,7 +236,7 @@ stuff/mystuff"
 @test "add quietly" {
   _prefetch busybox
   createrandom ${TESTDIR}/randomfile
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
   run_buildah add --quiet $cid ${TESTDIR}/randomfile /tmp/random
   expect_output ""
@@ -248,15 +248,15 @@ stuff/mystuff"
 @test "add from container" {
   _prefetch busybox
   createrandom ${TESTDIR}/randomfile
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   from=$output
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
   run_buildah add --quiet $from ${TESTDIR}/randomfile /tmp/random
   expect_output ""
-  run_buildah add --quiet --signature-policy ${TESTSDIR}/policy.json --from $from $cid /tmp/random /tmp/random # absolute path
+  run_buildah add --quiet $WITH_POLICY_JSON --from $from $cid /tmp/random /tmp/random # absolute path
   expect_output ""
-  run_buildah add --quiet --signature-policy ${TESTSDIR}/policy.json --from $from $cid  tmp/random /tmp/random2 # relative path
+  run_buildah add --quiet $WITH_POLICY_JSON --from $from $cid  tmp/random /tmp/random2 # relative path
   expect_output ""
   run_buildah mount $cid
   croot=$output
@@ -266,13 +266,13 @@ stuff/mystuff"
 
 @test "add from image" {
   _prefetch busybox
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah add --quiet --signature-policy ${TESTSDIR}/policy.json --from ubuntu $cid /etc/passwd /tmp/passwd # should pull the image, absolute path
+  run_buildah add --quiet $WITH_POLICY_JSON --from ubuntu $cid /etc/passwd /tmp/passwd # should pull the image, absolute path
   expect_output ""
-  run_buildah add --quiet --signature-policy ${TESTSDIR}/policy.json --from ubuntu $cid  etc/passwd /tmp/passwd2 # relative path
+  run_buildah add --quiet $WITH_POLICY_JSON --from ubuntu $cid  etc/passwd /tmp/passwd2 # relative path
   expect_output ""
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ubuntu
+  run_buildah from --quiet $WITH_POLICY_JSON ubuntu
   ubuntu=$output
   run_buildah mount $cid
   croot=$output

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -14,8 +14,8 @@ load helpers
 }
 
 @test "add-local-plain" {
-  createrandom ${TESTDIR}/randomfile
-  createrandom ${TESTDIR}/other-randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/other-randomfile
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
@@ -24,18 +24,18 @@ load helpers
   mkdir $root/subdir $root/other-subdir
   # Copy a file to the working directory
   run_buildah config --workingdir=/ $cid
-  run_buildah add $cid ${TESTDIR}/randomfile
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/randomfile
   # Copy a file to a specific subdirectory
-  run_buildah add $cid ${TESTDIR}/randomfile /subdir
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/randomfile /subdir
   # Copy two files to a specific subdirectory
-  run_buildah add $cid ${TESTDIR}/randomfile ${TESTDIR}/other-randomfile /other-subdir
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/randomfile ${TEST_SCRATCH_DIR}/other-randomfile /other-subdir
   # Copy two files to a specific location, which succeeds because we can create it as a directory.
-  run_buildah add $cid ${TESTDIR}/randomfile ${TESTDIR}/other-randomfile /notthereyet-subdir
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/randomfile ${TEST_SCRATCH_DIR}/other-randomfile /notthereyet-subdir
   # Copy two files to a specific location, which fails because it's not a directory.
-  run_buildah 125 add $cid ${TESTDIR}/randomfile ${TESTDIR}/other-randomfile /randomfile
+  run_buildah 125 add $cid ${TEST_SCRATCH_DIR}/randomfile ${TEST_SCRATCH_DIR}/other-randomfile /randomfile
   # Copy a file to a different working directory
   run_buildah config --workingdir=/cwd $cid
-  run_buildah add $cid ${TESTDIR}/randomfile
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/randomfile
   run_buildah unmount $cid
   run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
   run_buildah rm $cid
@@ -45,47 +45,47 @@ load helpers
   run_buildah mount $newcid
   newroot=$output
   test -s $newroot/randomfile
-  cmp ${TESTDIR}/randomfile $newroot/randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $newroot/randomfile
   test -s $newroot/subdir/randomfile
-  cmp ${TESTDIR}/randomfile $newroot/subdir/randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $newroot/subdir/randomfile
   test -s $newroot/other-subdir/randomfile
-  cmp ${TESTDIR}/randomfile $newroot/other-subdir/randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $newroot/other-subdir/randomfile
   test -s $newroot/other-subdir/other-randomfile
-  cmp ${TESTDIR}/other-randomfile $newroot/other-subdir/other-randomfile
+  cmp ${TEST_SCRATCH_DIR}/other-randomfile $newroot/other-subdir/other-randomfile
   test -d $newroot/cwd
   test -s $newroot/cwd/randomfile
-  cmp ${TESTDIR}/randomfile $newroot/cwd/randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $newroot/cwd/randomfile
   run_buildah rm $newcid
 }
 
 @test "add-local-archive" {
-  createrandom ${TESTDIR}/randomfile
-  createrandom ${TESTDIR}/other-randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/other-randomfile
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
 
-  dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/random1
-  dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/random2
-  tar -c -C ${TESTDIR}    -f ${TESTDIR}/tarball1.tar random1 random2
-  mkdir ${TESTDIR}/tarball2
-  dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/tarball2/tarball2.random1
-  dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/tarball2/tarball2.random2
-  tar -c -C ${TESTDIR} -z -f ${TESTDIR}/tarball2.tar.gz  tarball2
-  mkdir ${TESTDIR}/tarball3
-  dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/tarball3/tarball3.random1
-  dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/tarball3/tarball3.random2
-  tar -c -C ${TESTDIR} -j -f ${TESTDIR}/tarball3.tar.bz2 tarball3
-  mkdir ${TESTDIR}/tarball4
-  dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/tarball4/tarball4.random1
-  dd if=/dev/urandom bs=1024 count=4 of=${TESTDIR}/tarball4/tarball4.random2
-  tar -c -C ${TESTDIR} -j -f ${TESTDIR}/tarball4.tar.bz2 tarball4
+  dd if=/dev/urandom bs=1024 count=4 of=${TEST_SCRATCH_DIR}/random1
+  dd if=/dev/urandom bs=1024 count=4 of=${TEST_SCRATCH_DIR}/random2
+  tar -c -C ${TEST_SCRATCH_DIR}    -f ${TEST_SCRATCH_DIR}/tarball1.tar random1 random2
+  mkdir ${TEST_SCRATCH_DIR}/tarball2
+  dd if=/dev/urandom bs=1024 count=4 of=${TEST_SCRATCH_DIR}/tarball2/tarball2.random1
+  dd if=/dev/urandom bs=1024 count=4 of=${TEST_SCRATCH_DIR}/tarball2/tarball2.random2
+  tar -c -C ${TEST_SCRATCH_DIR} -z -f ${TEST_SCRATCH_DIR}/tarball2.tar.gz  tarball2
+  mkdir ${TEST_SCRATCH_DIR}/tarball3
+  dd if=/dev/urandom bs=1024 count=4 of=${TEST_SCRATCH_DIR}/tarball3/tarball3.random1
+  dd if=/dev/urandom bs=1024 count=4 of=${TEST_SCRATCH_DIR}/tarball3/tarball3.random2
+  tar -c -C ${TEST_SCRATCH_DIR} -j -f ${TEST_SCRATCH_DIR}/tarball3.tar.bz2 tarball3
+  mkdir ${TEST_SCRATCH_DIR}/tarball4
+  dd if=/dev/urandom bs=1024 count=4 of=${TEST_SCRATCH_DIR}/tarball4/tarball4.random1
+  dd if=/dev/urandom bs=1024 count=4 of=${TEST_SCRATCH_DIR}/tarball4/tarball4.random2
+  tar -c -C ${TEST_SCRATCH_DIR} -j -f ${TEST_SCRATCH_DIR}/tarball4.tar.bz2 tarball4
   # Add the files to the working directory, which should extract them all.
   run_buildah config --workingdir=/ $cid
-  run_buildah add $cid ${TESTDIR}/tarball1.tar
-  run_buildah add $cid ${TESTDIR}/tarball2.tar.gz
-  run_buildah add $cid ${TESTDIR}/tarball3.tar.bz2
-  run_buildah add $cid ${TESTDIR}/tarball4.tar.bz2
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/tarball1.tar
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/tarball2.tar.gz
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/tarball3.tar.bz2
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/tarball4.tar.bz2
   run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
   run_buildah rm $cid
 
@@ -94,32 +94,32 @@ load helpers
   run_buildah mount $newcid
   newroot=$output
   test -s $newroot/random1
-  cmp ${TESTDIR}/random1 $newroot/random1
+  cmp ${TEST_SCRATCH_DIR}/random1 $newroot/random1
   test -s $newroot/random2
-  cmp ${TESTDIR}/random2 $newroot/random2
+  cmp ${TEST_SCRATCH_DIR}/random2 $newroot/random2
   test -s $newroot/tarball2/tarball2.random1
-  cmp ${TESTDIR}/tarball2/tarball2.random1 $newroot/tarball2/tarball2.random1
+  cmp ${TEST_SCRATCH_DIR}/tarball2/tarball2.random1 $newroot/tarball2/tarball2.random1
   test -s $newroot/tarball2/tarball2.random2
-  cmp ${TESTDIR}/tarball2/tarball2.random2 $newroot/tarball2/tarball2.random2
+  cmp ${TEST_SCRATCH_DIR}/tarball2/tarball2.random2 $newroot/tarball2/tarball2.random2
   test -s $newroot/tarball3/tarball3.random1
-  cmp ${TESTDIR}/tarball3/tarball3.random1 $newroot/tarball3/tarball3.random1
+  cmp ${TEST_SCRATCH_DIR}/tarball3/tarball3.random1 $newroot/tarball3/tarball3.random1
   test -s $newroot/tarball3/tarball3.random2
-  cmp ${TESTDIR}/tarball3/tarball3.random2 $newroot/tarball3/tarball3.random2
+  cmp ${TEST_SCRATCH_DIR}/tarball3/tarball3.random2 $newroot/tarball3/tarball3.random2
   test -s $newroot/tarball4/tarball4.random1
-  cmp ${TESTDIR}/tarball4/tarball4.random1 $newroot/tarball4/tarball4.random1
+  cmp ${TEST_SCRATCH_DIR}/tarball4/tarball4.random1 $newroot/tarball4/tarball4.random1
   test -s $newroot/tarball4/tarball4.random2
-  cmp ${TESTDIR}/tarball4/tarball4.random2 $newroot/tarball4/tarball4.random2
+  cmp ${TEST_SCRATCH_DIR}/tarball4/tarball4.random2 $newroot/tarball4/tarball4.random2
 }
 
 @test "add single file creates absolute path with correct permissions" {
   _prefetch ubuntu
   imgName=ubuntu-image
-  createrandom ${TESTDIR}/distutils.cfg
-  permission=$(stat -c "%a" ${TESTDIR}/distutils.cfg)
+  createrandom ${TEST_SCRATCH_DIR}/distutils.cfg
+  permission=$(stat -c "%a" ${TEST_SCRATCH_DIR}/distutils.cfg)
 
   run_buildah from --quiet $WITH_POLICY_JSON ubuntu
   cid=$output
-  run_buildah add $cid ${TESTDIR}/distutils.cfg /usr/lib/python3.7/distutils
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/distutils.cfg /usr/lib/python3.7/distutils
   run_buildah run $cid stat -c "%a" /usr/lib/python3.7/distutils
   expect_output $permission
   run_buildah commit $WITH_POLICY_JSON $cid containers-storage:${imgName}
@@ -134,12 +134,12 @@ load helpers
 @test "add single file creates relative path with correct permissions" {
   _prefetch ubuntu
   imgName=ubuntu-image
-  createrandom ${TESTDIR}/distutils.cfg
-  permission=$(stat -c "%a" ${TESTDIR}/distutils.cfg)
+  createrandom ${TEST_SCRATCH_DIR}/distutils.cfg
+  permission=$(stat -c "%a" ${TEST_SCRATCH_DIR}/distutils.cfg)
 
   run_buildah from --quiet $WITH_POLICY_JSON ubuntu
   cid=$output
-  run_buildah add $cid ${TESTDIR}/distutils.cfg lib/custom
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/distutils.cfg lib/custom
   run_buildah run $cid stat -c "%a" lib/custom
   expect_output $permission
   run_buildah commit $WITH_POLICY_JSON $cid containers-storage:${imgName}
@@ -153,10 +153,10 @@ load helpers
 
 @test "add with chown" {
   _prefetch busybox
-  createrandom ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
   run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah add --chown bin:bin $cid ${TESTDIR}/randomfile /tmp/random
+  run_buildah add --chown bin:bin $cid ${TEST_SCRATCH_DIR}/randomfile /tmp/random
   run_buildah run $cid ls -l /tmp/random
 
   expect_output --substring bin.*bin
@@ -164,10 +164,10 @@ load helpers
 
 @test "add with chmod" {
   _prefetch busybox
-  createrandom ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
   run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah add --chmod 777 $cid ${TESTDIR}/randomfile /tmp/random
+  run_buildah add --chmod 777 $cid ${TEST_SCRATCH_DIR}/randomfile /tmp/random
   run_buildah run $cid ls -l /tmp/random
 
   expect_output --substring rwxrwxrwx
@@ -201,7 +201,7 @@ load helpers
 }
 
 @test "add --ignorefile" {
-  mytest=${TESTDIR}/mytest
+  mytest=${TEST_SCRATCH_DIR}/mytest
   mkdir -p ${mytest}
   touch ${mytest}/mystuff
   touch ${mytest}/source.go
@@ -235,24 +235,24 @@ stuff/mystuff"
 
 @test "add quietly" {
   _prefetch busybox
-  createrandom ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
   run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah add --quiet $cid ${TESTDIR}/randomfile /tmp/random
+  run_buildah add --quiet $cid ${TEST_SCRATCH_DIR}/randomfile /tmp/random
   expect_output ""
   run_buildah mount $cid
   croot=$output
-  cmp ${TESTDIR}/randomfile ${croot}/tmp/random
+  cmp ${TEST_SCRATCH_DIR}/randomfile ${croot}/tmp/random
 }
 
 @test "add from container" {
   _prefetch busybox
-  createrandom ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
   run_buildah from --quiet $WITH_POLICY_JSON busybox
   from=$output
   run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah add --quiet $from ${TESTDIR}/randomfile /tmp/random
+  run_buildah add --quiet $from ${TEST_SCRATCH_DIR}/randomfile /tmp/random
   expect_output ""
   run_buildah add --quiet $WITH_POLICY_JSON --from $from $cid /tmp/random /tmp/random # absolute path
   expect_output ""
@@ -260,8 +260,8 @@ stuff/mystuff"
   expect_output ""
   run_buildah mount $cid
   croot=$output
-  cmp ${TESTDIR}/randomfile ${croot}/tmp/random
-  cmp ${TESTDIR}/randomfile ${croot}/tmp/random2
+  cmp ${TEST_SCRATCH_DIR}/randomfile ${croot}/tmp/random
+  cmp ${TEST_SCRATCH_DIR}/randomfile ${croot}/tmp/random2
 }
 
 @test "add from image" {

--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -60,8 +60,8 @@ load helpers
   expect_output --from="${lines[-1]}" "my-alpine-work-ctr"
 
   # Create Dockerfile for bud tests
-  mkdir -p ${TESTDIR}/dockerdir
-  DOCKERFILE=${TESTDIR}/dockerdir/Dockerfile
+  mkdir -p ${TEST_SCRATCH_DIR}/dockerdir
+  DOCKERFILE=${TEST_SCRATCH_DIR}/dockerdir/Dockerfile
   /bin/cat <<EOM >$DOCKERFILE
 FROM localhost:$REGISTRY_PORT/my-alpine
 EOM
@@ -105,8 +105,8 @@ EOM
   run_buildah commit $WITH_POLICY_JSON --cert-dir=$REGISTRY_DIR --tls-verify=true --creds=testuser:testpassword $cid docker://localhost:$REGISTRY_PORT/my-alpine
 
   # Create Dockerfile for bud tests
-  mkdir -p ${TESTDIR}/dockerdir
-  DOCKERFILE=${TESTDIR}/dockerdir/Dockerfile
+  mkdir -p ${TEST_SCRATCH_DIR}/dockerdir
+  DOCKERFILE=${TEST_SCRATCH_DIR}/dockerdir/Dockerfile
   /bin/cat <<EOM >$DOCKERFILE
 FROM localhost:$REGISTRY_PORT/my-alpine
 RUN rm testfile

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -4,39 +4,39 @@ load helpers
 
 @test "from" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah rm $cid
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah rm $cid
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json --name i-love-naming-things alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON --name i-love-naming-things alpine
   cid=$output
   run_buildah rm i-love-naming-things
 }
 
 @test "from-defaultpull" {
   _prefetch alpine
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah rm $cid
 }
 
 @test "from-scratch" {
-  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull=false $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah rm $cid
-  run_buildah from --pull=true  --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull=true  $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah rm $cid
 }
 
 @test "from-nopull" {
-  run_buildah 125 from --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah 125 from --pull-never $WITH_POLICY_JSON alpine
 }
 
 @test "mount" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
@@ -49,7 +49,7 @@ load helpers
 }
 
 @test "by-name" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name scratch-working-image-for-test scratch
+  run_buildah from $WITH_POLICY_JSON --name scratch-working-image-for-test scratch
   cid=$output
   run_buildah mount scratch-working-image-for-test
   root=$output
@@ -61,35 +61,35 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
   cp ${TESTDIR}/randomfile $root/randomfile
   run_buildah unmount $cid
-  run_buildah commit --iidfile ${TESTDIR}/output.iid --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  run_buildah commit --iidfile ${TESTDIR}/output.iid $WITH_POLICY_JSON $cid containers-storage:new-image
   iid=$(< ${TESTDIR}/output.iid)
   assert "$iid" =~ "sha256:[0-9a-f]{64}"
   run_buildah rmi $iid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
   run_buildah rm $cid
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  run_buildah from --quiet $WITH_POLICY_JSON new-image
   newcid=$output
   run_buildah mount $newcid
   newroot=$output
   test -s $newroot/randomfile
   cmp ${TESTDIR}/randomfile $newroot/randomfile
   cp ${TESTDIR}/other-randomfile $newroot/other-randomfile
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:other-new-image
+  run_buildah commit $WITH_POLICY_JSON $newcid containers-storage:other-new-image
   # Not an allowed ordering of arguments and flags.  Check that it's rejected.
-  run_buildah 125 commit $newcid --signature-policy ${TESTSDIR}/policy.json containers-storage:rejected-new-image
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:another-new-image
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid yet-another-new-image
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:gratuitous-new-image
+  run_buildah 125 commit $newcid $WITH_POLICY_JSON containers-storage:rejected-new-image
+  run_buildah commit $WITH_POLICY_JSON $newcid containers-storage:another-new-image
+  run_buildah commit $WITH_POLICY_JSON $newcid yet-another-new-image
+  run_buildah commit $WITH_POLICY_JSON $newcid containers-storage:gratuitous-new-image
   run_buildah unmount $newcid
   run_buildah rm $newcid
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json other-new-image
+  run_buildah from --quiet $WITH_POLICY_JSON other-new-image
   othernewcid=$output
   run_buildah mount $othernewcid
   othernewroot=$output
@@ -99,7 +99,7 @@ load helpers
   cmp ${TESTDIR}/other-randomfile $othernewroot/other-randomfile
   run_buildah rm $othernewcid
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json another-new-image
+  run_buildah from --quiet $WITH_POLICY_JSON another-new-image
   anothernewcid=$output
   run_buildah mount $anothernewcid
   anothernewroot=$output
@@ -109,7 +109,7 @@ load helpers
   cmp ${TESTDIR}/other-randomfile $anothernewroot/other-randomfile
   run_buildah rm $anothernewcid
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json yet-another-new-image
+  run_buildah from --quiet $WITH_POLICY_JSON yet-another-new-image
   yetanothernewcid=$output
   run_buildah mount $yetanothernewcid
   yetanothernewroot=$output
@@ -119,9 +119,9 @@ load helpers
   cmp ${TESTDIR}/other-randomfile $yetanothernewroot/other-randomfile
   run_buildah delete $yetanothernewcid
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  run_buildah from --quiet $WITH_POLICY_JSON new-image
   newcid=$output
-  run_buildah commit --rm --signature-policy ${TESTSDIR}/policy.json $newcid containers-storage:remove-container-image
+  run_buildah commit --rm $WITH_POLICY_JSON $newcid containers-storage:remove-container-image
   run_buildah 125 mount $newcid
 
   run_buildah rmi remove-container-image

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -58,17 +58,17 @@ load helpers
 }
 
 @test "commit" {
-  createrandom ${TESTDIR}/randomfile
-  createrandom ${TESTDIR}/other-randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/other-randomfile
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
-  cp ${TESTDIR}/randomfile $root/randomfile
+  cp ${TEST_SCRATCH_DIR}/randomfile $root/randomfile
   run_buildah unmount $cid
-  run_buildah commit --iidfile ${TESTDIR}/output.iid $WITH_POLICY_JSON $cid containers-storage:new-image
-  iid=$(< ${TESTDIR}/output.iid)
+  run_buildah commit --iidfile ${TEST_SCRATCH_DIR}/output.iid $WITH_POLICY_JSON $cid containers-storage:new-image
+  iid=$(< ${TEST_SCRATCH_DIR}/output.iid)
   assert "$iid" =~ "sha256:[0-9a-f]{64}"
   run_buildah rmi $iid
   run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
@@ -78,8 +78,8 @@ load helpers
   run_buildah mount $newcid
   newroot=$output
   test -s $newroot/randomfile
-  cmp ${TESTDIR}/randomfile $newroot/randomfile
-  cp ${TESTDIR}/other-randomfile $newroot/other-randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $newroot/randomfile
+  cp ${TEST_SCRATCH_DIR}/other-randomfile $newroot/other-randomfile
   run_buildah commit $WITH_POLICY_JSON $newcid containers-storage:other-new-image
   # Not an allowed ordering of arguments and flags.  Check that it's rejected.
   run_buildah 125 commit $newcid $WITH_POLICY_JSON containers-storage:rejected-new-image
@@ -94,9 +94,9 @@ load helpers
   run_buildah mount $othernewcid
   othernewroot=$output
   test -s $othernewroot/randomfile
-  cmp ${TESTDIR}/randomfile $othernewroot/randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $othernewroot/randomfile
   test -s $othernewroot/other-randomfile
-  cmp ${TESTDIR}/other-randomfile $othernewroot/other-randomfile
+  cmp ${TEST_SCRATCH_DIR}/other-randomfile $othernewroot/other-randomfile
   run_buildah rm $othernewcid
 
   run_buildah from --quiet $WITH_POLICY_JSON another-new-image
@@ -104,9 +104,9 @@ load helpers
   run_buildah mount $anothernewcid
   anothernewroot=$output
   test -s $anothernewroot/randomfile
-  cmp ${TESTDIR}/randomfile $anothernewroot/randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $anothernewroot/randomfile
   test -s $anothernewroot/other-randomfile
-  cmp ${TESTDIR}/other-randomfile $anothernewroot/other-randomfile
+  cmp ${TEST_SCRATCH_DIR}/other-randomfile $anothernewroot/other-randomfile
   run_buildah rm $anothernewcid
 
   run_buildah from --quiet $WITH_POLICY_JSON yet-another-new-image
@@ -114,9 +114,9 @@ load helpers
   run_buildah mount $yetanothernewcid
   yetanothernewroot=$output
   test -s $yetanothernewroot/randomfile
-  cmp ${TESTDIR}/randomfile $yetanothernewroot/randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $yetanothernewroot/randomfile
   test -s $yetanothernewroot/other-randomfile
-  cmp ${TESTDIR}/other-randomfile $yetanothernewroot/other-randomfile
+  cmp ${TEST_SCRATCH_DIR}/other-randomfile $yetanothernewroot/other-randomfile
   run_buildah delete $yetanothernewcid
 
   run_buildah from --quiet $WITH_POLICY_JSON new-image

--- a/tests/blobcache.bats
+++ b/tests/blobcache.bats
@@ -6,7 +6,7 @@ load helpers
 	blobcachedir=${TESTDIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah pull --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
+	run_buildah pull --blob-cache=${blobcachedir} $WITH_POLICY_JSON k8s.gcr.io/pause
 	# Check that we dropped some files in there.
 	run find ${blobcachedir} -type f
 	echo "$output"
@@ -18,7 +18,7 @@ load helpers
 	blobcachedir=${TESTDIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah from --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
+	run_buildah from --blob-cache=${blobcachedir} $WITH_POLICY_JSON k8s.gcr.io/pause
 	# Check that we dropped some files in there.
 	run find ${blobcachedir} -type f
 	echo "$output"
@@ -59,14 +59,14 @@ function _check_matches() {
 	blobcachedir=${TESTDIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
+	run_buildah from --quiet --blob-cache=${blobcachedir} $WITH_POLICY_JSON k8s.gcr.io/pause
 	ctr="$output"
 	run_buildah add ${ctr} ${TESTSDIR}/bud/add-file/file /
 	# Commit the image without using the blob cache, using compression so that uncompressed blobs
 	# in the cache which we inherited from our base image won't be matched.
 	doomeddir=${TESTDIR}/doomed
 	mkdir -p ${doomeddir}
-	run_buildah commit --signature-policy ${TESTSDIR}/policy.json --disable-compression=false ${ctr} dir:${doomeddir}
+	run_buildah commit $WITH_POLICY_JSON --disable-compression=false ${ctr} dir:${doomeddir}
         _check_matches $doomeddir $blobcachedir \
                        0 "nothing" \
                        6 "everything"
@@ -77,7 +77,7 @@ function _check_matches() {
 	destdir=${TESTDIR}/dest
 	mkdir -p ${destdir}
 	ls -l ${blobcachedir}
-	run_buildah commit --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} --disable-compression=false ${ctr} dir:${destdir}
+	run_buildah commit $WITH_POLICY_JSON --blob-cache=${blobcachedir} --disable-compression=false ${ctr} dir:${destdir}
 	_check_matches $destdir $blobcachedir \
                        5 "base layers, new layer, config, and manifest" \
                        1 "version"
@@ -88,17 +88,17 @@ function _check_matches() {
 	blobcachedir=${TESTDIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah from --quiet --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
+	run_buildah from --quiet --blob-cache=${blobcachedir} $WITH_POLICY_JSON k8s.gcr.io/pause
 	ctr="$output"
 	run_buildah add ${ctr} ${TESTSDIR}/bud/add-file/file /
 	# Commit the image using the blob cache.
 	ls -l ${blobcachedir}
-	run_buildah commit --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} --disable-compression=false ${ctr} ${target}
+	run_buildah commit $WITH_POLICY_JSON --blob-cache=${blobcachedir} --disable-compression=false ${ctr} ${target}
 	# Try to push the image without the blob cache.
 	doomeddir=${TESTDIR}/doomed
 	mkdir -p ${doomeddir}
 	ls -l ${blobcachedir}
-	run_buildah push --signature-policy ${TESTSDIR}/policy.json ${target} dir:${doomeddir}
+	run_buildah push $WITH_POLICY_JSON ${target} dir:${doomeddir}
         _check_matches $doomeddir $blobcachedir \
                        2 "only config and new layer" \
                        4 "version, manifest, base layers"
@@ -108,7 +108,7 @@ function _check_matches() {
 	mkdir -p ${destdir}
 	ls -l ${blobcachedir}
 
-	run_buildah push --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} ${target} dir:${destdir}
+	run_buildah push $WITH_POLICY_JSON --blob-cache=${blobcachedir} ${target} dir:${destdir}
         _check_matches $destdir $blobcachedir \
                        5 "base image layers, new layer, config, and manifest" \
                        1 "version"
@@ -120,14 +120,14 @@ function _check_matches() {
 	target=new-image
 	# Build an image while pulling the base image.  Compress the layers so that they get added
 	# to the blob cache in their compressed forms.
-	run_buildah build-using-dockerfile -t ${target} --pull-always --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} --disable-compression=false ${TESTSDIR}/bud/add-file
+	run_buildah build-using-dockerfile -t ${target} --pull-always $WITH_POLICY_JSON --blob-cache=${blobcachedir} --disable-compression=false ${TESTSDIR}/bud/add-file
 	# Now try to push the image using the blob cache.  The blob cache will only suggest the
 	# compressed version of a blob if it's been told that we want to compress things, so
 	# we also request compression here to avoid having the copy logic just compress the
 	# uncompressed copy again.
 	destdir=${TESTDIR}/dest
 	mkdir -p ${destdir}
-	run_buildah push --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} --disable-compression=false ${target} dir:${destdir}
+	run_buildah push $WITH_POLICY_JSON --blob-cache=${blobcachedir} --disable-compression=false ${target} dir:${destdir}
         _check_matches $destdir $blobcachedir \
                        4 "config, base layer, new layer, and manifest" \
                        1 "version"
@@ -138,11 +138,11 @@ function _check_matches() {
 	mkdir -p ${blobcachedir}
 	target=new-image
 	# Build an image while pulling the base image.
-	run_buildah build-using-dockerfile -t ${target} -D --pull-always --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/add-file
+	run_buildah build-using-dockerfile -t ${target} -D --pull-always --blob-cache=${blobcachedir} $WITH_POLICY_JSON ${TESTSDIR}/bud/add-file
 	# Now try to push the image using the blob cache.
 	destdir=${TESTDIR}/dest
 	mkdir -p ${destdir}
-	run_buildah push --signature-policy ${TESTSDIR}/policy.json --blob-cache=${blobcachedir} ${target} dir:${destdir}
+	run_buildah push $WITH_POLICY_JSON --blob-cache=${blobcachedir} ${target} dir:${destdir}
 	_check_matches $destdir $blobcachedir \
                        2 "config and previously-compressed base layer" \
                        3 "version, new layer, and manifest"
@@ -155,7 +155,7 @@ function _check_matches() {
 	destdir=${TESTDIR}/dest
 	mkdir -p ${destdir}
 	# Build an image while pulling the base image, implicitly pushing while writing.
-	run_buildah build-using-dockerfile -t dir:${destdir} --pull-always --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/add-file
+	run_buildah build-using-dockerfile -t dir:${destdir} --pull-always --blob-cache=${blobcachedir} $WITH_POLICY_JSON ${TESTSDIR}/bud/add-file
         _check_matches $destdir $blobcachedir \
                        4 "base image, layer, config, and manifest" \
                        1 "version"
@@ -168,7 +168,7 @@ function _check_matches() {
 	destdir=${TESTDIR}/dest
 	mkdir -p ${destdir}
 	# Build an image while pulling the base image, implicitly pushing while writing.
-	run_buildah build-using-dockerfile -t dir:${destdir} -D --pull-always --blob-cache=${blobcachedir} --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/add-file
+	run_buildah build-using-dockerfile -t dir:${destdir} -D --pull-always --blob-cache=${blobcachedir} $WITH_POLICY_JSON ${TESTSDIR}/bud/add-file
         _check_matches $destdir $blobcachedir \
                        4 "base image, our layer, config, and manifest" \
                        1 "version"

--- a/tests/blobcache.bats
+++ b/tests/blobcache.bats
@@ -61,7 +61,7 @@ function _check_matches() {
 	# Pull an image using a fresh directory for the blob cache.
 	run_buildah from --quiet --blob-cache=${blobcachedir} $WITH_POLICY_JSON k8s.gcr.io/pause
 	ctr="$output"
-	run_buildah add ${ctr} ${TESTSDIR}/bud/add-file/file /
+	run_buildah add ${ctr} $BUDFILES/add-file/file /
 	# Commit the image without using the blob cache, using compression so that uncompressed blobs
 	# in the cache which we inherited from our base image won't be matched.
 	doomeddir=${TESTDIR}/doomed
@@ -90,7 +90,7 @@ function _check_matches() {
 	# Pull an image using a fresh directory for the blob cache.
 	run_buildah from --quiet --blob-cache=${blobcachedir} $WITH_POLICY_JSON k8s.gcr.io/pause
 	ctr="$output"
-	run_buildah add ${ctr} ${TESTSDIR}/bud/add-file/file /
+	run_buildah add ${ctr} $BUDFILES/add-file/file /
 	# Commit the image using the blob cache.
 	ls -l ${blobcachedir}
 	run_buildah commit $WITH_POLICY_JSON --blob-cache=${blobcachedir} --disable-compression=false ${ctr} ${target}
@@ -120,7 +120,7 @@ function _check_matches() {
 	target=new-image
 	# Build an image while pulling the base image.  Compress the layers so that they get added
 	# to the blob cache in their compressed forms.
-	run_buildah build-using-dockerfile -t ${target} --pull-always $WITH_POLICY_JSON --blob-cache=${blobcachedir} --disable-compression=false ${TESTSDIR}/bud/add-file
+	run_buildah build-using-dockerfile -t ${target} --pull-always $WITH_POLICY_JSON --blob-cache=${blobcachedir} --disable-compression=false $BUDFILES/add-file
 	# Now try to push the image using the blob cache.  The blob cache will only suggest the
 	# compressed version of a blob if it's been told that we want to compress things, so
 	# we also request compression here to avoid having the copy logic just compress the
@@ -138,7 +138,7 @@ function _check_matches() {
 	mkdir -p ${blobcachedir}
 	target=new-image
 	# Build an image while pulling the base image.
-	run_buildah build-using-dockerfile -t ${target} -D --pull-always --blob-cache=${blobcachedir} $WITH_POLICY_JSON ${TESTSDIR}/bud/add-file
+	run_buildah build-using-dockerfile -t ${target} -D --pull-always --blob-cache=${blobcachedir} $WITH_POLICY_JSON $BUDFILES/add-file
 	# Now try to push the image using the blob cache.
 	destdir=${TESTDIR}/dest
 	mkdir -p ${destdir}
@@ -155,7 +155,7 @@ function _check_matches() {
 	destdir=${TESTDIR}/dest
 	mkdir -p ${destdir}
 	# Build an image while pulling the base image, implicitly pushing while writing.
-	run_buildah build-using-dockerfile -t dir:${destdir} --pull-always --blob-cache=${blobcachedir} $WITH_POLICY_JSON ${TESTSDIR}/bud/add-file
+	run_buildah build-using-dockerfile -t dir:${destdir} --pull-always --blob-cache=${blobcachedir} $WITH_POLICY_JSON $BUDFILES/add-file
         _check_matches $destdir $blobcachedir \
                        4 "base image, layer, config, and manifest" \
                        1 "version"
@@ -168,7 +168,7 @@ function _check_matches() {
 	destdir=${TESTDIR}/dest
 	mkdir -p ${destdir}
 	# Build an image while pulling the base image, implicitly pushing while writing.
-	run_buildah build-using-dockerfile -t dir:${destdir} -D --pull-always --blob-cache=${blobcachedir} $WITH_POLICY_JSON ${TESTSDIR}/bud/add-file
+	run_buildah build-using-dockerfile -t dir:${destdir} -D --pull-always --blob-cache=${blobcachedir} $WITH_POLICY_JSON $BUDFILES/add-file
         _check_matches $destdir $blobcachedir \
                        4 "base image, our layer, config, and manifest" \
                        1 "version"

--- a/tests/blobcache.bats
+++ b/tests/blobcache.bats
@@ -3,7 +3,7 @@
 load helpers
 
 @test "blobcache-pull" {
-	blobcachedir=${TESTDIR}/cache
+	blobcachedir=${TEST_SCRATCH_DIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
 	run_buildah pull --blob-cache=${blobcachedir} $WITH_POLICY_JSON k8s.gcr.io/pause
@@ -15,7 +15,7 @@ load helpers
 }
 
 @test "blobcache-from" {
-	blobcachedir=${TESTDIR}/cache
+	blobcachedir=${TEST_SCRATCH_DIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
 	run_buildah from --blob-cache=${blobcachedir} $WITH_POLICY_JSON k8s.gcr.io/pause
@@ -56,7 +56,7 @@ function _check_matches() {
 }
 
 @test "blobcache-commit" {
-	blobcachedir=${TESTDIR}/cache
+	blobcachedir=${TEST_SCRATCH_DIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
 	run_buildah from --quiet --blob-cache=${blobcachedir} $WITH_POLICY_JSON k8s.gcr.io/pause
@@ -64,7 +64,7 @@ function _check_matches() {
 	run_buildah add ${ctr} $BUDFILES/add-file/file /
 	# Commit the image without using the blob cache, using compression so that uncompressed blobs
 	# in the cache which we inherited from our base image won't be matched.
-	doomeddir=${TESTDIR}/doomed
+	doomeddir=${TEST_SCRATCH_DIR}/doomed
 	mkdir -p ${doomeddir}
 	run_buildah commit $WITH_POLICY_JSON --disable-compression=false ${ctr} dir:${doomeddir}
         _check_matches $doomeddir $blobcachedir \
@@ -74,7 +74,7 @@ function _check_matches() {
 	# Commit the image using the blob cache, again using compression.  We'll have recorded the
 	# compressed digests that match the uncompressed digests the last time around, so we should
 	# get some matches this time.
-	destdir=${TESTDIR}/dest
+	destdir=${TEST_SCRATCH_DIR}/dest
 	mkdir -p ${destdir}
 	ls -l ${blobcachedir}
 	run_buildah commit $WITH_POLICY_JSON --blob-cache=${blobcachedir} --disable-compression=false ${ctr} dir:${destdir}
@@ -85,7 +85,7 @@ function _check_matches() {
 
 @test "blobcache-push" {
 	target=targetimage
-	blobcachedir=${TESTDIR}/cache
+	blobcachedir=${TEST_SCRATCH_DIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
 	run_buildah from --quiet --blob-cache=${blobcachedir} $WITH_POLICY_JSON k8s.gcr.io/pause
@@ -95,7 +95,7 @@ function _check_matches() {
 	ls -l ${blobcachedir}
 	run_buildah commit $WITH_POLICY_JSON --blob-cache=${blobcachedir} --disable-compression=false ${ctr} ${target}
 	# Try to push the image without the blob cache.
-	doomeddir=${TESTDIR}/doomed
+	doomeddir=${TEST_SCRATCH_DIR}/doomed
 	mkdir -p ${doomeddir}
 	ls -l ${blobcachedir}
 	run_buildah push $WITH_POLICY_JSON ${target} dir:${doomeddir}
@@ -104,7 +104,7 @@ function _check_matches() {
                        4 "version, manifest, base layers"
 
 	# Now try to push the image using the blob cache.
-	destdir=${TESTDIR}/dest
+	destdir=${TEST_SCRATCH_DIR}/dest
 	mkdir -p ${destdir}
 	ls -l ${blobcachedir}
 
@@ -115,7 +115,7 @@ function _check_matches() {
 }
 
 @test "blobcache-build-compressed-using-dockerfile-explicit-push" {
-	blobcachedir=${TESTDIR}/cache
+	blobcachedir=${TEST_SCRATCH_DIR}/cache
 	mkdir -p ${blobcachedir}
 	target=new-image
 	# Build an image while pulling the base image.  Compress the layers so that they get added
@@ -125,7 +125,7 @@ function _check_matches() {
 	# compressed version of a blob if it's been told that we want to compress things, so
 	# we also request compression here to avoid having the copy logic just compress the
 	# uncompressed copy again.
-	destdir=${TESTDIR}/dest
+	destdir=${TEST_SCRATCH_DIR}/dest
 	mkdir -p ${destdir}
 	run_buildah push $WITH_POLICY_JSON --blob-cache=${blobcachedir} --disable-compression=false ${target} dir:${destdir}
         _check_matches $destdir $blobcachedir \
@@ -134,13 +134,13 @@ function _check_matches() {
 }
 
 @test "blobcache-build-uncompressed-using-dockerfile-explicit-push" {
-	blobcachedir=${TESTDIR}/cache
+	blobcachedir=${TEST_SCRATCH_DIR}/cache
 	mkdir -p ${blobcachedir}
 	target=new-image
 	# Build an image while pulling the base image.
 	run_buildah build-using-dockerfile -t ${target} -D --pull-always --blob-cache=${blobcachedir} $WITH_POLICY_JSON $BUDFILES/add-file
 	# Now try to push the image using the blob cache.
-	destdir=${TESTDIR}/dest
+	destdir=${TEST_SCRATCH_DIR}/dest
 	mkdir -p ${destdir}
 	run_buildah push $WITH_POLICY_JSON --blob-cache=${blobcachedir} ${target} dir:${destdir}
 	_check_matches $destdir $blobcachedir \
@@ -149,10 +149,10 @@ function _check_matches() {
 }
 
 @test "blobcache-build-compressed-using-dockerfile-implicit-push" {
-	blobcachedir=${TESTDIR}/cache
+	blobcachedir=${TEST_SCRATCH_DIR}/cache
 	mkdir -p ${blobcachedir}
 	target=new-image
-	destdir=${TESTDIR}/dest
+	destdir=${TEST_SCRATCH_DIR}/dest
 	mkdir -p ${destdir}
 	# Build an image while pulling the base image, implicitly pushing while writing.
 	run_buildah build-using-dockerfile -t dir:${destdir} --pull-always --blob-cache=${blobcachedir} $WITH_POLICY_JSON $BUDFILES/add-file
@@ -162,10 +162,10 @@ function _check_matches() {
 }
 
 @test "blobcache-build-uncompressed-using-dockerfile-implicit-push" {
-	blobcachedir=${TESTDIR}/cache
+	blobcachedir=${TEST_SCRATCH_DIR}/cache
 	mkdir -p ${blobcachedir}
 	target=new-image
-	destdir=${TESTDIR}/dest
+	destdir=${TEST_SCRATCH_DIR}/dest
 	mkdir -p ${destdir}
 	# Build an image while pulling the base image, implicitly pushing while writing.
 	run_buildah build-using-dockerfile -t dir:${destdir} -D --pull-always --blob-cache=${blobcachedir} $WITH_POLICY_JSON $BUDFILES/add-file

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -376,7 +376,7 @@ _EOF
   _prefetch alpine
   cp -a $BUDFILES/use-layers ${TESTDIR}/use-layers
   mkdir ${TESTDIR}/use-layers/blah
-  ln -s ${TESTSDIR}/policy.json ${TESTDIR}/use-layers/blah/policy.json
+  ln -s ${TEST_SOURCES}/policy.json ${TESTDIR}/use-layers/blah/policy.json
 
   run_buildah build $WITH_POLICY_JSON --layers -t test -f Dockerfile.dangling-symlink ${TESTDIR}/use-layers
   run_buildah images -a
@@ -1670,7 +1670,7 @@ function _test_http() {
 
 @test "bud with bad dir Dockerfile" {
   target=alpine-image
-  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/baddirname ${TESTSDIR}/baddirname
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f ${TEST_SOURCES}/baddirname ${TEST_SOURCES}/baddirname
   expect_output --substring "no such file or directory"
 }
 
@@ -1946,25 +1946,25 @@ function _test_http() {
   target=foo
 
   # A deny-all policy should prevent us from pulling the base image.
-  run_buildah 125 build --signature-policy ${TESTSDIR}/deny.json -t ${target} -v ${TESTSDIR}:/testdir $BUDFILES/mount
+  run_buildah 125 build --signature-policy ${TEST_SOURCES}/deny.json -t ${target} -v ${TEST_SOURCES}:/testdir $BUDFILES/mount
   expect_output --substring 'Source image rejected: Running image .* rejected by policy.'
 
   # A docker-only policy should allow us to pull the base image and commit.
-  run_buildah build --signature-policy ${TESTSDIR}/docker.json -t ${target} -v ${TESTSDIR}:/testdir $BUDFILES/mount
+  run_buildah build --signature-policy ${TEST_SOURCES}/docker.json -t ${target} -v ${TEST_SOURCES}:/testdir $BUDFILES/mount
   # A deny-all policy shouldn't break pushing, since policy is only evaluated
   # on the source image, and we force it to allow local storage.
-  run_buildah push --signature-policy ${TESTSDIR}/deny.json ${target} dir:${TESTDIR}/mount
+  run_buildah push --signature-policy ${TEST_SOURCES}/deny.json ${target} dir:${TESTDIR}/mount
   run_buildah rmi ${target}
 
   # A docker-only policy should allow us to pull the base image first...
-  run_buildah pull --signature-policy ${TESTSDIR}/docker.json alpine
+  run_buildah pull --signature-policy ${TEST_SOURCES}/docker.json alpine
   # ... and since we don't need to pull the base image, a deny-all policy shouldn't break a build.
-  run_buildah build --signature-policy ${TESTSDIR}/deny.json -t ${target} -v ${TESTSDIR}:/testdir $BUDFILES/mount
+  run_buildah build --signature-policy ${TEST_SOURCES}/deny.json -t ${target} -v ${TEST_SOURCES}:/testdir $BUDFILES/mount
   # A deny-all policy shouldn't break pushing, since policy is only evaluated
   # on the source image, and we force it to allow local storage.
-  run_buildah push --signature-policy ${TESTSDIR}/deny.json ${target} dir:${TESTDIR}/mount
+  run_buildah push --signature-policy ${TEST_SOURCES}/deny.json ${target} dir:${TESTDIR}/mount
   # Similarly, a deny-all policy shouldn't break committing directly to other locations.
-  run_buildah build --signature-policy ${TESTSDIR}/deny.json -t dir:${TESTDIR}/mount -v ${TESTSDIR}:/testdir $BUDFILES/mount
+  run_buildah build --signature-policy ${TEST_SOURCES}/deny.json -t dir:${TESTDIR}/mount -v ${TEST_SOURCES}:/testdir $BUDFILES/mount
 }
 
 @test "bud-copy-replace-symlink" {
@@ -2156,12 +2156,12 @@ _EOF
 
 @test "bud without any arguments should succeed" {
   cd $BUDFILES/from-scratch
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json
+  run_buildah build --signature-policy ${TEST_SOURCES}/policy.json
 }
 
 @test "bud without any arguments should fail when no Dockerfile exist" {
   cd $(mktemp -d)
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json
+  run_buildah 125 build --signature-policy ${TEST_SOURCES}/policy.json
   expect_output --substring "no such file or directory"
 }
 
@@ -2362,7 +2362,7 @@ _EOF
 }
 
 @test "bud using gitrepo and branch" {
-  if ! start_git_daemon ${TESTSDIR}/git-daemon/release-1.11-rhel.tar.gz ; then
+  if ! start_git_daemon ${TEST_SOURCES}/git-daemon/release-1.11-rhel.tar.gz ; then
     skip "error running git daemon"
   fi
   run_buildah build $WITH_POLICY_JSON --layers -t gittarget -f $BUDFILES/shell/Dockerfile git://localhost:${GITPORT}/repo#release-1.11-rhel
@@ -2378,7 +2378,7 @@ _EOF
   # First check to verify cache is used if the tar file does not change
   target=copy-archive
   date > $BUDFILES/${target}/test
-  tar -C $TESTSDIR -cJf $BUDFILES/${target}/test.tar.xz bud/${target}/test
+  tar -C $TEST_SOURCES -cJf $BUDFILES/${target}/test.tar.xz bud/${target}/test
   run_buildah build $WITH_POLICY_JSON --layers -t ${target} $BUDFILES/${target}
   expect_output --substring "COMMIT copy-archive"
 
@@ -2388,7 +2388,7 @@ _EOF
 
   # Now test that we do NOT use cache if the tar file changes
   echo This is a change >> $BUDFILES/${target}/test
-  tar -C $TESTSDIR -cJf $BUDFILES/${target}/test.tar.xz bud/${target}/test
+  tar -C $TEST_SOURCES -cJf $BUDFILES/${target}/test.tar.xz bud/${target}/test
   run_buildah build $WITH_POLICY_JSON --layers -t ${target} $BUDFILES/${target}
   if [[ "$output" =~ " Using cache" ]]; then
       expect_output "[no instance of 'Using cache']" "no cache used"

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3,17 +3,17 @@
 load helpers
 
 @test "bud with a path to a Dockerfile (-f) containing a non-directory entry" {
-  run_buildah 125 build -f ${TESTSDIR}/bud/non-directory-in-path/non-directory/Dockerfile
+  run_buildah 125 build -f $BUDFILES/non-directory-in-path/non-directory/Dockerfile
   expect_output --substring "non-directory/Dockerfile: not a directory"
 }
 
 @test "bud stdio is usable pipes" {
-  run_buildah build ${TESTSDIR}/bud/stdio
+  run_buildah build $BUDFILES/stdio
 }
 
 @test "bud with --dns* flags" {
   _prefetch alpine
-  run_buildah build --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc  $WITH_POLICY_JSON -f ${TESTSDIR}/bud/dns/Dockerfile  ${TESTSDIR}/bud/dns
+  run_buildah build --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc  $WITH_POLICY_JSON -f $BUDFILES/dns/Dockerfile  $BUDFILES/dns
   expect_output --substring "search example.com"
   expect_output --substring "nameserver 223.5.5.5"
   expect_output --substring "options use-vc"
@@ -21,10 +21,10 @@ load helpers
 
 @test "bud with .dockerignore #1" {
   _prefetch alpine busybox
-  run_buildah 125 build -t testbud $WITH_POLICY_JSON -f ${TESTSDIR}/bud/dockerignore/Dockerfile ${TESTSDIR}/bud/dockerignore
+  run_buildah 125 build -t testbud $WITH_POLICY_JSON -f $BUDFILES/dockerignore/Dockerfile $BUDFILES/dockerignore
   expect_output --substring 'error building.*"COPY subdir \./".*no such file or directory'
 
-  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTSDIR}/bud/dockerignore/Dockerfile.succeed ${TESTSDIR}/bud/dockerignore
+  run_buildah build -t testbud $WITH_POLICY_JSON -f $BUDFILES/dockerignore/Dockerfile.succeed $BUDFILES/dockerignore
 
   run_buildah from --name myctr testbud
 
@@ -41,10 +41,10 @@ load helpers
 
 @test "bud with .containerignore" {
   _prefetch alpine busybox
-  run_buildah 125 build -t testbud $WITH_POLICY_JSON -f ${TESTSDIR}/bud/containerignore/Dockerfile ${TESTSDIR}/bud/containerignore
+  run_buildah 125 build -t testbud $WITH_POLICY_JSON -f $BUDFILES/containerignore/Dockerfile $BUDFILES/containerignore
   expect_output --substring 'error building.*"COPY subdir \./".*no such file or directory'
 
-  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTSDIR}/bud/containerignore/Dockerfile.succeed ${TESTSDIR}/bud/containerignore
+  run_buildah build -t testbud $WITH_POLICY_JSON -f $BUDFILES/containerignore/Dockerfile.succeed $BUDFILES/containerignore
 
   run_buildah from --name myctr testbud
 
@@ -68,7 +68,7 @@ load helpers
   # on rawhide no longer packages circular symlinks (rpm issue #1159).
   # We used to include these symlinks in git and the rpm; now we need to
   # set them up manually as part of test setup to be able to package tests.
-  cp -a ${TESTSDIR}/bud/dockerignore2 ${TESTDIR}/dockerignore2
+  cp -a $BUDFILES/dockerignore2 ${TESTDIR}/dockerignore2
 
   # Create symlinks, including bad ones
   ln -sf subdir        ${TESTDIR}/dockerignore2/symlink
@@ -112,9 +112,9 @@ symlink(subdir)"
 }
 
 @test "bud with .dockerignore #2" {
-  run_buildah 125 build -t testbud3 $WITH_POLICY_JSON ${TESTSDIR}/bud/dockerignore3
+  run_buildah 125 build -t testbud3 $WITH_POLICY_JSON $BUDFILES/dockerignore3
   expect_output --substring 'error building.*"COPY test1.txt /upload/test1.txt".*no such file or directory'
-  expect_output --substring $(realpath "${TESTSDIR}/bud/dockerignore3/.dockerignore")
+  expect_output --substring $(realpath "$BUDFILES/dockerignore3/.dockerignore")
 }
 
 # Following test must fail since we are trying to run linux/arm64 on linux/amd64
@@ -172,7 +172,7 @@ _EOF
 }
 
 @test "bud with --layers and --no-cache flags" {
-  cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
+  cp -a $BUDFILES/use-layers ${TESTDIR}/use-layers
 
   # Run with --pull-always to have a regression test for
   # containers/podman/issues/10307.
@@ -222,7 +222,7 @@ _EOF
   run_buildah inspect --format "{{.FromImageDigest}}" alpine
   fromDigest="$output"
 
-  run_buildah build $WITH_POLICY_JSON --layers -t test -f Dockerfile.5 ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test -f Dockerfile.5 $BUDFILES/use-layers
   run_buildah images -a
   expect_line_count 3
 
@@ -232,7 +232,7 @@ _EOF
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.name" }}' test
   expect_output "docker.io/library/alpine:latest" "base name from alpine"
 
-  run_buildah build $WITH_POLICY_JSON --layers -t test1 -f Dockerfile.6 ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test1 -f Dockerfile.6 $BUDFILES/use-layers
   run_buildah images -a
   expect_line_count 4
 
@@ -247,7 +247,7 @@ _EOF
 
 @test "bud with --layers, multistage, and COPY with --from" {
   _prefetch alpine
-  cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
+  cp -a $BUDFILES/use-layers ${TESTDIR}/use-layers
 
   mkdir -p ${TESTDIR}/use-layers/uuid
   uuidgen > ${TESTDIR}/use-layers/uuid/data
@@ -294,12 +294,12 @@ _EOF
   _prefetch alpine
   target=foo
   # build the first stage
-  run_buildah build $WITH_POLICY_JSON --layers -f ${TESTSDIR}/bud/cache-stages/Dockerfile.1 ${TESTSDIR}/bud/cache-stages
+  run_buildah build $WITH_POLICY_JSON --layers -f $BUDFILES/cache-stages/Dockerfile.1 $BUDFILES/cache-stages
   # expect alpine + 1 image record for the first stage
   run_buildah images -a
   expect_line_count 3
   # build the second stage, itself not cached, when the first stage is found in the cache
-  run_buildah build $WITH_POLICY_JSON --layers -f ${TESTSDIR}/bud/cache-stages/Dockerfile.2 -t ${target} ${TESTSDIR}/bud/cache-stages
+  run_buildah build $WITH_POLICY_JSON --layers -f $BUDFILES/cache-stages/Dockerfile.2 -t ${target} $BUDFILES/cache-stages
   # expect alpine + 1 image record for the first stage, then two more image records for the second stage
   run_buildah images -a
   expect_line_count 5
@@ -308,7 +308,7 @@ _EOF
 @test "bud-multistage-copy-final-slash" {
   _prefetch busybox
   target=foo
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/dest-final-slash
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/dest-final-slash
   run_buildah from --pull=false $WITH_POLICY_JSON ${target}
   cid="$output"
   run_buildah run ${cid} /test/ls -lR /test/ls
@@ -320,7 +320,7 @@ _EOF
   fromDigest="$output"
 
   target=foo
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/multi-stage-builds/Dockerfile.reused $BUDFILES/multi-stage-builds
 
   # Also check for base-image annotations.
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' ${target}
@@ -330,14 +330,14 @@ _EOF
 
   run_buildah from $WITH_POLICY_JSON ${target}
   run_buildah rmi -f ${target}
-  run_buildah build $WITH_POLICY_JSON -t ${target} --layers -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON -t ${target} --layers -f $BUDFILES/multi-stage-builds/Dockerfile.reused $BUDFILES/multi-stage-builds
   run_buildah from $WITH_POLICY_JSON ${target}
 }
 
 @test "bud-multistage-cache" {
   _prefetch alpine busybox
   target=foo
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.extended ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/multi-stage-builds/Dockerfile.extended $BUDFILES/multi-stage-builds
   run_buildah from $WITH_POLICY_JSON ${target}
   cid="$output"
   run_buildah mount "$cid"
@@ -350,12 +350,12 @@ _EOF
 
 @test "bud-multistage-pull-always" {
   _prefetch busybox
-  run_buildah build --pull-always $WITH_POLICY_JSON -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.extended ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build --pull-always $WITH_POLICY_JSON -f $BUDFILES/multi-stage-builds/Dockerfile.extended $BUDFILES/multi-stage-builds
 }
 
 @test "bud with --layers and symlink file" {
   _prefetch alpine
-  cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
+  cp -a $BUDFILES/use-layers ${TESTDIR}/use-layers
   echo 'echo "Hello World!"' > ${TESTDIR}/use-layers/hello.sh
   ln -s hello.sh ${TESTDIR}/use-layers/hello_world.sh
   run_buildah build $WITH_POLICY_JSON --layers -t test -f Dockerfile.4 ${TESTDIR}/use-layers
@@ -374,7 +374,7 @@ _EOF
 
 @test "bud with --layers and dangling symlink" {
   _prefetch alpine
-  cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
+  cp -a $BUDFILES/use-layers ${TESTDIR}/use-layers
   mkdir ${TESTDIR}/use-layers/blah
   ln -s ${TESTSDIR}/policy.json ${TESTDIR}/use-layers/blah/policy.json
 
@@ -395,12 +395,12 @@ _EOF
 @test "bud with --layers and --build-args" {
   _prefetch alpine
   # base plus 3, plus the header line
-  run_buildah build $WITH_POLICY_JSON --build-arg=user=0 --layers -t test -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --build-arg=user=0 --layers -t test -f Dockerfile.build-args $BUDFILES/use-layers
   run_buildah images -a
   expect_line_count 5
 
   # running the same build again does not run the commands again
-  run_buildah build $WITH_POLICY_JSON --build-arg=user=0 --layers -t test -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --build-arg=user=0 --layers -t test -f Dockerfile.build-args $BUDFILES/use-layers
   if [[ "$output" =~ "MAo=" ]]; then
     # MAo= is the base64 of "0\n" (i.e. `echo 0`)
     printf "Expected command not to run again if layer is cached\n" >&2
@@ -408,17 +408,17 @@ _EOF
   fi
 
   # two more, starting at the "echo $user | base64" instruction
-  run_buildah build $WITH_POLICY_JSON --build-arg=user=1 --layers -t test1 -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --build-arg=user=1 --layers -t test1 -f Dockerfile.build-args $BUDFILES/use-layers
   run_buildah images -a
   expect_line_count 7
 
   # one more, because we added a new name to the same image
-  run_buildah build $WITH_POLICY_JSON --build-arg=user=1 --layers -t test2 -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --build-arg=user=1 --layers -t test2 -f Dockerfile.build-args $BUDFILES/use-layers
   run_buildah images -a
   expect_line_count 8
 
   # two more, starting at the "echo $user | base64" instruction
-  run_buildah build $WITH_POLICY_JSON --layers -t test3 -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test3 -f Dockerfile.build-args $BUDFILES/use-layers
   run_buildah images -a
   expect_line_count 11
 }
@@ -427,10 +427,10 @@ _EOF
 @test "bud with --layers and --build-args: override ARG with ENV and image must be cached" {
   _prefetch alpine
   #when ARG is overridden by config
-  run_buildah build $WITH_POLICY_JSON --build-arg=FOO=1 --layers -t args-cache -f ${TESTSDIR}/bud/with-arg/Dockerfile
+  run_buildah build $WITH_POLICY_JSON --build-arg=FOO=1 --layers -t args-cache -f $BUDFILES/with-arg/Dockerfile
   run_buildah inspect -f '{{.FromImageID}}' args-cache
   idbefore="$output"
-  run_buildah build $WITH_POLICY_JSON --build-arg=FOO=12 --layers -t args-cache -f ${TESTSDIR}/bud/with-arg/Dockerfile
+  run_buildah build $WITH_POLICY_JSON --build-arg=FOO=12 --layers -t args-cache -f $BUDFILES/with-arg/Dockerfile
   run_buildah inspect -f '{{.FromImageID}}' args-cache
   expect_output --substring ${idbefore}
   run_buildah rmi args-cache
@@ -438,10 +438,10 @@ _EOF
 
 @test "bud with --layers and --build-args: use raw ARG and cache should not be used" {
   # when ARG is used as a raw value
-  run_buildah build $WITH_POLICY_JSON --build-arg=FOO=1 --layers -t args-cache -f ${TESTSDIR}/bud/with-arg/Dockerfile2
+  run_buildah build $WITH_POLICY_JSON --build-arg=FOO=1 --layers -t args-cache -f $BUDFILES/with-arg/Dockerfile2
   run_buildah inspect -f '{{.FromImageID}}' args-cache
   idbefore="$output"
-  run_buildah build $WITH_POLICY_JSON --build-arg=FOO=12 --layers -t args-cache -f ${TESTSDIR}/bud/with-arg/Dockerfile2
+  run_buildah build $WITH_POLICY_JSON --build-arg=FOO=12 --layers -t args-cache -f $BUDFILES/with-arg/Dockerfile2
   run_buildah inspect -f '{{.FromImageID}}' args-cache
   idafter="$output"
   run_buildah rmi args-cache
@@ -452,35 +452,35 @@ _EOF
 
 @test "bud with --rm flag" {
   _prefetch alpine
-  run_buildah build $WITH_POLICY_JSON --layers -t test1 ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test1 $BUDFILES/use-layers
   run_buildah containers
   expect_line_count 1
 
-  run_buildah build $WITH_POLICY_JSON --rm=false --layers -t test2 ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --rm=false --layers -t test2 $BUDFILES/use-layers
   run_buildah containers
   expect_line_count 7
 }
 
 @test "bud with --force-rm flag" {
   _prefetch alpine
-  run_buildah 125 build $WITH_POLICY_JSON --force-rm --layers -t test1 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
+  run_buildah 125 build $WITH_POLICY_JSON --force-rm --layers -t test1 -f Dockerfile.fail-case $BUDFILES/use-layers
   run_buildah containers
   expect_line_count 1
 
-  run_buildah 125 build $WITH_POLICY_JSON --layers -t test2 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
+  run_buildah 125 build $WITH_POLICY_JSON --layers -t test2 -f Dockerfile.fail-case $BUDFILES/use-layers
   run_buildah containers
   expect_line_count 2
 }
 
 @test "bud --layers with non-existent/down registry" {
   _prefetch alpine
-  run_buildah 125 build $WITH_POLICY_JSON --force-rm --layers -t test1 -f Dockerfile.non-existent-registry ${TESTSDIR}/bud/use-layers
+  run_buildah 125 build $WITH_POLICY_JSON --force-rm --layers -t test1 -f Dockerfile.non-existent-registry $BUDFILES/use-layers
   expect_output --substring "no such host"
 }
 
 @test "bud from base image should have base image ENV also" {
   _prefetch alpine
-  run_buildah build $WITH_POLICY_JSON -t test -f Dockerfile.check-env ${TESTSDIR}/bud/env
+  run_buildah build $WITH_POLICY_JSON -t test -f Dockerfile.check-env $BUDFILES/env
   run_buildah from --quiet $WITH_POLICY_JSON test
   cid=$output
   run_buildah config --env random=hello,goodbye ${cid}
@@ -493,14 +493,14 @@ _EOF
 
 @test "bud-from-scratch" {
   target=scratch-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   run_buildah from ${target}
   expect_output "${target}-working-container"
 }
 
 @test "bud-with-unlimited-memory-swap" {
   target=scratch-image
-  run_buildah build $WITH_POLICY_JSON --memory-swap -1 -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build $WITH_POLICY_JSON --memory-swap -1 -t ${target} $BUDFILES/from-scratch
   run_buildah rmi -f ${target}
 }
 
@@ -552,7 +552,7 @@ _EOF
 }
 
 @test "bud-from-scratch-untagged" {
-  run_buildah build --iidfile ${TESTDIR}/output.iid $WITH_POLICY_JSON ${TESTSDIR}/bud/from-scratch
+  run_buildah build --iidfile ${TESTDIR}/output.iid $WITH_POLICY_JSON $BUDFILES/from-scratch
   iid=$(cat ${TESTDIR}/output.iid)
   expect_output --substring --from="$iid" '^sha256:[0-9a-f]{64}$'
   run_buildah from ${iid}
@@ -569,26 +569,26 @@ _EOF
 
 @test "bud with --tag " {
   target=scratch-image
-  run_buildah build --quiet=false --tag test1 $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --quiet=false --tag test1 $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   expect_output --substring "Successfully tagged localhost/test1:latest"
 
-  run_buildah build --quiet=false --tag test1 --tag test2 $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --quiet=false --tag test1 --tag test2 $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   expect_output --substring "Successfully tagged localhost/test1:latest"
   expect_output --substring "Successfully tagged localhost/test2:latest"
 }
 
 @test "bud with bad --tag " {
   target=scratch-image
-  run_buildah 125 build --quiet=false --tag TEST1 $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build --quiet=false --tag TEST1 $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   expect_output --substring "tag TEST1: invalid reference format: repository name must be lowercase"
 
-  run_buildah 125 build --quiet=false --tag test1 --tag TEST2 $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build --quiet=false --tag test1 --tag TEST2 $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   expect_output --substring "tag TEST2: invalid reference format: repository name must be lowercase"
 }
 
 @test "bud-from-scratch-iid" {
   target=scratch-image
-  run_buildah build --iidfile ${TESTDIR}/output.iid $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --iidfile ${TESTDIR}/output.iid $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   iid=$(cat ${TESTDIR}/output.iid)
   expect_output --substring --from="$iid" '^sha256:[0-9a-f]{64}$'
   run_buildah from ${iid}
@@ -602,7 +602,7 @@ _EOF
   want_output='map["io.buildah.version":"'$buildah_version'" "test":"label"]'
 
   target=scratch-image
-  run_buildah build --label "test=label" $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --label "test=label" $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output "$want_output"
 }
@@ -614,29 +614,29 @@ _EOF
   want_output='map["io.buildah.version":"'$buildah_version'"]'
 
   target=scratch-image
-  run_buildah build --label "io.buildah.version=oldversion" $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --label "io.buildah.version=oldversion" $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output "$want_output"
 }
 
 @test "bud-from-scratch-remove-identity-label" {
   target=scratch-image
-  run_buildah build --identity-label=false $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --identity-label=false $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output "map[]"
 }
 
 @test "bud-from-scratch-annotation" {
   target=scratch-image
-  run_buildah build --annotation "test=annotation1,annotation2=z" $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --annotation "test=annotation1,annotation2=z" $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   run_buildah inspect --format '{{index .ImageAnnotations "test"}}' ${target}
   expect_output "annotation1,annotation2=z"
 }
 
 @test "bud-from-scratch-layers" {
   target=scratch-image
-  run_buildah build $WITH_POLICY_JSON -f  ${TESTSDIR}/bud/from-scratch/Containerfile2 -t ${target} ${TESTSDIR}/bud/from-scratch
-  run_buildah build $WITH_POLICY_JSON -f  ${TESTSDIR}/bud/from-scratch/Containerfile2 -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build $WITH_POLICY_JSON -f  $BUDFILES/from-scratch/Containerfile2 -t ${target} $BUDFILES/from-scratch
+  run_buildah build $WITH_POLICY_JSON -f  $BUDFILES/from-scratch/Containerfile2 -t ${target} $BUDFILES/from-scratch
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah images
@@ -647,125 +647,125 @@ _EOF
 
 @test "bud-from-multiple-files-one-from" {
   target=scratch-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/from-multiple-files/Dockerfile1.scratch -f $BUDFILES/from-multiple-files/Dockerfile2.nofrom $BUDFILES/from-multiple-files
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
-  cmp $root/Dockerfile1 ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch
-  cmp $root/Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom
+  cmp $root/Dockerfile1 $BUDFILES/from-multiple-files/Dockerfile1.scratch
+  cmp $root/Dockerfile2.nofrom $BUDFILES/from-multiple-files/Dockerfile2.nofrom
   test ! -s $root/etc/passwd
   run_buildah rm ${cid}
   run_buildah rmi -a
 
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile1.alpine -f Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile1.alpine -f Dockerfile2.nofrom $BUDFILES/from-multiple-files
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
-  cmp $root/Dockerfile1 ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.alpine
-  cmp $root/Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom
+  cmp $root/Dockerfile1 $BUDFILES/from-multiple-files/Dockerfile1.alpine
+  cmp $root/Dockerfile2.nofrom $BUDFILES/from-multiple-files/Dockerfile2.nofrom
   test -s $root/etc/passwd
 }
 
 @test "bud-from-multiple-files-two-froms" {
   _prefetch alpine
   target=scratch-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile1.scratch -f Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile1.scratch -f Dockerfile2.withfrom $BUDFILES/from-multiple-files
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
   test ! -s $root/Dockerfile1
-  cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
+  cmp $root/Dockerfile2.withfrom $BUDFILES/from-multiple-files/Dockerfile2.withfrom
   test -s $root/etc/passwd
   run_buildah rm ${cid}
   run_buildah rmi -a
 
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile1.alpine -f Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile1.alpine -f Dockerfile2.withfrom $BUDFILES/from-multiple-files
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
   test ! -s $root/Dockerfile1
-  cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
+  cmp $root/Dockerfile2.withfrom $BUDFILES/from-multiple-files/Dockerfile2.withfrom
   test -s $root/etc/passwd
 }
 
 @test "bud-multi-stage-builds" {
   _prefetch alpine
   target=multi-stage-index
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/multi-stage-builds/Dockerfile.index $BUDFILES/multi-stage-builds
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
-  cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index
+  cmp $root/Dockerfile.index $BUDFILES/multi-stage-builds/Dockerfile.index
   test -s $root/etc/passwd
   run_buildah rm ${cid}
   run_buildah rmi -a
 
   _prefetch alpine
   target=multi-stage-name
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.name $BUDFILES/multi-stage-builds
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
-  cmp $root/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.name
+  cmp $root/Dockerfile.name $BUDFILES/multi-stage-builds/Dockerfile.name
   test ! -s $root/etc/passwd
   run_buildah rm ${cid}
   run_buildah rmi -a
 
   target=multi-stage-mixed
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/multi-stage-builds/Dockerfile.mixed $BUDFILES/multi-stage-builds
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
-  cmp $root/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.name
-  cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index
-  cmp $root/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.mixed
+  cmp $root/Dockerfile.name $BUDFILES/multi-stage-builds/Dockerfile.name
+  cmp $root/Dockerfile.index $BUDFILES/multi-stage-builds/Dockerfile.index
+  cmp $root/Dockerfile.mixed $BUDFILES/multi-stage-builds/Dockerfile.mixed
 }
 
 @test "bud-multi-stage-builds-small-as" {
   _prefetch alpine
   target=multi-stage-index
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/multi-stage-builds-small-as/Dockerfile.index $BUDFILES/multi-stage-builds-small-as
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
-  cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index
+  cmp $root/Dockerfile.index $BUDFILES/multi-stage-builds-small-as/Dockerfile.index
   test -s $root/etc/passwd
   run_buildah rm ${cid}
   run_buildah rmi -a
 
   _prefetch alpine
   target=multi-stage-name
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.name $BUDFILES/multi-stage-builds-small-as
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
-  cmp $root/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.name
+  cmp $root/Dockerfile.name $BUDFILES/multi-stage-builds-small-as/Dockerfile.name
   test ! -s $root/etc/passwd
   run_buildah rm ${cid}
   run_buildah rmi -a
 
   target=multi-stage-mixed
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds-small-as
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/multi-stage-builds-small-as/Dockerfile.mixed $BUDFILES/multi-stage-builds-small-as
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
-  cmp $root/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.name
-  cmp $root/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index
-  cmp $root/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.mixed
+  cmp $root/Dockerfile.name $BUDFILES/multi-stage-builds-small-as/Dockerfile.name
+  cmp $root/Dockerfile.index $BUDFILES/multi-stage-builds-small-as/Dockerfile.index
+  cmp $root/Dockerfile.mixed $BUDFILES/multi-stage-builds-small-as/Dockerfile.mixed
 }
 
 @test "bud-preserve-subvolumes" {
@@ -774,7 +774,7 @@ _EOF
 
   _prefetch alpine
   target=volume-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/preserve-volumes
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/preserve-volumes
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -805,7 +805,7 @@ function _test_http() {
   local testdir=$1; shift;        # in: subdirectory under bud/
   local urlpath=$1; shift;        # in: path to request from localhost
 
-  starthttpd "${TESTSDIR}/bud/$testdir"
+  starthttpd "$BUDFILES/$testdir"
   target=scratch-image
   run_buildah build $WITH_POLICY_JSON \
 	      -t ${target} \
@@ -870,7 +870,7 @@ function _test_http() {
   target=scratch-image
   target2=another-scratch-image
   target3=so-many-scratch-images
-  run_buildah build $WITH_POLICY_JSON -t ${target} -t docker.io/${target2} -t ${target3} ${TESTSDIR}/bud/from-scratch
+  run_buildah build $WITH_POLICY_JSON -t ${target} -t docker.io/${target2} -t ${target3} $BUDFILES/from-scratch
   run_buildah images
   run_buildah from --quiet ${target}
   cid=$output
@@ -895,8 +895,8 @@ function _test_http() {
   target2=another-tagged-image
   target3=yet-another-tagged-image
   target4=still-another-tagged-image
-  run_buildah build --layers $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/addtl-tags
-  run_buildah build --layers $WITH_POLICY_JSON -t ${target2} -t ${target3} -t ${target4} ${TESTSDIR}/bud/addtl-tags
+  run_buildah build --layers $WITH_POLICY_JSON -t ${target} $BUDFILES/addtl-tags
+  run_buildah build --layers $WITH_POLICY_JSON -t ${target2} -t ${target3} -t ${target4} $BUDFILES/addtl-tags
   run_buildah inspect -f '{{.FromImageID}}' busybox
   busyboxid="$output"
   run_buildah inspect -f '{{.FromImageID}}' ${target}
@@ -916,7 +916,7 @@ function _test_http() {
 
   _prefetch alpine
   target=volume-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/volume-perms
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/volume-perms
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -933,7 +933,7 @@ function _test_http() {
 
   _prefetch alpine
   target=volume-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/volume-ownership
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/volume-ownership
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah run $cid stat -c "%U %G" /vol/subvol
@@ -946,14 +946,14 @@ function _test_http() {
 
   _prefetch alpine
   target=volume-symlink
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/volume-symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/volume-symlink
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah run $cid echo hello
   expect_output "hello"
 
   target=volume-no-symlink
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/volume-symlink/Dockerfile.no-symlink ${TESTSDIR}/bud/volume-symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/volume-symlink/Dockerfile.no-symlink $BUDFILES/volume-symlink
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah run $cid echo hello
@@ -963,19 +963,19 @@ function _test_http() {
 @test "bud-from-glob" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile2.glob ${TESTSDIR}/bud/from-multiple-files
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile2.glob $BUDFILES/from-multiple-files
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
-  cmp $root/Dockerfile1.alpine ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.alpine
-  cmp $root/Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.withfrom
+  cmp $root/Dockerfile1.alpine $BUDFILES/from-multiple-files/Dockerfile1.alpine
+  cmp $root/Dockerfile2.withfrom $BUDFILES/from-multiple-files/Dockerfile2.withfrom
 }
 
 @test "bud-maintainer" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/maintainer
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/maintainer
   run_buildah inspect --type=image --format '{{.Docker.Author}}' ${target}
   expect_output "kilroy"
   run_buildah inspect --type=image --format '{{.OCIv1.Author}}' ${target}
@@ -985,14 +985,14 @@ function _test_http() {
 @test "bud-unrecognized-instruction" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 125 build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/unrecognized
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} $BUDFILES/unrecognized
   expect_output --substring "BOGUS"
 }
 
 @test "bud-shell" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/shell
+  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} $BUDFILES/shell
   run_buildah inspect --type=image --format '{{printf "%q" .Docker.Config.Shell}}' ${target}
   expect_output '["/bin/sh" "-c"]' ".Docker.Config.Shell (original)"
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
@@ -1005,35 +1005,35 @@ function _test_http() {
 @test "bud-shell during build in Docker format" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
+  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} -f $BUDFILES/shell/Dockerfile.build-shell-default $BUDFILES/shell
   expect_output --substring "SHELL=/bin/sh"
 }
 
 @test "bud-shell during build in OCI format" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/shell/Dockerfile.build-shell-default $BUDFILES/shell
   expect_output --substring "SHELL=/bin/sh"
 }
 
 @test "bud-shell changed during build in Docker format" {
   _prefetch ubuntu
   target=ubuntu-image
-  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
+  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} -f $BUDFILES/shell/Dockerfile.build-shell-custom $BUDFILES/shell
   expect_output --substring "SHELL=/bin/bash"
 }
 
 @test "bud-shell changed during build in OCI format" {
   _prefetch ubuntu
   target=ubuntu-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/shell/Dockerfile.build-shell-custom $BUDFILES/shell
   expect_output --substring "SHELL is not supported for OCI image format, \[/bin/bash -c\] will be ignored."
 }
 
 @test "bud with symlinks" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/symlink
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -1052,7 +1052,7 @@ function _test_http() {
 @test "bud with symlinks to relative path" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.relative-symlink ${TESTSDIR}/bud/symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.relative-symlink $BUDFILES/symlink
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -1070,7 +1070,7 @@ function _test_http() {
 @test "bud with multiple symlinks in a path" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.multiple-symlinks ${TESTSDIR}/bud/symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/symlink/Dockerfile.multiple-symlinks $BUDFILES/symlink
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -1096,14 +1096,14 @@ function _test_http() {
 @test "bud with multiple symlink pointing to itself" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.symlink-points-to-itself ${TESTSDIR}/bud/symlink
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/symlink/Dockerfile.symlink-points-to-itself $BUDFILES/symlink
   assert "$output" =~ "error building .* open /test-log/test: too many levels of symbolic links"
 }
 
 @test "bud multi-stage with symlink to absolute path" {
   _prefetch ubuntu
   target=ubuntu-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.absolute-symlink ${TESTSDIR}/bud/symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.absolute-symlink $BUDFILES/symlink
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -1120,7 +1120,7 @@ function _test_http() {
 @test "bud multi-stage with dir symlink to absolute path" {
   _prefetch ubuntu
   target=ubuntu-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.absolute-dir-symlink ${TESTSDIR}/bud/symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.absolute-dir-symlink $BUDFILES/symlink
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -1133,7 +1133,7 @@ function _test_http() {
 @test "bud with ENTRYPOINT and RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.entrypoint-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.entrypoint-run $BUDFILES/run-scenarios
   expect_output --substring "unique.test.string"
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
 }
@@ -1141,7 +1141,7 @@ function _test_http() {
 @test "bud with ENTRYPOINT and empty RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 2 bud $WITH_POLICY_JSON -t ${target} -f Dockerfile.entrypoint-empty-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah 2 bud $WITH_POLICY_JSON -t ${target} -f Dockerfile.entrypoint-empty-run $BUDFILES/run-scenarios
   expect_output --substring " -c requires an argument"
   expect_output --substring "error building at STEP.*: exit status 2"
 }
@@ -1149,7 +1149,7 @@ function _test_http() {
 @test "bud with CMD and RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.cmd-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/run-scenarios/Dockerfile.cmd-run $BUDFILES/run-scenarios
   expect_output --substring "unique.test.string"
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
 }
@@ -1157,7 +1157,7 @@ function _test_http() {
 @test "bud with CMD and empty RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 2 bud $WITH_POLICY_JSON -t ${target} -f Dockerfile.cmd-empty-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah 2 bud $WITH_POLICY_JSON -t ${target} -f Dockerfile.cmd-empty-run $BUDFILES/run-scenarios
   expect_output --substring " -c requires an argument"
   expect_output --substring "error building at STEP.*: exit status 2"
 }
@@ -1165,7 +1165,7 @@ function _test_http() {
 @test "bud with ENTRYPOINT, CMD and RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/run-scenarios/Dockerfile.entrypoint-cmd-run $BUDFILES/run-scenarios
   expect_output --substring "unique.test.string"
   run_buildah from $WITH_POLICY_JSON ${target}
 }
@@ -1173,7 +1173,7 @@ function _test_http() {
 @test "bud with ENTRYPOINT, CMD and empty RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 2 bud $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-empty-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah 2 bud $WITH_POLICY_JSON -t ${target} -f $BUDFILES/run-scenarios/Dockerfile.entrypoint-cmd-empty-run $BUDFILES/run-scenarios
   expect_output --substring " -c requires an argument"
   expect_output --substring "error building at STEP.*: exit status 2"
 }
@@ -1182,7 +1182,7 @@ function _test_http() {
 @test "bud access ENV variable defined in same source file" {
   _prefetch alpine
   target=env-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/env/Dockerfile.env-same-file ${TESTSDIR}/bud/env
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/env/Dockerfile.env-same-file $BUDFILES/env
   expect_output --substring ":unique.test.string:"
   run_buildah from $WITH_POLICY_JSON ${target}
 }
@@ -1192,8 +1192,8 @@ function _test_http() {
   _prefetch alpine
   from_target=env-from-image
   target=env-image
-  run_buildah build $WITH_POLICY_JSON -t ${from_target} -f ${TESTSDIR}/bud/env/Dockerfile.env-same-file ${TESTSDIR}/bud/env
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/env/Dockerfile.env-from-image ${TESTSDIR}/bud/env
+  run_buildah build $WITH_POLICY_JSON -t ${from_target} -f $BUDFILES/env/Dockerfile.env-same-file $BUDFILES/env
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/env/Dockerfile.env-from-image $BUDFILES/env
   expect_output --substring "@unique.test.string@"
   run_buildah from --quiet ${from_target}
   from_cid=$output
@@ -1203,7 +1203,7 @@ function _test_http() {
 @test "bud ENV preserves special characters after commit" {
   _prefetch ubuntu
   from_target=special-chars
-  run_buildah build $WITH_POLICY_JSON -t ${from_target} -f ${TESTSDIR}/bud/env/Dockerfile.special-chars ${TESTSDIR}/bud/env
+  run_buildah build $WITH_POLICY_JSON -t ${from_target} -f $BUDFILES/env/Dockerfile.special-chars $BUDFILES/env
   run_buildah from --quiet ${from_target}
   cid=$output
   run_buildah run ${cid} env
@@ -1227,63 +1227,63 @@ function _test_http() {
 # When provided with a -f flag and directory, buildah will look for the alternate Dockerfile name in the supplied directory
 @test "bud with -f flag, alternate Dockerfile name" {
   target=fileflag-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.noop-flags $BUDFILES/run-scenarios
   run_buildah from ${target}
 }
 
 # Following flags are configured to result in noop but should not affect buildah bud behavior
 @test "bud with --cache-from noop flag" {
   target=noop-image
-  run_buildah build --cache-from=invalidimage $WITH_POLICY_JSON -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
+  run_buildah build --cache-from=invalidimage $WITH_POLICY_JSON -t ${target} -f Dockerfile.noop-flags $BUDFILES/run-scenarios
   run_buildah from ${target}
 }
 
 @test "bud with --compress noop flag" {
   target=noop-image
-  run_buildah build --compress $WITH_POLICY_JSON -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
+  run_buildah build --compress $WITH_POLICY_JSON -t ${target} -f Dockerfile.noop-flags $BUDFILES/run-scenarios
   run_buildah from ${target}
 }
 
 @test "bud with --cpu-shares flag, no argument" {
   target=bud-flag
-  run_buildah 125 build --cpu-shares $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build --cpu-shares $WITH_POLICY_JSON -t ${target} -f $BUDFILES/from-scratch/Containerfile $BUDFILES/from-scratch
   expect_output --substring "invalid argument .* invalid syntax"
 }
 
 @test "bud with --cpu-shares flag, invalid argument" {
   target=bud-flag
-  run_buildah 125 build --cpu-shares bogus $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build --cpu-shares bogus $WITH_POLICY_JSON -t ${target} -f $BUDFILES/from-scratch/Containerfile $BUDFILES/from-scratch
   expect_output --substring "invalid argument \"bogus\" for "
 }
 
 @test "bud with --cpu-shares flag, valid argument" {
   target=bud-flag
-  run_buildah build --cpu-shares 2 $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah build --cpu-shares 2 $WITH_POLICY_JSON -t ${target} -f $BUDFILES/from-scratch/Containerfile $BUDFILES/from-scratch
   run_buildah from ${target}
 }
 
 @test "bud with --cpu-shares short flag (-c), no argument" {
   target=bud-flag
-  run_buildah 125 build -c $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build -c $WITH_POLICY_JSON -t ${target} -f $BUDFILES/from-scratch/Containerfile $BUDFILES/from-scratch
   expect_output --substring "invalid argument .* invalid syntax"
 }
 
 @test "bud with --cpu-shares short flag (-c), invalid argument" {
   target=bud-flag
-  run_buildah 125 build -c bogus $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build -c bogus $WITH_POLICY_JSON -t ${target} -f $BUDFILES/from-scratch/Containerfile $BUDFILES/from-scratch
   expect_output --substring "invalid argument \"bogus\" for "
 }
 
 @test "bud with --cpu-shares short flag (-c), valid argument" {
   target=bud-flag
-  run_buildah build -c 2 $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build -c 2 $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   run_buildah from ${target}
 }
 
 @test "bud-onbuild" {
   _prefetch alpine
   target=onbuild
-  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/onbuild
+  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} $BUDFILES/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild1" "RUN touch /onbuild2"]'
   run_buildah from --quiet ${target}
@@ -1298,7 +1298,7 @@ function _test_http() {
   run_buildah rm ${cid}
 
   target=onbuild-image2
-  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} -f Dockerfile1 ${TESTSDIR}/bud/onbuild
+  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} -f Dockerfile1 $BUDFILES/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild3"]'
   run_buildah from --quiet ${target}
@@ -1322,7 +1322,7 @@ function _test_http() {
 @test "bud-onbuild-layers" {
   _prefetch alpine
   target=onbuild
-  run_buildah build --format docker $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile2 ${TESTSDIR}/bud/onbuild
+  run_buildah build --format docker $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile2 $BUDFILES/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild1" "RUN touch /onbuild2"]'
 }
@@ -1330,24 +1330,24 @@ function _test_http() {
 @test "bud-logfile" {
   _prefetch alpine
   rm -f ${TESTDIR}/logfile
-  run_buildah build --logfile ${TESTDIR}/logfile $WITH_POLICY_JSON ${TESTSDIR}/bud/preserve-volumes
+  run_buildah build --logfile ${TESTDIR}/logfile $WITH_POLICY_JSON $BUDFILES/preserve-volumes
   test -s ${TESTDIR}/logfile
 }
 
 @test "bud with ARGS" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.args ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.args $BUDFILES/run-scenarios
   expect_output --substring "arg_value"
 }
 
 @test "bud with unused ARGS" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE $BUDFILES/run-scenarios
   expect_output --substring "USED_VALUE"
   [[ ! "$output" =~ "one or more build args were not consumed: [UNUSED_ARG]" ]]
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE --build-arg UNUSED_ARG=whaaaat ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE --build-arg UNUSED_ARG=whaaaat $BUDFILES/run-scenarios
   expect_output --substring "USED_VALUE"
   expect_output --substring "one or more build args were not consumed: \[UNUSED_ARG\]"
 }
@@ -1355,7 +1355,7 @@ function _test_http() {
 @test "bud with multi-value ARGS" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=plugin1,plugin2,plugin3 ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=plugin1,plugin2,plugin3 $BUDFILES/run-scenarios
   expect_output --substring "plugin1,plugin2,plugin3"
    if [[ "$output" =~ "one or more build args were not consumed" ]]; then
       expect_output "[not expecting to see 'one or more build args were not consumed']"
@@ -1364,7 +1364,7 @@ function _test_http() {
 
 @test "bud-from-stdin" {
   target=scratch-image
-  cat ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch | run_buildah build $WITH_POLICY_JSON -t ${target} -f - ${TESTSDIR}/bud/from-multiple-files
+  cat $BUDFILES/from-multiple-files/Dockerfile1.scratch | run_buildah build $WITH_POLICY_JSON -t ${target} -f - $BUDFILES/from-multiple-files
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -1375,18 +1375,18 @@ function _test_http() {
 @test "bud with preprocessor" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build -q $WITH_POLICY_JSON -t ${target} -f Decomposed.in ${TESTSDIR}/bud/preprocess
+  run_buildah build -q $WITH_POLICY_JSON -t ${target} -f Decomposed.in $BUDFILES/preprocess
 }
 
 @test "bud with preprocessor error" {
   target=alpine-image
-  run_buildah 0 bud -q $WITH_POLICY_JSON -t ${target} -f Error.in ${TESTSDIR}/bud/preprocess
+  run_buildah 0 bud -q $WITH_POLICY_JSON -t ${target} -f Error.in $BUDFILES/preprocess
   expect_output --substring "Ignoring <stdin>:5:2: error: #error"
 }
 
 @test "bud-with-rejected-name" {
   target=ThisNameShouldBeRejected
-  run_buildah 125 build -q $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build -q $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   expect_output --substring "must be lower"
 }
 
@@ -1394,7 +1394,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/copy-chown
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} $BUDFILES/copy-chown
   expect_output --substring "user:2367 group:3267"
   run_buildah from --name ${ctrName} ${imgName}
   run_buildah run alpine-chown -- stat -c '%u' /tmp/copychown.txt
@@ -1410,7 +1410,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chmod
-  run_buildah build $WITH_POLICY_JSON  -t ${imgName} -f ${TESTSDIR}/bud/copy-chmod/Dockerfile.combined ${TESTSDIR}/bud/copy-chmod
+  run_buildah build $WITH_POLICY_JSON  -t ${imgName} -f $BUDFILES/copy-chmod/Dockerfile.combined $BUDFILES/copy-chmod
   expect_output --substring "chmod:777 user:2367 group:3267"
 }
 
@@ -1418,7 +1418,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chmod
-  run_buildah build $WITH_POLICY_JSON  -t ${imgName} -f ${TESTSDIR}/bud/add-chmod/Dockerfile.combined ${TESTSDIR}/bud/add-chmod
+  run_buildah build $WITH_POLICY_JSON  -t ${imgName} -f $BUDFILES/add-chmod/Dockerfile.combined $BUDFILES/add-chmod
   expect_output --substring "chmod:777 user:2367 group:3267"
 }
 
@@ -1426,7 +1426,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${imgName} -f ${TESTSDIR}/bud/copy-chown/Dockerfile.bad ${TESTSDIR}/bud/copy-chown
+  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${imgName} -f $BUDFILES/copy-chown/Dockerfile.bad $BUDFILES/copy-chown
   expect_output --substring "COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image\|stage> flags"
 }
 
@@ -1434,7 +1434,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah 125 build $WITH_POLICY_JSON -t ${imgName} -f ${TESTSDIR}/bud/copy-chown/Dockerfile.bad2 ${TESTSDIR}/bud/copy-chown
+  run_buildah 125 build $WITH_POLICY_JSON -t ${imgName} -f $BUDFILES/copy-chown/Dockerfile.bad2 $BUDFILES/copy-chown
   expect_output --substring "error looking up UID/GID for \":\": can't find uid for user"
 }
 
@@ -1442,7 +1442,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chmod
-  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/copy-chmod
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} $BUDFILES/copy-chmod
   expect_output --substring "rwxrwxrwx"
   run_buildah from --name ${ctrName} ${imgName}
   run_buildah run alpine-chmod ls -l /tmp/copychmod.txt
@@ -1454,7 +1454,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chmod
-  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${imgName} -f ${TESTSDIR}/bud/copy-chmod/Dockerfile.bad ${TESTSDIR}/bud/copy-chmod
+  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${imgName} -f $BUDFILES/copy-chmod/Dockerfile.bad $BUDFILES/copy-chmod
   expect_output --substring "COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image\|stage> flags"
 }
 
@@ -1462,7 +1462,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chmod
-  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/add-chmod
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} $BUDFILES/add-chmod
   expect_output --substring "rwxrwxrwx"
   run_buildah from --name ${ctrName} ${imgName}
   run_buildah run alpine-chmod ls -l /tmp/addchmod.txt
@@ -1474,7 +1474,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/add-chown
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} $BUDFILES/add-chown
   expect_output --substring "user:2367 group:3267"
   run_buildah from --name ${ctrName} ${imgName}
   run_buildah run alpine-chown -- stat -c '%u' /tmp/addchown.txt
@@ -1490,7 +1490,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${imgName} -f ${TESTSDIR}/bud/add-chown/Dockerfile.bad ${TESTSDIR}/bud/add-chown
+  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${imgName} -f $BUDFILES/add-chown/Dockerfile.bad $BUDFILES/add-chown
   expect_output --substring "ADD only supports the --chmod=<permissions> and the --chown=<uid:gid> flags"
 }
 
@@ -1498,13 +1498,13 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chmod
-  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${imgName} -f ${TESTSDIR}/bud/add-chmod/Dockerfile.bad ${TESTSDIR}/bud/add-chmod
+  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${imgName} -f $BUDFILES/add-chmod/Dockerfile.bad $BUDFILES/add-chmod
   expect_output --substring "ADD only supports the --chmod=<permissions> and the --chown=<uid:gid> flags"
 }
 
 @test "bud with ADD file construct" {
   _prefetch busybox
-  run_buildah build $WITH_POLICY_JSON -t test1 ${TESTSDIR}/bud/add-file
+  run_buildah build $WITH_POLICY_JSON -t test1 $BUDFILES/add-file
   run_buildah images -a
   expect_output --substring "test1"
 
@@ -1521,7 +1521,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/copy-create-absolute-path
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} $BUDFILES/copy-create-absolute-path
   expect_output --substring "permissions=755"
 
   run_buildah from --name ${ctrName} ${imgName}
@@ -1533,7 +1533,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/copy-create-relative-path
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} $BUDFILES/copy-create-relative-path
   expect_output --substring "permissions=755"
 
   run_buildah from --name ${ctrName} ${imgName}
@@ -1545,7 +1545,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/add-create-absolute-path
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} $BUDFILES/add-create-absolute-path
   expect_output --substring "permissions=755"
 
   run_buildah from --name ${ctrName} ${imgName}
@@ -1557,7 +1557,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/add-create-relative-path
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} $BUDFILES/add-create-relative-path
   expect_output --substring "permissions=755"
 
   run_buildah from --name ${ctrName} ${imgName}
@@ -1569,7 +1569,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah build $WITH_POLICY_JSON -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.absolute -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
+  run_buildah build $WITH_POLICY_JSON -f $BUDFILES/copy-multistage-paths/Dockerfile.absolute -t ${imgName} $BUDFILES/copy-multistage-paths
   expect_output --substring "permissions=755"
 
   run_buildah from --name ${ctrName} ${imgName}
@@ -1581,7 +1581,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah build $WITH_POLICY_JSON -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.relative -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
+  run_buildah build $WITH_POLICY_JSON -f $BUDFILES/copy-multistage-paths/Dockerfile.relative -t ${imgName} $BUDFILES/copy-multistage-paths
   expect_output --substring "permissions=755"
 
   run_buildah from --name ${ctrName} ${imgName}
@@ -1593,18 +1593,18 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah 125 build $WITH_POLICY_JSON -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.invalid_from -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
+  run_buildah 125 build $WITH_POLICY_JSON -f $BUDFILES/copy-multistage-paths/Dockerfile.invalid_from -t ${imgName} $BUDFILES/copy-multistage-paths
   expect_output --substring "COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image\|stage> flags"
 }
 
 @test "bud COPY to root succeeds" {
   _prefetch ubuntu
-  run_buildah build $WITH_POLICY_JSON ${TESTSDIR}/bud/copy-root
+  run_buildah build $WITH_POLICY_JSON $BUDFILES/copy-root
 }
 
 @test "bud with FROM AS construct" {
   _prefetch alpine
-  run_buildah build $WITH_POLICY_JSON -t test1 ${TESTSDIR}/bud/from-as
+  run_buildah build $WITH_POLICY_JSON -t test1 $BUDFILES/from-as
   run_buildah images -a
   expect_output --substring "test1"
 
@@ -1619,7 +1619,7 @@ function _test_http() {
 
 @test "bud with FROM AS construct with layers" {
   _prefetch alpine
-  run_buildah build --layers $WITH_POLICY_JSON -t test1 ${TESTSDIR}/bud/from-as
+  run_buildah build --layers $WITH_POLICY_JSON -t test1 $BUDFILES/from-as
   run_buildah images -a
   expect_output --substring "test1"
 
@@ -1634,7 +1634,7 @@ function _test_http() {
 
 @test "bud with FROM AS skip FROM construct" {
   _prefetch alpine
-  run_buildah build $WITH_POLICY_JSON -t test1 -f ${TESTSDIR}/bud/from-as/Dockerfile.skip ${TESTSDIR}/bud/from-as
+  run_buildah build $WITH_POLICY_JSON -t test1 -f $BUDFILES/from-as/Dockerfile.skip $BUDFILES/from-as
   expect_output --substring "LOCAL=/1"
   expect_output --substring "LOCAL2=/2"
 
@@ -1658,13 +1658,13 @@ function _test_http() {
 @test "bud with symlink Dockerfile not specified in file" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/symlink ${TESTSDIR}/bud/symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/symlink $BUDFILES/symlink
   expect_output --substring "FROM alpine"
 }
 
 @test "bud with dir for file but no Dockerfile in dir" {
   target=alpine-image
-  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/empty-dir ${TESTSDIR}/bud/empty-dir
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/empty-dir $BUDFILES/empty-dir
   expect_output --substring "no such file or directory"
 }
 
@@ -1677,19 +1677,19 @@ function _test_http() {
 @test "bud with ARG before FROM default value" {
   _prefetch busybox
   target=leading-args-default
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/leading-args/Dockerfile ${TESTSDIR}/bud/leading-args
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/leading-args/Dockerfile $BUDFILES/leading-args
 }
 
 @test "bud with ARG before FROM" {
   _prefetch busybox:musl
   target=leading-args
-  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg=VERSION=musl -f ${TESTSDIR}/bud/leading-args/Dockerfile ${TESTSDIR}/bud/leading-args
+  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg=VERSION=musl -f $BUDFILES/leading-args/Dockerfile $BUDFILES/leading-args
 }
 
 @test "bud-with-healthcheck" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} --format docker ${TESTSDIR}/bud/healthcheck
+  run_buildah build $WITH_POLICY_JSON -t ${target} --format docker $BUDFILES/healthcheck
   run_buildah inspect -f '{{printf "%q" .Docker.Config.Healthcheck.Test}} {{printf "%d" .Docker.Config.Healthcheck.StartPeriod}} {{printf "%d" .Docker.Config.Healthcheck.Interval}} {{printf "%d" .Docker.Config.Healthcheck.Timeout}} {{printf "%d" .Docker.Config.Healthcheck.Retries}}' ${target}
   second=1000000000
   threeseconds=$(( 3 * $second ))
@@ -1701,9 +1701,9 @@ function _test_http() {
 @test "bud with unused build arg" {
   _prefetch alpine busybox
   target=busybox-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg foo=bar --build-arg foo2=bar2 -f ${TESTSDIR}/bud/build-arg ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg foo=bar --build-arg foo2=bar2 -f $BUDFILES/build-arg $BUDFILES/build-arg
   expect_output --substring "one or more build args were not consumed: \[foo2\]"
-  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg IMAGE=alpine -f ${TESTSDIR}/bud/build-arg/Dockerfile2 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg IMAGE=alpine -f $BUDFILES/build-arg/Dockerfile2 $BUDFILES/build-arg
   assert "$output" !~ "one or more build args were not consumed: \[IMAGE\]"
   expect_output --substring "FROM alpine"
 }
@@ -1711,10 +1711,10 @@ function _test_http() {
 @test "bud with copy-from and cache" {
   _prefetch busybox
   target=busybox-image
-  run_buildah build $WITH_POLICY_JSON --layers --iidfile ${TESTDIR}/iid1 -f ${TESTSDIR}/bud/copy-from/Dockerfile2 ${TESTSDIR}/bud/copy-from
+  run_buildah build $WITH_POLICY_JSON --layers --iidfile ${TESTDIR}/iid1 -f $BUDFILES/copy-from/Dockerfile2 $BUDFILES/copy-from
   cat ${TESTDIR}/iid1
   test -s ${TESTDIR}/iid1
-  run_buildah build $WITH_POLICY_JSON --layers --iidfile ${TESTDIR}/iid2 -f ${TESTSDIR}/bud/copy-from/Dockerfile2 ${TESTSDIR}/bud/copy-from
+  run_buildah build $WITH_POLICY_JSON --layers --iidfile ${TESTDIR}/iid2 -f $BUDFILES/copy-from/Dockerfile2 $BUDFILES/copy-from
   cat ${TESTDIR}/iid2
   test -s ${TESTDIR}/iid2
   cmp ${TESTDIR}/iid1 ${TESTDIR}/iid2
@@ -1723,7 +1723,7 @@ function _test_http() {
 @test "bud with copy-from in Dockerfile no prior FROM" {
   _prefetch busybox quay.io/libpod/testimage:20210610
   target=no-prior-from
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/copy-from ${TESTSDIR}/bud/copy-from
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/copy-from $BUDFILES/copy-from
 
   run_buildah from --quiet $WITH_POLICY_JSON ${target}
   ctr=$output
@@ -1738,7 +1738,7 @@ function _test_http() {
 @test "bud with copy-from with bad from flag in Dockerfile with --layers" {
   _prefetch busybox
   target=bad-from-flag
-  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile.bad ${TESTSDIR}/bud/copy-from
+  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${target} -f $BUDFILES/copy-from/Dockerfile.bad $BUDFILES/copy-from
   expect_output --substring "COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image\|stage> flags"
 }
 
@@ -1746,11 +1746,11 @@ function _test_http() {
   _prefetch busybox
   target=busybox-derived
   target_mt=busybox-mt-derived
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile3 ${TESTSDIR}/bud/copy-from
-  run_buildah build $WITH_POLICY_JSON --jobs 4 -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile3 ${TESTSDIR}/bud/copy-from
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/copy-from/Dockerfile3 $BUDFILES/copy-from
+  run_buildah build $WITH_POLICY_JSON --jobs 4 -t ${target} -f $BUDFILES/copy-from/Dockerfile3 $BUDFILES/copy-from
 
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile4 ${TESTSDIR}/bud/copy-from
-  run_buildah build --no-cache $WITH_POLICY_JSON --jobs 4 -t ${target_mt} -f ${TESTSDIR}/bud/copy-from/Dockerfile4 ${TESTSDIR}/bud/copy-from
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/copy-from/Dockerfile4 $BUDFILES/copy-from
+  run_buildah build --no-cache $WITH_POLICY_JSON --jobs 4 -t ${target_mt} -f $BUDFILES/copy-from/Dockerfile4 $BUDFILES/copy-from
 
   run_buildah from  --quiet ${target}
   cid=$output
@@ -1769,14 +1769,14 @@ function _test_http() {
 @test "bud with copy-from referencing the current stage" {
   _prefetch busybox
   target=busybox-derived
-  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile2.bad ${TESTSDIR}/bud/copy-from
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/copy-from/Dockerfile2.bad $BUDFILES/copy-from
   expect_output --substring "COPY --from=build: no stage or image found with that name"
 }
 
 @test "bud-target" {
   _prefetch alpine ubuntu
   target=target
-  run_buildah build $WITH_POLICY_JSON -t ${target} --target mytarget ${TESTSDIR}/bud/target
+  run_buildah build $WITH_POLICY_JSON -t ${target} --target mytarget $BUDFILES/target
   expect_output --substring "\[1/2] STEP 1/2: FROM ubuntu:latest"
   expect_output --substring "\[2/2] STEP 1/2: FROM alpine:latest AS mytarget"
   run_buildah from --quiet ${target}
@@ -1789,7 +1789,7 @@ function _test_http() {
 
 @test "bud-no-target-name" {
   _prefetch alpine
-  run_buildah build $WITH_POLICY_JSON ${TESTSDIR}/bud/maintainer
+  run_buildah build $WITH_POLICY_JSON $BUDFILES/maintainer
 }
 
 @test "bud-multi-stage-nocache-nocommit" {
@@ -1797,7 +1797,7 @@ function _test_http() {
   # pull the base image directly, so that we don't record it being written to local storage in the next step
   run_buildah pull $WITH_POLICY_JSON alpine
   # okay, build an image with two stages
-  run_buildah --log-level=debug bud $WITH_POLICY_JSON -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah --log-level=debug bud $WITH_POLICY_JSON -f $BUDFILES/multi-stage-builds/Dockerfile.name $BUDFILES/multi-stage-builds
   # debug messages should only record us creating one new image: the one for the second stage, since we don't base anything on the first
   run grep "created new image ID" <<< "$output"
   expect_line_count 1
@@ -1807,9 +1807,9 @@ function _test_http() {
   skip "FIXME: Broken in CI right now"
   _prefetch alpine
   # first time through, quite normal
-  run_buildah build --layers -t base $WITH_POLICY_JSON -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.rebase ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build --layers -t base $WITH_POLICY_JSON -f $BUDFILES/multi-stage-builds/Dockerfile.rebase $BUDFILES/multi-stage-builds
   # second time through, everything should be cached, and we shouldn't create a container based on the final image
-  run_buildah --log-level=debug bud --layers -t base $WITH_POLICY_JSON -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.rebase ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah --log-level=debug bud --layers -t base $WITH_POLICY_JSON -f $BUDFILES/multi-stage-builds/Dockerfile.rebase $BUDFILES/multi-stage-builds
   # skip everything up through the final COMMIT step, and make sure we didn't log a "Container ID:" after it
   run sed '0,/COMMIT base/ d' <<< "$output"
   echo "$output" >&2
@@ -1822,7 +1822,7 @@ function _test_http() {
   _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/dest-symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/dest-symlink
   expect_output --substring "STEP 5/6: RUN ln -s "
 
   run_buildah from $WITH_POLICY_JSON --name=${ctr} ${target}
@@ -1839,7 +1839,7 @@ function _test_http() {
   _prefetch ubuntu
   target=ubuntu-image
   ctr=ubuntu-ctr
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/dest-symlink-dangling
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/dest-symlink-dangling
   expect_output --substring "STEP 3/5: RUN ln -s "
 
   run_buildah from $WITH_POLICY_JSON --name=${ctr} ${target}
@@ -1856,7 +1856,7 @@ function _test_http() {
   _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/workdir-symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/workdir-symlink
   expect_output --substring "STEP 3/6: RUN ln -sf "
 
   run_buildah from $WITH_POLICY_JSON --name=${ctr} ${target}
@@ -1873,7 +1873,7 @@ function _test_http() {
   _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile-2 ${TESTSDIR}/bud/workdir-symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile-2 $BUDFILES/workdir-symlink
   expect_output --substring "STEP 2/6: RUN ln -sf "
 
   run_buildah from $WITH_POLICY_JSON --name=${ctr} ${target}
@@ -1893,7 +1893,7 @@ function _test_http() {
   _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile-3 ${TESTSDIR}/bud/workdir-symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile-3 $BUDFILES/workdir-symlink
   expect_output --substring "STEP 2/9: RUN ln -sf "
 
   run_buildah from $WITH_POLICY_JSON --name=${ctr} ${target}
@@ -1917,17 +1917,17 @@ function _test_http() {
   mkdir -p ${voldir}
 
   _prefetch alpine
-  run_buildah build $WITH_POLICY_JSON -v ${voldir}:/testdir ${TESTSDIR}/bud/mount
+  run_buildah build $WITH_POLICY_JSON -v ${voldir}:/testdir $BUDFILES/mount
   expect_output --substring "/testdir"
-  run_buildah build $WITH_POLICY_JSON -v ${voldir}:/testdir:rw ${TESTSDIR}/bud/mount
+  run_buildah build $WITH_POLICY_JSON -v ${voldir}:/testdir:rw $BUDFILES/mount
   expect_output --substring "/testdir"
-  run_buildah build $WITH_POLICY_JSON -v ${voldir}:/testdir:rw,z ${TESTSDIR}/bud/mount
+  run_buildah build $WITH_POLICY_JSON -v ${voldir}:/testdir:rw,z $BUDFILES/mount
   expect_output --substring "/testdir"
 }
 
 @test "bud-copy-dot with --layers picks up changed file" {
   _prefetch alpine
-  cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
+  cp -a $BUDFILES/use-layers ${TESTDIR}/use-layers
 
   mkdir -p ${TESTDIR}/use-layers/subdir
   touch ${TESTDIR}/use-layers/subdir/file.txt
@@ -1946,11 +1946,11 @@ function _test_http() {
   target=foo
 
   # A deny-all policy should prevent us from pulling the base image.
-  run_buildah 125 build --signature-policy ${TESTSDIR}/deny.json -t ${target} -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
+  run_buildah 125 build --signature-policy ${TESTSDIR}/deny.json -t ${target} -v ${TESTSDIR}:/testdir $BUDFILES/mount
   expect_output --substring 'Source image rejected: Running image .* rejected by policy.'
 
   # A docker-only policy should allow us to pull the base image and commit.
-  run_buildah build --signature-policy ${TESTSDIR}/docker.json -t ${target} -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
+  run_buildah build --signature-policy ${TESTSDIR}/docker.json -t ${target} -v ${TESTSDIR}:/testdir $BUDFILES/mount
   # A deny-all policy shouldn't break pushing, since policy is only evaluated
   # on the source image, and we force it to allow local storage.
   run_buildah push --signature-policy ${TESTSDIR}/deny.json ${target} dir:${TESTDIR}/mount
@@ -1959,17 +1959,17 @@ function _test_http() {
   # A docker-only policy should allow us to pull the base image first...
   run_buildah pull --signature-policy ${TESTSDIR}/docker.json alpine
   # ... and since we don't need to pull the base image, a deny-all policy shouldn't break a build.
-  run_buildah build --signature-policy ${TESTSDIR}/deny.json -t ${target} -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
+  run_buildah build --signature-policy ${TESTSDIR}/deny.json -t ${target} -v ${TESTSDIR}:/testdir $BUDFILES/mount
   # A deny-all policy shouldn't break pushing, since policy is only evaluated
   # on the source image, and we force it to allow local storage.
   run_buildah push --signature-policy ${TESTSDIR}/deny.json ${target} dir:${TESTDIR}/mount
   # Similarly, a deny-all policy shouldn't break committing directly to other locations.
-  run_buildah build --signature-policy ${TESTSDIR}/deny.json -t dir:${TESTDIR}/mount -v ${TESTSDIR}:/testdir ${TESTSDIR}/bud/mount
+  run_buildah build --signature-policy ${TESTSDIR}/deny.json -t dir:${TESTDIR}/mount -v ${TESTSDIR}:/testdir $BUDFILES/mount
 }
 
 @test "bud-copy-replace-symlink" {
   mkdir -p ${TESTDIR}/top
-  cp ${TESTSDIR}/bud/symlink/Dockerfile.replace-symlink ${TESTDIR}/top/
+  cp $BUDFILES/symlink/Dockerfile.replace-symlink ${TESTDIR}/top/
   ln -s Dockerfile.replace-symlink ${TESTDIR}/top/symlink
   echo foo > ${TESTDIR}/top/.dockerignore
   run_buildah build $WITH_POLICY_JSON -f ${TESTDIR}/top/Dockerfile.replace-symlink ${TESTDIR}/top
@@ -1977,7 +1977,7 @@ function _test_http() {
 
 @test "bud-copy-recurse" {
   mkdir -p ${TESTDIR}/recurse
-  cp ${TESTSDIR}/bud/recurse/Dockerfile ${TESTDIR}/recurse
+  cp $BUDFILES/recurse/Dockerfile ${TESTDIR}/recurse
   echo foo > ${TESTDIR}/recurse/.dockerignore
   run_buildah build $WITH_POLICY_JSON ${TESTDIR}/recurse
 }
@@ -2029,7 +2029,7 @@ _EOF
 
 @test "bud-copy-workdir" {
   target=testimage
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/copy-workdir
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/copy-workdir
   run_buildah from ${target}
   cid="$output"
   run_buildah mount "${cid}"
@@ -2044,7 +2044,7 @@ _EOF
   _prefetch alpine
 
   target=testimage
-  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile.2 ${TESTSDIR}/bud/copy-workdir
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile.2 $BUDFILES/copy-workdir
   run_buildah from ${target}
   cid="$output"
   run_buildah mount "${cid}"
@@ -2056,48 +2056,48 @@ _EOF
 @test "bud-build-arg-cache" {
   _prefetch busybox alpine
   target=derived-image
-  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 $BUDFILES/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
   targetid="$output"
 
   # With build args, we should not find the previous build as a cached result. This will be true because there is a RUN command after all the ARG
   # commands in the containerfile, so this does not truly test if the ARG commands were using cache or not. There is a test for that case below.
-  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata $BUDFILES/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
   argsid="$output"
   assert "$argsid" != "$initialid" \
          ".FromImageID of test-img-2 ($argsid) == same as test-img, it should be different"
 
   # With build args, even in a different order, we should end up using the previous build as a cached result.
-  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata $BUDFILES/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
   expect_output "$argsid" "FromImageID of build 3"
 
-  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata --build-arg=UID=17122 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata --build-arg=UID=17122 $BUDFILES/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
   expect_output "$argsid" "FromImageID of build 4"
 
-  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend $BUDFILES/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
   expect_output "$argsid" "FromImageID of build 5"
 
-  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=PGDATA=/pgdata --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=PGDATA=/pgdata --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup $BUDFILES/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
   expect_output "$argsid" "FromImageID of build 6"
 
   # If build-arg is specified via the command line and is different from the previous cached build, it should not use the cached layers.
   # Note, this containerfile does not have any RUN commands and we verify that the ARG steps are being rebuilt when a change is detected.
-  run_buildah build $WITH_POLICY_JSON --layers -t test-img -f Dockerfile4 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t test-img -f Dockerfile4 $BUDFILES/build-arg
   run_buildah inspect -f '{{.FromImageID}}' test-img
   initialid="$output"
 
   # Build the same containerfile again and verify that the cached layers were used
-  run_buildah build $WITH_POLICY_JSON --layers -t test-img-1 -f Dockerfile4 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t test-img-1 -f Dockerfile4 $BUDFILES/build-arg
   run_buildah inspect -f '{{.FromImageID}}' test-img-1
   expect_output "$initialid" "FromImageID of test-img-1 should match test-img"
 
   # Set the build-arg flag and verify that the cached layers are not used
-  run_buildah build $WITH_POLICY_JSON --layers -t test-img-2 --build-arg TEST=foo -f Dockerfile4 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t test-img-2 --build-arg TEST=foo -f Dockerfile4 $BUDFILES/build-arg
   run_buildah inspect -f '{{.FromImageID}}' test-img-2
   argsid="$output"
   assert "$argsid" != "$initialid" \
@@ -2105,7 +2105,7 @@ _EOF
 
   # Set the build-arg via an ENV in the local environment and verify that the cached layers are not used
   export TEST=bar
-  run_buildah build $WITH_POLICY_JSON --layers -t test-img-3 --build-arg TEST -f Dockerfile4 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t test-img-3 --build-arg TEST -f Dockerfile4 $BUDFILES/build-arg
   run_buildah inspect -f '{{.FromImageID}}' test-img-3
   argsid="$output"
   assert "$argsid" != "$initialid" \
@@ -2115,7 +2115,7 @@ _EOF
 @test "bud test RUN with a privileged command" {
   _prefetch alpine
   target=alpinepriv
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/run-privd/Dockerfile ${TESTSDIR}/bud/run-privd
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/run-privd/Dockerfile $BUDFILES/run-privd
   expect_output --substring "[^:][^[:graph:]]COMMIT ${target}"
   run_buildah images -q
   expect_line_count 2
@@ -2124,7 +2124,7 @@ _EOF
 @test "bud-copy-dockerignore-hardlinks" {
   target=image
   mkdir -p ${TESTDIR}/hardlinks/subdir
-  cp ${TESTSDIR}/bud/recurse/Dockerfile ${TESTDIR}/hardlinks
+  cp $BUDFILES/recurse/Dockerfile ${TESTDIR}/hardlinks
   echo foo > ${TESTDIR}/hardlinks/.dockerignore
   echo test1 > ${TESTDIR}/hardlinks/subdir/test1.txt
   ln ${TESTDIR}/hardlinks/subdir/test1.txt ${TESTDIR}/hardlinks/subdir/test2.txt
@@ -2155,7 +2155,7 @@ _EOF
 }
 
 @test "bud without any arguments should succeed" {
-  cd ${TESTSDIR}/bud/from-scratch
+  cd $BUDFILES/from-scratch
   run_buildah build --signature-policy ${TESTSDIR}/policy.json
 }
 
@@ -2201,7 +2201,7 @@ _EOF
   _prefetch alpine
   parent=alpine
   target=no-change-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/no-change
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/no-change
   run_buildah inspect --format '{{printf "%q" .FromImageDigest}}' ${parent}
   parentid="$output"
   run_buildah inspect --format '{{printf "%q" .FromImageDigest}}' ${target}
@@ -2217,7 +2217,7 @@ _EOF
   _prefetch alpine
   parent=alpine
   target=no-change-image
-  run_buildah build --label "test=label" $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/no-change
+  run_buildah build --label "test=label" $WITH_POLICY_JSON -t ${target} $BUDFILES/no-change
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output "$want_output"
 }
@@ -2225,19 +2225,19 @@ _EOF
 @test "bud-no-change-annotation" {
   _prefetch alpine
   target=no-change-image
-  run_buildah build --annotation "test=annotation" $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/no-change
+  run_buildah build --annotation "test=annotation" $WITH_POLICY_JSON -t ${target} $BUDFILES/no-change
   run_buildah inspect --format '{{index .ImageAnnotations "test"}}' ${target}
   expect_output "annotation"
 }
 
 @test "bud-squash-layers" {
   _prefetch alpine
-  run_buildah build $WITH_POLICY_JSON --squash ${TESTSDIR}/bud/layers-squash
+  run_buildah build $WITH_POLICY_JSON --squash $BUDFILES/layers-squash
 }
 
 @test "bud-squash-hardlinks" {
   _prefetch busybox
-  run_buildah build $WITH_POLICY_JSON --squash ${TESTSDIR}/bud/layers-squash/Dockerfile.hardlinks
+  run_buildah build $WITH_POLICY_JSON --squash $BUDFILES/layers-squash/Dockerfile.hardlinks
 }
 
 @test "bud with additional directory of devices" {
@@ -2249,14 +2249,14 @@ _EOF
   target=alpine-image
   mkdir -p ${TESTDIR}/foo
   mknod ${TESTDIR}/foo/null c 1 3
-  run_buildah build $WITH_POLICY_JSON --device ${TESTDIR}/foo:/dev/fuse  -t ${target} -f ${TESTSDIR}/bud/device/Dockerfile ${TESTSDIR}/bud/device
+  run_buildah build $WITH_POLICY_JSON --device ${TESTDIR}/foo:/dev/fuse  -t ${target} -f $BUDFILES/device/Dockerfile $BUDFILES/device
   expect_output --substring "null"
 }
 
 @test "bud with additional device" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON --device /dev/fuse -t ${target} -f ${TESTSDIR}/bud/device/Dockerfile ${TESTSDIR}/bud/device
+  run_buildah build $WITH_POLICY_JSON --device /dev/fuse -t ${target} -f $BUDFILES/device/Dockerfile $BUDFILES/device
   [ "${status}" -eq 0 ]
   expect_output --substring "/dev/fuse"
 }
@@ -2264,7 +2264,7 @@ _EOF
 @test "bud with Containerfile" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/containerfile
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/containerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 }
@@ -2272,7 +2272,7 @@ _EOF
 @test "bud with Containerfile.in" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/containerfile/Containerfile.in ${TESTSDIR}/bud/containerfile
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/containerfile/Containerfile.in $BUDFILES/containerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
   expect_output --substring "success"
@@ -2281,7 +2281,7 @@ _EOF
 @test "bud with Dockerfile" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/dockerfile
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/dockerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 }
@@ -2289,7 +2289,7 @@ _EOF
 @test "bud with Containerfile and Dockerfile" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/containeranddockerfile
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/containeranddockerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 }
@@ -2301,7 +2301,7 @@ _EOF
 @test "bud with Dockerfile from stdin" {
   _prefetch alpine
   target=df-stdin
-  run_buildah build $WITH_POLICY_JSON -t ${target} - < ${TESTSDIR}/bud/context-from-stdin/Dockerfile
+  run_buildah build $WITH_POLICY_JSON -t ${target} - < $BUDFILES/context-from-stdin/Dockerfile
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -2319,7 +2319,7 @@ _EOF
   _prefetch alpine
   target=df-stdin
   # 'cmd1 < <(cmd2)' == 'cmd2 | cmd1' but runs cmd1 in this shell, not sub.
-  run_buildah build $WITH_POLICY_JSON -t ${target} - < <(tar -c -C ${TESTSDIR}/bud/context-from-stdin .)
+  run_buildah build $WITH_POLICY_JSON -t ${target} - < <(tar -c -C $BUDFILES/context-from-stdin .)
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -2336,40 +2336,40 @@ _EOF
 @test "bud containerfile with args" {
   _prefetch alpine
   target=use-args
-  touch ${TESTSDIR}/bud/use-args/abc.txt
-  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg=abc.txt ${TESTSDIR}/bud/use-args
+  touch $BUDFILES/use-args/abc.txt
+  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg=abc.txt $BUDFILES/use-args
   expect_output --substring "COMMIT use-args"
   run_buildah from --quiet ${target}
   ctrID=$output
   run_buildah run $ctrID ls abc.txt
   expect_output --substring "abc.txt"
 
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Containerfile.destination --build-arg=testArg=abc.txt --build-arg=destination=/tmp ${TESTSDIR}/bud/use-args
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Containerfile.destination --build-arg=testArg=abc.txt --build-arg=destination=/tmp $BUDFILES/use-args
   expect_output --substring "COMMIT use-args"
   run_buildah from --quiet ${target}
   ctrID=$output
   run_buildah run $ctrID ls /tmp/abc.txt
   expect_output --substring "abc.txt"
 
-  run_buildah build $WITH_POLICY_JSON -t ${target} -f Containerfile.dest_nobrace --build-arg=testArg=abc.txt --build-arg=destination=/tmp ${TESTSDIR}/bud/use-args
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Containerfile.dest_nobrace --build-arg=testArg=abc.txt --build-arg=destination=/tmp $BUDFILES/use-args
   expect_output --substring "COMMIT use-args"
   run_buildah from --quiet ${target}
   ctrID=$output
   run_buildah run $ctrID ls /tmp/abc.txt
   expect_output --substring "abc.txt"
 
-  rm ${TESTSDIR}/bud/use-args/abc.txt
+  rm $BUDFILES/use-args/abc.txt
 }
 
 @test "bud using gitrepo and branch" {
   if ! start_git_daemon ${TESTSDIR}/git-daemon/release-1.11-rhel.tar.gz ; then
     skip "error running git daemon"
   fi
-  run_buildah build $WITH_POLICY_JSON --layers -t gittarget -f ${TESTSDIR}/bud/shell/Dockerfile git://localhost:${GITPORT}/repo#release-1.11-rhel
+  run_buildah build $WITH_POLICY_JSON --layers -t gittarget -f $BUDFILES/shell/Dockerfile git://localhost:${GITPORT}/repo#release-1.11-rhel
 }
 
 @test "bud using gitrepo with .git and branch" {
-  run_buildah build $WITH_POLICY_JSON --layers -t gittarget -f ${TESTSDIR}/bud/shell/Dockerfile https://github.com/containers/buildah.git#release-1.11-rhel
+  run_buildah build $WITH_POLICY_JSON --layers -t gittarget -f $BUDFILES/shell/Dockerfile https://github.com/containers/buildah.git#release-1.11-rhel
 }
 
 # Fixes #1906: buildah was not detecting changed tarfile
@@ -2377,55 +2377,55 @@ _EOF
   _prefetch busybox
   # First check to verify cache is used if the tar file does not change
   target=copy-archive
-  date > ${TESTSDIR}/bud/${target}/test
-  tar -C $TESTSDIR -cJf ${TESTSDIR}/bud/${target}/test.tar.xz bud/${target}/test
-  run_buildah build $WITH_POLICY_JSON --layers -t ${target} ${TESTSDIR}/bud/${target}
+  date > $BUDFILES/${target}/test
+  tar -C $TESTSDIR -cJf $BUDFILES/${target}/test.tar.xz bud/${target}/test
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} $BUDFILES/${target}
   expect_output --substring "COMMIT copy-archive"
 
-  run_buildah build $WITH_POLICY_JSON --layers -t ${target} ${TESTSDIR}/bud/${target}
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} $BUDFILES/${target}
   expect_output --substring " Using cache"
   expect_output --substring "COMMIT copy-archive"
 
   # Now test that we do NOT use cache if the tar file changes
-  echo This is a change >> ${TESTSDIR}/bud/${target}/test
-  tar -C $TESTSDIR -cJf ${TESTSDIR}/bud/${target}/test.tar.xz bud/${target}/test
-  run_buildah build $WITH_POLICY_JSON --layers -t ${target} ${TESTSDIR}/bud/${target}
+  echo This is a change >> $BUDFILES/${target}/test
+  tar -C $TESTSDIR -cJf $BUDFILES/${target}/test.tar.xz bud/${target}/test
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} $BUDFILES/${target}
   if [[ "$output" =~ " Using cache" ]]; then
       expect_output "[no instance of 'Using cache']" "no cache used"
   fi
   expect_output --substring "COMMIT copy-archive"
 
-  rm -f ${TESTSDIR}/bud/${target}/test*
+  rm -f $BUDFILES/${target}/test*
 }
 
 @test "bud pull never" {
   target=pull
-  run_buildah 125 build $WITH_POLICY_JSON -t ${target} --pull-never ${TESTSDIR}/bud/pull
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} --pull-never $BUDFILES/pull
   expect_output --substring "busybox: image not known"
 
-  run_buildah build $WITH_POLICY_JSON -t ${target} --pull ${TESTSDIR}/bud/pull
+  run_buildah build $WITH_POLICY_JSON -t ${target} --pull $BUDFILES/pull
   expect_output --substring "COMMIT pull"
 
-  run_buildah build $WITH_POLICY_JSON -t ${target} --pull=never ${TESTSDIR}/bud/pull
+  run_buildah build $WITH_POLICY_JSON -t ${target} --pull=never $BUDFILES/pull
   expect_output --substring "COMMIT pull"
 }
 
 @test "bud pull false no local image" {
   target=pull
-  run_buildah build $WITH_POLICY_JSON -t ${target} --pull=false ${TESTSDIR}/bud/pull
+  run_buildah build $WITH_POLICY_JSON -t ${target} --pull=false $BUDFILES/pull
   expect_output --substring "COMMIT pull"
 }
 
 @test "bud with Containerfile should fail with nonexistent authfile" {
   target=alpine-image
-  run_buildah 125 build --authfile /tmp/nonexistent $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/containerfile
+  run_buildah 125 build --authfile /tmp/nonexistent $WITH_POLICY_JSON -t ${target} $BUDFILES/containerfile
   expect_output "checking authfile: stat /tmp/nonexistent: no such file or directory"
 }
 
 
 @test "bud for multi-stage Containerfile with invalid registry and --authfile as a fd, should fail with no such host" {
   target=alpine-multi-stage-image
-  run_buildah 125 build --authfile=<(echo "{ \"auths\": { \"myrepository.example\": { \"auth\": \"$(echo 'username:password' | base64 --wrap=0)\" } } }") -t ${target} --file ${TESTSDIR}/bud/from-invalid-registry/Containerfile
+  run_buildah 125 build --authfile=<(echo "{ \"auths\": { \"myrepository.example\": { \"auth\": \"$(echo 'username:password' | base64 --wrap=0)\" } } }") -t ${target} --file $BUDFILES/from-invalid-registry/Containerfile
   # Should fail with `no such host` instead of: error reading JSON file "/dev/fd/x"
   expect_output --substring "no such host"
 }
@@ -2444,19 +2444,19 @@ EOM
 
 @test "bud quiet" {
   _prefetch alpine
-  run_buildah build --format docker -t quiet-test $WITH_POLICY_JSON -q ${TESTSDIR}/bud/shell
+  run_buildah build --format docker -t quiet-test $WITH_POLICY_JSON -q $BUDFILES/shell
   expect_line_count 1
   expect_output --substring '^[0-9a-f]{64}$'
 }
 
 @test "bud COPY with Env Var in Containerfile" {
   _prefetch alpine
-  run_buildah build $WITH_POLICY_JSON -t testctr ${TESTSDIR}/bud/copy-envvar
+  run_buildah build $WITH_POLICY_JSON -t testctr $BUDFILES/copy-envvar
   run_buildah from testctr
   run_buildah run testctr-working-container ls /file-0.0.1.txt
   run_buildah rm -a
 
-  run_buildah build $WITH_POLICY_JSON --layers -t testctr ${TESTSDIR}/bud/copy-envvar
+  run_buildah build $WITH_POLICY_JSON --layers -t testctr $BUDFILES/copy-envvar
   run_buildah from testctr
   run_buildah run testctr-working-container ls /file-0.0.1.txt
   run_buildah rm -a
@@ -2464,7 +2464,7 @@ EOM
 
 @test "bud with custom arch" {
   run_buildah build $WITH_POLICY_JSON \
-    -f ${TESTSDIR}/bud/from-scratch/Containerfile \
+    -f $BUDFILES/from-scratch/Containerfile \
     -t arch-test \
     --arch=arm
 
@@ -2477,7 +2477,7 @@ EOM
 
 @test "bud with custom os" {
   run_buildah build $WITH_POLICY_JSON \
-    -f ${TESTSDIR}/bud/from-scratch/Containerfile \
+    -f $BUDFILES/from-scratch/Containerfile \
     -t os-test \
     --os=windows
 
@@ -2490,7 +2490,7 @@ EOM
 
 @test "bud with custom platform" {
   run_buildah build $WITH_POLICY_JSON \
-    -f ${TESTSDIR}/bud/from-scratch/Containerfile \
+    -f $BUDFILES/from-scratch/Containerfile \
     -t platform-test \
     --platform=windows/arm
 
@@ -2509,7 +2509,7 @@ EOM
 
 @test "bud with custom platform and empty os or arch" {
   run_buildah build $WITH_POLICY_JSON \
-    -f ${TESTSDIR}/bud/from-scratch/Containerfile \
+    -f $BUDFILES/from-scratch/Containerfile \
     -t platform-test \
     --platform=windows/
 
@@ -2520,7 +2520,7 @@ EOM
   expect_output windows
 
   run_buildah build $WITH_POLICY_JSON \
-    -f ${TESTSDIR}/bud/from-scratch/Containerfile \
+    -f $BUDFILES/from-scratch/Containerfile \
     -t platform-test2 \
     --platform=/arm
 
@@ -2533,14 +2533,14 @@ EOM
 
 @test "bud Add with linked tarball" {
   _prefetch alpine
-  run_buildah build $WITH_POLICY_JSON -f ${TESTSDIR}/bud/symlink/Containerfile.add-tar-with-link -t testctr ${TESTSDIR}/bud/symlink
+  run_buildah build $WITH_POLICY_JSON -f $BUDFILES/symlink/Containerfile.add-tar-with-link -t testctr $BUDFILES/symlink
   run_buildah from testctr
   run_buildah run testctr-working-container ls /tmp/testdir/testfile.txt
   run_buildah rm -a
   run_buildah rmi -a -f
 
   _prefetch alpine
-  run_buildah build $WITH_POLICY_JSON -f ${TESTSDIR}/bud/symlink/Containerfile.add-tar-gz-with-link -t testctr ${TESTSDIR}/bud/symlink
+  run_buildah build $WITH_POLICY_JSON -f $BUDFILES/symlink/Containerfile.add-tar-gz-with-link -t testctr $BUDFILES/symlink
   run_buildah from testctr
   run_buildah run testctr-working-container ls /tmp/testdir/testfile.txt
   run_buildah rm -a
@@ -2548,13 +2548,13 @@ EOM
 }
 
 @test "bud file above context directory" {
-  run_buildah 125 build $WITH_POLICY_JSON -t testctr ${TESTSDIR}/bud/context-escape-dir/testdir
+  run_buildah 125 build $WITH_POLICY_JSON -t testctr $BUDFILES/context-escape-dir/testdir
   expect_output --substring "escaping context directory error"
 }
 
 @test "bud-multi-stage-args-scope" {
   _prefetch alpine
-  run_buildah build $WITH_POLICY_JSON --layers -t multi-stage-args --build-arg SECRET=secretthings -f Dockerfile.arg ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON --layers -t multi-stage-args --build-arg SECRET=secretthings -f Dockerfile.arg $BUDFILES/multi-stage-builds
   run_buildah from --name test-container multi-stage-args
   run_buildah run test-container -- cat test_file
   expect_output ""
@@ -2562,7 +2562,7 @@ EOM
 
 @test "bud-multi-stage-args-history" {
   _prefetch alpine
-  run_buildah build $WITH_POLICY_JSON --layers -t multi-stage-args --build-arg SECRET=secretthings -f Dockerfile.arg ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON --layers -t multi-stage-args --build-arg SECRET=secretthings -f Dockerfile.arg $BUDFILES/multi-stage-builds
   run_buildah inspect --format '{{range .History}}{{println .CreatedBy}}{{end}}' multi-stage-args
   run grep "secretthings" <<< "$output"
   expect_output ""
@@ -2609,28 +2609,28 @@ EOM
   target=busybox-image
 
   # Envariable not present at all
-  run_buildah --log-level "warn" bud $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/build-arg
+  run_buildah --log-level "warn" bud $WITH_POLICY_JSON -t ${target} $BUDFILES/build-arg
   expect_output --substring 'missing \\"foo\\" build argument. Try adding'
 
   # Envariable explicitly set on command line
-  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg foo=bar ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg foo=bar $BUDFILES/build-arg
   assert "${lines[3]}" = "bar"
 
   # Envariable from environment
   export foo=$(random_string 20)
-  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg foo ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg foo $BUDFILES/build-arg
   assert "${lines[3]}" = "$foo"
 }
 
 @test "bud arg and env var with same name" {
   # Regression test for https://github.com/containers/buildah/issues/2345
-  run_buildah build $WITH_POLICY_JSON -t testctr ${TESTSDIR}/bud/dupe-arg-env-name
+  run_buildah build $WITH_POLICY_JSON -t testctr $BUDFILES/dupe-arg-env-name
   expect_output --substring "https://example.org/bar"
 }
 
 @test "bud copy chown with newuser" {
   # Regression test for https://github.com/containers/buildah/issues/2192
-  run_buildah build $WITH_POLICY_JSON -t testctr -f ${TESTSDIR}/bud/copy-chown/Containerfile.chown_user ${TESTSDIR}/bud/copy-chown
+  run_buildah build $WITH_POLICY_JSON -t testctr -f $BUDFILES/copy-chown/Containerfile.chown_user $BUDFILES/copy-chown
   expect_output --substring "myuser myuser"
 }
 
@@ -2638,7 +2638,7 @@ EOM
   _prefetch alpine
   parent=alpine
   target=no-change-image
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   run_buildah --version
   local -a output_fields=($output)
   buildah_version=${output_fields[2]}
@@ -2654,7 +2654,7 @@ EOM
   _prefetch alpine
   _prefetch debian
 
-  run_buildah build --build-arg base=alpine --build-arg toolchainname=busybox --build-arg destinationpath=/tmp --pull=false $WITH_POLICY_JSON -f ${TESTSDIR}/bud/from-with-arg/Containerfile .
+  run_buildah build --build-arg base=alpine --build-arg toolchainname=busybox --build-arg destinationpath=/tmp --pull=false $WITH_POLICY_JSON -f $BUDFILES/from-with-arg/Containerfile .
   expect_output --substring "FROM alpine"
   expect_output --substring 'STEP 4/4: COPY --from=\$\{toolchainname\} \/ \$\{destinationpath\}'
   run_buildah rm -a
@@ -2663,7 +2663,7 @@ EOM
 @test "bud timestamp" {
   _prefetch alpine
   timestamp=40
-  run_buildah build --timestamp=${timestamp} --quiet --pull=false $WITH_POLICY_JSON -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
+  run_buildah build --timestamp=${timestamp} --quiet --pull=false $WITH_POLICY_JSON -t timestamp -f Dockerfile.1 $BUDFILES/cache-stages
   cid=$output
   run_buildah inspect --format '{{ .Docker.Created }}' timestamp
   expect_output --substring "1970-01-01"
@@ -2686,13 +2686,13 @@ EOM
 @test "bud timestamp compare" {
   _prefetch alpine
   TIMESTAMP=$(date '+%s')
-  run_buildah build --timestamp=${TIMESTAMP} --quiet --pull=false $WITH_POLICY_JSON -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
+  run_buildah build --timestamp=${TIMESTAMP} --quiet --pull=false $WITH_POLICY_JSON -t timestamp -f Dockerfile.1 $BUDFILES/cache-stages
   cid=$output
 
   run_buildah images --format "{{.Created}}" timestamp
   expect_output ${timestamp}
 
-  run_buildah build --timestamp=${TIMESTAMP} --quiet --pull=false $WITH_POLICY_JSON -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
+  run_buildah build --timestamp=${TIMESTAMP} --quiet --pull=false $WITH_POLICY_JSON -t timestamp -f Dockerfile.1 $BUDFILES/cache-stages
   expect_output "$cid"
 
   rm -rf ${TESTDIR}/tmp
@@ -2700,7 +2700,7 @@ EOM
 
 @test "bud with-rusage" {
   _prefetch alpine
-  run_buildah build --log-rusage --layers --pull=false --format docker $WITH_POLICY_JSON ${TESTSDIR}/bud/shell
+  run_buildah build --log-rusage --layers --pull=false --format docker $WITH_POLICY_JSON $BUDFILES/shell
   cid=$output
   # expect something that looks like it was formatted using pkg/rusage.FormatDiff()
   expect_output --substring ".*\(system\).*\(user\).*\(elapsed\).*input.*output"
@@ -2708,7 +2708,7 @@ EOM
 
 @test "bud with-rusage-logfile" {
   _prefetch alpine
-  run_buildah build --log-rusage --rusage-logfile ${TESTDIR}/foo.log --layers --pull=false --format docker $WITH_POLICY_JSON ${TESTSDIR}/bud/shell
+  run_buildah build --log-rusage --rusage-logfile ${TESTDIR}/foo.log --layers --pull=false --format docker $WITH_POLICY_JSON $BUDFILES/shell
   # the logfile should exist
   if [ ! -e ${TESTDIR}/foo.log ]; then die "rusage-logfile foo.log did not get created!"; fi
   # expect that foo.log only contains lines that were formatted using pkg/rusage.FormatDiff()
@@ -2722,51 +2722,51 @@ EOM
 @test "bud-caching-from-scratch" {
   _prefetch alpine
   # run the build once
-  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON $BUDFILES/cache-scratch
   iid="$output"
 
   # now run it again - the cache should give us the same final image ID
-  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON $BUDFILES/cache-scratch
   assert "$output" = "$iid"
 
   # now run it *again*, except with more content added at an intermediate step, which should invalidate the cache
-  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.different1 ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.different1 $BUDFILES/cache-scratch
   assert "$output" !~ "$iid"
 
   # now run it *again* again, except with more content added at an intermediate step, which should invalidate the cache
-  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.different2 ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.different2 $BUDFILES/cache-scratch
   assert "$output" !~ "$iid"
 }
 
 @test "bud-caching-from-scratch-config" {
   _prefetch alpine
   # run the build once
-  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.config ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.config $BUDFILES/cache-scratch
   iid="$output"
 
   # now run it again - the cache should give us the same final image ID
-  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.config ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.config $BUDFILES/cache-scratch
   assert "$output" = "$iid"
 
   # now run it *again*, except with more content added at an intermediate step, which should invalidate the cache
-  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.different1 ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.different1 $BUDFILES/cache-scratch
   assert "$output" !~ "$iid"
 
   # now run it *again* again, except with more content added at an intermediate step, which should invalidate the cache
-  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.different2 ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.different2 $BUDFILES/cache-scratch
   assert "$output" !~ "$iid"
 }
 
 @test "bud capabilities test" {
   _prefetch busybox
   # something not enabled by default in containers.conf
-  run_buildah build --cap-add cap_sys_ptrace -t testcap $WITH_POLICY_JSON -f ${TESTSDIR}/bud/capabilities/Dockerfile
+  run_buildah build --cap-add cap_sys_ptrace -t testcap $WITH_POLICY_JSON -f $BUDFILES/capabilities/Dockerfile
   expect_output --substring "uid=3267"
   expect_output --substring "CapBnd:	00000000a80c25fb"
   expect_output --substring "CapEff:	0000000000000000"
 
   # some things enabled by default in containers.conf
-  run_buildah build --cap-drop cap_chown,cap_dac_override,cap_fowner -t testcapd $WITH_POLICY_JSON -f ${TESTSDIR}/bud/capabilities/Dockerfile
+  run_buildah build --cap-drop cap_chown,cap_dac_override,cap_fowner -t testcapd $WITH_POLICY_JSON -f $BUDFILES/capabilities/Dockerfile
   expect_output --substring "uid=3267"
   expect_output --substring "CapBnd:	00000000a80425f0"
   expect_output --substring "CapEff:	0000000000000000"
@@ -2796,16 +2796,16 @@ EOF
 
 @test "bud cache by format" {
   # Build first in Docker format.  Whether we do OCI or Docker first shouldn't matter, so we picked one.
-  run_buildah build --iidfile ${TESTDIR}/first-docker  --format docker --layers --quiet $WITH_POLICY_JSON ${TESTSDIR}/bud/cache-format
+  run_buildah build --iidfile ${TESTDIR}/first-docker  --format docker --layers --quiet $WITH_POLICY_JSON $BUDFILES/cache-format
 
   # Build in OCI format.  Cache should not re-use the same images, so we should get a different image ID.
-  run_buildah build --iidfile ${TESTDIR}/first-oci     --format oci    --layers --quiet $WITH_POLICY_JSON ${TESTSDIR}/bud/cache-format
+  run_buildah build --iidfile ${TESTDIR}/first-oci     --format oci    --layers --quiet $WITH_POLICY_JSON $BUDFILES/cache-format
 
   # Build in Docker format again.  Cache traversal should 100% hit the Docker image, so we should get its image ID.
-  run_buildah build --iidfile ${TESTDIR}/second-docker --format docker --layers --quiet $WITH_POLICY_JSON ${TESTSDIR}/bud/cache-format
+  run_buildah build --iidfile ${TESTDIR}/second-docker --format docker --layers --quiet $WITH_POLICY_JSON $BUDFILES/cache-format
 
   # Build in OCI format again.  Cache traversal should 100% hit the OCI image, so we should get its image ID.
-  run_buildah build --iidfile ${TESTDIR}/second-oci    --format oci    --layers --quiet $WITH_POLICY_JSON ${TESTSDIR}/bud/cache-format
+  run_buildah build --iidfile ${TESTDIR}/second-oci    --format oci    --layers --quiet $WITH_POLICY_JSON $BUDFILES/cache-format
 
   # Compare them.  The two images we built in Docker format should be the same, the two we built in OCI format
   # should be the same, but the OCI and Docker format images should be different.
@@ -2829,7 +2829,7 @@ EOF
       iidfile=${TESTDIR}/${action}${i}
       containerfile=Dockerfile.${action}$(((i-1) % 2 + 1))
 
-      run_buildah build --iidfile $iidfile --layers --quiet $WITH_POLICY_JSON -f $containerfile ${TESTSDIR}/bud/cache-chown
+      run_buildah build --iidfile $iidfile --layers --quiet $WITH_POLICY_JSON -f $containerfile $BUDFILES/cache-chown
     done
   done
 
@@ -2861,14 +2861,14 @@ EOF
 }
 
 @test "bud-terminal" {
-  run_buildah build ${TESTSDIR}/bud/terminal
+  run_buildah build $BUDFILES/terminal
 }
 
 @test "bud --ignorefile containerignore" {
   _prefetch alpine busybox
 
   CONTEXTDIR=${TESTDIR}/dockerignore
-  cp -r ${TESTSDIR}/bud/dockerignore ${CONTEXTDIR}
+  cp -r $BUDFILES/dockerignore ${CONTEXTDIR}
   mv ${CONTEXTDIR}/.dockerignore ${TESTDIR}/containerignore
 
   run_buildah build -t testbud $WITH_POLICY_JSON -f ${CONTEXTDIR}/Dockerfile.succeed --ignorefile  ${TESTDIR}/containerignore  ${CONTEXTDIR}
@@ -2894,15 +2894,15 @@ EOF
   _prefetch alpine
   target=alpine-image
 
-  run_buildah build --network=none $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/containerfile
+  run_buildah build --network=none $WITH_POLICY_JSON -t ${target} $BUDFILES/containerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 
-  run_buildah build --network=private $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/containerfile
+  run_buildah build --network=private $WITH_POLICY_JSON -t ${target} $BUDFILES/containerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 
-  run_buildah build --network=container $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/containerfile
+  run_buildah build --network=container $WITH_POLICY_JSON -t ${target} $BUDFILES/containerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 }
@@ -2911,7 +2911,7 @@ EOF
   _prefetch alpine busybox
   # override the first FROM (fedora) image in the Containerfile
   # with alpine, leave the second (busybox) alone.
-  run_buildah build $WITH_POLICY_JSON --from=alpine ${TESTSDIR}/bud/build-with-from
+  run_buildah build $WITH_POLICY_JSON --from=alpine $BUDFILES/build-with-from
   expect_output --substring "\[1/2] STEP 1/1: FROM alpine AS builder"
   expect_output --substring "\[2/2] STEP 1/2: FROM busybox"
 }
@@ -3203,7 +3203,7 @@ _EOF
 }
 
 @test "bud - accept at most one arg" {
-    run_buildah 125 build $WITH_POLICY_JSON ${TESTSDIR}/bud/dns extraarg
+    run_buildah 125 build $WITH_POLICY_JSON $BUDFILES/dns extraarg
     assert "$output" =~ ".*accepts at most 1 arg\(s\), received 2" "Should fail when passed extra arg after context directory"
 }
 
@@ -3419,9 +3419,9 @@ _EOF
 
 @test "bud with --pull-always" {
   _prefetch docker.io/library/alpine
-  run_buildah build --pull-always $WITH_POLICY_JSON -t testpull ${TESTSDIR}/bud/containerfile
+  run_buildah build --pull-always $WITH_POLICY_JSON -t testpull $BUDFILES/containerfile
   expect_output --from="${lines[1]}" "Trying to pull docker.io/library/alpine:latest..."
-  run_buildah build --pull=always $WITH_POLICY_JSON -t testpull ${TESTSDIR}/bud/containerfile
+  run_buildah build --pull=always $WITH_POLICY_JSON -t testpull $BUDFILES/containerfile
   expect_output --from="${lines[1]}" "Trying to pull docker.io/library/alpine:latest..."
 }
 
@@ -3493,10 +3493,10 @@ _EOF
 }
 
 @test "bud with .dockerignore #3" {
-  run_buildah build -t test $WITH_POLICY_JSON ${TESTSDIR}/bud/copy-globs
-  run_buildah build -t test2 -f Containerfile.missing $WITH_POLICY_JSON ${TESTSDIR}/bud/copy-globs
+  run_buildah build -t test $WITH_POLICY_JSON $BUDFILES/copy-globs
+  run_buildah build -t test2 -f Containerfile.missing $WITH_POLICY_JSON $BUDFILES/copy-globs
 
-  run_buildah 125 build -t test3 -f Containerfile.bad $WITH_POLICY_JSON ${TESTSDIR}/bud/copy-globs
+  run_buildah 125 build -t test3 -f Containerfile.bad $WITH_POLICY_JSON $BUDFILES/copy-globs
   expect_output --substring 'error building.*"COPY \*foo /testdir".*no such file or directory'
 }
 
@@ -3508,7 +3508,7 @@ _EOF
 SOMESECRETDATA
 _EOF
 
-  run_buildah build --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret ${TESTSDIR}/bud/run-mounts
+  run_buildah build --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretimg -f $BUDFILES/run-mounts/Dockerfile.secret $BUDFILES/run-mounts
   expect_output --substring "SOMESECRETDATA"
 
   run_buildah from secretimg
@@ -3525,7 +3525,7 @@ _EOF
 SOMESECRETDATA
 _EOF
 
-  run_buildah 1 bud --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-access ${TESTSDIR}/bud/run-mounts
+  run_buildah 1 bud --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretimg -f $BUDFILES/run-mounts/Dockerfile.secret-access $BUDFILES/run-mounts
   expect_output --substring "SOMESECRETDATA"
   expect_output --substring "cat: can't open '/mysecret': No such file or directory"
 }
@@ -3538,7 +3538,7 @@ _EOF
 SOMESECRETDATA
 _EOF
 
-  run_buildah bud --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretmode -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-mode ${TESTSDIR}/bud/run-mounts
+  run_buildah bud --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretmode -f $BUDFILES/run-mounts/Dockerfile.secret-mode $BUDFILES/run-mounts
   expect_output --substring "400"
 }
 
@@ -3550,7 +3550,7 @@ _EOF
 SOMESECRETDATA
 _EOF
 
-  run_buildah build --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretopts -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-options ${TESTSDIR}/bud/run-mounts
+  run_buildah build --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretopts -f $BUDFILES/run-mounts/Dockerfile.secret-options $BUDFILES/run-mounts
   expect_output --substring "444"
   expect_output --substring "1000"
   expect_output --substring "1001"
@@ -3559,19 +3559,19 @@ _EOF
 @test "bud with containerfile secret not required" {
   _prefetch alpine
 
-  run_buildah build $WITH_POLICY_JSON  -t secretnotreq -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-not-required ${TESTSDIR}/bud/run-mounts
+  run_buildah build $WITH_POLICY_JSON  -t secretnotreq -f $BUDFILES/run-mounts/Dockerfile.secret-not-required $BUDFILES/run-mounts
 }
 
 @test "bud with containerfile secret required" {
   _prefetch alpine
 
-  run_buildah 125 build $WITH_POLICY_JSON  -t secretreq -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-required ${TESTSDIR}/bud/run-mounts
+  run_buildah 125 build $WITH_POLICY_JSON  -t secretreq -f $BUDFILES/run-mounts/Dockerfile.secret-required $BUDFILES/run-mounts
   expect_output --substring "secret required but no secret with id mysecret found"
 }
 
 @test "bud with containerfile env secret" {
   export MYSECRET=SOMESECRETDATA
-  run_buildah build --secret=id=mysecret,src=MYSECRET,type=env $WITH_POLICY_JSON  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret ${TESTSDIR}/bud/run-mounts
+  run_buildah build --secret=id=mysecret,src=MYSECRET,type=env $WITH_POLICY_JSON  -t secretimg -f $BUDFILES/run-mounts/Dockerfile.secret $BUDFILES/run-mounts
   expect_output --substring "SOMESECRETDATA"
 
   run_buildah from secretimg
@@ -3579,7 +3579,7 @@ _EOF
   expect_output --substring "cat: can't open '/run/secrets/mysecret': No such file or directory"
   run_buildah rm -a
 
-  run_buildah build --secret=id=mysecret,env=MYSECRET $WITH_POLICY_JSON  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret ${TESTSDIR}/bud/run-mounts
+  run_buildah build --secret=id=mysecret,env=MYSECRET $WITH_POLICY_JSON  -t secretimg -f $BUDFILES/run-mounts/Dockerfile.secret $BUDFILES/run-mounts
   expect_output --substring "SOMESECRETDATA"
 
   run_buildah from secretimg
@@ -3597,7 +3597,7 @@ SOMESECRETDATA
 _EOF
 
   export mysecret=ENVDATA
-  run_buildah build --secret=id=mysecret $WITH_POLICY_JSON  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret ${TESTSDIR}/bud/run-mounts
+  run_buildah build --secret=id=mysecret $WITH_POLICY_JSON  -t secretimg -f $BUDFILES/run-mounts/Dockerfile.secret $BUDFILES/run-mounts
   expect_output --substring "ENVDATA"
 }
 
@@ -3618,7 +3618,7 @@ _EOF
   fi
 
   # build for those architectures - RUN gets exercised
-  run_buildah build $WITH_POLICY_JSON --jobs=0 --platform=$os/arm,$os/386 --manifest $outputlist ${TESTSDIR}/bud/multiarch
+  run_buildah build $WITH_POLICY_JSON --jobs=0 --platform=$os/arm,$os/386 --manifest $outputlist $BUDFILES/multiarch
   run_buildah manifest inspect $outputlist
   list="$output"
   run jq -r '.manifests[0].digest' <<< "$list"
@@ -3632,7 +3632,7 @@ _EOF
 
 @test "bud-multiple-platform-no-partial-manifest-list" {
   outputlist=localhost/testlist
-  run_buildah 1 bud $WITH_POLICY_JSON --platform=linux/arm,linux/amd64 --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.fail ${TESTSDIR}/bud/multiarch
+  run_buildah 1 bud $WITH_POLICY_JSON --platform=linux/arm,linux/amd64 --manifest $outputlist -f $BUDFILES/multiarch/Dockerfile.fail $BUDFILES/multiarch
   expect_output --substring "error building at STEP \"RUN test .arch. = x86_64"
   run_buildah 125 manifest inspect $outputlist
   expect_output --substring "reading image .* pinging container registry"
@@ -3656,7 +3656,7 @@ _EOF
     skip "unable to run arm container, assuming emulation is not available"
   fi
   outputlist=localhost/testlist
-  run_buildah 125 build $WITH_POLICY_JSON --jobs=0 --platform=linux/arm64,linux/amd64 --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.fail-multistage ${TESTSDIR}/bud/multiarch
+  run_buildah 125 build $WITH_POLICY_JSON --jobs=0 --platform=linux/arm64,linux/amd64 --manifest $outputlist -f $BUDFILES/multiarch/Dockerfile.fail-multistage $BUDFILES/multiarch
   expect_output --substring 'error building at STEP "RUN false"'
 }
 
@@ -3666,7 +3666,7 @@ _EOF
   # concurrency to maximum which uncovers all sorts of race condition causing
   # flakes in CI. Please put this back to --jobs=0 when https://github.com/containers/buildah/issues/3710
   # is resolved.
-  run_buildah build $WITH_POLICY_JSON --jobs=1 --all-platforms --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.no-run ${TESTSDIR}/bud/multiarch
+  run_buildah build $WITH_POLICY_JSON --jobs=1 --all-platforms --manifest $outputlist -f $BUDFILES/multiarch/Dockerfile.no-run $BUDFILES/multiarch
   run_buildah manifest inspect $outputlist
   echo "$output"
   run jq '.manifests | length' <<< "$output"
@@ -3683,7 +3683,7 @@ _EOF
   fromDigest="$output"
 
   target=relabel
-  run_buildah build --layers --label "label1=value1" $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build --layers --label "label1=value1" $WITH_POLICY_JSON -t ${target} -f $BUDFILES/multi-stage-builds/Dockerfile.reused $BUDFILES/multi-stage-builds
 
   # Store base digest of first image
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' ${target}
@@ -3698,7 +3698,7 @@ _EOF
   expect_output --substring "label1:value1"
 
   # Rebuild with new label
-  run_buildah build --layers --label "label1=value2" $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build --layers --label "label1=value2" $WITH_POLICY_JSON -t ${target} -f $BUDFILES/multi-stage-builds/Dockerfile.reused $BUDFILES/multi-stage-builds
 
   # Base digest should match with first build
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' ${target}
@@ -3709,7 +3709,7 @@ _EOF
   expect_output --substring "label1:value2"
 
   # Rebuild everything with label1=value1 and everything should be cached from first image
-  run_buildah build --layers --label "label1=value1" $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build --layers --label "label1=value1" $WITH_POLICY_JSON -t ${target} -f $BUDFILES/multi-stage-builds/Dockerfile.reused $BUDFILES/multi-stage-builds
 
   # Enitre image must be picked from cache
   run_buildah inspect --format '{{ .FromImageID }}' ${target}
@@ -3729,7 +3729,7 @@ _EOF
   busyboxDigest="$output"
 
   target=relabel2
-  run_buildah build --layers --label "label1=value1" --from=alpine -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --layers --label "label1=value1" --from=alpine -t ${target} $BUDFILES/from-scratch
 
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' ${target}
   expect_output "$alpineDigest" "base digest from alpine"
@@ -3739,7 +3739,7 @@ _EOF
   expect_output --substring "label1:value1"
 
 
-  run_buildah build --layers --label "label1=value2" --from=busybox -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --layers --label "label1=value2" --from=busybox -t ${target} $BUDFILES/from-scratch
 
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' ${target}
   expect_output "$busyboxDigest" "base digest from busybox"
@@ -3760,7 +3760,7 @@ _EOF
   mkdir ${TESTDIR}/${target}
 
   # Build and export container to tar
-  run_buildah build --no-cache $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/containerfile/Containerfile.in ${TESTSDIR}/bud/containerfile
+  run_buildah build --no-cache $WITH_POLICY_JSON -t ${target} -f $BUDFILES/containerfile/Containerfile.in $BUDFILES/containerfile
   podman export $(podman create --name ${target} --net=host ${target}) --output=${TESTDIR}/${target}.tar
 
   # We are done exporting so remove images and containers which are not needed
@@ -3783,7 +3783,7 @@ _EOF
   mkdir ${TESTDIR}/${target}
 
   # Build and export container to tar
-  run_buildah build --no-cache $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/add-run-dir
+  run_buildah build --no-cache $WITH_POLICY_JSON -t ${target} -f $BUDFILES/add-run-dir
   podman export $(podman create --name ${target} --net=host ${target}) --output=${TESTDIR}/${target}.tar
 
   # We are done exporting so remove images and containers which are not needed
@@ -3800,7 +3800,7 @@ _EOF
 @test "bud-with-mount-like-buildkit" {
   skip_if_no_runtime
   skip_if_in_container
-  cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
+  cp -R $BUDFILES/buildkit-mount ${TESTDIR}/buildkit-mount
   run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfile ${TESTDIR}/buildkit-mount/
   expect_output --substring "hello"
   run_buildah rmi -f testbud
@@ -3809,7 +3809,7 @@ _EOF
 @test "bud-with-mount-no-source-like-buildkit" {
   skip_if_no_runtime
   skip_if_in_container
-  cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
+  cp -R $BUDFILES/buildkit-mount ${TESTDIR}/buildkit-mount
   run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfile2 ${TESTDIR}/buildkit-mount/
   expect_output --substring "hello"
   run_buildah rmi -f testbud
@@ -3818,7 +3818,7 @@ _EOF
 @test "bud-with-mount-no-subdir-like-buildkit" {
   skip_if_no_runtime
   skip_if_in_container
-  cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
+  cp -R $BUDFILES/buildkit-mount ${TESTDIR}/buildkit-mount
   run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfile ${TESTDIR}/buildkit-mount/subdir/
   expect_output --substring "hello"
   run_buildah rmi -f testbud
@@ -3827,7 +3827,7 @@ _EOF
 @test "bud-with-mount-relative-path-like-buildkit" {
   skip_if_no_runtime
   skip_if_in_container
-  cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
+  cp -R $BUDFILES/buildkit-mount ${TESTDIR}/buildkit-mount
   run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfile4 ${TESTDIR}/buildkit-mount/
   expect_output --substring "hello"
   run_buildah rmi -f testbud
@@ -3836,7 +3836,7 @@ _EOF
 @test "bud-with-mount-with-rw-like-buildkit" {
   skip_if_no_runtime
   skip_if_in_container
-  cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
+  cp -R $BUDFILES/buildkit-mount ${TESTDIR}/buildkit-mount
   run_buildah build --isolation chroot -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfile3 ${TESTDIR}/buildkit-mount/subdir/
   expect_output --substring "world"
   run_buildah rmi -f testbud
@@ -3845,7 +3845,7 @@ _EOF
 @test "bud-with-mount-with-tmpfs-like-buildkit" {
   skip_if_no_runtime
   skip_if_in_container
-  cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
+  cp -R $BUDFILES/buildkit-mount ${TESTDIR}/buildkit-mount
   # tmpfs mount: target should be available on container without creating any special directory on container
   run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfiletmpfs
   [ "$status" -eq 0 ]
@@ -3855,7 +3855,7 @@ _EOF
 @test "bud-with-mount-with-tmpfs-with-copyup-like-buildkit" {
   skip_if_no_runtime
   skip_if_in_container
-  cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
+  cp -R $BUDFILES/buildkit-mount ${TESTDIR}/buildkit-mount
   run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfiletmpfscopyup
   expect_output --substring "certs"
   run_buildah rmi -f testbud
@@ -3864,7 +3864,7 @@ _EOF
 @test "bud-with-mount-cache-like-buildkit" {
   skip_if_no_runtime
   skip_if_in_container
-  cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
+  cp -R $BUDFILES/buildkit-mount ${TESTDIR}/buildkit-mount
   # try writing something to persistent cache
   run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfilecachewrite
   # try reading something from persistent cache in a different build
@@ -3878,7 +3878,7 @@ _EOF
   # Note: this test is just testing syntax for sharing, actual behviour test needs parallel build in order to test locking.
   skip_if_no_runtime
   skip_if_in_container
-  cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
+  cp -R $BUDFILES/buildkit-mount ${TESTDIR}/buildkit-mount
   # try writing something to persistent cache
   run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfilecachewritesharing
   expect_output --substring "world"
@@ -3887,7 +3887,7 @@ _EOF
 
 @test "bud with user in groups" {
   target=bud-group
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/group
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/group
 }
 
 @test "build proxy" {
@@ -3914,7 +3914,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
-  cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
+  cp -R $BUDFILES/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # build base image which we will use as our `from`
   run_buildah build -t buildkitbase $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
   # try reading something from another image in a different build
@@ -3928,7 +3928,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
-  cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
+  cp -R $BUDFILES/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # build base image which we will use as our `from`
   run_buildah build -t buildkitbase $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
   # try reading something from another image in a different build
@@ -3942,7 +3942,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
-  cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
+  cp -R $BUDFILES/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # build base image which we will use as our `from`
   run_buildah build -t buildkitbase $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
   # try reading something from another image in a different build
@@ -3956,7 +3956,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
-  cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
+  cp -R $BUDFILES/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # build base image which we will use as our `from`
   run_buildah build -t buildkitbase $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
   # try reading something from image in a different build
@@ -3969,7 +3969,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
-  cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
+  cp -R $BUDFILES/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # try reading something from persistent cache in a different build
   run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilecachefrom ${TESTDIR}/bud/buildkit-mount-from/
   expect_output --substring "hello"
@@ -3981,7 +3981,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
-  cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
+  cp -R $BUDFILES/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
 
   # build base image which we will use as our `from`
   run_buildah build -t buildkitbase $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
@@ -3996,7 +3996,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
-  cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
+  cp -R $BUDFILES/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # try reading something from persistent cache in a different build
   run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilecachemultiplefrom ${TESTDIR}/bud/buildkit-mount-from/
   expect_output --substring "hello"
@@ -4008,7 +4008,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
-  cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
+  cp -R $BUDFILES/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # build base image which we will use as our `from`
   run_buildah build -t buildkitbaserelative $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbaserelative ${TESTDIR}/bud/buildkit-mount-from/
   # try reading something from image in a different build
@@ -4020,7 +4020,7 @@ _EOF
 
 @test "bud-with-mount-bind-from-multistage-relative-like-buildkit" {
   mkdir ${TESTDIR}/bud
-  cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
+  cp -R $BUDFILES/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   skip_if_no_runtime
   skip_if_in_container
   # build base image which we will use as our `from`
@@ -4033,7 +4033,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   mkdir ${TESTDIR}/bud
-  cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
+  cp -R $BUDFILES/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # build base image which we will use as our `from`
   run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilemultistagefromcache ${TESTDIR}/bud/buildkit-mount-from/
   expect_output --substring "hello"
@@ -4048,11 +4048,11 @@ _EOF
 
   _prefetch alpine
 
-  run_buildah 125 bud $WITH_POLICY_JSON --network notexists ${TESTSDIR}/bud/network
+  run_buildah 125 bud $WITH_POLICY_JSON --network notexists $BUDFILES/network
   expect_output --substring "network not found"
 
   if test "$BUILDAH_ISOLATION" = "oci"; then
-    run_buildah bud $WITH_POLICY_JSON --network podman ${TESTSDIR}/bud/network
+    run_buildah bud $WITH_POLICY_JSON --network podman $BUDFILES/network
     # default subnet is 10.88.0.0/16
     expect_output --substring "10.88."
   fi
@@ -4062,7 +4062,7 @@ _EOF
   _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/workdir-user
+  run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/workdir-user
   expect_output --substring "1000:1000 /home/http/public"
 }
 
@@ -4073,7 +4073,7 @@ _EOF
 
   mkfifo ${TESTDIR}/pipe
   # start the build running in the background - don't use the function wrapper because that sets '$!' to a value that's not what we want
-  ${BUILDAH_BINARY} ${BUILDAH_REGISTRY_OPTS} ${ROOTDIR_OPTS} $WITH_POLICY_JSON build ${TESTSDIR}/bud/long-sleep > ${TESTDIR}/pipe 2>&1 &
+  ${BUILDAH_BINARY} ${BUILDAH_REGISTRY_OPTS} ${ROOTDIR_OPTS} $WITH_POLICY_JSON build $BUDFILES/long-sleep > ${TESTDIR}/pipe 2>&1 &
   buildah_pid="${!}"
   echo buildah is pid ${buildah_pid}
   # save what's written to the fifo to a plain file

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -13,7 +13,7 @@ load helpers
 
 @test "bud with --dns* flags" {
   _prefetch alpine
-  run_buildah build --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc  --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/dns/Dockerfile  ${TESTSDIR}/bud/dns
+  run_buildah build --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc  $WITH_POLICY_JSON -f ${TESTSDIR}/bud/dns/Dockerfile  ${TESTSDIR}/bud/dns
   expect_output --substring "search example.com"
   expect_output --substring "nameserver 223.5.5.5"
   expect_output --substring "options use-vc"
@@ -21,10 +21,10 @@ load helpers
 
 @test "bud with .dockerignore #1" {
   _prefetch alpine busybox
-  run_buildah 125 build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/dockerignore/Dockerfile ${TESTSDIR}/bud/dockerignore
+  run_buildah 125 build -t testbud $WITH_POLICY_JSON -f ${TESTSDIR}/bud/dockerignore/Dockerfile ${TESTSDIR}/bud/dockerignore
   expect_output --substring 'error building.*"COPY subdir \./".*no such file or directory'
 
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/dockerignore/Dockerfile.succeed ${TESTSDIR}/bud/dockerignore
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTSDIR}/bud/dockerignore/Dockerfile.succeed ${TESTSDIR}/bud/dockerignore
 
   run_buildah from --name myctr testbud
 
@@ -41,10 +41,10 @@ load helpers
 
 @test "bud with .containerignore" {
   _prefetch alpine busybox
-  run_buildah 125 build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/containerignore/Dockerfile ${TESTSDIR}/bud/containerignore
+  run_buildah 125 build -t testbud $WITH_POLICY_JSON -f ${TESTSDIR}/bud/containerignore/Dockerfile ${TESTSDIR}/bud/containerignore
   expect_output --substring 'error building.*"COPY subdir \./".*no such file or directory'
 
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/containerignore/Dockerfile.succeed ${TESTSDIR}/bud/containerignore
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTSDIR}/bud/containerignore/Dockerfile.succeed ${TESTSDIR}/bud/containerignore
 
   run_buildah from --name myctr testbud
 
@@ -76,7 +76,7 @@ load helpers
   ln -sf no-such-file  ${TESTDIR}/dockerignore2/subdir/dangling-link
 
   # Build, create a container, mount it, and list all files therein
-  run_buildah build -t testbud2 --signature-policy ${TESTSDIR}/policy.json ${TESTDIR}/dockerignore2
+  run_buildah build -t testbud2 $WITH_POLICY_JSON ${TESTDIR}/dockerignore2
 
   run_buildah from --pull=false testbud2
   cid=$output
@@ -112,7 +112,7 @@ symlink(subdir)"
 }
 
 @test "bud with .dockerignore #2" {
-  run_buildah 125 build -t testbud3 --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/dockerignore3
+  run_buildah 125 build -t testbud3 $WITH_POLICY_JSON ${TESTSDIR}/bud/dockerignore3
   expect_output --substring 'error building.*"COPY test1.txt /upload/test1.txt".*no such file or directory'
   expect_output --substring $(realpath "${TESTSDIR}/bud/dockerignore3/.dockerignore")
 }
@@ -136,7 +136,7 @@ FROM --platform=linux/${otherarch} alpine
 RUN uname -m
 _EOF
 
-  run_buildah '?' build --signature-policy ${TESTSDIR}/policy.json -t test ${TESTDIR}/bud/platform
+  run_buildah '?' build $WITH_POLICY_JSON -t test ${TESTDIR}/bud/platform
   if [[ $status -eq 0 ]]; then
     run_buildah inspect --format '{{ .OCIv1.Architecture }}' test
     expect_output --substring "$otherarch"
@@ -165,7 +165,7 @@ RUN uname -m
 _EOF
 
   # Tries building image where baseImage has --platform=linux/HostArch
-  run_buildah build --platform linux/${targetarch} --signature-policy ${TESTSDIR}/policy.json -t test ${TESTDIR}/bud/platform
+  run_buildah build --platform linux/${targetarch} $WITH_POLICY_JSON -t test ${TESTDIR}/bud/platform
   run_buildah inspect --format '{{ .OCIv1.Architecture }}' test
   # base image is pulled as HostArch but tagged as non host arch
   expect_output --substring $targetarch
@@ -176,11 +176,11 @@ _EOF
 
   # Run with --pull-always to have a regression test for
   # containers/podman/issues/10307.
-  run_buildah build --pull-always --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTDIR}/use-layers
+  run_buildah build --pull-always $WITH_POLICY_JSON --layers -t test1 ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 8
 
-  run_buildah build --pull-never --signature-policy ${TESTSDIR}/policy.json --layers -t test2 ${TESTDIR}/use-layers
+  run_buildah build --pull-never $WITH_POLICY_JSON --layers -t test2 ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 10
   run_buildah inspect --format "{{index .Docker.ContainerConfig.Env 1}}" test1
@@ -194,25 +194,25 @@ _EOF
   run_buildah inspect --format "{{index .Docker.History 2}}" test1
   expect_output --substring "FROM docker.io/library/alpine:latest"
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test3 -f Dockerfile.2 ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 12
 
   mkdir -p ${TESTDIR}/use-layers/mount/subdir
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test4 -f Dockerfile.3 ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test4 -f Dockerfile.3 ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 14
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test5 -f Dockerfile.3 ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test5 -f Dockerfile.3 ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 15
 
   touch ${TESTDIR}/use-layers/mount/subdir/file.txt
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test6 -f Dockerfile.3 ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test6 -f Dockerfile.3 ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 17
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --no-cache -t test7 -f Dockerfile.2 ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --no-cache -t test7 -f Dockerfile.2 ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 18
 }
@@ -222,7 +222,7 @@ _EOF
   run_buildah inspect --format "{{.FromImageDigest}}" alpine
   fromDigest="$output"
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test -f Dockerfile.5 ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test -f Dockerfile.5 ${TESTSDIR}/bud/use-layers
   run_buildah images -a
   expect_line_count 3
 
@@ -232,7 +232,7 @@ _EOF
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.name" }}' test
   expect_output "docker.io/library/alpine:latest" "base name from alpine"
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test1 -f Dockerfile.6 ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test1 -f Dockerfile.6 ${TESTSDIR}/bud/use-layers
   run_buildah images -a
   expect_line_count 4
 
@@ -254,30 +254,30 @@ _EOF
   mkdir -p ${TESTDIR}/use-layers/date
   date > ${TESTDIR}/use-layers/date/data
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test1 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test1 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 6
   # The second time through, the layers should all get reused.
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test1 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test1 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 6
   # The third time through, the layers should all get reused, but we'll have a new line of output for the new name.
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test2 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 7
 
   # Both interim images will be different, and all of the layers in the final image will be different.
   uuidgen > ${TESTDIR}/use-layers/uuid/data
   date > ${TESTDIR}/use-layers/date/data
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test3 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 11
   # No leftover containers, just the header line.
   run_buildah containers
   expect_line_count 1
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test3
+  run_buildah from --quiet $WITH_POLICY_JSON test3
   ctr=$output
   run_buildah mount ${ctr}
   mnt=$output
@@ -285,7 +285,7 @@ _EOF
   test -e $mnt/date
 
   # Layers won't get reused because this build won't use caching.
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t test4 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON -t test4 -f Dockerfile.multistage-copy ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 12
 }
@@ -294,12 +294,12 @@ _EOF
   _prefetch alpine
   target=foo
   # build the first stage
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -f ${TESTSDIR}/bud/cache-stages/Dockerfile.1 ${TESTSDIR}/bud/cache-stages
+  run_buildah build $WITH_POLICY_JSON --layers -f ${TESTSDIR}/bud/cache-stages/Dockerfile.1 ${TESTSDIR}/bud/cache-stages
   # expect alpine + 1 image record for the first stage
   run_buildah images -a
   expect_line_count 3
   # build the second stage, itself not cached, when the first stage is found in the cache
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -f ${TESTSDIR}/bud/cache-stages/Dockerfile.2 -t ${target} ${TESTSDIR}/bud/cache-stages
+  run_buildah build $WITH_POLICY_JSON --layers -f ${TESTSDIR}/bud/cache-stages/Dockerfile.2 -t ${target} ${TESTSDIR}/bud/cache-stages
   # expect alpine + 1 image record for the first stage, then two more image records for the second stage
   run_buildah images -a
   expect_line_count 5
@@ -308,8 +308,8 @@ _EOF
 @test "bud-multistage-copy-final-slash" {
   _prefetch busybox
   target=foo
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-final-slash
-  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/dest-final-slash
+  run_buildah from --pull=false $WITH_POLICY_JSON ${target}
   cid="$output"
   run_buildah run ${cid} /test/ls -lR /test/ls
 }
@@ -320,7 +320,7 @@ _EOF
   fromDigest="$output"
 
   target=foo
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
 
   # Also check for base-image annotations.
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' ${target}
@@ -328,17 +328,17 @@ _EOF
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.name" }}' ${target}
   expect_output "docker.io/library/busybox:latest" "base name from busybox"
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah from $WITH_POLICY_JSON ${target}
   run_buildah rmi -f ${target}
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --layers -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} --layers -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah from $WITH_POLICY_JSON ${target}
 }
 
 @test "bud-multistage-cache" {
   _prefetch alpine busybox
   target=foo
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.extended ${TESTSDIR}/bud/multi-stage-builds
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.extended ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah from $WITH_POLICY_JSON ${target}
   cid="$output"
   run_buildah mount "$cid"
   root="$output"
@@ -350,7 +350,7 @@ _EOF
 
 @test "bud-multistage-pull-always" {
   _prefetch busybox
-  run_buildah build --pull-always --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.extended ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build --pull-always $WITH_POLICY_JSON -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.extended ${TESTSDIR}/bud/multi-stage-builds
 }
 
 @test "bud with --layers and symlink file" {
@@ -358,16 +358,16 @@ _EOF
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers
   echo 'echo "Hello World!"' > ${TESTDIR}/use-layers/hello.sh
   ln -s hello.sh ${TESTDIR}/use-layers/hello_world.sh
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test -f Dockerfile.4 ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test -f Dockerfile.4 ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 4
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test1 -f Dockerfile.4 ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test1 -f Dockerfile.4 ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 5
 
   echo 'echo "Hello Cache!"' > ${TESTDIR}/use-layers/hello.sh
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.4 ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test2 -f Dockerfile.4 ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 7
 }
@@ -378,15 +378,15 @@ _EOF
   mkdir ${TESTDIR}/use-layers/blah
   ln -s ${TESTSDIR}/policy.json ${TESTDIR}/use-layers/blah/policy.json
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test -f Dockerfile.dangling-symlink ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test -f Dockerfile.dangling-symlink ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 3
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test1 -f Dockerfile.dangling-symlink ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test1 -f Dockerfile.dangling-symlink ${TESTDIR}/use-layers
   run_buildah images -a
   expect_line_count 4
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test
+  run_buildah from --quiet $WITH_POLICY_JSON test
   cid=$output
   run_buildah run $cid ls /tmp
   expect_output "policy.json"
@@ -395,12 +395,12 @@ _EOF
 @test "bud with --layers and --build-args" {
   _prefetch alpine
   # base plus 3, plus the header line
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --build-arg=user=0 --layers -t test -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --build-arg=user=0 --layers -t test -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
   run_buildah images -a
   expect_line_count 5
 
   # running the same build again does not run the commands again
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --build-arg=user=0 --layers -t test -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --build-arg=user=0 --layers -t test -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
   if [[ "$output" =~ "MAo=" ]]; then
     # MAo= is the base64 of "0\n" (i.e. `echo 0`)
     printf "Expected command not to run again if layer is cached\n" >&2
@@ -408,17 +408,17 @@ _EOF
   fi
 
   # two more, starting at the "echo $user | base64" instruction
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --build-arg=user=1 --layers -t test1 -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --build-arg=user=1 --layers -t test1 -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
   run_buildah images -a
   expect_line_count 7
 
   # one more, because we added a new name to the same image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --build-arg=user=1 --layers -t test2 -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --build-arg=user=1 --layers -t test2 -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
   run_buildah images -a
   expect_line_count 8
 
   # two more, starting at the "echo $user | base64" instruction
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test3 -f Dockerfile.build-args ${TESTSDIR}/bud/use-layers
   run_buildah images -a
   expect_line_count 11
 }
@@ -427,10 +427,10 @@ _EOF
 @test "bud with --layers and --build-args: override ARG with ENV and image must be cached" {
   _prefetch alpine
   #when ARG is overridden by config
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --build-arg=FOO=1 --layers -t args-cache -f ${TESTSDIR}/bud/with-arg/Dockerfile
+  run_buildah build $WITH_POLICY_JSON --build-arg=FOO=1 --layers -t args-cache -f ${TESTSDIR}/bud/with-arg/Dockerfile
   run_buildah inspect -f '{{.FromImageID}}' args-cache
   idbefore="$output"
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --build-arg=FOO=12 --layers -t args-cache -f ${TESTSDIR}/bud/with-arg/Dockerfile
+  run_buildah build $WITH_POLICY_JSON --build-arg=FOO=12 --layers -t args-cache -f ${TESTSDIR}/bud/with-arg/Dockerfile
   run_buildah inspect -f '{{.FromImageID}}' args-cache
   expect_output --substring ${idbefore}
   run_buildah rmi args-cache
@@ -438,10 +438,10 @@ _EOF
 
 @test "bud with --layers and --build-args: use raw ARG and cache should not be used" {
   # when ARG is used as a raw value
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --build-arg=FOO=1 --layers -t args-cache -f ${TESTSDIR}/bud/with-arg/Dockerfile2
+  run_buildah build $WITH_POLICY_JSON --build-arg=FOO=1 --layers -t args-cache -f ${TESTSDIR}/bud/with-arg/Dockerfile2
   run_buildah inspect -f '{{.FromImageID}}' args-cache
   idbefore="$output"
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --build-arg=FOO=12 --layers -t args-cache -f ${TESTSDIR}/bud/with-arg/Dockerfile2
+  run_buildah build $WITH_POLICY_JSON --build-arg=FOO=12 --layers -t args-cache -f ${TESTSDIR}/bud/with-arg/Dockerfile2
   run_buildah inspect -f '{{.FromImageID}}' args-cache
   idafter="$output"
   run_buildah rmi args-cache
@@ -452,39 +452,39 @@ _EOF
 
 @test "bud with --rm flag" {
   _prefetch alpine
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers -t test1 ${TESTSDIR}/bud/use-layers
   run_buildah containers
   expect_line_count 1
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --rm=false --layers -t test2 ${TESTSDIR}/bud/use-layers
+  run_buildah build $WITH_POLICY_JSON --rm=false --layers -t test2 ${TESTSDIR}/bud/use-layers
   run_buildah containers
   expect_line_count 7
 }
 
 @test "bud with --force-rm flag" {
   _prefetch alpine
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json --force-rm --layers -t test1 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
+  run_buildah 125 build $WITH_POLICY_JSON --force-rm --layers -t test1 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
   run_buildah containers
   expect_line_count 1
 
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
+  run_buildah 125 build $WITH_POLICY_JSON --layers -t test2 -f Dockerfile.fail-case ${TESTSDIR}/bud/use-layers
   run_buildah containers
   expect_line_count 2
 }
 
 @test "bud --layers with non-existent/down registry" {
   _prefetch alpine
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json --force-rm --layers -t test1 -f Dockerfile.non-existent-registry ${TESTSDIR}/bud/use-layers
+  run_buildah 125 build $WITH_POLICY_JSON --force-rm --layers -t test1 -f Dockerfile.non-existent-registry ${TESTSDIR}/bud/use-layers
   expect_output --substring "no such host"
 }
 
 @test "bud from base image should have base image ENV also" {
   _prefetch alpine
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t test -f Dockerfile.check-env ${TESTSDIR}/bud/env
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test
+  run_buildah build $WITH_POLICY_JSON -t test -f Dockerfile.check-env ${TESTSDIR}/bud/env
+  run_buildah from --quiet $WITH_POLICY_JSON test
   cid=$output
   run_buildah config --env random=hello,goodbye ${cid}
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json ${cid} test1
+  run_buildah commit $WITH_POLICY_JSON ${cid} test1
   run_buildah inspect --format '{{index .Docker.ContainerConfig.Env 1}}' test1
   expect_output "foo=bar"
   run_buildah inspect --format '{{index .Docker.ContainerConfig.Env 2}}' test1
@@ -493,14 +493,14 @@ _EOF
 
 @test "bud-from-scratch" {
   target=scratch-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah from ${target}
   expect_output "${target}-working-container"
 }
 
 @test "bud-with-unlimited-memory-swap" {
   target=scratch-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --memory-swap -1 -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build $WITH_POLICY_JSON --memory-swap -1 -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah rmi -f ${target}
 }
 
@@ -515,11 +515,11 @@ RUN echo world
 _EOF
 
   # This should do a fresh build and just populate build cache
-  run_buildah build --layers --signature-policy ${TESTSDIR}/policy.json -t test -f $mytmpdir/Containerfile .
+  run_buildah build --layers $WITH_POLICY_JSON -t test -f $mytmpdir/Containerfile .
   # This should also do a fresh build and just populate build cache
-  run_buildah build --no-cache --layers --signature-policy ${TESTSDIR}/policy.json -t test -f $mytmpdir/Containerfile .
+  run_buildah build --no-cache --layers $WITH_POLICY_JSON -t test -f $mytmpdir/Containerfile .
   # This should use everything from build cache
-  run_buildah build --layers --signature-policy ${TESTSDIR}/policy.json -t test -f $mytmpdir/Containerfile .
+  run_buildah build --layers $WITH_POLICY_JSON -t test -f $mytmpdir/Containerfile .
   expect_output --substring "Using cache"
 
 }
@@ -535,7 +535,7 @@ ENV foo="bar"
 ENV container="buildah"
 _EOF
   target=unsetenv-image
-  run_buildah build --unsetenv PATH --signature-policy ${TESTSDIR}/policy.json -t oci-${target} -f $mytmpdir/Containerfile .
+  run_buildah build --unsetenv PATH $WITH_POLICY_JSON -t oci-${target} -f $mytmpdir/Containerfile .
   run_buildah inspect --type=image --format '{{.OCIv1.Config.Env}}' oci-${target}
   expect_output "[date=today foo=bar container=buildah]" "No Path should be defined"
   run_buildah inspect --type=image --format '{{.Docker.Config.Env}}' oci-${target}
@@ -544,7 +544,7 @@ _EOF
 FROM oci-${target}
 ENV date="tomorrow"
 _EOF
-  run_buildah build --format docker --unsetenv PATH --unsetenv foo --signature-policy ${TESTSDIR}/policy.json -t docker-${target} -f $mytmpdir/Containerfile .
+  run_buildah build --format docker --unsetenv PATH --unsetenv foo $WITH_POLICY_JSON -t docker-${target} -f $mytmpdir/Containerfile .
   run_buildah inspect --type=image --format '{{.OCIv1.Config.Env}}' docker-${target}
   expect_output "[container=buildah date=tomorrow]" "No Path should be defined"
   run_buildah inspect --type=image --format '{{.Docker.Config.Env}}' docker-${target}
@@ -552,7 +552,7 @@ _EOF
 }
 
 @test "bud-from-scratch-untagged" {
-  run_buildah build --iidfile ${TESTDIR}/output.iid --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/from-scratch
+  run_buildah build --iidfile ${TESTDIR}/output.iid $WITH_POLICY_JSON ${TESTSDIR}/bud/from-scratch
   iid=$(cat ${TESTDIR}/output.iid)
   expect_output --substring --from="$iid" '^sha256:[0-9a-f]{64}$'
   run_buildah from ${iid}
@@ -569,26 +569,26 @@ _EOF
 
 @test "bud with --tag " {
   target=scratch-image
-  run_buildah build --quiet=false --tag test1 --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --quiet=false --tag test1 $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   expect_output --substring "Successfully tagged localhost/test1:latest"
 
-  run_buildah build --quiet=false --tag test1 --tag test2 --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --quiet=false --tag test1 --tag test2 $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   expect_output --substring "Successfully tagged localhost/test1:latest"
   expect_output --substring "Successfully tagged localhost/test2:latest"
 }
 
 @test "bud with bad --tag " {
   target=scratch-image
-  run_buildah 125 build --quiet=false --tag TEST1 --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build --quiet=false --tag TEST1 $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   expect_output --substring "tag TEST1: invalid reference format: repository name must be lowercase"
 
-  run_buildah 125 build --quiet=false --tag test1 --tag TEST2 --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build --quiet=false --tag test1 --tag TEST2 $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   expect_output --substring "tag TEST2: invalid reference format: repository name must be lowercase"
 }
 
 @test "bud-from-scratch-iid" {
   target=scratch-image
-  run_buildah build --iidfile ${TESTDIR}/output.iid --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --iidfile ${TESTDIR}/output.iid $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   iid=$(cat ${TESTDIR}/output.iid)
   expect_output --substring --from="$iid" '^sha256:[0-9a-f]{64}$'
   run_buildah from ${iid}
@@ -602,7 +602,7 @@ _EOF
   want_output='map["io.buildah.version":"'$buildah_version'" "test":"label"]'
 
   target=scratch-image
-  run_buildah build --label "test=label" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --label "test=label" $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output "$want_output"
 }
@@ -614,29 +614,29 @@ _EOF
   want_output='map["io.buildah.version":"'$buildah_version'"]'
 
   target=scratch-image
-  run_buildah build --label "io.buildah.version=oldversion" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --label "io.buildah.version=oldversion" $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output "$want_output"
 }
 
 @test "bud-from-scratch-remove-identity-label" {
   target=scratch-image
-  run_buildah build --identity-label=false --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --identity-label=false $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output "map[]"
 }
 
 @test "bud-from-scratch-annotation" {
   target=scratch-image
-  run_buildah build --annotation "test=annotation1,annotation2=z" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build --annotation "test=annotation1,annotation2=z" $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah inspect --format '{{index .ImageAnnotations "test"}}' ${target}
   expect_output "annotation1,annotation2=z"
 }
 
 @test "bud-from-scratch-layers" {
   target=scratch-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -f  ${TESTSDIR}/bud/from-scratch/Containerfile2 -t ${target} ${TESTSDIR}/bud/from-scratch
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -f  ${TESTSDIR}/bud/from-scratch/Containerfile2 -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build $WITH_POLICY_JSON -f  ${TESTSDIR}/bud/from-scratch/Containerfile2 -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build $WITH_POLICY_JSON -f  ${TESTSDIR}/bud/from-scratch/Containerfile2 -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah images
@@ -647,7 +647,7 @@ _EOF
 
 @test "bud-from-multiple-files-one-from" {
   target=scratch-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch -f ${TESTSDIR}/bud/from-multiple-files/Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -660,7 +660,7 @@ _EOF
 
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1.alpine -f Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile1.alpine -f Dockerfile2.nofrom ${TESTSDIR}/bud/from-multiple-files
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -673,7 +673,7 @@ _EOF
 @test "bud-from-multiple-files-two-froms" {
   _prefetch alpine
   target=scratch-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1.scratch -f Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile1.scratch -f Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -686,7 +686,7 @@ _EOF
 
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1.alpine -f Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile1.alpine -f Dockerfile2.withfrom ${TESTSDIR}/bud/from-multiple-files
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -699,7 +699,7 @@ _EOF
 @test "bud-multi-stage-builds" {
   _prefetch alpine
   target=multi-stage-index
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -711,7 +711,7 @@ _EOF
 
   _prefetch alpine
   target=multi-stage-name
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -722,7 +722,7 @@ _EOF
   run_buildah rmi -a
 
   target=multi-stage-mixed
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -735,7 +735,7 @@ _EOF
 @test "bud-multi-stage-builds-small-as" {
   _prefetch alpine
   target=multi-stage-index
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.index ${TESTSDIR}/bud/multi-stage-builds-small-as
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -747,7 +747,7 @@ _EOF
 
   _prefetch alpine
   target=multi-stage-name
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds-small-as
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -758,7 +758,7 @@ _EOF
   run_buildah rmi -a
 
   target=multi-stage-mixed
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds-small-as
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds-small-as/Dockerfile.mixed ${TESTSDIR}/bud/multi-stage-builds-small-as
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -774,7 +774,7 @@ _EOF
 
   _prefetch alpine
   target=volume-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/preserve-volumes
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/preserve-volumes
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -807,7 +807,7 @@ function _test_http() {
 
   starthttpd "${TESTSDIR}/bud/$testdir"
   target=scratch-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json \
+  run_buildah build $WITH_POLICY_JSON \
 	      -t ${target} \
 	      "$@"         \
 	      http://0.0.0.0:${HTTP_SERVER_PORT}/$urlpath
@@ -841,7 +841,7 @@ function _test_http() {
     skip "error running git daemon"
   fi
   gitrepo=git://localhost:${GITPORT}/repo
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} "${gitrepo}"
+  run_buildah build $WITH_POLICY_JSON -t ${target} "${gitrepo}"
   run_buildah from ${target}
 }
 
@@ -853,7 +853,7 @@ function _test_http() {
   fi
   target=giturl-image
   gitrepo=git:///tmp/no-such-repository
-  run_buildah 128 build --signature-policy ${TESTSDIR}/policy.json -t ${target} "${gitrepo}"
+  run_buildah 128 build $WITH_POLICY_JSON -t ${target} "${gitrepo}"
   # Expect part of what git would have told us... before things went horribly wrong
   expect_output --substring "Cloning into '"
 }
@@ -862,7 +862,7 @@ function _test_http() {
   target=github-image
   # Any repo should do, but this one is small and is FROM: scratch.
   gitrepo=github.com/projectatomic/nulecule-library
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} "${gitrepo}"
+  run_buildah build $WITH_POLICY_JSON -t ${target} "${gitrepo}"
   run_buildah from ${target}
 }
 
@@ -870,15 +870,15 @@ function _test_http() {
   target=scratch-image
   target2=another-scratch-image
   target3=so-many-scratch-images
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -t docker.io/${target2} -t ${target3} ${TESTSDIR}/bud/from-scratch
+  run_buildah build $WITH_POLICY_JSON -t ${target} -t docker.io/${target2} -t ${target3} ${TESTSDIR}/bud/from-scratch
   run_buildah images
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah rm ${cid}
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json library/${target2}
+  run_buildah from --quiet $WITH_POLICY_JSON library/${target2}
   cid=$output
   run_buildah rm ${cid}
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target3}:latest
+  run_buildah from --quiet $WITH_POLICY_JSON ${target3}:latest
   run_buildah rm $output
 
   run_buildah rmi $target3 $target2 $target
@@ -895,8 +895,8 @@ function _test_http() {
   target2=another-tagged-image
   target3=yet-another-tagged-image
   target4=still-another-tagged-image
-  run_buildah build --layers --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/addtl-tags
-  run_buildah build --layers --signature-policy ${TESTSDIR}/policy.json -t ${target2} -t ${target3} -t ${target4} ${TESTSDIR}/bud/addtl-tags
+  run_buildah build --layers $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/addtl-tags
+  run_buildah build --layers $WITH_POLICY_JSON -t ${target2} -t ${target3} -t ${target4} ${TESTSDIR}/bud/addtl-tags
   run_buildah inspect -f '{{.FromImageID}}' busybox
   busyboxid="$output"
   run_buildah inspect -f '{{.FromImageID}}' ${target}
@@ -916,8 +916,8 @@ function _test_http() {
 
   _prefetch alpine
   target=volume-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/volume-perms
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/volume-perms
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
@@ -933,8 +933,8 @@ function _test_http() {
 
   _prefetch alpine
   target=volume-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/volume-ownership
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/volume-ownership
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah run $cid stat -c "%U %G" /vol/subvol
   expect_output "testuser testgroup"
@@ -946,15 +946,15 @@ function _test_http() {
 
   _prefetch alpine
   target=volume-symlink
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/volume-symlink
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/volume-symlink
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah run $cid echo hello
   expect_output "hello"
 
   target=volume-no-symlink
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/volume-symlink/Dockerfile.no-symlink ${TESTSDIR}/bud/volume-symlink
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/volume-symlink/Dockerfile.no-symlink ${TESTSDIR}/bud/volume-symlink
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah run $cid echo hello
   expect_output "hello"
@@ -963,8 +963,8 @@ function _test_http() {
 @test "bud-from-glob" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile2.glob ${TESTSDIR}/bud/from-multiple-files
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile2.glob ${TESTSDIR}/bud/from-multiple-files
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
@@ -975,7 +975,7 @@ function _test_http() {
 @test "bud-maintainer" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/maintainer
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/maintainer
   run_buildah inspect --type=image --format '{{.Docker.Author}}' ${target}
   expect_output "kilroy"
   run_buildah inspect --type=image --format '{{.OCIv1.Author}}' ${target}
@@ -985,17 +985,17 @@ function _test_http() {
 @test "bud-unrecognized-instruction" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/unrecognized
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/unrecognized
   expect_output --substring "BOGUS"
 }
 
 @test "bud-shell" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/shell
+  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/shell
   run_buildah inspect --type=image --format '{{printf "%q" .Docker.Config.Shell}}' ${target}
   expect_output '["/bin/sh" "-c"]' ".Docker.Config.Shell (original)"
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
   ctr=$output
   run_buildah config --shell "/bin/bash -c" ${ctr}
   run_buildah inspect --type=container --format '{{printf "%q" .Docker.Config.Shell}}' ${ctr}
@@ -1005,36 +1005,36 @@ function _test_http() {
 @test "bud-shell during build in Docker format" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
+  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/sh"
 }
 
 @test "bud-shell during build in OCI format" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-default ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/sh"
 }
 
 @test "bud-shell changed during build in Docker format" {
   _prefetch ubuntu
   target=ubuntu-image
-  run_buildah build --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
+  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL=/bin/bash"
 }
 
 @test "bud-shell changed during build in OCI format" {
   _prefetch ubuntu
   target=ubuntu-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/shell/Dockerfile.build-shell-custom ${TESTSDIR}/bud/shell
   expect_output --substring "SHELL is not supported for OCI image format, \[/bin/bash -c\] will be ignored."
 }
 
 @test "bud with symlinks" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/symlink
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/symlink
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
@@ -1052,8 +1052,8 @@ function _test_http() {
 @test "bud with symlinks to relative path" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.relative-symlink ${TESTSDIR}/bud/symlink
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.relative-symlink ${TESTSDIR}/bud/symlink
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
@@ -1070,8 +1070,8 @@ function _test_http() {
 @test "bud with multiple symlinks in a path" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.multiple-symlinks ${TESTSDIR}/bud/symlink
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.multiple-symlinks ${TESTSDIR}/bud/symlink
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
@@ -1096,15 +1096,15 @@ function _test_http() {
 @test "bud with multiple symlink pointing to itself" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.symlink-points-to-itself ${TESTSDIR}/bud/symlink
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/symlink/Dockerfile.symlink-points-to-itself ${TESTSDIR}/bud/symlink
   assert "$output" =~ "error building .* open /test-log/test: too many levels of symbolic links"
 }
 
 @test "bud multi-stage with symlink to absolute path" {
   _prefetch ubuntu
   target=ubuntu-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.absolute-symlink ${TESTSDIR}/bud/symlink
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.absolute-symlink ${TESTSDIR}/bud/symlink
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
@@ -1120,8 +1120,8 @@ function _test_http() {
 @test "bud multi-stage with dir symlink to absolute path" {
   _prefetch ubuntu
   target=ubuntu-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.absolute-dir-symlink ${TESTSDIR}/bud/symlink
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.absolute-dir-symlink ${TESTSDIR}/bud/symlink
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
   cid=$output
   run_buildah mount ${cid}
   root=$output
@@ -1133,15 +1133,15 @@ function _test_http() {
 @test "bud with ENTRYPOINT and RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.entrypoint-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.entrypoint-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "unique.test.string"
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
 }
 
 @test "bud with ENTRYPOINT and empty RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 2 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.entrypoint-empty-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah 2 bud $WITH_POLICY_JSON -t ${target} -f Dockerfile.entrypoint-empty-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring " -c requires an argument"
   expect_output --substring "error building at STEP.*: exit status 2"
 }
@@ -1149,15 +1149,15 @@ function _test_http() {
 @test "bud with CMD and RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.cmd-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.cmd-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "unique.test.string"
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
 }
 
 @test "bud with CMD and empty RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 2 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.cmd-empty-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah 2 bud $WITH_POLICY_JSON -t ${target} -f Dockerfile.cmd-empty-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring " -c requires an argument"
   expect_output --substring "error building at STEP.*: exit status 2"
 }
@@ -1165,15 +1165,15 @@ function _test_http() {
 @test "bud with ENTRYPOINT, CMD and RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "unique.test.string"
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah from $WITH_POLICY_JSON ${target}
 }
 
 @test "bud with ENTRYPOINT, CMD and empty RUN" {
   _prefetch alpine
   target=alpine-image
-  run_buildah 2 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-empty-run ${TESTSDIR}/bud/run-scenarios
+  run_buildah 2 bud $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/run-scenarios/Dockerfile.entrypoint-cmd-empty-run ${TESTSDIR}/bud/run-scenarios
   expect_output --substring " -c requires an argument"
   expect_output --substring "error building at STEP.*: exit status 2"
 }
@@ -1182,9 +1182,9 @@ function _test_http() {
 @test "bud access ENV variable defined in same source file" {
   _prefetch alpine
   target=env-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/env/Dockerfile.env-same-file ${TESTSDIR}/bud/env
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/env/Dockerfile.env-same-file ${TESTSDIR}/bud/env
   expect_output --substring ":unique.test.string:"
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah from $WITH_POLICY_JSON ${target}
 }
 
 # Determines if a variable set with ENV in an image is available to commands in downstream Dockerfile
@@ -1192,8 +1192,8 @@ function _test_http() {
   _prefetch alpine
   from_target=env-from-image
   target=env-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${from_target} -f ${TESTSDIR}/bud/env/Dockerfile.env-same-file ${TESTSDIR}/bud/env
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/env/Dockerfile.env-from-image ${TESTSDIR}/bud/env
+  run_buildah build $WITH_POLICY_JSON -t ${from_target} -f ${TESTSDIR}/bud/env/Dockerfile.env-same-file ${TESTSDIR}/bud/env
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/env/Dockerfile.env-from-image ${TESTSDIR}/bud/env
   expect_output --substring "@unique.test.string@"
   run_buildah from --quiet ${from_target}
   from_cid=$output
@@ -1203,7 +1203,7 @@ function _test_http() {
 @test "bud ENV preserves special characters after commit" {
   _prefetch ubuntu
   from_target=special-chars
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${from_target} -f ${TESTSDIR}/bud/env/Dockerfile.special-chars ${TESTSDIR}/bud/env
+  run_buildah build $WITH_POLICY_JSON -t ${from_target} -f ${TESTSDIR}/bud/env/Dockerfile.special-chars ${TESTSDIR}/bud/env
   run_buildah from --quiet ${from_target}
   cid=$output
   run_buildah run ${cid} env
@@ -1213,77 +1213,77 @@ function _test_http() {
 @test "bud with Dockerfile from valid URL" {
   target=url-image
   url=https://raw.githubusercontent.com/containers/buildah/main/tests/bud/from-scratch/Dockerfile
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${url}
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${url}
   run_buildah from ${target}
 }
 
 @test "bud with Dockerfile from invalid URL" {
   target=url-image
   url=https://raw.githubusercontent.com/containers/buildah/main/tests/bud/from-scratch/Dockerfile.bogus
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${url}
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} ${url}
   expect_output "no FROM statement found"
 }
 
 # When provided with a -f flag and directory, buildah will look for the alternate Dockerfile name in the supplied directory
 @test "bud with -f flag, alternate Dockerfile name" {
   target=fileflag-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
   run_buildah from ${target}
 }
 
 # Following flags are configured to result in noop but should not affect buildah bud behavior
 @test "bud with --cache-from noop flag" {
   target=noop-image
-  run_buildah build --cache-from=invalidimage --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
+  run_buildah build --cache-from=invalidimage $WITH_POLICY_JSON -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
   run_buildah from ${target}
 }
 
 @test "bud with --compress noop flag" {
   target=noop-image
-  run_buildah build --compress --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
+  run_buildah build --compress $WITH_POLICY_JSON -t ${target} -f Dockerfile.noop-flags ${TESTSDIR}/bud/run-scenarios
   run_buildah from ${target}
 }
 
 @test "bud with --cpu-shares flag, no argument" {
   target=bud-flag
-  run_buildah 125 build --cpu-shares --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build --cpu-shares $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
   expect_output --substring "invalid argument .* invalid syntax"
 }
 
 @test "bud with --cpu-shares flag, invalid argument" {
   target=bud-flag
-  run_buildah 125 build --cpu-shares bogus --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build --cpu-shares bogus $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
   expect_output --substring "invalid argument \"bogus\" for "
 }
 
 @test "bud with --cpu-shares flag, valid argument" {
   target=bud-flag
-  run_buildah build --cpu-shares 2 --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah build --cpu-shares 2 $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
   run_buildah from ${target}
 }
 
 @test "bud with --cpu-shares short flag (-c), no argument" {
   target=bud-flag
-  run_buildah 125 build -c --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build -c $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
   expect_output --substring "invalid argument .* invalid syntax"
 }
 
 @test "bud with --cpu-shares short flag (-c), invalid argument" {
   target=bud-flag
-  run_buildah 125 build -c bogus --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build -c bogus $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/from-scratch/Containerfile ${TESTSDIR}/bud/from-scratch
   expect_output --substring "invalid argument \"bogus\" for "
 }
 
 @test "bud with --cpu-shares short flag (-c), valid argument" {
   target=bud-flag
-  run_buildah build -c 2 --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build -c 2 $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah from ${target}
 }
 
 @test "bud-onbuild" {
   _prefetch alpine
   target=onbuild
-  run_buildah build --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/onbuild
+  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild1" "RUN touch /onbuild2"]'
   run_buildah from --quiet ${target}
@@ -1298,7 +1298,7 @@ function _test_http() {
   run_buildah rm ${cid}
 
   target=onbuild-image2
-  run_buildah build --format docker --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile1 ${TESTSDIR}/bud/onbuild
+  run_buildah build --format docker $WITH_POLICY_JSON -t ${target} -f Dockerfile1 ${TESTSDIR}/bud/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild3"]'
   run_buildah from --quiet ${target}
@@ -1314,7 +1314,7 @@ function _test_http() {
   run_buildah config --onbuild "RUN touch /onbuild4" ${cid}
 
   target=onbuild-image3
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --format docker ${cid} ${target}
+  run_buildah commit $WITH_POLICY_JSON --format docker ${cid} ${target}
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild4"]'
 }
@@ -1322,7 +1322,7 @@ function _test_http() {
 @test "bud-onbuild-layers" {
   _prefetch alpine
   target=onbuild
-  run_buildah build --format docker --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile2 ${TESTSDIR}/bud/onbuild
+  run_buildah build --format docker $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile2 ${TESTSDIR}/bud/onbuild
   run_buildah inspect --format '{{printf "%q" .Docker.Config.OnBuild}}' ${target}
   expect_output '["RUN touch /onbuild1" "RUN touch /onbuild2"]'
 }
@@ -1330,24 +1330,24 @@ function _test_http() {
 @test "bud-logfile" {
   _prefetch alpine
   rm -f ${TESTDIR}/logfile
-  run_buildah build --logfile ${TESTDIR}/logfile --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/preserve-volumes
+  run_buildah build --logfile ${TESTDIR}/logfile $WITH_POLICY_JSON ${TESTSDIR}/bud/preserve-volumes
   test -s ${TESTDIR}/logfile
 }
 
 @test "bud with ARGS" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.args ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.args ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "arg_value"
 }
 
 @test "bud with unused ARGS" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "USED_VALUE"
   [[ ! "$output" =~ "one or more build args were not consumed: [UNUSED_ARG]" ]]
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE --build-arg UNUSED_ARG=whaaaat ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=USED_VALUE --build-arg UNUSED_ARG=whaaaat ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "USED_VALUE"
   expect_output --substring "one or more build args were not consumed: \[UNUSED_ARG\]"
 }
@@ -1355,7 +1355,7 @@ function _test_http() {
 @test "bud with multi-value ARGS" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=plugin1,plugin2,plugin3 ${TESTSDIR}/bud/run-scenarios
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile.multi-args --build-arg USED_ARG=plugin1,plugin2,plugin3 ${TESTSDIR}/bud/run-scenarios
   expect_output --substring "plugin1,plugin2,plugin3"
    if [[ "$output" =~ "one or more build args were not consumed" ]]; then
       expect_output "[not expecting to see 'one or more build args were not consumed']"
@@ -1364,7 +1364,7 @@ function _test_http() {
 
 @test "bud-from-stdin" {
   target=scratch-image
-  cat ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch | run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f - ${TESTSDIR}/bud/from-multiple-files
+  cat ${TESTSDIR}/bud/from-multiple-files/Dockerfile1.scratch | run_buildah build $WITH_POLICY_JSON -t ${target} -f - ${TESTSDIR}/bud/from-multiple-files
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -1375,18 +1375,18 @@ function _test_http() {
 @test "bud with preprocessor" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Decomposed.in ${TESTSDIR}/bud/preprocess
+  run_buildah build -q $WITH_POLICY_JSON -t ${target} -f Decomposed.in ${TESTSDIR}/bud/preprocess
 }
 
 @test "bud with preprocessor error" {
   target=alpine-image
-  run_buildah 0 bud -q --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Error.in ${TESTSDIR}/bud/preprocess
+  run_buildah 0 bud -q $WITH_POLICY_JSON -t ${target} -f Error.in ${TESTSDIR}/bud/preprocess
   expect_output --substring "Ignoring <stdin>:5:2: error: #error"
 }
 
 @test "bud-with-rejected-name" {
   target=ThisNameShouldBeRejected
-  run_buildah 125 build -q --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah 125 build -q $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   expect_output --substring "must be lower"
 }
 
@@ -1394,7 +1394,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-chown
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/copy-chown
   expect_output --substring "user:2367 group:3267"
   run_buildah from --name ${ctrName} ${imgName}
   run_buildah run alpine-chown -- stat -c '%u' /tmp/copychown.txt
@@ -1410,7 +1410,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chmod
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json  -t ${imgName} -f ${TESTSDIR}/bud/copy-chmod/Dockerfile.combined ${TESTSDIR}/bud/copy-chmod
+  run_buildah build $WITH_POLICY_JSON  -t ${imgName} -f ${TESTSDIR}/bud/copy-chmod/Dockerfile.combined ${TESTSDIR}/bud/copy-chmod
   expect_output --substring "chmod:777 user:2367 group:3267"
 }
 
@@ -1418,7 +1418,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chmod
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json  -t ${imgName} -f ${TESTSDIR}/bud/add-chmod/Dockerfile.combined ${TESTSDIR}/bud/add-chmod
+  run_buildah build $WITH_POLICY_JSON  -t ${imgName} -f ${TESTSDIR}/bud/add-chmod/Dockerfile.combined ${TESTSDIR}/bud/add-chmod
   expect_output --substring "chmod:777 user:2367 group:3267"
 }
 
@@ -1426,7 +1426,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json --layers -t ${imgName} -f ${TESTSDIR}/bud/copy-chown/Dockerfile.bad ${TESTSDIR}/bud/copy-chown
+  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${imgName} -f ${TESTSDIR}/bud/copy-chown/Dockerfile.bad ${TESTSDIR}/bud/copy-chown
   expect_output --substring "COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image\|stage> flags"
 }
 
@@ -1434,7 +1434,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json -t ${imgName} -f ${TESTSDIR}/bud/copy-chown/Dockerfile.bad2 ${TESTSDIR}/bud/copy-chown
+  run_buildah 125 build $WITH_POLICY_JSON -t ${imgName} -f ${TESTSDIR}/bud/copy-chown/Dockerfile.bad2 ${TESTSDIR}/bud/copy-chown
   expect_output --substring "error looking up UID/GID for \":\": can't find uid for user"
 }
 
@@ -1442,7 +1442,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chmod
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-chmod
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/copy-chmod
   expect_output --substring "rwxrwxrwx"
   run_buildah from --name ${ctrName} ${imgName}
   run_buildah run alpine-chmod ls -l /tmp/copychmod.txt
@@ -1454,7 +1454,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chmod
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json --layers -t ${imgName} -f ${TESTSDIR}/bud/copy-chmod/Dockerfile.bad ${TESTSDIR}/bud/copy-chmod
+  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${imgName} -f ${TESTSDIR}/bud/copy-chmod/Dockerfile.bad ${TESTSDIR}/bud/copy-chmod
   expect_output --substring "COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image\|stage> flags"
 }
 
@@ -1462,7 +1462,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chmod
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-chmod
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/add-chmod
   expect_output --substring "rwxrwxrwx"
   run_buildah from --name ${ctrName} ${imgName}
   run_buildah run alpine-chmod ls -l /tmp/addchmod.txt
@@ -1474,7 +1474,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-chown
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/add-chown
   expect_output --substring "user:2367 group:3267"
   run_buildah from --name ${ctrName} ${imgName}
   run_buildah run alpine-chown -- stat -c '%u' /tmp/addchown.txt
@@ -1490,7 +1490,7 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chown
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json --layers -t ${imgName} -f ${TESTSDIR}/bud/add-chown/Dockerfile.bad ${TESTSDIR}/bud/add-chown
+  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${imgName} -f ${TESTSDIR}/bud/add-chown/Dockerfile.bad ${TESTSDIR}/bud/add-chown
   expect_output --substring "ADD only supports the --chmod=<permissions> and the --chown=<uid:gid> flags"
 }
 
@@ -1498,17 +1498,17 @@ function _test_http() {
   _prefetch alpine
   imgName=alpine-image
   ctrName=alpine-chmod
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json --layers -t ${imgName} -f ${TESTSDIR}/bud/add-chmod/Dockerfile.bad ${TESTSDIR}/bud/add-chmod
+  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${imgName} -f ${TESTSDIR}/bud/add-chmod/Dockerfile.bad ${TESTSDIR}/bud/add-chmod
   expect_output --substring "ADD only supports the --chmod=<permissions> and the --chown=<uid:gid> flags"
 }
 
 @test "bud with ADD file construct" {
   _prefetch busybox
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/add-file
+  run_buildah build $WITH_POLICY_JSON -t test1 ${TESTSDIR}/bud/add-file
   run_buildah images -a
   expect_output --substring "test1"
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test1
+  run_buildah from --quiet $WITH_POLICY_JSON test1
   ctr=$output
   run_buildah containers -a
   expect_output --substring "test1"
@@ -1521,7 +1521,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-create-absolute-path
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/copy-create-absolute-path
   expect_output --substring "permissions=755"
 
   run_buildah from --name ${ctrName} ${imgName}
@@ -1533,7 +1533,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/copy-create-relative-path
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/copy-create-relative-path
   expect_output --substring "permissions=755"
 
   run_buildah from --name ${ctrName} ${imgName}
@@ -1545,7 +1545,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-create-absolute-path
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/add-create-absolute-path
   expect_output --substring "permissions=755"
 
   run_buildah from --name ${ctrName} ${imgName}
@@ -1557,7 +1557,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${imgName} ${TESTSDIR}/bud/add-create-relative-path
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} ${TESTSDIR}/bud/add-create-relative-path
   expect_output --substring "permissions=755"
 
   run_buildah from --name ${ctrName} ${imgName}
@@ -1569,7 +1569,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.absolute -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
+  run_buildah build $WITH_POLICY_JSON -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.absolute -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
   expect_output --substring "permissions=755"
 
   run_buildah from --name ${ctrName} ${imgName}
@@ -1581,7 +1581,7 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.relative -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
+  run_buildah build $WITH_POLICY_JSON -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.relative -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
   expect_output --substring "permissions=755"
 
   run_buildah from --name ${ctrName} ${imgName}
@@ -1593,22 +1593,22 @@ function _test_http() {
   _prefetch ubuntu
   imgName=ubuntu-image
   ctrName=ubuntu-copy
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.invalid_from -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
+  run_buildah 125 build $WITH_POLICY_JSON -f ${TESTSDIR}/bud/copy-multistage-paths/Dockerfile.invalid_from -t ${imgName} ${TESTSDIR}/bud/copy-multistage-paths
   expect_output --substring "COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image\|stage> flags"
 }
 
 @test "bud COPY to root succeeds" {
   _prefetch ubuntu
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/copy-root
+  run_buildah build $WITH_POLICY_JSON ${TESTSDIR}/bud/copy-root
 }
 
 @test "bud with FROM AS construct" {
   _prefetch alpine
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
+  run_buildah build $WITH_POLICY_JSON -t test1 ${TESTSDIR}/bud/from-as
   run_buildah images -a
   expect_output --substring "test1"
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test1
+  run_buildah from --quiet $WITH_POLICY_JSON test1
   ctr=$output
   run_buildah containers -a
   expect_output --substring "test1"
@@ -1619,11 +1619,11 @@ function _test_http() {
 
 @test "bud with FROM AS construct with layers" {
   _prefetch alpine
-  run_buildah build --layers --signature-policy ${TESTSDIR}/policy.json -t test1 ${TESTSDIR}/bud/from-as
+  run_buildah build --layers $WITH_POLICY_JSON -t test1 ${TESTSDIR}/bud/from-as
   run_buildah images -a
   expect_output --substring "test1"
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test1
+  run_buildah from --quiet $WITH_POLICY_JSON test1
   ctr=$output
   run_buildah containers -a
   expect_output --substring "test1"
@@ -1634,14 +1634,14 @@ function _test_http() {
 
 @test "bud with FROM AS skip FROM construct" {
   _prefetch alpine
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t test1 -f ${TESTSDIR}/bud/from-as/Dockerfile.skip ${TESTSDIR}/bud/from-as
+  run_buildah build $WITH_POLICY_JSON -t test1 -f ${TESTSDIR}/bud/from-as/Dockerfile.skip ${TESTSDIR}/bud/from-as
   expect_output --substring "LOCAL=/1"
   expect_output --substring "LOCAL2=/2"
 
   run_buildah images -a
   expect_output --substring "test1"
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json test1
+  run_buildah from --quiet $WITH_POLICY_JSON test1
   ctr=$output
   run_buildah containers -a
   expect_output --substring "test1"
@@ -1658,38 +1658,38 @@ function _test_http() {
 @test "bud with symlink Dockerfile not specified in file" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/symlink ${TESTSDIR}/bud/symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/symlink ${TESTSDIR}/bud/symlink
   expect_output --substring "FROM alpine"
 }
 
 @test "bud with dir for file but no Dockerfile in dir" {
   target=alpine-image
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/empty-dir ${TESTSDIR}/bud/empty-dir
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/empty-dir ${TESTSDIR}/bud/empty-dir
   expect_output --substring "no such file or directory"
 }
 
 @test "bud with bad dir Dockerfile" {
   target=alpine-image
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/baddirname ${TESTSDIR}/baddirname
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/baddirname ${TESTSDIR}/baddirname
   expect_output --substring "no such file or directory"
 }
 
 @test "bud with ARG before FROM default value" {
   _prefetch busybox
   target=leading-args-default
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/leading-args/Dockerfile ${TESTSDIR}/bud/leading-args
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/leading-args/Dockerfile ${TESTSDIR}/bud/leading-args
 }
 
 @test "bud with ARG before FROM" {
   _prefetch busybox:musl
   target=leading-args
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg=VERSION=musl -f ${TESTSDIR}/bud/leading-args/Dockerfile ${TESTSDIR}/bud/leading-args
+  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg=VERSION=musl -f ${TESTSDIR}/bud/leading-args/Dockerfile ${TESTSDIR}/bud/leading-args
 }
 
 @test "bud-with-healthcheck" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --format docker ${TESTSDIR}/bud/healthcheck
+  run_buildah build $WITH_POLICY_JSON -t ${target} --format docker ${TESTSDIR}/bud/healthcheck
   run_buildah inspect -f '{{printf "%q" .Docker.Config.Healthcheck.Test}} {{printf "%d" .Docker.Config.Healthcheck.StartPeriod}} {{printf "%d" .Docker.Config.Healthcheck.Interval}} {{printf "%d" .Docker.Config.Healthcheck.Timeout}} {{printf "%d" .Docker.Config.Healthcheck.Retries}}' ${target}
   second=1000000000
   threeseconds=$(( 3 * $second ))
@@ -1701,9 +1701,9 @@ function _test_http() {
 @test "bud with unused build arg" {
   _prefetch alpine busybox
   target=busybox-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg foo=bar --build-arg foo2=bar2 -f ${TESTSDIR}/bud/build-arg ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg foo=bar --build-arg foo2=bar2 -f ${TESTSDIR}/bud/build-arg ${TESTSDIR}/bud/build-arg
   expect_output --substring "one or more build args were not consumed: \[foo2\]"
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg IMAGE=alpine -f ${TESTSDIR}/bud/build-arg/Dockerfile2 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg IMAGE=alpine -f ${TESTSDIR}/bud/build-arg/Dockerfile2 ${TESTSDIR}/bud/build-arg
   assert "$output" !~ "one or more build args were not consumed: \[IMAGE\]"
   expect_output --substring "FROM alpine"
 }
@@ -1711,10 +1711,10 @@ function _test_http() {
 @test "bud with copy-from and cache" {
   _prefetch busybox
   target=busybox-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers --iidfile ${TESTDIR}/iid1 -f ${TESTSDIR}/bud/copy-from/Dockerfile2 ${TESTSDIR}/bud/copy-from
+  run_buildah build $WITH_POLICY_JSON --layers --iidfile ${TESTDIR}/iid1 -f ${TESTSDIR}/bud/copy-from/Dockerfile2 ${TESTSDIR}/bud/copy-from
   cat ${TESTDIR}/iid1
   test -s ${TESTDIR}/iid1
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers --iidfile ${TESTDIR}/iid2 -f ${TESTSDIR}/bud/copy-from/Dockerfile2 ${TESTSDIR}/bud/copy-from
+  run_buildah build $WITH_POLICY_JSON --layers --iidfile ${TESTDIR}/iid2 -f ${TESTSDIR}/bud/copy-from/Dockerfile2 ${TESTSDIR}/bud/copy-from
   cat ${TESTDIR}/iid2
   test -s ${TESTDIR}/iid2
   cmp ${TESTDIR}/iid1 ${TESTDIR}/iid2
@@ -1723,9 +1723,9 @@ function _test_http() {
 @test "bud with copy-from in Dockerfile no prior FROM" {
   _prefetch busybox quay.io/libpod/testimage:20210610
   target=no-prior-from
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy-from ${TESTSDIR}/bud/copy-from
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/copy-from ${TESTSDIR}/bud/copy-from
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ${target}
+  run_buildah from --quiet $WITH_POLICY_JSON ${target}
   ctr=$output
   run_buildah mount ${ctr}
   mnt=$output
@@ -1738,7 +1738,7 @@ function _test_http() {
 @test "bud with copy-from with bad from flag in Dockerfile with --layers" {
   _prefetch busybox
   target=bad-from-flag
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile.bad ${TESTSDIR}/bud/copy-from
+  run_buildah 125 build $WITH_POLICY_JSON --layers -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile.bad ${TESTSDIR}/bud/copy-from
   expect_output --substring "COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image\|stage> flags"
 }
 
@@ -1746,11 +1746,11 @@ function _test_http() {
   _prefetch busybox
   target=busybox-derived
   target_mt=busybox-mt-derived
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile3 ${TESTSDIR}/bud/copy-from
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --jobs 4 -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile3 ${TESTSDIR}/bud/copy-from
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile3 ${TESTSDIR}/bud/copy-from
+  run_buildah build $WITH_POLICY_JSON --jobs 4 -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile3 ${TESTSDIR}/bud/copy-from
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile4 ${TESTSDIR}/bud/copy-from
-  run_buildah build --no-cache --signature-policy ${TESTSDIR}/policy.json --jobs 4 -t ${target_mt} -f ${TESTSDIR}/bud/copy-from/Dockerfile4 ${TESTSDIR}/bud/copy-from
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile4 ${TESTSDIR}/bud/copy-from
+  run_buildah build --no-cache $WITH_POLICY_JSON --jobs 4 -t ${target_mt} -f ${TESTSDIR}/bud/copy-from/Dockerfile4 ${TESTSDIR}/bud/copy-from
 
   run_buildah from  --quiet ${target}
   cid=$output
@@ -1769,14 +1769,14 @@ function _test_http() {
 @test "bud with copy-from referencing the current stage" {
   _prefetch busybox
   target=busybox-derived
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile2.bad ${TESTSDIR}/bud/copy-from
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/copy-from/Dockerfile2.bad ${TESTSDIR}/bud/copy-from
   expect_output --substring "COPY --from=build: no stage or image found with that name"
 }
 
 @test "bud-target" {
   _prefetch alpine ubuntu
   target=target
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --target mytarget ${TESTSDIR}/bud/target
+  run_buildah build $WITH_POLICY_JSON -t ${target} --target mytarget ${TESTSDIR}/bud/target
   expect_output --substring "\[1/2] STEP 1/2: FROM ubuntu:latest"
   expect_output --substring "\[2/2] STEP 1/2: FROM alpine:latest AS mytarget"
   run_buildah from --quiet ${target}
@@ -1789,15 +1789,15 @@ function _test_http() {
 
 @test "bud-no-target-name" {
   _prefetch alpine
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/maintainer
+  run_buildah build $WITH_POLICY_JSON ${TESTSDIR}/bud/maintainer
 }
 
 @test "bud-multi-stage-nocache-nocommit" {
   _prefetch alpine
   # pull the base image directly, so that we don't record it being written to local storage in the next step
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah pull $WITH_POLICY_JSON alpine
   # okay, build an image with two stages
-  run_buildah --log-level=debug bud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah --log-level=debug bud $WITH_POLICY_JSON -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.name ${TESTSDIR}/bud/multi-stage-builds
   # debug messages should only record us creating one new image: the one for the second stage, since we don't base anything on the first
   run grep "created new image ID" <<< "$output"
   expect_line_count 1
@@ -1807,9 +1807,9 @@ function _test_http() {
   skip "FIXME: Broken in CI right now"
   _prefetch alpine
   # first time through, quite normal
-  run_buildah build --layers -t base --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.rebase ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build --layers -t base $WITH_POLICY_JSON -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.rebase ${TESTSDIR}/bud/multi-stage-builds
   # second time through, everything should be cached, and we shouldn't create a container based on the final image
-  run_buildah --log-level=debug bud --layers -t base --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.rebase ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah --log-level=debug bud --layers -t base $WITH_POLICY_JSON -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.rebase ${TESTSDIR}/bud/multi-stage-builds
   # skip everything up through the final COMMIT step, and make sure we didn't log a "Container ID:" after it
   run sed '0,/COMMIT base/ d' <<< "$output"
   echo "$output" >&2
@@ -1822,10 +1822,10 @@ function _test_http() {
   _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/dest-symlink
   expect_output --substring "STEP 5/6: RUN ln -s "
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
+  run_buildah from $WITH_POLICY_JSON --name=${ctr} ${target}
   expect_output --substring ${ctr}
 
   run_buildah run ${ctr} ls -alF /etc/hbase
@@ -1839,10 +1839,10 @@ function _test_http() {
   _prefetch ubuntu
   target=ubuntu-image
   ctr=ubuntu-ctr
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dest-symlink-dangling
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/dest-symlink-dangling
   expect_output --substring "STEP 3/5: RUN ln -s "
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
+  run_buildah from $WITH_POLICY_JSON --name=${ctr} ${target}
   expect_output --substring ${ctr}
 
   run_buildah run ${ctr} ls -alF /src
@@ -1856,10 +1856,10 @@ function _test_http() {
   _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/workdir-symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/workdir-symlink
   expect_output --substring "STEP 3/6: RUN ln -sf "
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
+  run_buildah from $WITH_POLICY_JSON --name=${ctr} ${target}
   expect_output --substring ${ctr}
 
   run_buildah run ${ctr} ls -alF /tempest
@@ -1873,10 +1873,10 @@ function _test_http() {
   _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile-2 ${TESTSDIR}/bud/workdir-symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile-2 ${TESTSDIR}/bud/workdir-symlink
   expect_output --substring "STEP 2/6: RUN ln -sf "
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
+  run_buildah from $WITH_POLICY_JSON --name=${ctr} ${target}
   expect_output --substring ${ctr}
 
   run_buildah run ${ctr} ls -alF /tempest
@@ -1893,10 +1893,10 @@ function _test_http() {
   _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Dockerfile-3 ${TESTSDIR}/bud/workdir-symlink
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Dockerfile-3 ${TESTSDIR}/bud/workdir-symlink
   expect_output --substring "STEP 2/9: RUN ln -sf "
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name=${ctr} ${target}
+  run_buildah from $WITH_POLICY_JSON --name=${ctr} ${target}
   expect_output --substring ${ctr}
 
   run_buildah run ${ctr} ls -alF /tempest
@@ -1917,11 +1917,11 @@ function _test_http() {
   mkdir -p ${voldir}
 
   _prefetch alpine
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -v ${voldir}:/testdir ${TESTSDIR}/bud/mount
+  run_buildah build $WITH_POLICY_JSON -v ${voldir}:/testdir ${TESTSDIR}/bud/mount
   expect_output --substring "/testdir"
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -v ${voldir}:/testdir:rw ${TESTSDIR}/bud/mount
+  run_buildah build $WITH_POLICY_JSON -v ${voldir}:/testdir:rw ${TESTSDIR}/bud/mount
   expect_output --substring "/testdir"
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -v ${voldir}:/testdir:rw,z ${TESTSDIR}/bud/mount
+  run_buildah build $WITH_POLICY_JSON -v ${voldir}:/testdir:rw,z ${TESTSDIR}/bud/mount
   expect_output --substring "/testdir"
 }
 
@@ -1931,10 +1931,10 @@ function _test_http() {
 
   mkdir -p ${TESTDIR}/use-layers/subdir
   touch ${TESTDIR}/use-layers/subdir/file.txt
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers --iidfile ${TESTDIR}/iid1 -f Dockerfile.7 ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers --iidfile ${TESTDIR}/iid1 -f Dockerfile.7 ${TESTDIR}/use-layers
 
   touch ${TESTDIR}/use-layers/subdir/file.txt
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers --iidfile ${TESTDIR}/iid2 -f Dockerfile.7 ${TESTDIR}/use-layers
+  run_buildah build $WITH_POLICY_JSON --layers --iidfile ${TESTDIR}/iid2 -f Dockerfile.7 ${TESTDIR}/use-layers
 
   if [[ $(cat ${TESTDIR}/iid1) != $(cat ${TESTDIR}/iid2) ]]; then
     echo "Expected image id to not change after touching a file copied into the image" >&2
@@ -1972,14 +1972,14 @@ function _test_http() {
   cp ${TESTSDIR}/bud/symlink/Dockerfile.replace-symlink ${TESTDIR}/top/
   ln -s Dockerfile.replace-symlink ${TESTDIR}/top/symlink
   echo foo > ${TESTDIR}/top/.dockerignore
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/top/Dockerfile.replace-symlink ${TESTDIR}/top
+  run_buildah build $WITH_POLICY_JSON -f ${TESTDIR}/top/Dockerfile.replace-symlink ${TESTDIR}/top
 }
 
 @test "bud-copy-recurse" {
   mkdir -p ${TESTDIR}/recurse
   cp ${TESTSDIR}/bud/recurse/Dockerfile ${TESTDIR}/recurse
   echo foo > ${TESTDIR}/recurse/.dockerignore
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json ${TESTDIR}/recurse
+  run_buildah build $WITH_POLICY_JSON ${TESTDIR}/recurse
 }
 
 @test "bud copy with .dockerignore #1" {
@@ -2000,7 +2000,7 @@ COPY stuff /tmp/stuff
 RUN find /tmp/stuff -type f
 _EOF
 
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json ${mytmpdir}
+  run_buildah build -t testbud $WITH_POLICY_JSON ${mytmpdir}
   expect_output --substring "file1"
   expect_output --substring "file2"
   assert "$output" !~ "file3"
@@ -2022,14 +2022,14 @@ COPY stuff /tmp/stuff
 RUN find /tmp/stuff -type f
 _EOF
 
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json ${mytmpdir}
+  run_buildah build -t testbud $WITH_POLICY_JSON ${mytmpdir}
   assert "$output" !~ file1
   assert "$output" !~ file2
 }
 
 @test "bud-copy-workdir" {
   target=testimage
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/copy-workdir
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/copy-workdir
   run_buildah from ${target}
   cid="$output"
   run_buildah mount "${cid}"
@@ -2044,7 +2044,7 @@ _EOF
   _prefetch alpine
 
   target=testimage
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile.2 ${TESTSDIR}/bud/copy-workdir
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile.2 ${TESTSDIR}/bud/copy-workdir
   run_buildah from ${target}
   cid="$output"
   run_buildah mount "${cid}"
@@ -2056,48 +2056,48 @@ _EOF
 @test "bud-build-arg-cache" {
   _prefetch busybox alpine
   target=derived-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 ${TESTSDIR}/bud/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
   targetid="$output"
 
   # With build args, we should not find the previous build as a cached result. This will be true because there is a RUN command after all the ARG
   # commands in the containerfile, so this does not truly test if the ARG commands were using cache or not. There is a test for that case below.
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata ${TESTSDIR}/bud/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
   argsid="$output"
   assert "$argsid" != "$initialid" \
          ".FromImageID of test-img-2 ($argsid) == same as test-img, it should be different"
 
   # With build args, even in a different order, we should end up using the previous build as a cached result.
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata ${TESTSDIR}/bud/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
   expect_output "$argsid" "FromImageID of build 3"
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata --build-arg=UID=17122 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata --build-arg=UID=17122 ${TESTSDIR}/bud/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
   expect_output "$argsid" "FromImageID of build 4"
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=USERNAME=praiskup --build-arg=PGDATA=/pgdata --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend ${TESTSDIR}/bud/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
   expect_output "$argsid" "FromImageID of build 5"
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} -f Dockerfile3 --build-arg=PGDATA=/pgdata --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} -f Dockerfile3 --build-arg=PGDATA=/pgdata --build-arg=UID=17122 --build-arg=CODE=/copr/coprs_frontend --build-arg=USERNAME=praiskup ${TESTSDIR}/bud/build-arg
   run_buildah inspect -f '{{.FromImageID}}' ${target}
   expect_output "$argsid" "FromImageID of build 6"
 
   # If build-arg is specified via the command line and is different from the previous cached build, it should not use the cached layers.
   # Note, this containerfile does not have any RUN commands and we verify that the ARG steps are being rebuilt when a change is detected.
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test-img -f Dockerfile4 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t test-img -f Dockerfile4 ${TESTSDIR}/bud/build-arg
   run_buildah inspect -f '{{.FromImageID}}' test-img
   initialid="$output"
 
   # Build the same containerfile again and verify that the cached layers were used
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test-img-1 -f Dockerfile4 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t test-img-1 -f Dockerfile4 ${TESTSDIR}/bud/build-arg
   run_buildah inspect -f '{{.FromImageID}}' test-img-1
   expect_output "$initialid" "FromImageID of test-img-1 should match test-img"
 
   # Set the build-arg flag and verify that the cached layers are not used
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test-img-2 --build-arg TEST=foo -f Dockerfile4 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t test-img-2 --build-arg TEST=foo -f Dockerfile4 ${TESTSDIR}/bud/build-arg
   run_buildah inspect -f '{{.FromImageID}}' test-img-2
   argsid="$output"
   assert "$argsid" != "$initialid" \
@@ -2105,7 +2105,7 @@ _EOF
 
   # Set the build-arg via an ENV in the local environment and verify that the cached layers are not used
   export TEST=bar
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t test-img-3 --build-arg TEST -f Dockerfile4 ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON --layers -t test-img-3 --build-arg TEST -f Dockerfile4 ${TESTSDIR}/bud/build-arg
   run_buildah inspect -f '{{.FromImageID}}' test-img-3
   argsid="$output"
   assert "$argsid" != "$initialid" \
@@ -2115,7 +2115,7 @@ _EOF
 @test "bud test RUN with a privileged command" {
   _prefetch alpine
   target=alpinepriv
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/run-privd/Dockerfile ${TESTSDIR}/bud/run-privd
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/run-privd/Dockerfile ${TESTSDIR}/bud/run-privd
   expect_output --substring "[^:][^[:graph:]]COMMIT ${target}"
   run_buildah images -q
   expect_line_count 2
@@ -2130,7 +2130,7 @@ _EOF
   ln ${TESTDIR}/hardlinks/subdir/test1.txt ${TESTDIR}/hardlinks/subdir/test2.txt
   ln ${TESTDIR}/hardlinks/subdir/test2.txt ${TESTDIR}/hardlinks/test3.txt
   ln ${TESTDIR}/hardlinks/test3.txt ${TESTDIR}/hardlinks/test4.txt
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTDIR}/hardlinks
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTDIR}/hardlinks
   run_buildah from ${target}
   ctrid="$output"
   run_buildah mount "$ctrid"
@@ -2167,33 +2167,33 @@ _EOF
 
 @test "bud with specified context should fail if directory contains no Dockerfile" {
   DIR=$(mktemp -d)
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json "$DIR"
+  run_buildah 125 build $WITH_POLICY_JSON "$DIR"
   expect_output --substring "no such file or directory"
 }
 
 @test "bud with specified context should fail if assumed Dockerfile is a directory" {
   DIR=$(mktemp -d)
   mkdir -p "$DIR"/Dockerfile
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json "$DIR"
+  run_buildah 125 build $WITH_POLICY_JSON "$DIR"
   expect_output --substring "is not a file"
 }
 
 @test "bud with specified context should fail if context contains not-existing Dockerfile" {
   DIR=$(mktemp -d)
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json "$DIR"/Dockerfile
+  run_buildah 125 build $WITH_POLICY_JSON "$DIR"/Dockerfile
   expect_output --substring "no such file or directory"
 }
 
 @test "bud with specified context should succeed if context contains existing Dockerfile" {
   DIR=$(mktemp -d)
   echo "FROM alpine" > "$DIR"/Dockerfile
-  run_buildah 0 bud --signature-policy ${TESTSDIR}/policy.json "$DIR"/Dockerfile
+  run_buildah 0 bud $WITH_POLICY_JSON "$DIR"/Dockerfile
 }
 
 @test "bud with specified context should fail if context contains empty Dockerfile" {
   DIR=$(mktemp -d)
   touch "$DIR"/Dockerfile
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json "$DIR"/Dockerfile
+  run_buildah 125 build $WITH_POLICY_JSON "$DIR"/Dockerfile
   expect_output --substring "no contents in \"$DIR/Dockerfile\""
 }
 
@@ -2201,7 +2201,7 @@ _EOF
   _prefetch alpine
   parent=alpine
   target=no-change-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/no-change
   run_buildah inspect --format '{{printf "%q" .FromImageDigest}}' ${parent}
   parentid="$output"
   run_buildah inspect --format '{{printf "%q" .FromImageDigest}}' ${target}
@@ -2217,7 +2217,7 @@ _EOF
   _prefetch alpine
   parent=alpine
   target=no-change-image
-  run_buildah build --label "test=label" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
+  run_buildah build --label "test=label" $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/no-change
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output "$want_output"
 }
@@ -2225,19 +2225,19 @@ _EOF
 @test "bud-no-change-annotation" {
   _prefetch alpine
   target=no-change-image
-  run_buildah build --annotation "test=annotation" --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/no-change
+  run_buildah build --annotation "test=annotation" $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/no-change
   run_buildah inspect --format '{{index .ImageAnnotations "test"}}' ${target}
   expect_output "annotation"
 }
 
 @test "bud-squash-layers" {
   _prefetch alpine
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --squash ${TESTSDIR}/bud/layers-squash
+  run_buildah build $WITH_POLICY_JSON --squash ${TESTSDIR}/bud/layers-squash
 }
 
 @test "bud-squash-hardlinks" {
   _prefetch busybox
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --squash ${TESTSDIR}/bud/layers-squash/Dockerfile.hardlinks
+  run_buildah build $WITH_POLICY_JSON --squash ${TESTSDIR}/bud/layers-squash/Dockerfile.hardlinks
 }
 
 @test "bud with additional directory of devices" {
@@ -2249,14 +2249,14 @@ _EOF
   target=alpine-image
   mkdir -p ${TESTDIR}/foo
   mknod ${TESTDIR}/foo/null c 1 3
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --device ${TESTDIR}/foo:/dev/fuse  -t ${target} -f ${TESTSDIR}/bud/device/Dockerfile ${TESTSDIR}/bud/device
+  run_buildah build $WITH_POLICY_JSON --device ${TESTDIR}/foo:/dev/fuse  -t ${target} -f ${TESTSDIR}/bud/device/Dockerfile ${TESTSDIR}/bud/device
   expect_output --substring "null"
 }
 
 @test "bud with additional device" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --device /dev/fuse -t ${target} -f ${TESTSDIR}/bud/device/Dockerfile ${TESTSDIR}/bud/device
+  run_buildah build $WITH_POLICY_JSON --device /dev/fuse -t ${target} -f ${TESTSDIR}/bud/device/Dockerfile ${TESTSDIR}/bud/device
   [ "${status}" -eq 0 ]
   expect_output --substring "/dev/fuse"
 }
@@ -2264,7 +2264,7 @@ _EOF
 @test "bud with Containerfile" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/containerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 }
@@ -2272,7 +2272,7 @@ _EOF
 @test "bud with Containerfile.in" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/containerfile/Containerfile.in ${TESTSDIR}/bud/containerfile
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/containerfile/Containerfile.in ${TESTSDIR}/bud/containerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
   expect_output --substring "success"
@@ -2281,7 +2281,7 @@ _EOF
 @test "bud with Dockerfile" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/dockerfile
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/dockerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 }
@@ -2289,7 +2289,7 @@ _EOF
 @test "bud with Containerfile and Dockerfile" {
   _prefetch alpine
   target=alpine-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containeranddockerfile
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/containeranddockerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 }
@@ -2301,7 +2301,7 @@ _EOF
 @test "bud with Dockerfile from stdin" {
   _prefetch alpine
   target=df-stdin
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} - < ${TESTSDIR}/bud/context-from-stdin/Dockerfile
+  run_buildah build $WITH_POLICY_JSON -t ${target} - < ${TESTSDIR}/bud/context-from-stdin/Dockerfile
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -2319,7 +2319,7 @@ _EOF
   _prefetch alpine
   target=df-stdin
   # 'cmd1 < <(cmd2)' == 'cmd2 | cmd1' but runs cmd1 in this shell, not sub.
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} - < <(tar -c -C ${TESTSDIR}/bud/context-from-stdin .)
+  run_buildah build $WITH_POLICY_JSON -t ${target} - < <(tar -c -C ${TESTSDIR}/bud/context-from-stdin .)
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}
@@ -2337,21 +2337,21 @@ _EOF
   _prefetch alpine
   target=use-args
   touch ${TESTSDIR}/bud/use-args/abc.txt
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg=abc.txt ${TESTSDIR}/bud/use-args
+  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg=abc.txt ${TESTSDIR}/bud/use-args
   expect_output --substring "COMMIT use-args"
   run_buildah from --quiet ${target}
   ctrID=$output
   run_buildah run $ctrID ls abc.txt
   expect_output --substring "abc.txt"
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Containerfile.destination --build-arg=testArg=abc.txt --build-arg=destination=/tmp ${TESTSDIR}/bud/use-args
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Containerfile.destination --build-arg=testArg=abc.txt --build-arg=destination=/tmp ${TESTSDIR}/bud/use-args
   expect_output --substring "COMMIT use-args"
   run_buildah from --quiet ${target}
   ctrID=$output
   run_buildah run $ctrID ls /tmp/abc.txt
   expect_output --substring "abc.txt"
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} -f Containerfile.dest_nobrace --build-arg=testArg=abc.txt --build-arg=destination=/tmp ${TESTSDIR}/bud/use-args
+  run_buildah build $WITH_POLICY_JSON -t ${target} -f Containerfile.dest_nobrace --build-arg=testArg=abc.txt --build-arg=destination=/tmp ${TESTSDIR}/bud/use-args
   expect_output --substring "COMMIT use-args"
   run_buildah from --quiet ${target}
   ctrID=$output
@@ -2365,11 +2365,11 @@ _EOF
   if ! start_git_daemon ${TESTSDIR}/git-daemon/release-1.11-rhel.tar.gz ; then
     skip "error running git daemon"
   fi
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t gittarget -f ${TESTSDIR}/bud/shell/Dockerfile git://localhost:${GITPORT}/repo#release-1.11-rhel
+  run_buildah build $WITH_POLICY_JSON --layers -t gittarget -f ${TESTSDIR}/bud/shell/Dockerfile git://localhost:${GITPORT}/repo#release-1.11-rhel
 }
 
 @test "bud using gitrepo with .git and branch" {
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t gittarget -f ${TESTSDIR}/bud/shell/Dockerfile https://github.com/containers/buildah.git#release-1.11-rhel
+  run_buildah build $WITH_POLICY_JSON --layers -t gittarget -f ${TESTSDIR}/bud/shell/Dockerfile https://github.com/containers/buildah.git#release-1.11-rhel
 }
 
 # Fixes #1906: buildah was not detecting changed tarfile
@@ -2379,17 +2379,17 @@ _EOF
   target=copy-archive
   date > ${TESTSDIR}/bud/${target}/test
   tar -C $TESTSDIR -cJf ${TESTSDIR}/bud/${target}/test.tar.xz bud/${target}/test
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} ${TESTSDIR}/bud/${target}
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} ${TESTSDIR}/bud/${target}
   expect_output --substring "COMMIT copy-archive"
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} ${TESTSDIR}/bud/${target}
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} ${TESTSDIR}/bud/${target}
   expect_output --substring " Using cache"
   expect_output --substring "COMMIT copy-archive"
 
   # Now test that we do NOT use cache if the tar file changes
   echo This is a change >> ${TESTSDIR}/bud/${target}/test
   tar -C $TESTSDIR -cJf ${TESTSDIR}/bud/${target}/test.tar.xz bud/${target}/test
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t ${target} ${TESTSDIR}/bud/${target}
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target} ${TESTSDIR}/bud/${target}
   if [[ "$output" =~ " Using cache" ]]; then
       expect_output "[no instance of 'Using cache']" "no cache used"
   fi
@@ -2400,25 +2400,25 @@ _EOF
 
 @test "bud pull never" {
   target=pull
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull-never ${TESTSDIR}/bud/pull
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} --pull-never ${TESTSDIR}/bud/pull
   expect_output --substring "busybox: image not known"
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull ${TESTSDIR}/bud/pull
+  run_buildah build $WITH_POLICY_JSON -t ${target} --pull ${TESTSDIR}/bud/pull
   expect_output --substring "COMMIT pull"
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull=never ${TESTSDIR}/bud/pull
+  run_buildah build $WITH_POLICY_JSON -t ${target} --pull=never ${TESTSDIR}/bud/pull
   expect_output --substring "COMMIT pull"
 }
 
 @test "bud pull false no local image" {
   target=pull
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull=false ${TESTSDIR}/bud/pull
+  run_buildah build $WITH_POLICY_JSON -t ${target} --pull=false ${TESTSDIR}/bud/pull
   expect_output --substring "COMMIT pull"
 }
 
 @test "bud with Containerfile should fail with nonexistent authfile" {
   target=alpine-image
-  run_buildah 125 build --authfile /tmp/nonexistent --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
+  run_buildah 125 build --authfile /tmp/nonexistent $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/containerfile
   expect_output "checking authfile: stat /tmp/nonexistent: no such file or directory"
 }
 
@@ -2438,32 +2438,32 @@ FROM alpine:latest
 COPY https://getfedora.org/index.html .
 EOM
 
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json -t foo -f ${TESTDIR}/budcopy/Dockerfile.url
+  run_buildah 125 build $WITH_POLICY_JSON -t foo -f ${TESTDIR}/budcopy/Dockerfile.url
   expect_output --substring "error building .* source can.t be a URL for COPY"
 }
 
 @test "bud quiet" {
   _prefetch alpine
-  run_buildah build --format docker -t quiet-test --signature-policy ${TESTSDIR}/policy.json -q ${TESTSDIR}/bud/shell
+  run_buildah build --format docker -t quiet-test $WITH_POLICY_JSON -q ${TESTSDIR}/bud/shell
   expect_line_count 1
   expect_output --substring '^[0-9a-f]{64}$'
 }
 
 @test "bud COPY with Env Var in Containerfile" {
   _prefetch alpine
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t testctr ${TESTSDIR}/bud/copy-envvar
+  run_buildah build $WITH_POLICY_JSON -t testctr ${TESTSDIR}/bud/copy-envvar
   run_buildah from testctr
   run_buildah run testctr-working-container ls /file-0.0.1.txt
   run_buildah rm -a
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t testctr ${TESTSDIR}/bud/copy-envvar
+  run_buildah build $WITH_POLICY_JSON --layers -t testctr ${TESTSDIR}/bud/copy-envvar
   run_buildah from testctr
   run_buildah run testctr-working-container ls /file-0.0.1.txt
   run_buildah rm -a
 }
 
 @test "bud with custom arch" {
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json \
+  run_buildah build $WITH_POLICY_JSON \
     -f ${TESTSDIR}/bud/from-scratch/Containerfile \
     -t arch-test \
     --arch=arm
@@ -2476,7 +2476,7 @@ EOM
 }
 
 @test "bud with custom os" {
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json \
+  run_buildah build $WITH_POLICY_JSON \
     -f ${TESTSDIR}/bud/from-scratch/Containerfile \
     -t os-test \
     --os=windows
@@ -2489,7 +2489,7 @@ EOM
 }
 
 @test "bud with custom platform" {
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json \
+  run_buildah build $WITH_POLICY_JSON \
     -f ${TESTSDIR}/bud/from-scratch/Containerfile \
     -t platform-test \
     --platform=windows/arm
@@ -2508,7 +2508,7 @@ EOM
 }
 
 @test "bud with custom platform and empty os or arch" {
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json \
+  run_buildah build $WITH_POLICY_JSON \
     -f ${TESTSDIR}/bud/from-scratch/Containerfile \
     -t platform-test \
     --platform=windows/
@@ -2519,7 +2519,7 @@ EOM
   run_buildah inspect --format "{{ .OCIv1.OS }}" platform-test
   expect_output windows
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json \
+  run_buildah build $WITH_POLICY_JSON \
     -f ${TESTSDIR}/bud/from-scratch/Containerfile \
     -t platform-test2 \
     --platform=/arm
@@ -2533,14 +2533,14 @@ EOM
 
 @test "bud Add with linked tarball" {
   _prefetch alpine
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/symlink/Containerfile.add-tar-with-link -t testctr ${TESTSDIR}/bud/symlink
+  run_buildah build $WITH_POLICY_JSON -f ${TESTSDIR}/bud/symlink/Containerfile.add-tar-with-link -t testctr ${TESTSDIR}/bud/symlink
   run_buildah from testctr
   run_buildah run testctr-working-container ls /tmp/testdir/testfile.txt
   run_buildah rm -a
   run_buildah rmi -a -f
 
   _prefetch alpine
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/symlink/Containerfile.add-tar-gz-with-link -t testctr ${TESTSDIR}/bud/symlink
+  run_buildah build $WITH_POLICY_JSON -f ${TESTSDIR}/bud/symlink/Containerfile.add-tar-gz-with-link -t testctr ${TESTSDIR}/bud/symlink
   run_buildah from testctr
   run_buildah run testctr-working-container ls /tmp/testdir/testfile.txt
   run_buildah rm -a
@@ -2548,13 +2548,13 @@ EOM
 }
 
 @test "bud file above context directory" {
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json -t testctr ${TESTSDIR}/bud/context-escape-dir/testdir
+  run_buildah 125 build $WITH_POLICY_JSON -t testctr ${TESTSDIR}/bud/context-escape-dir/testdir
   expect_output --substring "escaping context directory error"
 }
 
 @test "bud-multi-stage-args-scope" {
   _prefetch alpine
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t multi-stage-args --build-arg SECRET=secretthings -f Dockerfile.arg ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON --layers -t multi-stage-args --build-arg SECRET=secretthings -f Dockerfile.arg ${TESTSDIR}/bud/multi-stage-builds
   run_buildah from --name test-container multi-stage-args
   run_buildah run test-container -- cat test_file
   expect_output ""
@@ -2562,7 +2562,7 @@ EOM
 
 @test "bud-multi-stage-args-history" {
   _prefetch alpine
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --layers -t multi-stage-args --build-arg SECRET=secretthings -f Dockerfile.arg ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build $WITH_POLICY_JSON --layers -t multi-stage-args --build-arg SECRET=secretthings -f Dockerfile.arg ${TESTSDIR}/bud/multi-stage-builds
   run_buildah inspect --format '{{range .History}}{{println .CreatedBy}}{{end}}' multi-stage-args
   run grep "secretthings" <<< "$output"
   expect_output ""
@@ -2583,22 +2583,22 @@ EOM
   openssl genrsa -out ${TESTDIR}/tmp/mykey2.pem 1024
   openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
   start_registry
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword --encryption-key jwe:${TESTDIR}/tmp/mykey.pub busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah push $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword --encryption-key jwe:${TESTDIR}/tmp/mykey.pub busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
 
   target=busybox-image
   echo FROM localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest > ${TESTDIR}/tmp/Dockerfile
 
   # Try to build from encrypted image without key
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json --tls-verify=false  --creds testuser:testpassword -t ${target} -f ${TESTDIR}/tmp/Dockerfile
+  run_buildah 125 build $WITH_POLICY_JSON --tls-verify=false  --creds testuser:testpassword -t ${target} -f ${TESTDIR}/tmp/Dockerfile
   assert "$output" =~ "missing private key needed for decryption"
 
   # Try to build from encrypted image with wrong key
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json --tls-verify=false  --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey2.pem -t ${target} -f ${TESTDIR}/tmp/Dockerfile
+  run_buildah 125 build $WITH_POLICY_JSON --tls-verify=false  --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey2.pem -t ${target} -f ${TESTDIR}/tmp/Dockerfile
   assert "$output" =~ "no suitable key found for decrypting layer key"
   assert "$output" =~ "- JWE: No suitable private key found for decryption"
 
   # Try to build with the correct key
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --tls-verify=false  --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey.pem -t ${target} -f ${TESTDIR}/tmp/Dockerfile
+  run_buildah build $WITH_POLICY_JSON --tls-verify=false  --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey.pem -t ${target} -f ${TESTDIR}/tmp/Dockerfile
   assert "$output" =~ "Successfully tagged localhost:$REGISTRY_PORT/"
 
   rm -rf ${TESTDIR}/tmp
@@ -2609,28 +2609,28 @@ EOM
   target=busybox-image
 
   # Envariable not present at all
-  run_buildah --log-level "warn" bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/build-arg
+  run_buildah --log-level "warn" bud $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/build-arg
   expect_output --substring 'missing \\"foo\\" build argument. Try adding'
 
   # Envariable explicitly set on command line
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg foo=bar ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg foo=bar ${TESTSDIR}/bud/build-arg
   assert "${lines[3]}" = "bar"
 
   # Envariable from environment
   export foo=$(random_string 20)
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} --build-arg foo ${TESTSDIR}/bud/build-arg
+  run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg foo ${TESTSDIR}/bud/build-arg
   assert "${lines[3]}" = "$foo"
 }
 
 @test "bud arg and env var with same name" {
   # Regression test for https://github.com/containers/buildah/issues/2345
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t testctr ${TESTSDIR}/bud/dupe-arg-env-name
+  run_buildah build $WITH_POLICY_JSON -t testctr ${TESTSDIR}/bud/dupe-arg-env-name
   expect_output --substring "https://example.org/bar"
 }
 
 @test "bud copy chown with newuser" {
   # Regression test for https://github.com/containers/buildah/issues/2192
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t testctr -f ${TESTSDIR}/bud/copy-chown/Containerfile.chown_user ${TESTSDIR}/bud/copy-chown
+  run_buildah build $WITH_POLICY_JSON -t testctr -f ${TESTSDIR}/bud/copy-chown/Containerfile.chown_user ${TESTSDIR}/bud/copy-chown
   expect_output --substring "myuser myuser"
 }
 
@@ -2638,7 +2638,7 @@ EOM
   _prefetch alpine
   parent=alpine
   target=no-change-image
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
   run_buildah --version
   local -a output_fields=($output)
   buildah_version=${output_fields[2]}
@@ -2654,7 +2654,7 @@ EOM
   _prefetch alpine
   _prefetch debian
 
-  run_buildah build --build-arg base=alpine --build-arg toolchainname=busybox --build-arg destinationpath=/tmp --pull=false --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/from-with-arg/Containerfile .
+  run_buildah build --build-arg base=alpine --build-arg toolchainname=busybox --build-arg destinationpath=/tmp --pull=false $WITH_POLICY_JSON -f ${TESTSDIR}/bud/from-with-arg/Containerfile .
   expect_output --substring "FROM alpine"
   expect_output --substring 'STEP 4/4: COPY --from=\$\{toolchainname\} \/ \$\{destinationpath\}'
   run_buildah rm -a
@@ -2663,7 +2663,7 @@ EOM
 @test "bud timestamp" {
   _prefetch alpine
   timestamp=40
-  run_buildah build --timestamp=${timestamp} --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
+  run_buildah build --timestamp=${timestamp} --quiet --pull=false $WITH_POLICY_JSON -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
   cid=$output
   run_buildah inspect --format '{{ .Docker.Created }}' timestamp
   expect_output --substring "1970-01-01"
@@ -2672,7 +2672,7 @@ EOM
   run_buildah inspect --format '{{ .History }}' timestamp
   expect_output --substring "1970-01-01 00:00:${timestamp}"
 
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json timestamp
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON timestamp
   cid=$output
   run_buildah run $cid ls -l /tmpfile
   expect_output --substring "1970"
@@ -2686,13 +2686,13 @@ EOM
 @test "bud timestamp compare" {
   _prefetch alpine
   TIMESTAMP=$(date '+%s')
-  run_buildah build --timestamp=${TIMESTAMP} --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
+  run_buildah build --timestamp=${TIMESTAMP} --quiet --pull=false $WITH_POLICY_JSON -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
   cid=$output
 
   run_buildah images --format "{{.Created}}" timestamp
   expect_output ${timestamp}
 
-  run_buildah build --timestamp=${TIMESTAMP} --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
+  run_buildah build --timestamp=${TIMESTAMP} --quiet --pull=false $WITH_POLICY_JSON -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
   expect_output "$cid"
 
   rm -rf ${TESTDIR}/tmp
@@ -2700,7 +2700,7 @@ EOM
 
 @test "bud with-rusage" {
   _prefetch alpine
-  run_buildah build --log-rusage --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/shell
+  run_buildah build --log-rusage --layers --pull=false --format docker $WITH_POLICY_JSON ${TESTSDIR}/bud/shell
   cid=$output
   # expect something that looks like it was formatted using pkg/rusage.FormatDiff()
   expect_output --substring ".*\(system\).*\(user\).*\(elapsed\).*input.*output"
@@ -2708,7 +2708,7 @@ EOM
 
 @test "bud with-rusage-logfile" {
   _prefetch alpine
-  run_buildah build --log-rusage --rusage-logfile ${TESTDIR}/foo.log --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/shell
+  run_buildah build --log-rusage --rusage-logfile ${TESTDIR}/foo.log --layers --pull=false --format docker $WITH_POLICY_JSON ${TESTSDIR}/bud/shell
   # the logfile should exist
   if [ ! -e ${TESTDIR}/foo.log ]; then die "rusage-logfile foo.log did not get created!"; fi
   # expect that foo.log only contains lines that were formatted using pkg/rusage.FormatDiff()
@@ -2722,51 +2722,51 @@ EOM
 @test "bud-caching-from-scratch" {
   _prefetch alpine
   # run the build once
-  run_buildah build --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON ${TESTSDIR}/bud/cache-scratch
   iid="$output"
 
   # now run it again - the cache should give us the same final image ID
-  run_buildah build --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON ${TESTSDIR}/bud/cache-scratch
   assert "$output" = "$iid"
 
   # now run it *again*, except with more content added at an intermediate step, which should invalidate the cache
-  run_buildah build --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.different1 ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.different1 ${TESTSDIR}/bud/cache-scratch
   assert "$output" !~ "$iid"
 
   # now run it *again* again, except with more content added at an intermediate step, which should invalidate the cache
-  run_buildah build --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.different2 ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.different2 ${TESTSDIR}/bud/cache-scratch
   assert "$output" !~ "$iid"
 }
 
 @test "bud-caching-from-scratch-config" {
   _prefetch alpine
   # run the build once
-  run_buildah build --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.config ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.config ${TESTSDIR}/bud/cache-scratch
   iid="$output"
 
   # now run it again - the cache should give us the same final image ID
-  run_buildah build --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.config ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.config ${TESTSDIR}/bud/cache-scratch
   assert "$output" = "$iid"
 
   # now run it *again*, except with more content added at an intermediate step, which should invalidate the cache
-  run_buildah build --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.different1 ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.different1 ${TESTSDIR}/bud/cache-scratch
   assert "$output" !~ "$iid"
 
   # now run it *again* again, except with more content added at an intermediate step, which should invalidate the cache
-  run_buildah build --quiet --layers --pull=false --format docker --signature-policy ${TESTSDIR}/policy.json -f Dockerfile.different2 ${TESTSDIR}/bud/cache-scratch
+  run_buildah build --quiet --layers --pull=false --format docker $WITH_POLICY_JSON -f Dockerfile.different2 ${TESTSDIR}/bud/cache-scratch
   assert "$output" !~ "$iid"
 }
 
 @test "bud capabilities test" {
   _prefetch busybox
   # something not enabled by default in containers.conf
-  run_buildah build --cap-add cap_sys_ptrace -t testcap --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/capabilities/Dockerfile
+  run_buildah build --cap-add cap_sys_ptrace -t testcap $WITH_POLICY_JSON -f ${TESTSDIR}/bud/capabilities/Dockerfile
   expect_output --substring "uid=3267"
   expect_output --substring "CapBnd:	00000000a80c25fb"
   expect_output --substring "CapEff:	0000000000000000"
 
   # some things enabled by default in containers.conf
-  run_buildah build --cap-drop cap_chown,cap_dac_override,cap_fowner -t testcapd --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/capabilities/Dockerfile
+  run_buildah build --cap-drop cap_chown,cap_dac_override,cap_fowner -t testcapd $WITH_POLICY_JSON -f ${TESTSDIR}/bud/capabilities/Dockerfile
   expect_output --substring "uid=3267"
   expect_output --substring "CapBnd:	00000000a80425f0"
   expect_output --substring "CapEff:	0000000000000000"
@@ -2789,23 +2789,23 @@ EOF
   # if 'buildah bud' was in cmdlist, everything past it would be lost.
   #
   # This is ugly but effective: it checks that buildah passes stdin untouched.
-  passthru=$(echo "$random_msg" | (run_buildah build --quiet --signature-policy ${TESTSDIR}/policy.json -t stdin-test ${ctxdir} >/dev/null; cat))
+  passthru=$(echo "$random_msg" | (run_buildah build --quiet $WITH_POLICY_JSON -t stdin-test ${ctxdir} >/dev/null; cat))
 
   expect_output --from="$passthru" "$random_msg" "stdin was passed through"
 }
 
 @test "bud cache by format" {
   # Build first in Docker format.  Whether we do OCI or Docker first shouldn't matter, so we picked one.
-  run_buildah build --iidfile ${TESTDIR}/first-docker  --format docker --layers --quiet --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/cache-format
+  run_buildah build --iidfile ${TESTDIR}/first-docker  --format docker --layers --quiet $WITH_POLICY_JSON ${TESTSDIR}/bud/cache-format
 
   # Build in OCI format.  Cache should not re-use the same images, so we should get a different image ID.
-  run_buildah build --iidfile ${TESTDIR}/first-oci     --format oci    --layers --quiet --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/cache-format
+  run_buildah build --iidfile ${TESTDIR}/first-oci     --format oci    --layers --quiet $WITH_POLICY_JSON ${TESTSDIR}/bud/cache-format
 
   # Build in Docker format again.  Cache traversal should 100% hit the Docker image, so we should get its image ID.
-  run_buildah build --iidfile ${TESTDIR}/second-docker --format docker --layers --quiet --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/cache-format
+  run_buildah build --iidfile ${TESTDIR}/second-docker --format docker --layers --quiet $WITH_POLICY_JSON ${TESTSDIR}/bud/cache-format
 
   # Build in OCI format again.  Cache traversal should 100% hit the OCI image, so we should get its image ID.
-  run_buildah build --iidfile ${TESTDIR}/second-oci    --format oci    --layers --quiet --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/cache-format
+  run_buildah build --iidfile ${TESTDIR}/second-oci    --format oci    --layers --quiet $WITH_POLICY_JSON ${TESTSDIR}/bud/cache-format
 
   # Compare them.  The two images we built in Docker format should be the same, the two we built in OCI format
   # should be the same, but the OCI and Docker format images should be different.
@@ -2829,7 +2829,7 @@ EOF
       iidfile=${TESTDIR}/${action}${i}
       containerfile=Dockerfile.${action}$(((i-1) % 2 + 1))
 
-      run_buildah build --iidfile $iidfile --layers --quiet --signature-policy ${TESTSDIR}/policy.json -f $containerfile ${TESTSDIR}/bud/cache-chown
+      run_buildah build --iidfile $iidfile --layers --quiet $WITH_POLICY_JSON -f $containerfile ${TESTSDIR}/bud/cache-chown
     done
   done
 
@@ -2871,7 +2871,7 @@ EOF
   cp -r ${TESTSDIR}/bud/dockerignore ${CONTEXTDIR}
   mv ${CONTEXTDIR}/.dockerignore ${TESTDIR}/containerignore
 
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${CONTEXTDIR}/Dockerfile.succeed --ignorefile  ${TESTDIR}/containerignore  ${CONTEXTDIR}
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${CONTEXTDIR}/Dockerfile.succeed --ignorefile  ${TESTDIR}/containerignore  ${CONTEXTDIR}
 
   run_buildah from --name myctr testbud
 
@@ -2894,15 +2894,15 @@ EOF
   _prefetch alpine
   target=alpine-image
 
-  run_buildah build --network=none --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
+  run_buildah build --network=none $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/containerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 
-  run_buildah build --network=private --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
+  run_buildah build --network=private $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/containerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 
-  run_buildah build --network=container --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
+  run_buildah build --network=container $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/containerfile
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
 }
@@ -2911,7 +2911,7 @@ EOF
   _prefetch alpine busybox
   # override the first FROM (fedora) image in the Containerfile
   # with alpine, leave the second (busybox) alone.
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --from=alpine ${TESTSDIR}/bud/build-with-from
+  run_buildah build $WITH_POLICY_JSON --from=alpine ${TESTSDIR}/bud/build-with-from
   expect_output --substring "\[1/2] STEP 1/1: FROM alpine AS builder"
   expect_output --substring "\[2/2] STEP 1/2: FROM busybox"
 }
@@ -2927,10 +2927,10 @@ RUN touch /tmp/done
 _EOF
 
   # fail without --stdin
-  run_buildah 1 bud -t testbud --signature-policy ${TESTSDIR}/policy.json ${mytmpdir} <<< input
+  run_buildah 1 bud -t testbud $WITH_POLICY_JSON ${mytmpdir} <<< input
   expect_output --substring "error building .*: exit status 1"
 
-  run_buildah build --stdin -t testbud --signature-policy ${TESTSDIR}/policy.json ${mytmpdir} <<< input
+  run_buildah build --stdin -t testbud $WITH_POLICY_JSON ${mytmpdir} <<< input
   expect_output --substring "test got <input>"
 }
 
@@ -2943,10 +2943,10 @@ FROM alpine
 #RUN arch
 _EOF
 
-  run_buildah build --arch=arm64 -t arch-test --signature-policy ${TESTSDIR}/policy.json ${mytmpdir} <<< input
+  run_buildah build --arch=arm64 -t arch-test $WITH_POLICY_JSON ${mytmpdir} <<< input
 # expect_output --substring "aarch64"
 
-#  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json arch-test
+#  run_buildah from --quiet --pull=false $WITH_POLICY_JSON arch-test
 #  cid=$output
 #  run_buildah run $cid arch
 #  expect_output --substring "aarch64"
@@ -2961,7 +2961,7 @@ from alpine
 run echo hello
 _EOF
 
-  run_buildah build -q --manifest=testlist -t arch-test --signature-policy ${TESTSDIR}/policy.json ${mytmpdir} <<< input
+  run_buildah build -q --manifest=testlist -t arch-test $WITH_POLICY_JSON ${mytmpdir} <<< input
   cid=$output
   run_buildah images
   expect_output --substring testlist
@@ -2984,7 +2984,7 @@ _EOF
 
   run_buildah manifest create testlist
 
-  run_buildah build -q --manifest=testlist -t arch-test --signature-policy ${TESTSDIR}/policy.json ${mytmpdir} <<< input
+  run_buildah build -q --manifest=testlist -t arch-test $WITH_POLICY_JSON ${mytmpdir} <<< input
   cid=$output
   run_buildah images
   expect_output --substring testlist
@@ -3014,7 +3014,7 @@ COPY --from=galaxy /usr/share/ansible/roles /usr/share/ansible/roles
 COPY --from=galaxy /usr/share/ansible/collections /usr/share/ansible/collections
 _EOF
 
-  run_buildah build --layers --signature-policy ${TESTSDIR}/policy.json -t testbud $mytmpdir
+  run_buildah build --layers $WITH_POLICY_JSON -t testbud $mytmpdir
   expect_output --substring "COPY --from=galaxy /usr/share/ansible/collections /usr/share/ansible/collections"
 }
 
@@ -3033,12 +3033,12 @@ FROM image-a
 FROM scratch
 _EOF
 
-  run_buildah build -f Containerfile.a -q --manifest=testlist -t image-a --signature-policy ${TESTSDIR}/policy.json ${mytmpdir} <<< input
+  run_buildah build -f Containerfile.a -q --manifest=testlist -t image-a $WITH_POLICY_JSON ${mytmpdir} <<< input
   cid=$output
   run_buildah images -f "label=image=a"
   expect_output --substring image-a
 
-  run_buildah build -f Containerfile.b -q --manifest=testlist -t image-b --signature-policy ${TESTSDIR}/policy.json ${mytmpdir} <<< input
+  run_buildah build -f Containerfile.b -q --manifest=testlist -t image-b $WITH_POLICY_JSON ${mytmpdir} <<< input
   cid=$output
   run_buildah images
   expect_output --substring image-a
@@ -3050,14 +3050,14 @@ _EOF
 cat > $mytmpdir/Containerfile << _EOF
 FROM registry.access.redhat.com/ubi8-minimal
 _EOF
-  run_buildah build -f Containerfile --pull=false -q --arch=amd64 -t image-amd --signature-policy ${TESTSDIR}/policy.json ${mytmpdir}
+  run_buildah build -f Containerfile --pull=false -q --arch=amd64 -t image-amd $WITH_POLICY_JSON ${mytmpdir}
   run_buildah inspect --format '{{ index .Docker.Config.Labels "architecture" }}' image-amd
   expect_output --substring x86_64
 
   # Tag the image to localhost/ubi8-minimal to make sure that the image gets
   # pulled since the local one does not match the requested architecture.
   run_buildah tag image-amd localhost/ubi8-minimal
-  run_buildah build -f Containerfile --pull=false -q --arch=arm64 -t image-arm --signature-policy ${TESTSDIR}/policy.json ${mytmpdir}
+  run_buildah build -f Containerfile --pull=false -q --arch=arm64 -t image-arm $WITH_POLICY_JSON ${mytmpdir}
   run_buildah inspect --format '{{ index .Docker.Config.Labels "architecture" }}' image-arm
   expect_output --substring arm64
 
@@ -3076,14 +3076,14 @@ _EOF
 FROM alpine
 _EOF
 
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+  run_buildah build -t testbud $WITH_POLICY_JSON --file ${mytmpdir} .
 }
 
 @test "bud --authfile" {
   _prefetch alpine
   start_registry
   run_buildah login --tls-verify=false --authfile ${TESTDIR}/test.auth --username testuser --password testpassword localhost:${REGISTRY_PORT}
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --authfile ${TESTDIR}/test.auth alpine docker://localhost:${REGISTRY_PORT}/buildah/alpine
+  run_buildah push $WITH_POLICY_JSON --tls-verify=false --authfile ${TESTDIR}/test.auth alpine docker://localhost:${REGISTRY_PORT}/buildah/alpine
 
   mytmpdir=${TESTDIR}/my-dir
   mkdir -p ${mytmpdir}
@@ -3091,7 +3091,7 @@ _EOF
 FROM localhost:${REGISTRY_PORT}/buildah/alpine
 RUN touch /test
 _EOF
-  run_buildah build -t myalpine --authfile ${TESTDIR}/test.auth --tls-verify=false --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+  run_buildah build -t myalpine --authfile ${TESTDIR}/test.auth --tls-verify=false $WITH_POLICY_JSON --file ${mytmpdir} .
   run_buildah rmi localhost:${REGISTRY_PORT}/buildah/alpine
   run_buildah rmi myalpine
 }
@@ -3110,11 +3110,11 @@ FROM alpine
 RUN echo "$SECRET"
 _EOF
 
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+  run_buildah build -t testbud $WITH_POLICY_JSON --file ${mytmpdir} .
   assert "$output" !~ '--build-arg SECRET=<VALUE>'
   expect_output --substring '\-\-build-arg NEWSECRET=<VALUE>'
 
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json --build-arg NEWSECRET="VerySecret" --file ${mytmpdir} .
+  run_buildah build -t testbud $WITH_POLICY_JSON --build-arg NEWSECRET="VerySecret" --file ${mytmpdir} .
   assert "$output" !~ '--build-arg SECRET=<VALUE>'
   assert "$output" !~ '--build-arg NEWSECRET=<VALUE>'
 }
@@ -3143,7 +3143,7 @@ _EOF
     if is_cgroupsv2; then
       # The result with cgroup v2 depends on the version of runc.
       run_buildah ? bud --runtime=runc --runtime-flag=debug \
-                        -q -t alpine-bud-runc --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                        -q -t alpine-bud-runc $WITH_POLICY_JSON --file ${mytmpdir} .
       if [ "$status" -eq 0 ]; then
         expect_output --substring "$flag_accepted_rx"
       else
@@ -3152,7 +3152,7 @@ _EOF
       fi
     else
       run_buildah build --runtime=runc --runtime-flag=debug \
-                      -q -t alpine-bud-runc --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                      -q -t alpine-bud-runc $WITH_POLICY_JSON --file ${mytmpdir} .
       expect_output --substring "$flag_accepted_rx"
     fi
 
@@ -3175,7 +3175,7 @@ _EOF
 _EOF
 
     run_buildah build --runtime=crun --runtime-flag=debug --security-opt seccomp=${TESTDIR}/seccomp.json \
-                    -q -t alpine-bud-crun --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                    -q -t alpine-bud-crun $WITH_POLICY_JSON --file ${mytmpdir} .
     expect_output --substring "unknown seccomp syscall"
   fi
 
@@ -3198,12 +3198,12 @@ from alpine
 run echo hello
 _EOF
 
-    run_buildah 1 build --signature-policy ${TESTSDIR}/policy.json --runtime-flag invalidflag -t build_test $mytmpdir
+    run_buildah 1 build $WITH_POLICY_JSON --runtime-flag invalidflag -t build_test $mytmpdir
     assert "$output" =~ ".*invalidflag" "failed when passing undefined flags to the runtime"
 }
 
 @test "bud - accept at most one arg" {
-    run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/dns extraarg
+    run_buildah 125 build $WITH_POLICY_JSON ${TESTSDIR}/bud/dns extraarg
     assert "$output" =~ ".*accepts at most 1 arg\(s\), received 2" "Should fail when passed extra arg after context directory"
 }
 
@@ -3221,16 +3221,16 @@ _EOF
 
   ip=123.45.67.$(( $RANDOM % 256 ))
   run_buildah build --add-host=myhostname:$ip -t testbud \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   expect_output --from="${lines[2]}" --substring "^$ip\s+myhostname"
 
   run_buildah 125 build --no-cache --add-host=myhostname:$ip \
                   --no-hosts \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   expect_output --substring "\-\-no-hosts and \-\-add-host conflict, can not be used together"
 
   run_buildah 1 build --no-cache --no-hosts \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   expect_output --substring 'error building at STEP "RUN grep "myhostname" /etc/hosts'
 }
 
@@ -3250,7 +3250,7 @@ _EOF
 
   # with cgroup-parent
   run_buildah --cgroup-manager cgroupfs build --cgroupns=host --cgroup-parent test-cgroup -t with-flag \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   if is_cgroupsv2; then
     expect_output --from="${lines[2]}" "0::/test-cgroup"
   else
@@ -3258,7 +3258,7 @@ _EOF
   fi
   # without cgroup-parent
   run_buildah --cgroup-manager cgroupfs build -t without-flag \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   if [ -n "$(grep "test-cgroup" <<< "$output")" ]; then
     die "Unexpected cgroup."
   fi
@@ -3288,7 +3288,7 @@ _EOF
   fi
 
   run_buildah build --cpu-period=1234 --cpu-quota=5678 -t testcpu \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   expect_output --from="${lines[2]}" "5678 1234"
 }
 
@@ -3301,7 +3301,7 @@ _EOF
 from alpine
 run ls /sys/fs/cgroup
 _EOF
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir}/Containerfile .
+  run_buildah build $WITH_POLICY_JSON --file ${mytmpdir}/Containerfile .
   expect_output --substring "cpu"
   expect_output --substring "memory"
 }
@@ -3335,7 +3335,7 @@ _EOF
   fi
 
   run_buildah build --cpu-shares=${shares} -t testcpu \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   expect_output --from="${lines[2]}" "${expect}"
 }
 
@@ -3363,7 +3363,7 @@ _EOF
   fi
 
   run_buildah build --cpuset-cpus=0 -t testcpuset \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   expect_output --from="${lines[2]}" "cpuset-cpus 0"
 }
 
@@ -3391,7 +3391,7 @@ _EOF
   fi
 
   run_buildah build --cpuset-mems=0 -t testcpuset \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   expect_output --from="${lines[2]}" "cpuset-mems 0"
 }
 
@@ -3412,16 +3412,16 @@ _EOF
   run readlink /proc/self/ns/pid
   host_pidns=$output
   run_buildah build --isolation chroot -t testisolation --pid private \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   # chroot isolation doesn't make a new PID namespace.
   expect_output --from="${lines[2]}" "${host_pidns}"
 }
 
 @test "bud with --pull-always" {
   _prefetch docker.io/library/alpine
-  run_buildah build --pull-always --signature-policy ${TESTSDIR}/policy.json -t testpull ${TESTSDIR}/bud/containerfile
+  run_buildah build --pull-always $WITH_POLICY_JSON -t testpull ${TESTSDIR}/bud/containerfile
   expect_output --from="${lines[1]}" "Trying to pull docker.io/library/alpine:latest..."
-  run_buildah build --pull=always --signature-policy ${TESTSDIR}/policy.json -t testpull ${TESTSDIR}/bud/containerfile
+  run_buildah build --pull=always $WITH_POLICY_JSON -t testpull ${TESTSDIR}/bud/containerfile
   expect_output --from="${lines[1]}" "Trying to pull docker.io/library/alpine:latest..."
 }
 
@@ -3454,7 +3454,7 @@ _EOF
   fi
 
   run_buildah build --memory=40m --memory-swap=70m -t testmemory \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   expect_output --from="${lines[2]}" "memory-max=41943040"
   expect_output --from="${lines[4]}" "memory-swap-result=${expect_swap}"
 }
@@ -3473,7 +3473,7 @@ run df -h /dev/shm
 _EOF
 
   run_buildah build --shm-size=80m -t testshm \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   expect_output --from="${lines[3]}" --substring "shm\s+80.0M"
 }
 
@@ -3488,15 +3488,15 @@ run printf "ulimit=" && ulimit -t
 _EOF
 
   run_buildah build --ulimit cpu=300 -t testulimit \
-                  --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+                  $WITH_POLICY_JSON --file ${mytmpdir} .
   expect_output --from="${lines[2]}" "ulimit=300"
 }
 
 @test "bud with .dockerignore #3" {
-  run_buildah build -t test --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/copy-globs
-  run_buildah build -t test2 -f Containerfile.missing --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/copy-globs
+  run_buildah build -t test $WITH_POLICY_JSON ${TESTSDIR}/bud/copy-globs
+  run_buildah build -t test2 -f Containerfile.missing $WITH_POLICY_JSON ${TESTSDIR}/bud/copy-globs
 
-  run_buildah 125 build -t test3 -f Containerfile.bad --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/copy-globs
+  run_buildah 125 build -t test3 -f Containerfile.bad $WITH_POLICY_JSON ${TESTSDIR}/bud/copy-globs
   expect_output --substring 'error building.*"COPY \*foo /testdir".*no such file or directory'
 }
 
@@ -3508,7 +3508,7 @@ _EOF
 SOMESECRETDATA
 _EOF
 
-  run_buildah build --secret=id=mysecret,src=${mytmpdir}/mysecret --signature-policy ${TESTSDIR}/policy.json  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret ${TESTSDIR}/bud/run-mounts
+  run_buildah build --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret ${TESTSDIR}/bud/run-mounts
   expect_output --substring "SOMESECRETDATA"
 
   run_buildah from secretimg
@@ -3525,7 +3525,7 @@ _EOF
 SOMESECRETDATA
 _EOF
 
-  run_buildah 1 bud --secret=id=mysecret,src=${mytmpdir}/mysecret --signature-policy ${TESTSDIR}/policy.json  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-access ${TESTSDIR}/bud/run-mounts
+  run_buildah 1 bud --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-access ${TESTSDIR}/bud/run-mounts
   expect_output --substring "SOMESECRETDATA"
   expect_output --substring "cat: can't open '/mysecret': No such file or directory"
 }
@@ -3538,7 +3538,7 @@ _EOF
 SOMESECRETDATA
 _EOF
 
-  run_buildah bud --secret=id=mysecret,src=${mytmpdir}/mysecret --signature-policy ${TESTSDIR}/policy.json  -t secretmode -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-mode ${TESTSDIR}/bud/run-mounts
+  run_buildah bud --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretmode -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-mode ${TESTSDIR}/bud/run-mounts
   expect_output --substring "400"
 }
 
@@ -3550,7 +3550,7 @@ _EOF
 SOMESECRETDATA
 _EOF
 
-  run_buildah build --secret=id=mysecret,src=${mytmpdir}/mysecret --signature-policy ${TESTSDIR}/policy.json  -t secretopts -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-options ${TESTSDIR}/bud/run-mounts
+  run_buildah build --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretopts -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-options ${TESTSDIR}/bud/run-mounts
   expect_output --substring "444"
   expect_output --substring "1000"
   expect_output --substring "1001"
@@ -3559,19 +3559,19 @@ _EOF
 @test "bud with containerfile secret not required" {
   _prefetch alpine
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json  -t secretnotreq -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-not-required ${TESTSDIR}/bud/run-mounts
+  run_buildah build $WITH_POLICY_JSON  -t secretnotreq -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-not-required ${TESTSDIR}/bud/run-mounts
 }
 
 @test "bud with containerfile secret required" {
   _prefetch alpine
 
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json  -t secretreq -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-required ${TESTSDIR}/bud/run-mounts
+  run_buildah 125 build $WITH_POLICY_JSON  -t secretreq -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret-required ${TESTSDIR}/bud/run-mounts
   expect_output --substring "secret required but no secret with id mysecret found"
 }
 
 @test "bud with containerfile env secret" {
   export MYSECRET=SOMESECRETDATA
-  run_buildah build --secret=id=mysecret,src=MYSECRET,type=env --signature-policy ${TESTSDIR}/policy.json  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret ${TESTSDIR}/bud/run-mounts
+  run_buildah build --secret=id=mysecret,src=MYSECRET,type=env $WITH_POLICY_JSON  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret ${TESTSDIR}/bud/run-mounts
   expect_output --substring "SOMESECRETDATA"
 
   run_buildah from secretimg
@@ -3579,7 +3579,7 @@ _EOF
   expect_output --substring "cat: can't open '/run/secrets/mysecret': No such file or directory"
   run_buildah rm -a
 
-  run_buildah build --secret=id=mysecret,env=MYSECRET --signature-policy ${TESTSDIR}/policy.json  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret ${TESTSDIR}/bud/run-mounts
+  run_buildah build --secret=id=mysecret,env=MYSECRET $WITH_POLICY_JSON  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret ${TESTSDIR}/bud/run-mounts
   expect_output --substring "SOMESECRETDATA"
 
   run_buildah from secretimg
@@ -3597,7 +3597,7 @@ SOMESECRETDATA
 _EOF
 
   export mysecret=ENVDATA
-  run_buildah build --secret=id=mysecret --signature-policy ${TESTSDIR}/policy.json  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret ${TESTSDIR}/bud/run-mounts
+  run_buildah build --secret=id=mysecret $WITH_POLICY_JSON  -t secretimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.secret ${TESTSDIR}/bud/run-mounts
   expect_output --substring "ENVDATA"
 }
 
@@ -3606,19 +3606,19 @@ _EOF
   # check if we can run a couple of 32-bit versions of an image, and if we can,
   # assume that emulation for other architectures is in place.
   os=`go env GOOS`
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name try-386 --platform=$os/386 alpine
+  run_buildah from $WITH_POLICY_JSON --name try-386 --platform=$os/386 alpine
   run_buildah '?' run try-386 true
   if test $status -ne 0 ; then
     skip "unable to run 386 container, assuming emulation is not available"
   fi
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name try-arm --platform=$os/arm alpine
+  run_buildah from $WITH_POLICY_JSON --name try-arm --platform=$os/arm alpine
   run_buildah '?' run try-arm true
   if test $status -ne 0 ; then
     skip "unable to run arm container, assuming emulation is not available"
   fi
 
   # build for those architectures - RUN gets exercised
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --jobs=0 --platform=$os/arm,$os/386 --manifest $outputlist ${TESTSDIR}/bud/multiarch
+  run_buildah build $WITH_POLICY_JSON --jobs=0 --platform=$os/arm,$os/386 --manifest $outputlist ${TESTSDIR}/bud/multiarch
   run_buildah manifest inspect $outputlist
   list="$output"
   run jq -r '.manifests[0].digest' <<< "$list"
@@ -3632,7 +3632,7 @@ _EOF
 
 @test "bud-multiple-platform-no-partial-manifest-list" {
   outputlist=localhost/testlist
-  run_buildah 1 bud --signature-policy ${TESTSDIR}/policy.json --platform=linux/arm,linux/amd64 --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.fail ${TESTSDIR}/bud/multiarch
+  run_buildah 1 bud $WITH_POLICY_JSON --platform=linux/arm,linux/amd64 --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.fail ${TESTSDIR}/bud/multiarch
   expect_output --substring "error building at STEP \"RUN test .arch. = x86_64"
   run_buildah 125 manifest inspect $outputlist
   expect_output --substring "reading image .* pinging container registry"
@@ -3645,18 +3645,18 @@ _EOF
   if test "$os" != linux ; then
     skip "test Dockerfile is ubi, we can't run it"
   fi
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name try-386 --platform=$os/386 alpine
+  run_buildah from $WITH_POLICY_JSON --name try-386 --platform=$os/386 alpine
   run_buildah '?' run try-386 true
   if test $status -ne 0 ; then
     skip "unable to run 386 container, assuming emulation is not available"
   fi
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name try-arm --platform=$os/arm alpine
+  run_buildah from $WITH_POLICY_JSON --name try-arm --platform=$os/arm alpine
   run_buildah '?' run try-arm true
   if test $status -ne 0 ; then
     skip "unable to run arm container, assuming emulation is not available"
   fi
   outputlist=localhost/testlist
-  run_buildah 125 build --signature-policy ${TESTSDIR}/policy.json --jobs=0 --platform=linux/arm64,linux/amd64 --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.fail-multistage ${TESTSDIR}/bud/multiarch
+  run_buildah 125 build $WITH_POLICY_JSON --jobs=0 --platform=linux/arm64,linux/amd64 --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.fail-multistage ${TESTSDIR}/bud/multiarch
   expect_output --substring 'error building at STEP "RUN false"'
 }
 
@@ -3666,7 +3666,7 @@ _EOF
   # concurrency to maximum which uncovers all sorts of race condition causing
   # flakes in CI. Please put this back to --jobs=0 when https://github.com/containers/buildah/issues/3710
   # is resolved.
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json --jobs=1 --all-platforms --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.no-run ${TESTSDIR}/bud/multiarch
+  run_buildah build $WITH_POLICY_JSON --jobs=1 --all-platforms --manifest $outputlist -f ${TESTSDIR}/bud/multiarch/Dockerfile.no-run ${TESTSDIR}/bud/multiarch
   run_buildah manifest inspect $outputlist
   echo "$output"
   run jq '.manifests | length' <<< "$output"
@@ -3683,7 +3683,7 @@ _EOF
   fromDigest="$output"
 
   target=relabel
-  run_buildah build --layers --label "label1=value1" --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build --layers --label "label1=value1" $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
 
   # Store base digest of first image
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' ${target}
@@ -3698,7 +3698,7 @@ _EOF
   expect_output --substring "label1:value1"
 
   # Rebuild with new label
-  run_buildah build --layers --label "label1=value2" --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build --layers --label "label1=value2" $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
 
   # Base digest should match with first build
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' ${target}
@@ -3709,7 +3709,7 @@ _EOF
   expect_output --substring "label1:value2"
 
   # Rebuild everything with label1=value1 and everything should be cached from first image
-  run_buildah build --layers --label "label1=value1" --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
+  run_buildah build --layers --label "label1=value1" $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/multi-stage-builds/Dockerfile.reused ${TESTSDIR}/bud/multi-stage-builds
 
   # Enitre image must be picked from cache
   run_buildah inspect --format '{{ .FromImageID }}' ${target}
@@ -3760,7 +3760,7 @@ _EOF
   mkdir ${TESTDIR}/${target}
 
   # Build and export container to tar
-  run_buildah build --no-cache --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/containerfile/Containerfile.in ${TESTSDIR}/bud/containerfile
+  run_buildah build --no-cache $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/containerfile/Containerfile.in ${TESTSDIR}/bud/containerfile
   podman export $(podman create --name ${target} --net=host ${target}) --output=${TESTDIR}/${target}.tar
 
   # We are done exporting so remove images and containers which are not needed
@@ -3783,7 +3783,7 @@ _EOF
   mkdir ${TESTDIR}/${target}
 
   # Build and export container to tar
-  run_buildah build --no-cache --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/add-run-dir
+  run_buildah build --no-cache $WITH_POLICY_JSON -t ${target} -f ${TESTSDIR}/bud/add-run-dir
   podman export $(podman create --name ${target} --net=host ${target}) --output=${TESTDIR}/${target}.tar
 
   # We are done exporting so remove images and containers which are not needed
@@ -3801,7 +3801,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/buildkit-mount/Dockerfile ${TESTDIR}/buildkit-mount/
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfile ${TESTDIR}/buildkit-mount/
   expect_output --substring "hello"
   run_buildah rmi -f testbud
 }
@@ -3810,7 +3810,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/buildkit-mount/Dockerfile2 ${TESTDIR}/buildkit-mount/
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfile2 ${TESTDIR}/buildkit-mount/
   expect_output --substring "hello"
   run_buildah rmi -f testbud
 }
@@ -3819,7 +3819,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/buildkit-mount/Dockerfile ${TESTDIR}/buildkit-mount/subdir/
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfile ${TESTDIR}/buildkit-mount/subdir/
   expect_output --substring "hello"
   run_buildah rmi -f testbud
 }
@@ -3828,7 +3828,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/buildkit-mount/Dockerfile4 ${TESTDIR}/buildkit-mount/
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfile4 ${TESTDIR}/buildkit-mount/
   expect_output --substring "hello"
   run_buildah rmi -f testbud
 }
@@ -3837,7 +3837,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
-  run_buildah build --isolation chroot -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/buildkit-mount/Dockerfile3 ${TESTDIR}/buildkit-mount/subdir/
+  run_buildah build --isolation chroot -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfile3 ${TESTDIR}/buildkit-mount/subdir/
   expect_output --substring "world"
   run_buildah rmi -f testbud
 }
@@ -3847,7 +3847,7 @@ _EOF
   skip_if_in_container
   cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
   # tmpfs mount: target should be available on container without creating any special directory on container
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/buildkit-mount/Dockerfiletmpfs
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfiletmpfs
   [ "$status" -eq 0 ]
   run_buildah rmi -f testbud
 }
@@ -3856,7 +3856,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/buildkit-mount/Dockerfiletmpfscopyup
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfiletmpfscopyup
   expect_output --substring "certs"
   run_buildah rmi -f testbud
 }
@@ -3866,9 +3866,9 @@ _EOF
   skip_if_in_container
   cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
   # try writing something to persistent cache
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/buildkit-mount/Dockerfilecachewrite
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfilecachewrite
   # try reading something from persistent cache in a different build
-  run_buildah build -t testbud2 --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/buildkit-mount/Dockerfilecacheread
+  run_buildah build -t testbud2 $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfilecacheread
   expect_output --substring "hello"
   run_buildah rmi -f testbud
   run_buildah rmi -f testbud2
@@ -3880,14 +3880,14 @@ _EOF
   skip_if_in_container
   cp -R ${TESTSDIR}/bud/buildkit-mount ${TESTDIR}/buildkit-mount
   # try writing something to persistent cache
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/buildkit-mount/Dockerfilecachewritesharing
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/buildkit-mount/Dockerfilecachewritesharing
   expect_output --substring "world"
   run_buildah rmi -f testbud
 }
 
 @test "bud with user in groups" {
   target=bud-group
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/group
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/group
 }
 
 @test "build proxy" {
@@ -3901,7 +3901,7 @@ _EOF
   target=env-image
   check="FTP_PROXY="FTP" ftp_proxy=ftp http_proxy=http HTTPS_PROXY=HTTPS"
   bogus="BOGUS_PROXY=BOGUS"
-  eval $check $bogus run_buildah build --unsetenv PATH --signature-policy ${TESTSDIR}/policy.json -t oci-${target} -f $mytmpdir/Containerfile .
+  eval $check $bogus run_buildah build --unsetenv PATH $WITH_POLICY_JSON -t oci-${target} -f $mytmpdir/Containerfile .
   for i in $check; do
     expect_output --substring "$i" "Environment variables available within build"
   done
@@ -3916,9 +3916,9 @@ _EOF
   mkdir ${TESTDIR}/bud
   cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # build base image which we will use as our `from`
-  run_buildah build -t buildkitbase --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
+  run_buildah build -t buildkitbase $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
   # try reading something from another image in a different build
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebindfrom
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebindfrom
   expect_output --substring "hello"
   run_buildah rmi -f buildkitbase
   run_buildah rmi -f testbud
@@ -3930,9 +3930,9 @@ _EOF
   mkdir ${TESTDIR}/bud
   cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # build base image which we will use as our `from`
-  run_buildah build -t buildkitbase --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
+  run_buildah build -t buildkitbase $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
   # try reading something from another image in a different build
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebindfromwriteable
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebindfromwriteable
   expect_output --substring "world"
   run_buildah rmi -f buildkitbase
   run_buildah rmi -f testbud
@@ -3944,9 +3944,9 @@ _EOF
   mkdir ${TESTDIR}/bud
   cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # build base image which we will use as our `from`
-  run_buildah build -t buildkitbase --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
+  run_buildah build -t buildkitbase $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
   # try reading something from another image in a different build
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebindfromwithoutsource
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebindfromwithoutsource
   expect_output --substring "hello"
   run_buildah rmi -f buildkitbase
   run_buildah rmi -f testbud
@@ -3958,9 +3958,9 @@ _EOF
   mkdir ${TESTDIR}/bud
   cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # build base image which we will use as our `from`
-  run_buildah build -t buildkitbase --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
+  run_buildah build -t buildkitbase $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
   # try reading something from image in a different build
-  run_buildah 125 build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebindfromwithemptyfrom
+  run_buildah 125 build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebindfromwithemptyfrom
   expect_output --substring "points to an empty value"
   run_buildah rmi -f buildkitbase
 }
@@ -3971,7 +3971,7 @@ _EOF
   mkdir ${TESTDIR}/bud
   cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # try reading something from persistent cache in a different build
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilecachefrom ${TESTDIR}/bud/buildkit-mount-from/
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilecachefrom ${TESTDIR}/bud/buildkit-mount-from/
   expect_output --substring "hello"
   run_buildah rmi -f testbud
 }
@@ -3984,10 +3984,10 @@ _EOF
   cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
 
   # build base image which we will use as our `from`
-  run_buildah build -t buildkitbase --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
+  run_buildah build -t buildkitbase $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTDIR}/bud/buildkit-mount-from/
 
   # try reading something from persistent cache in a different build
-  run_buildah 125 build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilecachefromimage
+  run_buildah 125 build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilecachefromimage
   expect_output --substring "no stage found with name buildkitbase"
   run_buildah rmi -f buildkitbase
 }
@@ -3998,7 +3998,7 @@ _EOF
   mkdir ${TESTDIR}/bud
   cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # try reading something from persistent cache in a different build
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilecachemultiplefrom ${TESTDIR}/bud/buildkit-mount-from/
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilecachemultiplefrom ${TESTDIR}/bud/buildkit-mount-from/
   expect_output --substring "hello"
   expect_output --substring "hello2"
   run_buildah rmi -f testbud
@@ -4010,9 +4010,9 @@ _EOF
   mkdir ${TESTDIR}/bud
   cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # build base image which we will use as our `from`
-  run_buildah build -t buildkitbaserelative --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbaserelative ${TESTDIR}/bud/buildkit-mount-from/
+  run_buildah build -t buildkitbaserelative $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbaserelative ${TESTDIR}/bud/buildkit-mount-from/
   # try reading something from image in a different build
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebindfromrelative
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilebindfromrelative
   expect_output --substring "hello"
   run_buildah rmi -f buildkitbaserelative
   run_buildah rmi -f testbud
@@ -4024,7 +4024,7 @@ _EOF
   skip_if_no_runtime
   skip_if_in_container
   # build base image which we will use as our `from`
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilemultistagefrom ${TESTDIR}/bud/buildkit-mount-from/
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilemultistagefrom ${TESTDIR}/bud/buildkit-mount-from/
   expect_output --substring "hello"
   run_buildah rmi -f testbud
 }
@@ -4035,7 +4035,7 @@ _EOF
   mkdir ${TESTDIR}/bud
   cp -R ${TESTSDIR}/bud/buildkit-mount-from ${TESTDIR}/bud/buildkit-mount-from
   # build base image which we will use as our `from`
-  run_buildah build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilemultistagefromcache ${TESTDIR}/bud/buildkit-mount-from/
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TESTDIR}/bud/buildkit-mount-from/Dockerfilemultistagefromcache ${TESTDIR}/bud/buildkit-mount-from/
   expect_output --substring "hello"
   expect_output --substring "hello2"
   run_buildah rmi -f testbud
@@ -4048,11 +4048,11 @@ _EOF
 
   _prefetch alpine
 
-  run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json --network notexists ${TESTSDIR}/bud/network
+  run_buildah 125 bud $WITH_POLICY_JSON --network notexists ${TESTSDIR}/bud/network
   expect_output --substring "network not found"
 
   if test "$BUILDAH_ISOLATION" = "oci"; then
-    run_buildah bud --signature-policy ${TESTSDIR}/policy.json --network podman ${TESTSDIR}/bud/network
+    run_buildah bud $WITH_POLICY_JSON --network podman ${TESTSDIR}/bud/network
     # default subnet is 10.88.0.0/16
     expect_output --substring "10.88."
   fi
@@ -4062,7 +4062,7 @@ _EOF
   _prefetch alpine
   target=alpine-image
   ctr=alpine-ctr
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/workdir-user
+  run_buildah build $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/workdir-user
   expect_output --substring "1000:1000 /home/http/public"
 }
 
@@ -4073,7 +4073,7 @@ _EOF
 
   mkfifo ${TESTDIR}/pipe
   # start the build running in the background - don't use the function wrapper because that sets '$!' to a value that's not what we want
-  ${BUILDAH_BINARY} ${BUILDAH_REGISTRY_OPTS} ${ROOTDIR_OPTS} --signature-policy ${TESTSDIR}/policy.json build ${TESTSDIR}/bud/long-sleep > ${TESTDIR}/pipe 2>&1 &
+  ${BUILDAH_BINARY} ${BUILDAH_REGISTRY_OPTS} ${ROOTDIR_OPTS} $WITH_POLICY_JSON build ${TESTSDIR}/bud/long-sleep > ${TESTDIR}/pipe 2>&1 &
   buildah_pid="${!}"
   echo buildah is pid ${buildah_pid}
   # save what's written to the fifo to a plain file

--- a/tests/bud_overlay_leaks.bats
+++ b/tests/bud_overlay_leaks.bats
@@ -11,7 +11,7 @@ load helpers
   run_buildah 125 --storage-driver=overlay bud $WITH_POLICY_JSON -t ${target} --pull-never $BUDFILES/pull
   expect_output --substring "image not known"
 
-  leftover=$(mount | grep $TESTDIR | cat)
+  leftover=$(mount | grep $TEST_SCRATCH_DIR | cat)
   if [ -n "$leftover" ]; then
     die "buildah leaked a mount on error: $leftover"
   fi

--- a/tests/bud_overlay_leaks.bats
+++ b/tests/bud_overlay_leaks.bats
@@ -8,7 +8,7 @@ load helpers
   fi
 
   target=pull
-  run_buildah 125 --storage-driver=overlay bud $WITH_POLICY_JSON -t ${target} --pull-never ${TESTSDIR}/bud/pull
+  run_buildah 125 --storage-driver=overlay bud $WITH_POLICY_JSON -t ${target} --pull-never $BUDFILES/pull
   expect_output --substring "image not known"
 
   leftover=$(mount | grep $TESTDIR | cat)

--- a/tests/bud_overlay_leaks.bats
+++ b/tests/bud_overlay_leaks.bats
@@ -8,7 +8,7 @@ load helpers
   fi
 
   target=pull
-  run_buildah 125 --storage-driver=overlay bud --signature-policy ${TESTSDIR}/policy.json -t ${target} --pull-never ${TESTSDIR}/bud/pull
+  run_buildah 125 --storage-driver=overlay bud $WITH_POLICY_JSON -t ${target} --pull-never ${TESTSDIR}/bud/pull
   expect_output --substring "image not known"
 
   leftover=$(mount | grep $TESTDIR | cat)

--- a/tests/byid.bats
+++ b/tests/byid.bats
@@ -7,7 +7,7 @@ load helpers
   _prefetch $image
 
   # Pull down the image, if we have to.
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON $image
   expect_output "$image-working-container"
   cid=$output
   run_buildah rm $cid
@@ -18,13 +18,13 @@ load helpers
   iid="$output"
 
   # Use the image's ID to create a container.
-  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json ${iid}
+  run_buildah from --pull=false $WITH_POLICY_JSON ${iid}
   expect_line_count 1
   cid="$output"
   run_buildah rm $cid
 
   # Use a truncated form of the image's ID to create a container.
-  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json ${iid:0:6}
+  run_buildah from --pull=false $WITH_POLICY_JSON ${iid:0:6}
   expect_line_count 1
   cid="$output"
   run_buildah rm $cid
@@ -37,7 +37,7 @@ load helpers
   _prefetch $image
 
   # Pull down the image, if we have to.
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON $image
   expect_output "$image-working-container"
   cid=$output
   run_buildah rm $cid
@@ -65,7 +65,7 @@ load helpers
     mkdir -p $TARGET $TARGET-truncated
 
     # Pull down the image, if we have to.
-    run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
+    run_buildah from --quiet --pull=false $WITH_POLICY_JSON $image
     expect_output "${image##*/}-working-container"  # image, w/o registry prefix
     run_buildah rm $output
 
@@ -75,10 +75,10 @@ load helpers
     iid="$output"
 
     # Use the image's ID to push it.
-    run_buildah push --signature-policy ${TESTSDIR}/policy.json $iid dir:$TARGET
+    run_buildah push $WITH_POLICY_JSON $iid dir:$TARGET
 
     # Use a truncated form of the image's ID to push it.
-    run_buildah push --signature-policy ${TESTSDIR}/policy.json ${iid:0:6} dir:$TARGET-truncated
+    run_buildah push $WITH_POLICY_JSON ${iid:0:6} dir:$TARGET-truncated
 
     # Use the image's complete ID to remove it.
     run_buildah rmi $iid
@@ -90,7 +90,7 @@ load helpers
   _prefetch $image
 
   # Pull down the image, if we have to.
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON $image
   expect_output "$image-working-container"
   run_buildah rm $output
 

--- a/tests/byid.bats
+++ b/tests/byid.bats
@@ -61,7 +61,7 @@ load helpers
     echo pulling/pushing image $image
     _prefetch $image
 
-    TARGET=${TESTDIR}/subdir-$(basename $image)
+    TARGET=${TEST_SCRATCH_DIR}/subdir-$(basename $image)
     mkdir -p $TARGET $TARGET-truncated
 
     # Pull down the image, if we have to.

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -18,17 +18,17 @@ load helpers
 
 @test "commit" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
+  run_buildah commit $WITH_POLICY_JSON $cid alpine-image
   run_buildah images alpine-image
 }
 
 @test "commit-with-remove-identity-label" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
-  run_buildah commit --identity-label=false --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
+  run_buildah commit --identity-label=false $WITH_POLICY_JSON $cid alpine-image
   run_buildah images alpine-image
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' alpine-image
   expect_output "map[]"
@@ -36,10 +36,10 @@ load helpers
 
 @test "commit format test" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-oci
-  run_buildah commit --format docker --disable-compression=false --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-docker
+  run_buildah commit $WITH_POLICY_JSON $cid alpine-image-oci
+  run_buildah commit --format docker --disable-compression=false $WITH_POLICY_JSON $cid alpine-image-docker
 
   run_buildah inspect --type=image --format '{{.Manifest}}' alpine-image-oci
   mediatype=$(jq -r '.layers[0].mediaType' <<<"$output")
@@ -51,10 +51,10 @@ load helpers
 
 @test "commit --unsetenv PATH" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
-  run_buildah commit --unsetenv PATH --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-oci
-  run_buildah commit --unsetenv PATH --format docker --disable-compression=false --signature-policy ${TESTSDIR}/policy.json $cid alpine-image-docker
+  run_buildah commit --unsetenv PATH $WITH_POLICY_JSON $cid alpine-image-oci
+  run_buildah commit --unsetenv PATH --format docker --disable-compression=false $WITH_POLICY_JSON $cid alpine-image-docker
 
   run_buildah inspect --type=image --format '{{.OCIv1.Config.Env}}' alpine-image-oci
   expect_output "[]" "No Path should be defined"
@@ -64,17 +64,17 @@ load helpers
 
 @test "commit quiet test" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
-  run_buildah commit --iidfile /dev/null --signature-policy ${TESTSDIR}/policy.json -q $cid alpine-image
+  run_buildah commit --iidfile /dev/null $WITH_POLICY_JSON -q $cid alpine-image
   expect_output ""
 }
 
 @test "commit rm test" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --rm $cid alpine-image
+  run_buildah commit $WITH_POLICY_JSON --rm $cid alpine-image
   run_buildah 125 rm $cid
   expect_output --substring "error removing container \"alpine-working-container\": container not known"
 }
@@ -82,19 +82,19 @@ load helpers
 @test "commit-alternate-storage" {
   _prefetch alpine
   echo FROM
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   echo COMMIT
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid "containers-storage:[vfs@${TESTDIR}/root2+${TESTDIR}/runroot2]newimage"
+  run_buildah commit $WITH_POLICY_JSON $cid "containers-storage:[vfs@${TESTDIR}/root2+${TESTDIR}/runroot2]newimage"
   echo FROM
-  run_buildah --storage-driver vfs --root ${TESTDIR}/root2 --runroot ${TESTDIR}/runroot2 from --signature-policy ${TESTSDIR}/policy.json newimage
+  run_buildah --storage-driver vfs --root ${TESTDIR}/root2 --runroot ${TESTDIR}/runroot2 from $WITH_POLICY_JSON newimage
 }
 
 @test "commit-rejected-name" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
-  run_buildah 125 commit --signature-policy ${TESTSDIR}/policy.json $cid ThisNameShouldBeRejected
+  run_buildah 125 commit $WITH_POLICY_JSON $cid ThisNameShouldBeRejected
   expect_output --substring "must be lower"
 }
 
@@ -104,11 +104,11 @@ load helpers
   fi
   target=new-image
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
 
   run_buildah config --created-by "untracked actions" $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
+  run_buildah commit $WITH_POLICY_JSON $cid ${target}
   run_buildah inspect --format '{{.Config}}' ${target}
   config="$output"
   run python3 -c 'import json, sys; config = json.load(sys.stdin); print(config["history"][len(config["history"])-1]["created_by"])' <<< "$config"
@@ -117,7 +117,7 @@ load helpers
   expect_output "untracked actions"
 
   run_buildah config --created-by "" $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid ${target}
+  run_buildah commit $WITH_POLICY_JSON $cid ${target}
   run_buildah inspect --format '{{.Config}}' ${target}
   config="$output"
   run python3 -c 'import json, sys; config = json.load(sys.stdin); print(config["history"][len(config["history"])-1]["created_by"])' <<< "$config"
@@ -128,23 +128,23 @@ load helpers
 
 @test "commit-no-name" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid
+  run_buildah commit $WITH_POLICY_JSON $cid
 }
 
 @test "commit should fail with nonexistent authfile" {
   _prefetch alpine
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull $WITH_POLICY_JSON alpine
   cid=$output
-  run_buildah 125 commit --authfile /tmp/nonexistent --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
+  run_buildah 125 commit --authfile /tmp/nonexistent $WITH_POLICY_JSON $cid alpine-image
 }
 
 @test "commit-builder-identity" {
 	_prefetch alpine
-	run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull $WITH_POLICY_JSON alpine
 	cid=$output
-	run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid alpine-image
+	run_buildah commit $WITH_POLICY_JSON $cid alpine-image
 
 	run_buildah --version
         local -a output_fields=($output)
@@ -156,39 +156,39 @@ load helpers
 
 @test "commit-parent-id" {
   _prefetch alpine
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah inspect --format '{{.FromImageID}}' $cid
   iid=$output
 
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --format docker $cid alpine-image
+  run_buildah commit $WITH_POLICY_JSON --format docker $cid alpine-image
   run_buildah inspect --format '{{.Docker.Parent}}' alpine-image
   expect_output "sha256:$iid" "alpine-image -> .Docker.Parent"
 }
 
 @test "commit-container-id" {
   _prefetch alpine
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull $WITH_POLICY_JSON alpine
 
   # There is exactly one container. Get its ID.
   run_buildah containers --format '{{.ContainerID}}'
   cid=$output
 
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --format docker $cid alpine-image
+  run_buildah commit $WITH_POLICY_JSON --format docker $cid alpine-image
   run_buildah inspect --format '{{.Docker.Container}}' alpine-image
   expect_output "$cid" "alpine-image -> .Docker.Container"
 }
 
 @test "commit with name" {
   _prefetch busybox
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json --name busyboxc busybox
+  run_buildah from --quiet $WITH_POLICY_JSON --name busyboxc busybox
   expect_output "busyboxc"
 
   # Commit with a new name
   newname="commitbyname/busyboxname"
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json busyboxc $newname
+  run_buildah commit $WITH_POLICY_JSON busyboxc $newname
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json localhost/$newname
+  run_buildah from $WITH_POLICY_JSON localhost/$newname
   expect_output "busyboxname-working-container"
 
   cname=$output
@@ -198,10 +198,10 @@ load helpers
 
 @test "commit to docker-distribution" {
   _prefetch busybox
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc busybox
+  run_buildah from $WITH_POLICY_JSON --name busyboxc busybox
   start_registry
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword busyboxc docker://localhost:${REGISTRY_PORT}/commit/busybox
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name fromdocker --tls-verify=false --creds testuser:testpassword docker://localhost:${REGISTRY_PORT}/commit/busybox
+  run_buildah commit $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword busyboxc docker://localhost:${REGISTRY_PORT}/commit/busybox
+  run_buildah from $WITH_POLICY_JSON --name fromdocker --tls-verify=false --creds testuser:testpassword docker://localhost:${REGISTRY_PORT}/commit/busybox
 }
 
 @test "commit encrypted local oci image" {
@@ -210,9 +210,9 @@ load helpers
   mkdir ${TESTDIR}/tmp
   openssl genrsa -out ${TESTDIR}/tmp/mykey.pem 1024
   openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah commit --iidfile /dev/null --signature-policy ${TESTSDIR}/policy.json --encryption-key jwe:${TESTDIR}/tmp/mykey.pub -q $cid oci:${TESTDIR}/tmp/busybox_enc
+  run_buildah commit --iidfile /dev/null $WITH_POLICY_JSON --encryption-key jwe:${TESTDIR}/tmp/mykey.pub -q $cid oci:${TESTDIR}/tmp/busybox_enc
   imgtype  -show-manifest oci:${TESTDIR}/tmp/busybox_enc | grep "+encrypted"
   rm -rf ${TESTDIR}/tmp
 }
@@ -223,9 +223,9 @@ load helpers
   openssl genrsa -out ${TESTDIR}/tmp/mykey.pem 1024
   openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
   start_registry
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah commit --iidfile /dev/null --tls-verify=false --creds testuser:testpassword --signature-policy ${TESTSDIR}/policy.json --encryption-key jwe:${TESTDIR}/tmp/mykey.pub -q $cid docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah commit --iidfile /dev/null --tls-verify=false --creds testuser:testpassword $WITH_POLICY_JSON --encryption-key jwe:${TESTDIR}/tmp/mykey.pub -q $cid docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
   # this test, just checks the ability to commit an image to a registry
   # there is no good way to test the details of the image unless with ./buildah pull, test will be in pull.bats
   rm -rf ${TESTDIR}/tmp
@@ -233,17 +233,17 @@ load helpers
 
 @test "commit omit-timestamp" {
   _prefetch busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid=$output
   run_buildah run $cid touch /test
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --omit-timestamp -q $cid omit
+  run_buildah commit $WITH_POLICY_JSON --omit-timestamp -q $cid omit
   run_buildah inspect --format '{{ .Docker.Created }}' omit
   expect_output --substring "1970-01-01"
   run_buildah inspect --format '{{ .OCIv1.Created }}' omit
   expect_output --substring "1970-01-01"
 
 
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json omit
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON omit
   cid=$output
   run_buildah run $cid ls -l /test
   expect_output --substring "1970"
@@ -253,17 +253,17 @@ load helpers
 
 @test "commit timestamp" {
   _prefetch busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid=$output
   run_buildah run $cid touch /test
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --timestamp 0 -q $cid omit
+  run_buildah commit $WITH_POLICY_JSON --timestamp 0 -q $cid omit
   run_buildah inspect --format '{{ .Docker.Created }}' omit
   expect_output --substring "1970-01-01"
   run_buildah inspect --format '{{ .OCIv1.Created }}' omit
   expect_output --substring "1970-01-01"
 
 
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json omit
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON omit
   cid=$output
   run_buildah run $cid ls -l /test
   expect_output --substring "1970"
@@ -273,12 +273,12 @@ load helpers
 
 @test "commit with authfile" {
   _prefetch busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid=$output
   run_buildah run $cid touch /test
 
   start_registry
   run_buildah login --authfile ${TESTDIR}/test.auth --username testuser --password testpassword --tls-verify=false localhost:${REGISTRY_PORT}
-  run_buildah commit --authfile ${TESTDIR}/test.auth --signature-policy ${TESTSDIR}/policy.json --tls-verify=false $cid docker://localhost:${REGISTRY_PORT}/buildah/my-busybox
+  run_buildah commit --authfile ${TESTDIR}/test.auth $WITH_POLICY_JSON --tls-verify=false $cid docker://localhost:${REGISTRY_PORT}/buildah/my-busybox
   expect_output --substring "Writing manifest to image destination"
 }

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -85,9 +85,9 @@ load helpers
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   echo COMMIT
-  run_buildah commit $WITH_POLICY_JSON $cid "containers-storage:[vfs@${TESTDIR}/root2+${TESTDIR}/runroot2]newimage"
+  run_buildah commit $WITH_POLICY_JSON $cid "containers-storage:[vfs@${TEST_SCRATCH_DIR}/root2+${TEST_SCRATCH_DIR}/runroot2]newimage"
   echo FROM
-  run_buildah --storage-driver vfs --root ${TESTDIR}/root2 --runroot ${TESTDIR}/runroot2 from $WITH_POLICY_JSON newimage
+  run_buildah --storage-driver vfs --root ${TEST_SCRATCH_DIR}/root2 --runroot ${TEST_SCRATCH_DIR}/runroot2 from $WITH_POLICY_JSON newimage
 }
 
 @test "commit-rejected-name" {
@@ -207,28 +207,28 @@ load helpers
 @test "commit encrypted local oci image" {
   skip_if_rootless_environment
   _prefetch busybox
-  mkdir ${TESTDIR}/tmp
-  openssl genrsa -out ${TESTDIR}/tmp/mykey.pem 1024
-  openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
+  mkdir ${TEST_SCRATCH_DIR}/tmp
+  openssl genrsa -out ${TEST_SCRATCH_DIR}/tmp/mykey.pem 1024
+  openssl rsa -in ${TEST_SCRATCH_DIR}/tmp/mykey.pem -pubout > ${TEST_SCRATCH_DIR}/tmp/mykey.pub
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah commit --iidfile /dev/null $WITH_POLICY_JSON --encryption-key jwe:${TESTDIR}/tmp/mykey.pub -q $cid oci:${TESTDIR}/tmp/busybox_enc
-  imgtype  -show-manifest oci:${TESTDIR}/tmp/busybox_enc | grep "+encrypted"
-  rm -rf ${TESTDIR}/tmp
+  run_buildah commit --iidfile /dev/null $WITH_POLICY_JSON --encryption-key jwe:${TEST_SCRATCH_DIR}/tmp/mykey.pub -q $cid oci:${TEST_SCRATCH_DIR}/tmp/busybox_enc
+  imgtype  -show-manifest oci:${TEST_SCRATCH_DIR}/tmp/busybox_enc | grep "+encrypted"
+  rm -rf ${TEST_SCRATCH_DIR}/tmp
 }
 
 @test "commit oci encrypt to registry" {
   _prefetch busybox
-  mkdir ${TESTDIR}/tmp
-  openssl genrsa -out ${TESTDIR}/tmp/mykey.pem 1024
-  openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
+  mkdir ${TEST_SCRATCH_DIR}/tmp
+  openssl genrsa -out ${TEST_SCRATCH_DIR}/tmp/mykey.pem 1024
+  openssl rsa -in ${TEST_SCRATCH_DIR}/tmp/mykey.pem -pubout > ${TEST_SCRATCH_DIR}/tmp/mykey.pub
   start_registry
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah commit --iidfile /dev/null --tls-verify=false --creds testuser:testpassword $WITH_POLICY_JSON --encryption-key jwe:${TESTDIR}/tmp/mykey.pub -q $cid docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah commit --iidfile /dev/null --tls-verify=false --creds testuser:testpassword $WITH_POLICY_JSON --encryption-key jwe:${TEST_SCRATCH_DIR}/tmp/mykey.pub -q $cid docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
   # this test, just checks the ability to commit an image to a registry
   # there is no good way to test the details of the image unless with ./buildah pull, test will be in pull.bats
-  rm -rf ${TESTDIR}/tmp
+  rm -rf ${TEST_SCRATCH_DIR}/tmp
 }
 
 @test "commit omit-timestamp" {
@@ -248,7 +248,7 @@ load helpers
   run_buildah run $cid ls -l /test
   expect_output --substring "1970"
 
-  rm -rf ${TESTDIR}/tmp
+  rm -rf ${TEST_SCRATCH_DIR}/tmp
 }
 
 @test "commit timestamp" {
@@ -268,7 +268,7 @@ load helpers
   run_buildah run $cid ls -l /test
   expect_output --substring "1970"
 
-  rm -rf ${TESTDIR}/tmp
+  rm -rf ${TEST_SCRATCH_DIR}/tmp
 }
 
 @test "commit with authfile" {
@@ -278,7 +278,7 @@ load helpers
   run_buildah run $cid touch /test
 
   start_registry
-  run_buildah login --authfile ${TESTDIR}/test.auth --username testuser --password testpassword --tls-verify=false localhost:${REGISTRY_PORT}
-  run_buildah commit --authfile ${TESTDIR}/test.auth $WITH_POLICY_JSON --tls-verify=false $cid docker://localhost:${REGISTRY_PORT}/buildah/my-busybox
+  run_buildah login --authfile ${TEST_SCRATCH_DIR}/test.auth --username testuser --password testpassword --tls-verify=false localhost:${REGISTRY_PORT}
+  run_buildah commit --authfile ${TEST_SCRATCH_DIR}/test.auth $WITH_POLICY_JSON --tls-verify=false $cid docker://localhost:${REGISTRY_PORT}/buildah/my-busybox
   expect_output --substring "Writing manifest to image destination"
 }

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -299,7 +299,7 @@ function check_matrix() {
 
 @test "docker formatted builds must inherit healthcheck from base image" {
   _prefetch busybox
-  ctxdir=${TESTDIR}/bud
+  ctxdir=${TEST_SCRATCH_DIR}/bud
   mkdir -p $ctxdir
   cat >$ctxdir/Dockerfile <<EOF
 FROM busybox

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -17,7 +17,7 @@ load helpers
 }
 
 @test "config-flags-verification" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --label LABEL $cid
   run_buildah config --annotation ANNOTATION $cid
@@ -52,79 +52,79 @@ function check_matrix() {
 }
 
 @test "config entrypoint using single element in JSON array (exec form)" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
 
   check_matrix "Config.Entrypoint" '[/ENTRYPOINT]'
 }
 
 @test "config entrypoint using multiple elements in JSON array (exec form)" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --entrypoint '[ "/ENTRYPOINT", "ELEMENT2" ]' $cid
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
 
   check_matrix 'Config.Entrypoint' '[/ENTRYPOINT ELEMENT2]'
 }
 
 @test "config entrypoint using string (shell form)" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --entrypoint /ENTRYPOINT $cid
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
 
   check_matrix 'Config.Entrypoint' '[/bin/sh -c /ENTRYPOINT]'
 }
 
 @test "config set empty entrypoint doesn't wipe cmd" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --cmd "command" $cid
   run_buildah config --entrypoint "" $cid
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
 
   check_matrix 'Config.Cmd' '[command]'
 }
 
 @test "config cmd without entrypoint" {
-  run_buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull-never $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config \
    --cmd COMMAND-OR-ARGS \
   $cid
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
 
   check_matrix 'Config.Cmd' '[COMMAND-OR-ARGS]'
   check_matrix 'Config.Entrypoint' '[]'
 }
 
 @test "config entrypoint with cmd" {
-  run_buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull-never $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config \
    --entrypoint /ENTRYPOINT \
    --cmd COMMAND-OR-ARGS \
   $cid
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
 
   check_matrix 'Config.Cmd' '[COMMAND-OR-ARGS]'
 
-  run_buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull-never $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config \
    --entrypoint /ENTRYPOINT \
   $cid
 
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
 
   check_matrix 'Config.Cmd' '[]'
 
@@ -133,8 +133,8 @@ function check_matrix() {
    --cmd COMMAND-OR-ARGS \
   $cid
 
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
   check_matrix 'Config.Cmd' '[COMMAND-OR-ARGS]'
 
   run_buildah config \
@@ -142,13 +142,13 @@ function check_matrix() {
    --cmd '[ "/COMMAND", "ARG1", "ARG2"]' \
   $cid
 
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
   check_matrix 'Config.Cmd' '[/COMMAND ARG1 ARG2]'
 }
 
 @test "config remove all" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config \
    --port 12345 \
@@ -157,8 +157,8 @@ function check_matrix() {
    --volume /VOLUME \
    --label LABEL=VALUE \
   $cid
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
 
   run_buildah inspect --type=image --format '{{index .ImageAnnotations "ANNOTATION"}}' scratch-image-oci
   expect_output "VALUE1,VALUE2"
@@ -168,7 +168,7 @@ function check_matrix() {
   check_matrix 'Config.Env'          '[VARIABLE=VALUE1,VALUE2]'
   check_matrix 'Config.Labels.LABEL' 'VALUE'
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config \
    --port - \
@@ -178,8 +178,8 @@ function check_matrix() {
    --label - \
   $cid
 
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
 
   run_buildah inspect --type=image --format '{{.ImageAnnotations}}'                      scratch-image-oci
   expect_output "map[]"
@@ -191,7 +191,7 @@ function check_matrix() {
 }
 
 @test "config" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config \
    --author TESTAUTHOR \
@@ -223,8 +223,8 @@ function check_matrix() {
    --onbuild "RUN touch /foo" \
   $cid
 
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
 
   check_matrix 'Author'       'TESTAUTHOR'
   check_matrix 'Architecture' 'amd64'
@@ -284,11 +284,11 @@ function check_matrix() {
 
 @test "config env using local environment" {
   export foo=bar
-  run_buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull-never $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --env 'foo' $cid
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid env-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid env-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid env-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid env-image-oci
 
   run_buildah inspect --type=image --format '{{.Docker.Config.Env}}' env-image-docker
   expect_output --substring "foo=bar"
@@ -306,25 +306,25 @@ FROM busybox
 HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1
 EOF
 
-  run_buildah build --format docker --signature-policy ${TESTSDIR}/policy.json -t test ${ctxdir}
+  run_buildah build --format docker $WITH_POLICY_JSON -t test ${ctxdir}
 
   cat >$ctxdir/Dockerfile <<EOF
 FROM test
 RUN echo hello
 EOF
 
-  run_buildah build --format docker --signature-policy ${TESTSDIR}/policy.json -t test2 ${ctxdir}
+  run_buildah build --format docker $WITH_POLICY_JSON -t test2 ${ctxdir}
   run_buildah inspect --type=image --format '{{.Docker.ContainerConfig.Healthcheck.Test}}' test2
   expect_output --substring "localhost:3000"
 }
 
 @test "config env using --env expansion" {
-  run_buildah from --pull-never --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull-never $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --env 'foo=bar' --env 'foo1=bar1' $cid
   run_buildah config --env 'combined=$foo/${foo1}' $cid
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid env-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid env-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid env-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid env-image-oci
 
   run_buildah inspect --type=image --format '{{.Docker.Config.Env}}' env-image-docker
   expect_output --substring "combined=bar/bar1"
@@ -335,7 +335,7 @@ EOF
 
 @test "user" {
   _prefetch alpine
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah run $cid grep CapBnd /proc/self/status
   bndoutput=$output
@@ -351,7 +351,7 @@ EOF
 }
 
 @test "remove configs using '-' syntax" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config \
    --created-by COINCIDENCE \
@@ -362,8 +362,8 @@ EOF
    --annotation ANNOTATION=VALUE1,VALUE2 \
   $cid
 
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
   run_buildah inspect --format '{{.ImageCreatedBy}}' $cid
   expect_output "COINCIDENCE"
 
@@ -385,8 +385,8 @@ EOF
    --annotation ANNOTATION- \
   $cid
 
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
   run_buildah inspect --format '{{.ImageCreatedBy}}' $cid
   expect_output "COINCIDENCE"
   check_matrix 'Config.Volumes'      'map[]'
@@ -406,8 +406,8 @@ EOF
    --annotation ANNOTATION=VALUE1,VALUE2 \
   $cid
 
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
   run_buildah inspect --format '{{.ImageCreatedBy}}' $cid
   expect_output "COINCIDENCE"
 

--- a/tests/containers.bats
+++ b/tests/containers.bats
@@ -74,7 +74,7 @@ load helpers
 
   _prefetch alpine busybox
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
-  podman create --root ${TESTDIR}/root --storage-driver ${STORAGE_DRIVER} --net=host busybox ls
+  podman create --root ${TEST_SCRATCH_DIR}/root --storage-driver ${STORAGE_DRIVER} --net=host busybox ls
   run_buildah containers
   expect_line_count 2
   run_buildah containers -a

--- a/tests/containers.bats
+++ b/tests/containers.bats
@@ -4,17 +4,17 @@ load helpers
 
 @test "containers" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   run_buildah containers
   expect_line_count 3
 }
 
 @test "containers filter test" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid2=$output
   run_buildah containers --filter name=$cid1
   expect_line_count 2
@@ -22,8 +22,8 @@ load helpers
 
 @test "containers format test" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   run_buildah containers --format "{{.ContainerName}}"
   expect_line_count 2
   expect_output --from="${lines[0]}" "alpine-working-container"
@@ -32,15 +32,15 @@ load helpers
 
 @test "containers json test" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   run_buildah containers --json
   expect_output --substring '\{'
 }
 
 @test "containers noheading test" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   run_buildah containers --noheading
   expect_line_count 2
   if [[ $output =~ "NAME" ]]; then
@@ -50,8 +50,8 @@ load helpers
 
 @test "containers quiet test" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   run_buildah containers --quiet
   expect_line_count 2
 
@@ -62,7 +62,7 @@ load helpers
 
 @test "containers notruncate test" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   run_buildah containers --notruncate
   expect_line_count 2
   expect_output --substring --from="${lines[1]}" '^[0-9a-f]{64}'
@@ -73,7 +73,7 @@ load helpers
   skip_if_no_podman
 
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   podman create --root ${TESTDIR}/root --storage-driver ${STORAGE_DRIVER} --net=host busybox ls
   run_buildah containers
   expect_line_count 2

--- a/tests/containers_conf.bats
+++ b/tests/containers_conf.bats
@@ -15,9 +15,9 @@ load helpers
 
     run_buildah rm $cid
 
-    sed "s/^label = true/label = false/g" ${TEST_SOURCES}/containers.conf > ${TESTDIR}/containers.conf
+    sed "s/^label = true/label = false/g" ${TEST_SOURCES}/containers.conf > ${TEST_SCRATCH_DIR}/containers.conf
     cid=$(buildah from $WITH_POLICY_JSON alpine)
-    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah 1 --log-level=error run $cid sh -c "cat /proc/self/attr/current | grep container_t"
+    CONTAINERS_CONF=${TEST_SCRATCH_DIR}/containers.conf run_buildah 1 --log-level=error run $cid sh -c "cat /proc/self/attr/current | grep container_t"
 }
 
 @test "containers.conf ulimit test" {
@@ -46,11 +46,11 @@ load helpers
     CONTAINERS_CONF=$CONTAINERS_CONF run_buildah 1 --log-level=error run $cid ls /dev/foo1
     run_buildah rm $cid
 
-    sed '/^devices.*/a "\/dev\/foo:\/dev\/foo1:rmw",' ${TEST_SOURCES}/containers.conf > ${TESTDIR}/containers.conf
+    sed '/^devices.*/a "\/dev\/foo:\/dev\/foo1:rmw",' ${TEST_SOURCES}/containers.conf > ${TEST_SCRATCH_DIR}/containers.conf
     rm -f /dev/foo; mknod /dev/foo c 1 1
-    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah from --quiet $WITH_POLICY_JSON alpine
+    CONTAINERS_CONF=${TEST_SCRATCH_DIR}/containers.conf run_buildah from --quiet $WITH_POLICY_JSON alpine
     cid="$output"
-    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah  --log-level=error run $cid ls /dev/foo1
+    CONTAINERS_CONF=${TEST_SCRATCH_DIR}/containers.conf run_buildah  --log-level=error run $cid ls /dev/foo1
     rm -f /dev/foo
 }
 
@@ -64,11 +64,11 @@ load helpers
     expect_output "00000000a80425fb"
     run_buildah rm $cid
 
-    sed "/AUDIT_WRITE/d" ${TEST_SOURCES}/containers.conf > ${TESTDIR}/containers.conf
-    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah from --quiet $WITH_POLICY_JSON alpine
+    sed "/AUDIT_WRITE/d" ${TEST_SOURCES}/containers.conf > ${TEST_SCRATCH_DIR}/containers.conf
+    CONTAINERS_CONF=${TEST_SCRATCH_DIR}/containers.conf run_buildah from --quiet $WITH_POLICY_JSON alpine
     cid="$output"
 
-    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah --log-level=error run $cid sh -c 'grep  CapEff /proc/self/status | cut -f2'
+    CONTAINERS_CONF=${TEST_SCRATCH_DIR}/containers.conf run_buildah --log-level=error run $cid sh -c 'grep  CapEff /proc/self/status | cut -f2'
     run_buildah rm $cid
 
     test "$output" != "$CapEff"
@@ -93,16 +93,16 @@ load helpers
 
     test -x /usr/bin/crun || skip "/usr/bin/crun doesn't exist"
 
-    ln -s /usr/bin/crun ${TESTDIR}/runtime
+    ln -s /usr/bin/crun ${TEST_SCRATCH_DIR}/runtime
 
-    cat >${TESTDIR}/containers.conf << EOF
+    cat >${TEST_SCRATCH_DIR}/containers.conf << EOF
 [engine]
 runtime = "nonstandard_runtime_name"
 [engine.runtimes]
-nonstandard_runtime_name = ["${TESTDIR}/runtime"]
+nonstandard_runtime_name = ["${TEST_SCRATCH_DIR}/runtime"]
 EOF
 
     _prefetch alpine
     cid=$(buildah from $WITH_POLICY_JSON alpine)
-    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah --log-level=error run $cid true
+    CONTAINERS_CONF=${TEST_SCRATCH_DIR}/containers.conf run_buildah --log-level=error run $cid true
 }

--- a/tests/containers_conf.bats
+++ b/tests/containers_conf.bats
@@ -15,7 +15,7 @@ load helpers
 
     run_buildah rm $cid
 
-    sed "s/^label = true/label = false/g" ${TESTSDIR}/containers.conf > ${TESTDIR}/containers.conf
+    sed "s/^label = true/label = false/g" ${TEST_SOURCES}/containers.conf > ${TESTDIR}/containers.conf
     cid=$(buildah from $WITH_POLICY_JSON alpine)
     CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah 1 --log-level=error run $cid sh -c "cat /proc/self/attr/current | grep container_t"
 }
@@ -46,7 +46,7 @@ load helpers
     CONTAINERS_CONF=$CONTAINERS_CONF run_buildah 1 --log-level=error run $cid ls /dev/foo1
     run_buildah rm $cid
 
-    sed '/^devices.*/a "\/dev\/foo:\/dev\/foo1:rmw",' ${TESTSDIR}/containers.conf > ${TESTDIR}/containers.conf
+    sed '/^devices.*/a "\/dev\/foo:\/dev\/foo1:rmw",' ${TEST_SOURCES}/containers.conf > ${TESTDIR}/containers.conf
     rm -f /dev/foo; mknod /dev/foo c 1 1
     CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah from --quiet $WITH_POLICY_JSON alpine
     cid="$output"
@@ -64,7 +64,7 @@ load helpers
     expect_output "00000000a80425fb"
     run_buildah rm $cid
 
-    sed "/AUDIT_WRITE/d" ${TESTSDIR}/containers.conf > ${TESTDIR}/containers.conf
+    sed "/AUDIT_WRITE/d" ${TEST_SOURCES}/containers.conf > ${TESTDIR}/containers.conf
     CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah from --quiet $WITH_POLICY_JSON alpine
     cid="$output"
 

--- a/tests/containers_conf.bats
+++ b/tests/containers_conf.bats
@@ -10,13 +10,13 @@ load helpers
     fi
 
     _prefetch alpine
-    cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+    cid=$(buildah from $WITH_POLICY_JSON alpine)
     run_buildah --log-level=error run $cid sh -c "cat /proc/self/attr/current | grep container_t"
 
     run_buildah rm $cid
 
     sed "s/^label = true/label = false/g" ${TESTSDIR}/containers.conf > ${TESTDIR}/containers.conf
-    cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+    cid=$(buildah from $WITH_POLICY_JSON alpine)
     CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah 1 --log-level=error run $cid sh -c "cat /proc/self/attr/current | grep container_t"
 }
 
@@ -26,11 +26,11 @@ load helpers
     fi
 
     _prefetch alpine
-    cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+    cid=$(buildah from $WITH_POLICY_JSON alpine)
     run_buildah --log-level=error run $cid  awk '/open files/{print $4}' /proc/self/limits
     expect_output "500" "limits: open files (w/file limit)"
 
-    cid=$(buildah from --ulimit nofile=300:400 --signature-policy ${TESTSDIR}/policy.json alpine)
+    cid=$(buildah from --ulimit nofile=300:400 $WITH_POLICY_JSON alpine)
     run_buildah --log-level=error run $cid awk '/open files/{print $4}' /proc/self/limits
     expect_output "300" "limits: open files (w/file limit)"
 }
@@ -42,13 +42,13 @@ load helpers
     fi
 
     _prefetch alpine
-    cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+    cid=$(buildah from $WITH_POLICY_JSON alpine)
     CONTAINERS_CONF=$CONTAINERS_CONF run_buildah 1 --log-level=error run $cid ls /dev/foo1
     run_buildah rm $cid
 
     sed '/^devices.*/a "\/dev\/foo:\/dev\/foo1:rmw",' ${TESTSDIR}/containers.conf > ${TESTDIR}/containers.conf
     rm -f /dev/foo; mknod /dev/foo c 1 1
-    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah from --quiet $WITH_POLICY_JSON alpine
     cid="$output"
     CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah  --log-level=error run $cid ls /dev/foo1
     rm -f /dev/foo
@@ -57,7 +57,7 @@ load helpers
 @test "containers.conf capabilities test" {
     _prefetch alpine
 
-    run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+    run_buildah from --quiet $WITH_POLICY_JSON alpine
     cid="$output"
     run_buildah --log-level=error run $cid sh -c 'grep  CapEff /proc/self/status | cut -f2'
     CapEff="$output"
@@ -65,7 +65,7 @@ load helpers
     run_buildah rm $cid
 
     sed "/AUDIT_WRITE/d" ${TESTSDIR}/containers.conf > ${TESTDIR}/containers.conf
-    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+    CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah from --quiet $WITH_POLICY_JSON alpine
     cid="$output"
 
     CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah --log-level=error run $cid sh -c 'grep  CapEff /proc/self/status | cut -f2'
@@ -80,7 +80,7 @@ load helpers
     fi
 
     _prefetch alpine
-    run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+    run_buildah from --quiet $WITH_POLICY_JSON alpine
     cid="$output"
     run_buildah --log-level=error run $cid sh -c 'df /dev/shm | awk '\''/shm/{print $4}'\'''
     expect_output "200"
@@ -103,6 +103,6 @@ nonstandard_runtime_name = ["${TESTDIR}/runtime"]
 EOF
 
     _prefetch alpine
-    cid=$(buildah from --signature-policy ${TESTSDIR}/policy.json alpine)
+    cid=$(buildah from $WITH_POLICY_JSON alpine)
     CONTAINERS_CONF=${TESTDIR}/containers.conf run_buildah --log-level=error run $cid true
 }

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -14,23 +14,23 @@ load helpers
 }
 
 @test "copy-local-multiple" {
-  createrandom ${TESTDIR}/randomfile
-  createrandom ${TESTDIR}/other-randomfile
-  createrandom ${TESTDIR}/third-randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/other-randomfile
+  createrandom ${TEST_SCRATCH_DIR}/third-randomfile
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
   run_buildah config --workingdir / $cid
-  # copy ${TESTDIR}/randomfile to a file of the same name in the container's working directory
-  run_buildah copy $cid ${TESTDIR}/randomfile
-  # copy ${TESTDIR}/other-randomfile and ${TESTDIR}/third-randomfile to a new directory named ${TESTDIR}/randomfile in the container
-  run_buildah copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile
-  # try to copy ${TESTDIR}/other-randomfile and ${TESTDIR}/third-randomfile to a /randomfile, which already exists and is a file
-  run_buildah 125 copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile /randomfile
-  # copy ${TESTDIR}/other-randomfile and ${TESTDIR}/third-randomfile to previously-created directory named ${TESTDIR}/randomfile in the container
-  run_buildah copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile
+  # copy ${TEST_SCRATCH_DIR}/randomfile to a file of the same name in the container's working directory
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/randomfile
+  # copy ${TEST_SCRATCH_DIR}/other-randomfile and ${TEST_SCRATCH_DIR}/third-randomfile to a new directory named ${TEST_SCRATCH_DIR}/randomfile in the container
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/other-randomfile ${TEST_SCRATCH_DIR}/third-randomfile ${TEST_SCRATCH_DIR}/randomfile
+  # try to copy ${TEST_SCRATCH_DIR}/other-randomfile and ${TEST_SCRATCH_DIR}/third-randomfile to a /randomfile, which already exists and is a file
+  run_buildah 125 copy $cid ${TEST_SCRATCH_DIR}/other-randomfile ${TEST_SCRATCH_DIR}/third-randomfile /randomfile
+  # copy ${TEST_SCRATCH_DIR}/other-randomfile and ${TEST_SCRATCH_DIR}/third-randomfile to previously-created directory named ${TEST_SCRATCH_DIR}/randomfile in the container
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/other-randomfile ${TEST_SCRATCH_DIR}/third-randomfile ${TEST_SCRATCH_DIR}/randomfile
   run_buildah rm $cid
 
   _prefetch alpine
@@ -39,8 +39,8 @@ load helpers
   run_buildah mount $cid
   root=$output
   run_buildah config --workingdir / $cid
-  run_buildah copy $cid ${TESTDIR}/randomfile
-  run_buildah copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile /etc
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/randomfile
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/other-randomfile ${TEST_SCRATCH_DIR}/third-randomfile ${TEST_SCRATCH_DIR}/randomfile /etc
   run_buildah rm $cid
 
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
@@ -48,22 +48,22 @@ load helpers
   run_buildah mount $cid
   root=$output
   run_buildah config --workingdir / $cid
-  run_buildah copy $cid "${TESTDIR}/*randomfile" /etc
-  (cd ${TESTDIR}; for i in *randomfile; do cmp $i ${root}/etc/$i; done)
+  run_buildah copy $cid "${TEST_SCRATCH_DIR}/*randomfile" /etc
+  (cd ${TEST_SCRATCH_DIR}; for i in *randomfile; do cmp $i ${root}/etc/$i; done)
 }
 
 @test "copy-local-plain" {
-  createrandom ${TESTDIR}/randomfile
-  createrandom ${TESTDIR}/other-randomfile
-  createrandom ${TESTDIR}/third-randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/other-randomfile
+  createrandom ${TEST_SCRATCH_DIR}/third-randomfile
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
   run_buildah config --workingdir / $cid
-  run_buildah copy $cid ${TESTDIR}/randomfile
-  run_buildah copy $cid ${TESTDIR}/other-randomfile
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/randomfile
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/other-randomfile
   run_buildah unmount $cid
   run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
   run_buildah rm $cid
@@ -73,98 +73,98 @@ load helpers
   run_buildah mount $newcid
   newroot=$output
   test -s $newroot/randomfile
-  cmp ${TESTDIR}/randomfile $newroot/randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $newroot/randomfile
   test -s $newroot/other-randomfile
-  cmp ${TESTDIR}/other-randomfile $newroot/other-randomfile
+  cmp ${TEST_SCRATCH_DIR}/other-randomfile $newroot/other-randomfile
 }
 
 @test "copy-local-subdirectory" {
-  mkdir -p ${TESTDIR}/subdir
-  createrandom ${TESTDIR}/subdir/randomfile
-  createrandom ${TESTDIR}/subdir/other-randomfile
+  mkdir -p ${TEST_SCRATCH_DIR}/subdir
+  createrandom ${TEST_SCRATCH_DIR}/subdir/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/subdir/other-randomfile
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --workingdir /container-subdir $cid
-  run_buildah copy $cid ${TESTDIR}/subdir
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/subdir
   run_buildah mount $cid
   root=$output
   test -s $root/container-subdir/randomfile
-  cmp ${TESTDIR}/subdir/randomfile $root/container-subdir/randomfile
+  cmp ${TEST_SCRATCH_DIR}/subdir/randomfile $root/container-subdir/randomfile
   test -s $root/container-subdir/other-randomfile
-  cmp ${TESTDIR}/subdir/other-randomfile $root/container-subdir/other-randomfile
-  run_buildah copy $cid ${TESTDIR}/subdir /other-subdir
+  cmp ${TEST_SCRATCH_DIR}/subdir/other-randomfile $root/container-subdir/other-randomfile
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/subdir /other-subdir
   test -s $root/other-subdir/randomfile
-  cmp ${TESTDIR}/subdir/randomfile $root/other-subdir/randomfile
+  cmp ${TEST_SCRATCH_DIR}/subdir/randomfile $root/other-subdir/randomfile
   test -s $root/other-subdir/other-randomfile
-  cmp ${TESTDIR}/subdir/other-randomfile $root/other-subdir/other-randomfile
+  cmp ${TEST_SCRATCH_DIR}/subdir/other-randomfile $root/other-subdir/other-randomfile
 }
 
 @test "copy-local-force-directory" {
-  createrandom ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --workingdir / $cid
-  run_buildah copy $cid ${TESTDIR}/randomfile /randomfile
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/randomfile /randomfile
   run_buildah mount $cid
   root=$output
   test -s $root/randomfile
-  cmp ${TESTDIR}/randomfile $root/randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $root/randomfile
   run_buildah rm $cid
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --workingdir / $cid
-  run_buildah copy $cid ${TESTDIR}/randomfile /randomsubdir/
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/randomfile /randomsubdir/
   run_buildah mount $cid
   root=$output
   test -s $root/randomsubdir/randomfile
-  cmp ${TESTDIR}/randomfile $root/randomsubdir/randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $root/randomsubdir/randomfile
 }
 
 @test "copy-url-mtime" {
   # Create a file with random content and a non-now timestamp (so we can
   # can trust that buildah correctly set mtime on copy)
-  createrandom ${TESTDIR}/randomfile
-  touch -t 201910310123.45 ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
+  touch -t 201910310123.45 ${TEST_SCRATCH_DIR}/randomfile
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --workingdir / $cid
-  starthttpd ${TESTDIR}
+  starthttpd ${TEST_SCRATCH_DIR}
   run_buildah copy $cid http://0.0.0.0:${HTTP_SERVER_PORT}/randomfile /urlfile
   stophttpd
   run_buildah mount $cid
   root=$output
   test -s $root/urlfile
-  cmp ${TESTDIR}/randomfile $root/urlfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $root/urlfile
 
   # Compare timestamps. Display them in human-readable form, so if there's
   # a mismatch it will be shown in the test log.
-  mtime_randomfile=$(stat --format %y ${TESTDIR}/randomfile)
+  mtime_randomfile=$(stat --format %y ${TEST_SCRATCH_DIR}/randomfile)
   mtime_urlfile=$(stat --format %y $root/urlfile)
 
   expect_output --from="$mtime_randomfile" "$mtime_urlfile" "mtime[randomfile] == mtime[urlfile]"
 }
 
 @test "copy --chown" {
-  mkdir -p ${TESTDIR}/subdir
-  mkdir -p ${TESTDIR}/other-subdir
-  createrandom ${TESTDIR}/subdir/randomfile
-  createrandom ${TESTDIR}/subdir/other-randomfile
-  createrandom ${TESTDIR}/randomfile
-  createrandom ${TESTDIR}/other-subdir/randomfile
-  createrandom ${TESTDIR}/other-subdir/other-randomfile
+  mkdir -p ${TEST_SCRATCH_DIR}/subdir
+  mkdir -p ${TEST_SCRATCH_DIR}/other-subdir
+  createrandom ${TEST_SCRATCH_DIR}/subdir/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/subdir/other-randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/other-subdir/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/other-subdir/other-randomfile
 
   _prefetch alpine
   run_buildah from --quiet $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah config --workingdir / $cid
-  run_buildah copy --chown 1:1 $cid ${TESTDIR}/randomfile
-  run_buildah copy --chown root:1 $cid ${TESTDIR}/randomfile /randomfile2
-  run_buildah copy --chown nobody $cid ${TESTDIR}/randomfile /randomfile3
-  run_buildah copy --chown nobody:root $cid ${TESTDIR}/subdir /subdir
+  run_buildah copy --chown 1:1 $cid ${TEST_SCRATCH_DIR}/randomfile
+  run_buildah copy --chown root:1 $cid ${TEST_SCRATCH_DIR}/randomfile /randomfile2
+  run_buildah copy --chown nobody $cid ${TEST_SCRATCH_DIR}/randomfile /randomfile3
+  run_buildah copy --chown nobody:root $cid ${TEST_SCRATCH_DIR}/subdir /subdir
   run_buildah run $cid stat -c "%u:%g" /randomfile
   expect_output "1:1" "stat ug /randomfile"
 
@@ -183,7 +183,7 @@ load helpers
   run_buildah run $cid stat -c "%U:%G" /subdir
   expect_output "nobody:root" "stat UG /subdir"
 
-  run_buildah copy --chown root:root $cid ${TESTDIR}/other-subdir /subdir
+  run_buildah copy --chown root:root $cid ${TEST_SCRATCH_DIR}/other-subdir /subdir
   for i in randomfile other-randomfile ; do
       run_buildah run $cid stat -c "%U:%G" /subdir/$i
       expect_output "root:root" "stat UG /subdir/$i (after chown)"
@@ -195,22 +195,22 @@ load helpers
 }
 
 @test "copy --chmod" {
-  mkdir -p ${TESTDIR}/subdir
-  mkdir -p ${TESTDIR}/other-subdir
-  createrandom ${TESTDIR}/subdir/randomfile
-  createrandom ${TESTDIR}/subdir/other-randomfile
-  createrandom ${TESTDIR}/randomfile
-  createrandom ${TESTDIR}/other-subdir/randomfile
-  createrandom ${TESTDIR}/other-subdir/other-randomfile
+  mkdir -p ${TEST_SCRATCH_DIR}/subdir
+  mkdir -p ${TEST_SCRATCH_DIR}/other-subdir
+  createrandom ${TEST_SCRATCH_DIR}/subdir/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/subdir/other-randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/other-subdir/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/other-subdir/other-randomfile
 
   _prefetch alpine
   run_buildah from --quiet $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah config --workingdir / $cid
-  run_buildah copy --chmod 777 $cid ${TESTDIR}/randomfile
-  run_buildah copy --chmod 700 $cid ${TESTDIR}/randomfile /randomfile2
-  run_buildah copy --chmod 755 $cid ${TESTDIR}/randomfile /randomfile3
-  run_buildah copy --chmod 660 $cid ${TESTDIR}/subdir /subdir
+  run_buildah copy --chmod 777 $cid ${TEST_SCRATCH_DIR}/randomfile
+  run_buildah copy --chmod 700 $cid ${TEST_SCRATCH_DIR}/randomfile /randomfile2
+  run_buildah copy --chmod 755 $cid ${TEST_SCRATCH_DIR}/randomfile /randomfile3
+  run_buildah copy --chmod 660 $cid ${TEST_SCRATCH_DIR}/subdir /subdir
 
   run_buildah run $cid ls -l /randomfile
   expect_output --substring rwxrwxrwx
@@ -229,7 +229,7 @@ load helpers
   run_buildah run $cid ls -l /subdir
   expect_output --substring rw-rw----
 
-  run_buildah copy --chmod 600 $cid ${TESTDIR}/other-subdir /subdir
+  run_buildah copy --chmod 600 $cid ${TEST_SCRATCH_DIR}/other-subdir /subdir
   for i in randomfile other-randomfile ; do
       run_buildah run $cid ls -l /subdir/$i
       expect_output --substring rw-------
@@ -237,15 +237,15 @@ load helpers
 }
 
 @test "copy-symlink" {
-  createrandom ${TESTDIR}/randomfile
-  ln -s ${TESTDIR}/randomfile ${TESTDIR}/link-randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
+  ln -s ${TEST_SCRATCH_DIR}/randomfile ${TEST_SCRATCH_DIR}/link-randomfile
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
   run_buildah config --workingdir / $cid
-  run_buildah copy $cid ${TESTDIR}/link-randomfile
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/link-randomfile
   run_buildah unmount $cid
   run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
   run_buildah rm $cid
@@ -256,22 +256,22 @@ load helpers
   newroot=$output
   test -s $newroot/link-randomfile
   test -f $newroot/link-randomfile
-  cmp ${TESTDIR}/randomfile $newroot/link-randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $newroot/link-randomfile
 }
 
 @test "ignore-socket" {
-  createrandom ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
   # This seems to be the least-worst way to create a socket: run and kill nc
-  nc -lkU ${TESTDIR}/test.socket &
+  nc -lkU ${TEST_SCRATCH_DIR}/test.socket &
   nc_pid=$!
   # This should succeed fairly quickly. We test with a timeout in case of
   # failure (likely reason: 'nc' not installed.)
   retries=50
-  while ! test -e ${TESTDIR}/test.socket; do
+  while ! test -e ${TEST_SCRATCH_DIR}/test.socket; do
       sleep 0.1
       retries=$((retries - 1))
       if [[ $retries -eq 0 ]]; then
-          die "Timed out waiting for ${TESTDIR}/test.socket (is nc installed?)"
+          die "Timed out waiting for ${TEST_SCRATCH_DIR}/test.socket (is nc installed?)"
       fi
   done
   kill $nc_pid
@@ -293,15 +293,15 @@ load helpers
 }
 
 @test "copy-symlink-archive-suffix" {
-  createrandom ${TESTDIR}/randomfile.tar.gz
-  ln -s ${TESTDIR}/randomfile.tar.gz ${TESTDIR}/link-randomfile.tar.gz
+  createrandom ${TEST_SCRATCH_DIR}/randomfile.tar.gz
+  ln -s ${TEST_SCRATCH_DIR}/randomfile.tar.gz ${TEST_SCRATCH_DIR}/link-randomfile.tar.gz
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
   run_buildah config --workingdir / $cid
-  run_buildah copy $cid ${TESTDIR}/link-randomfile.tar.gz
+  run_buildah copy $cid ${TEST_SCRATCH_DIR}/link-randomfile.tar.gz
   run_buildah unmount $cid
   run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
   run_buildah rm $cid
@@ -312,22 +312,22 @@ load helpers
   newroot=$output
   test -s $newroot/link-randomfile.tar.gz
   test -f $newroot/link-randomfile.tar.gz
-  cmp ${TESTDIR}/randomfile.tar.gz $newroot/link-randomfile.tar.gz
+  cmp ${TEST_SCRATCH_DIR}/randomfile.tar.gz $newroot/link-randomfile.tar.gz
 }
 
 @test "copy-detect-missing-data" {
   _prefetch busybox
 
-  : > ${TESTDIR}/Dockerfile
-  echo FROM busybox AS builder                                >> ${TESTDIR}/Dockerfile
-  echo FROM scratch                                           >> ${TESTDIR}/Dockerfile
-  echo COPY --from=builder /bin/-no-such-file-error- /usr/bin >> ${TESTDIR}/Dockerfile
-  run_buildah 125 build-using-dockerfile $WITH_POLICY_JSON ${TESTDIR}
+  : > ${TEST_SCRATCH_DIR}/Dockerfile
+  echo FROM busybox AS builder                                >> ${TEST_SCRATCH_DIR}/Dockerfile
+  echo FROM scratch                                           >> ${TEST_SCRATCH_DIR}/Dockerfile
+  echo COPY --from=builder /bin/-no-such-file-error- /usr/bin >> ${TEST_SCRATCH_DIR}/Dockerfile
+  run_buildah 125 build-using-dockerfile $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
   expect_output --substring "no such file or directory"
 }
 
 @test "copy --ignorefile" {
-  mytest=${TESTDIR}/mytest
+  mytest=${TEST_SCRATCH_DIR}/mytest
   mkdir -p ${mytest}
   touch ${mytest}/mystuff
   touch ${mytest}/source.go
@@ -360,27 +360,27 @@ stuff/mystuff"
 }
 
 @test "copy-quiet" {
-  createrandom ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
   _prefetch alpine
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah mount $cid
   root=$output
-  run_buildah copy --quiet $cid ${TESTDIR}/randomfile /
+  run_buildah copy --quiet $cid ${TEST_SCRATCH_DIR}/randomfile /
   expect_output ""
-  cmp ${TESTDIR}/randomfile $root/randomfile
+  cmp ${TEST_SCRATCH_DIR}/randomfile $root/randomfile
   run_buildah umount $cid
   run_buildah rm $cid
 }
 
 @test "copy-from-container" {
   _prefetch busybox
-  createrandom ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
   run_buildah from --quiet $WITH_POLICY_JSON busybox
   from=$output
   run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah copy --quiet $from ${TESTDIR}/randomfile /tmp/random
+  run_buildah copy --quiet $from ${TEST_SCRATCH_DIR}/randomfile /tmp/random
   expect_output ""
   run_buildah copy --quiet $WITH_POLICY_JSON --from $from $cid /tmp/random /tmp/random # absolute path
   expect_output ""
@@ -388,25 +388,25 @@ stuff/mystuff"
   expect_output ""
   run_buildah mount $cid
   croot=$output
-  cmp ${TESTDIR}/randomfile ${croot}/tmp/random
-  cmp ${TESTDIR}/randomfile ${croot}/tmp/random2
+  cmp ${TEST_SCRATCH_DIR}/randomfile ${croot}/tmp/random
+  cmp ${TEST_SCRATCH_DIR}/randomfile ${croot}/tmp/random2
 }
 
 @test "copy-container-root" {
   _prefetch busybox
-  createrandom ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
   run_buildah from --quiet $WITH_POLICY_JSON busybox
   from=$output
   run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah copy --quiet $from ${TESTDIR}/randomfile /tmp/random
+  run_buildah copy --quiet $from ${TEST_SCRATCH_DIR}/randomfile /tmp/random
   expect_output ""
   run_buildah copy --quiet $WITH_POLICY_JSON --from $from $cid / /tmp/
   expect_output "" || \
     expect_output --substring "copier: file disappeared while reading"
   run_buildah mount $cid
   croot=$output
-  cmp ${TESTDIR}/randomfile ${croot}/tmp/tmp/random
+  cmp ${TEST_SCRATCH_DIR}/randomfile ${croot}/tmp/tmp/random
 }
 
 @test "add-from-image" {
@@ -445,16 +445,16 @@ stuff/mystuff"
 }
 
 @test "copy-preserving-extended-attributes" {
-  createrandom ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
   # if we need to change which image we use, any image that can provide a working setattr/setcap/getfattr will do
   image="quay.io/libpod/fedora-minimal:34"
   if ! which setfattr > /dev/null 2> /dev/null; then
-    skip "setfattr not available, unable to check if it'll work in filesystem at ${TESTDIR}"
+    skip "setfattr not available, unable to check if it'll work in filesystem at ${TEST_SCRATCH_DIR}"
   fi
-  run setfattr -n user.yeah -v butno ${TESTDIR}/root
+  run setfattr -n user.yeah -v butno ${TEST_SCRATCH_DIR}/root
   if [ "$status" -ne 0 ] ; then
     if [[ "$output" =~ "not supported" ]] ; then
-      skip "setfattr not supported in filesystem at ${TESTDIR}"
+      skip "setfattr not supported in filesystem at ${TEST_SCRATCH_DIR}"
     fi
     skip "$output"
   fi
@@ -462,7 +462,7 @@ stuff/mystuff"
   run_buildah from --quiet $WITH_POLICY_JSON $image
   first="$output"
   run_buildah run $first microdnf -y install /usr/bin/setfattr /usr/sbin/setcap
-  run_buildah copy $first ${TESTDIR}/randomfile /
+  run_buildah copy $first ${TEST_SCRATCH_DIR}/randomfile /
   # set security.capability
   run_buildah run $first setcap cap_setuid=ep /randomfile
   # set user.something
@@ -482,13 +482,13 @@ stuff/mystuff"
 @test "copy-relative-context-dir" {
   image=busybox
   _prefetch $image
-  mkdir -p ${TESTDIR}/context
-  createrandom ${TESTDIR}/context/excluded_test_file
-  createrandom ${TESTDIR}/context/test_file
-  echo excluded_test_file | tee ${TESTDIR}/context/.containerignore | tee ${TESTDIR}/context/.dockerignore
+  mkdir -p ${TEST_SCRATCH_DIR}/context
+  createrandom ${TEST_SCRATCH_DIR}/context/excluded_test_file
+  createrandom ${TEST_SCRATCH_DIR}/context/test_file
+  echo excluded_test_file | tee ${TEST_SCRATCH_DIR}/context/.containerignore | tee ${TEST_SCRATCH_DIR}/context/.dockerignore
   run_buildah from --quiet $WITH_POLICY_JSON $image
   ctr="$output"
-  cd ${TESTDIR}/context
+  cd ${TEST_SCRATCH_DIR}/context
   run_buildah copy --contextdir . $ctr / /opt/
   run_buildah run $ctr ls -1 /opt/
   expect_line_count 1

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -18,7 +18,7 @@ load helpers
   createrandom ${TESTDIR}/other-randomfile
   createrandom ${TESTDIR}/third-randomfile
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
@@ -34,7 +34,7 @@ load helpers
   run_buildah rm $cid
 
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah mount $cid
   root=$output
@@ -43,7 +43,7 @@ load helpers
   run_buildah copy $cid ${TESTDIR}/other-randomfile ${TESTDIR}/third-randomfile ${TESTDIR}/randomfile /etc
   run_buildah rm $cid
 
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah mount $cid
   root=$output
@@ -57,7 +57,7 @@ load helpers
   createrandom ${TESTDIR}/other-randomfile
   createrandom ${TESTDIR}/third-randomfile
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
@@ -65,10 +65,10 @@ load helpers
   run_buildah copy $cid ${TESTDIR}/randomfile
   run_buildah copy $cid ${TESTDIR}/other-randomfile
   run_buildah unmount $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
   run_buildah rm $cid
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  run_buildah from --quiet $WITH_POLICY_JSON new-image
   newcid=$output
   run_buildah mount $newcid
   newroot=$output
@@ -83,7 +83,7 @@ load helpers
   createrandom ${TESTDIR}/subdir/randomfile
   createrandom ${TESTDIR}/subdir/other-randomfile
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --workingdir /container-subdir $cid
   run_buildah copy $cid ${TESTDIR}/subdir
@@ -103,7 +103,7 @@ load helpers
 @test "copy-local-force-directory" {
   createrandom ${TESTDIR}/randomfile
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --workingdir / $cid
   run_buildah copy $cid ${TESTDIR}/randomfile /randomfile
@@ -113,7 +113,7 @@ load helpers
   cmp ${TESTDIR}/randomfile $root/randomfile
   run_buildah rm $cid
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --workingdir / $cid
   run_buildah copy $cid ${TESTDIR}/randomfile /randomsubdir/
@@ -129,7 +129,7 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   touch -t 201910310123.45 ${TESTDIR}/randomfile
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah config --workingdir / $cid
   starthttpd ${TESTDIR}
@@ -158,7 +158,7 @@ load helpers
   createrandom ${TESTDIR}/other-subdir/other-randomfile
 
   _prefetch alpine
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah config --workingdir / $cid
   run_buildah copy --chown 1:1 $cid ${TESTDIR}/randomfile
@@ -204,7 +204,7 @@ load helpers
   createrandom ${TESTDIR}/other-subdir/other-randomfile
 
   _prefetch alpine
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah config --workingdir / $cid
   run_buildah copy --chmod 777 $cid ${TESTDIR}/randomfile
@@ -240,17 +240,17 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   ln -s ${TESTDIR}/randomfile ${TESTDIR}/link-randomfile
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
   run_buildah config --workingdir / $cid
   run_buildah copy $cid ${TESTDIR}/link-randomfile
   run_buildah unmount $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
   run_buildah rm $cid
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  run_buildah from --quiet $WITH_POLICY_JSON new-image
   newcid=$output
   run_buildah mount $newcid
   newroot=$output
@@ -276,16 +276,16 @@ load helpers
   done
   kill $nc_pid
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
   run_buildah config --workingdir / $cid
   run_buildah unmount $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
   run_buildah rm $cid
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  run_buildah from --quiet $WITH_POLICY_JSON new-image
   newcid=$output
   run_buildah mount $newcid
   newroot=$output
@@ -296,17 +296,17 @@ load helpers
   createrandom ${TESTDIR}/randomfile.tar.gz
   ln -s ${TESTDIR}/randomfile.tar.gz ${TESTDIR}/link-randomfile.tar.gz
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah mount $cid
   root=$output
   run_buildah config --workingdir / $cid
   run_buildah copy $cid ${TESTDIR}/link-randomfile.tar.gz
   run_buildah unmount $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
   run_buildah rm $cid
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json new-image
+  run_buildah from --quiet $WITH_POLICY_JSON new-image
   newcid=$output
   run_buildah mount $newcid
   newroot=$output
@@ -322,7 +322,7 @@ load helpers
   echo FROM busybox AS builder                                >> ${TESTDIR}/Dockerfile
   echo FROM scratch                                           >> ${TESTDIR}/Dockerfile
   echo COPY --from=builder /bin/-no-such-file-error- /usr/bin >> ${TESTDIR}/Dockerfile
-  run_buildah 125 build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json ${TESTDIR}
+  run_buildah 125 build-using-dockerfile $WITH_POLICY_JSON ${TESTDIR}
   expect_output --substring "no such file or directory"
 }
 
@@ -343,7 +343,7 @@ expect="
 stuff
 stuff/mystuff"
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
 
   run_buildah 125 copy --ignorefile ${mytest}/.ignore $cid ${mytest} /stuff
@@ -362,7 +362,7 @@ stuff/mystuff"
 @test "copy-quiet" {
   createrandom ${TESTDIR}/randomfile
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah mount $cid
   root=$output
@@ -376,15 +376,15 @@ stuff/mystuff"
 @test "copy-from-container" {
   _prefetch busybox
   createrandom ${TESTDIR}/randomfile
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   from=$output
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
   run_buildah copy --quiet $from ${TESTDIR}/randomfile /tmp/random
   expect_output ""
-  run_buildah copy --quiet --signature-policy ${TESTSDIR}/policy.json --from $from $cid /tmp/random /tmp/random # absolute path
+  run_buildah copy --quiet $WITH_POLICY_JSON --from $from $cid /tmp/random /tmp/random # absolute path
   expect_output ""
-  run_buildah copy --quiet --signature-policy ${TESTSDIR}/policy.json --from $from $cid  tmp/random /tmp/random2 # relative path
+  run_buildah copy --quiet $WITH_POLICY_JSON --from $from $cid  tmp/random /tmp/random2 # relative path
   expect_output ""
   run_buildah mount $cid
   croot=$output
@@ -395,13 +395,13 @@ stuff/mystuff"
 @test "copy-container-root" {
   _prefetch busybox
   createrandom ${TESTDIR}/randomfile
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   from=$output
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
   run_buildah copy --quiet $from ${TESTDIR}/randomfile /tmp/random
   expect_output ""
-  run_buildah copy --quiet --signature-policy ${TESTSDIR}/policy.json --from $from $cid / /tmp/
+  run_buildah copy --quiet $WITH_POLICY_JSON --from $from $cid / /tmp/
   expect_output "" || \
     expect_output --substring "copier: file disappeared while reading"
   run_buildah mount $cid
@@ -411,13 +411,13 @@ stuff/mystuff"
 
 @test "add-from-image" {
   _prefetch busybox
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah add --signature-policy ${TESTSDIR}/policy.json --quiet --from ubuntu $cid /etc/passwd /tmp/passwd # should pull the image, absolute path
+  run_buildah add $WITH_POLICY_JSON --quiet --from ubuntu $cid /etc/passwd /tmp/passwd # should pull the image, absolute path
   expect_output ""
-  run_buildah add --quiet --signature-policy ${TESTSDIR}/policy.json --from ubuntu $cid  etc/passwd /tmp/passwd2 # relative path
+  run_buildah add --quiet $WITH_POLICY_JSON --from ubuntu $cid  etc/passwd /tmp/passwd2 # relative path
   expect_output ""
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json ubuntu
+  run_buildah from --quiet $WITH_POLICY_JSON ubuntu
   ubuntu=$output
   run_buildah mount $cid
   croot=$output
@@ -429,7 +429,7 @@ stuff/mystuff"
 
 @test "copy with .dockerignore" {
   _prefetch alpine busybox
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet $WITH_POLICY_JSON alpine
   from=$output
   run_buildah copy --contextdir=${TESTSDIR}/bud/dockerignore $from ${TESTSDIR}/bud/dockerignore ./
 
@@ -459,7 +459,7 @@ stuff/mystuff"
     skip "$output"
   fi
   _prefetch $image
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet $WITH_POLICY_JSON $image
   first="$output"
   run_buildah run $first microdnf -y install /usr/bin/setfattr /usr/sbin/setcap
   run_buildah copy $first ${TESTDIR}/randomfile /
@@ -468,7 +468,7 @@ stuff/mystuff"
   # set user.something
   run_buildah run $first setfattr -n user.yeah -v butno /randomfile
   # copy the file to a second container
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet $WITH_POLICY_JSON $image
   second="$output"
   run_buildah run $second microdnf -y install /usr/bin/getfattr
   run_buildah copy --from $first $second /randomfile /
@@ -486,7 +486,7 @@ stuff/mystuff"
   createrandom ${TESTDIR}/context/excluded_test_file
   createrandom ${TESTDIR}/context/test_file
   echo excluded_test_file | tee ${TESTDIR}/context/.containerignore | tee ${TESTDIR}/context/.dockerignore
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet $WITH_POLICY_JSON $image
   ctr="$output"
   cd ${TESTDIR}/context
   run_buildah copy --contextdir . $ctr / /opt/

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -431,7 +431,7 @@ stuff/mystuff"
   _prefetch alpine busybox
   run_buildah from --quiet $WITH_POLICY_JSON alpine
   from=$output
-  run_buildah copy --contextdir=${TESTSDIR}/bud/dockerignore $from ${TESTSDIR}/bud/dockerignore ./
+  run_buildah copy --contextdir=$BUDFILES/dockerignore $from $BUDFILES/dockerignore ./
 
   run_buildah 1 run $from ls -l test1.txt
 

--- a/tests/digest.bats
+++ b/tests/digest.bats
@@ -17,7 +17,7 @@ fromreftest() {
   fi
 
   # This is all we test: basically, that buildah doesn't crash when pushing
-  pushdir=${TESTDIR}/fromreftest
+  pushdir=${TEST_SCRATCH_DIR}/fromreftest
   mkdir -p ${pushdir}/{1,2,3}
   run_buildah push $WITH_POLICY_JSON $img dir:${pushdir}/1
   run_buildah commit $WITH_POLICY_JSON $cid new-image

--- a/tests/digest.bats
+++ b/tests/digest.bats
@@ -5,7 +5,7 @@ load helpers
 fromreftest() {
   local img=$1
 
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json $img
+  run_buildah from --quiet --pull $WITH_POLICY_JSON $img
   cid=$output
 
   # If image includes '_v2sN', verify that image is schema version N
@@ -19,11 +19,11 @@ fromreftest() {
   # This is all we test: basically, that buildah doesn't crash when pushing
   pushdir=${TESTDIR}/fromreftest
   mkdir -p ${pushdir}/{1,2,3}
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json $img dir:${pushdir}/1
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid new-image
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json new-image dir:${pushdir}/2
+  run_buildah push $WITH_POLICY_JSON $img dir:${pushdir}/1
+  run_buildah commit $WITH_POLICY_JSON $cid new-image
+  run_buildah push $WITH_POLICY_JSON new-image dir:${pushdir}/2
   run_buildah rmi new-image
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${pushdir}/3
+  run_buildah commit $WITH_POLICY_JSON $cid dir:${pushdir}/3
 
   run_buildah rm $cid
   rm -fr ${pushdir}

--- a/tests/formats.bats
+++ b/tests/formats.bats
@@ -60,9 +60,9 @@ function check_imgtype() {
 
 @test "bud-formats" {
   skip_if_rootless_environment
-  run_buildah build-using-dockerfile $WITH_POLICY_JSON -t scratch-image-default -f Containerfile ${TESTSDIR}/bud/from-scratch
-  run_buildah build-using-dockerfile --format docker $WITH_POLICY_JSON -t scratch-image-docker -f Containerfile ${TESTSDIR}/bud/from-scratch
-  run_buildah build-using-dockerfile --format oci $WITH_POLICY_JSON -t scratch-image-oci -f Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah build-using-dockerfile $WITH_POLICY_JSON -t scratch-image-default -f Containerfile $BUDFILES/from-scratch
+  run_buildah build-using-dockerfile --format docker $WITH_POLICY_JSON -t scratch-image-docker -f Containerfile $BUDFILES/from-scratch
+  run_buildah build-using-dockerfile --format oci $WITH_POLICY_JSON -t scratch-image-oci -f Containerfile $BUDFILES/from-scratch
 
   check_imgtype scratch-image-default oci
   check_imgtype scratch-image-oci     oci

--- a/tests/formats.bats
+++ b/tests/formats.bats
@@ -47,11 +47,11 @@ function check_imgtype() {
 
 @test "write-formats" {
   skip_if_rootless_environment
-  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull=false $WITH_POLICY_JSON scratch
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-default
-  run_buildah commit --format docker --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-docker
-  run_buildah commit --format oci --signature-policy ${TESTSDIR}/policy.json $cid scratch-image-oci
+  run_buildah commit $WITH_POLICY_JSON $cid scratch-image-default
+  run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
+  run_buildah commit --format oci $WITH_POLICY_JSON $cid scratch-image-oci
 
   check_imgtype scratch-image-default oci
   check_imgtype scratch-image-oci     oci
@@ -60,9 +60,9 @@ function check_imgtype() {
 
 @test "bud-formats" {
   skip_if_rootless_environment
-  run_buildah build-using-dockerfile --signature-policy ${TESTSDIR}/policy.json -t scratch-image-default -f Containerfile ${TESTSDIR}/bud/from-scratch
-  run_buildah build-using-dockerfile --format docker --signature-policy ${TESTSDIR}/policy.json -t scratch-image-docker -f Containerfile ${TESTSDIR}/bud/from-scratch
-  run_buildah build-using-dockerfile --format oci --signature-policy ${TESTSDIR}/policy.json -t scratch-image-oci -f Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah build-using-dockerfile $WITH_POLICY_JSON -t scratch-image-default -f Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah build-using-dockerfile --format docker $WITH_POLICY_JSON -t scratch-image-docker -f Containerfile ${TESTSDIR}/bud/from-scratch
+  run_buildah build-using-dockerfile --format oci $WITH_POLICY_JSON -t scratch-image-oci -f Containerfile ${TESTSDIR}/bud/from-scratch
 
   check_imgtype scratch-image-default oci
   check_imgtype scratch-image-oci     oci

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -35,42 +35,42 @@ load helpers
   elsewhere=${TESTDIR}/elsewhere-img
   mkdir -p ${elsewhere}
 
-  run_buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull $WITH_POLICY_JSON scratch
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid dir:${elsewhere}
+  run_buildah commit $WITH_POLICY_JSON $cid dir:${elsewhere}
   run_buildah rm $cid
 
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere}
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON dir:${elsewhere}
   expect_output "dir-working-container"
   run_buildah rm $output
 
-  run_buildah from --quiet --pull-always --signature-policy ${TESTSDIR}/policy.json dir:${elsewhere}
+  run_buildah from --quiet --pull-always $WITH_POLICY_JSON dir:${elsewhere}
   expect_output "dir-working-container"
 
-  run_buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull $WITH_POLICY_JSON scratch
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid oci-archive:${elsewhere}.oci
+  run_buildah commit $WITH_POLICY_JSON $cid oci-archive:${elsewhere}.oci
   run_buildah rm $cid
 
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json oci-archive:${elsewhere}.oci
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON oci-archive:${elsewhere}.oci
   expect_output "oci-archive-working-container"
   run_buildah rm $output
 
-  run_buildah from --pull --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull $WITH_POLICY_JSON scratch
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid docker-archive:${elsewhere}.docker
+  run_buildah commit $WITH_POLICY_JSON $cid docker-archive:${elsewhere}.docker
   run_buildah rm $cid
 
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json docker-archive:${elsewhere}.docker
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON docker-archive:${elsewhere}.docker
   expect_output "docker-archive-working-container"
   run_buildah rm $output
 }
 
 @test "from-tagged-image" {
   # GitHub #396: Make sure the container name starts with the correct image even when it's tagged.
-  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull=false $WITH_POLICY_JSON scratch
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json "$cid" scratch2
+  run_buildah commit $WITH_POLICY_JSON "$cid" scratch2
   # Also check for base-image annotations.
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' scratch2
   expect_output "" "no base digest for scratch"
@@ -79,84 +79,84 @@ load helpers
   run_buildah rm $cid
   run_buildah tag scratch2 scratch3
   # Set --pull=false to prevent looking for a newer scratch3 image.
-  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch3
+  run_buildah from --pull=false $WITH_POLICY_JSON scratch3
   expect_output --substring "scratch3-working-container"
   run_buildah rm $output
   run_buildah rmi scratch2 scratch3
 
   # GitHub https://github.com/containers/buildah/issues/396#issuecomment-360949396
-  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah rm $cid
   run_buildah tag alpine alpine2
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json localhost/alpine2
+  run_buildah from --quiet $WITH_POLICY_JSON localhost/alpine2
   expect_output "alpine2-working-container"
   run_buildah rm $output
   tmp=$RANDOM
-  run_buildah from --suffix $tmp --quiet --signature-policy ${TESTSDIR}/policy.json localhost/alpine2
+  run_buildah from --suffix $tmp --quiet $WITH_POLICY_JSON localhost/alpine2
   expect_output "alpine2-$tmp"
   run_buildah rm $output
   run_buildah rmi alpine alpine2
 
-  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON docker.io/alpine
   run_buildah rm $output
   run_buildah rmi docker.io/alpine
 
-  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/alpine:latest
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON docker.io/alpine:latest
   run_buildah rm $output
   run_buildah rmi docker.io/alpine:latest
 
-  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/centos:7
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON docker.io/centos:7
   run_buildah rm $output
   run_buildah rmi docker.io/centos:7
 
-  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker.io/centos:latest
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON docker.io/centos:latest
   run_buildah rm $output
   run_buildah rmi docker.io/centos:latest
 }
 
 @test "from the following transports: docker-archive, oci-archive, and dir" {
   _prefetch alpine
-  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON alpine
   run_buildah rm $output
 
-  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json docker:latest
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON docker:latest
   run_buildah rm $output
 
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine docker-archive:${TESTDIR}/docker-alp.tar:alpine
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine    oci-archive:${TESTDIR}/oci-alp.tar:alpine
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine            dir:${TESTDIR}/alp-dir
+  run_buildah push $WITH_POLICY_JSON alpine docker-archive:${TESTDIR}/docker-alp.tar:alpine
+  run_buildah push $WITH_POLICY_JSON alpine    oci-archive:${TESTDIR}/oci-alp.tar:alpine
+  run_buildah push $WITH_POLICY_JSON alpine            dir:${TESTDIR}/alp-dir
   run_buildah rmi alpine
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json docker-archive:${TESTDIR}/docker-alp.tar
+  run_buildah from --quiet $WITH_POLICY_JSON docker-archive:${TESTDIR}/docker-alp.tar
   expect_output "alpine-working-container"
   run_buildah rm ${output}
   run_buildah rmi alpine
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json oci-archive:${TESTDIR}/oci-alp.tar
+  run_buildah from --quiet $WITH_POLICY_JSON oci-archive:${TESTDIR}/oci-alp.tar
   expect_output "alpine-working-container"
   run_buildah rm ${output}
   run_buildah rmi alpine
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json dir:${TESTDIR}/alp-dir
+  run_buildah from --quiet $WITH_POLICY_JSON dir:${TESTDIR}/alp-dir
   expect_output "dir-working-container"
 }
 
 @test "from the following transports: docker-archive and oci-archive with no image reference" {
   _prefetch alpine
-  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON alpine
   run_buildah rm $output
 
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine docker-archive:${TESTDIR}/docker-alp.tar
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json alpine    oci-archive:${TESTDIR}/oci-alp.tar
+  run_buildah push $WITH_POLICY_JSON alpine docker-archive:${TESTDIR}/docker-alp.tar
+  run_buildah push $WITH_POLICY_JSON alpine    oci-archive:${TESTDIR}/oci-alp.tar
   run_buildah rmi alpine
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json docker-archive:${TESTDIR}/docker-alp.tar
+  run_buildah from --quiet $WITH_POLICY_JSON docker-archive:${TESTDIR}/docker-alp.tar
   expect_output "alpine-working-container"
   run_buildah rm $output
   run_buildah rmi -a
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json oci-archive:${TESTDIR}/oci-alp.tar
+  run_buildah from --quiet $WITH_POLICY_JSON oci-archive:${TESTDIR}/oci-alp.tar
   expect_output "oci-archive-working-container"
   run_buildah rm $output
   run_buildah rmi -a
@@ -169,7 +169,7 @@ load helpers
   skip_if_no_runtime
 
   _prefetch alpine
-  run_buildah from --quiet --cpu-period=5000 --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --cpu-period=5000 --pull $WITH_POLICY_JSON alpine
   cid=$output
   if is_cgroupsv2; then
     run_buildah run $cid /bin/sh -c "cut -d ' ' -f 2 /sys/fs/cgroup/\$(awk -F: '{print \$NF}' /proc/self/cgroup)/cpu.max"
@@ -186,7 +186,7 @@ load helpers
   skip_if_no_runtime
 
   _prefetch alpine
-  run_buildah from --quiet --cpu-quota=5000 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --cpu-quota=5000 --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   if is_cgroupsv2; then
     run_buildah run $cid /bin/sh -c "cut -d ' ' -f 1 /sys/fs/cgroup/\$(awk -F: '{print \$NF}' /proc/self/cgroup)/cpu.max"
@@ -204,7 +204,7 @@ load helpers
 
   _prefetch alpine
   shares=2
-  run_buildah from --quiet --cpu-shares=${shares} --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --cpu-shares=${shares} --pull $WITH_POLICY_JSON alpine
   cid=$output
   if is_cgroupsv2; then
     run_buildah run $cid /bin/sh -c "cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpu.weight"
@@ -222,7 +222,7 @@ load helpers
   skip_if_no_runtime
 
   _prefetch alpine
-  run_buildah from --quiet --cpuset-cpus=0 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --cpuset-cpus=0 --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   if is_cgroupsv2; then
     run_buildah run $cid /bin/sh -c "cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpuset.cpus"
@@ -239,7 +239,7 @@ load helpers
   skip_if_no_runtime
 
   _prefetch alpine
-  run_buildah from --quiet --cpuset-mems=0 --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --cpuset-mems=0 --pull $WITH_POLICY_JSON alpine
   cid=$output
   if is_cgroupsv2; then
    run_buildah run $cid /bin/sh -c "cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpuset.mems"
@@ -255,7 +255,7 @@ load helpers
   skip_if_rootless_and_cgroupv1
 
   _prefetch alpine
-  run_buildah from --quiet --memory=40m --memory-swap=70m --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --memory=40m --memory-swap=70m --pull=false $WITH_POLICY_JSON alpine
   cid=$output
 
   # Life is much more complicated under cgroups v2
@@ -277,7 +277,7 @@ load helpers
   skip_if_no_runtime
 
   _prefetch alpine
-  run_buildah from --quiet --volume=${TESTDIR}:/myvol --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --volume=${TESTDIR}:/myvol --pull $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah run $cid -- cat /proc/mounts
   expect_output --substring " /myvol "
@@ -288,7 +288,7 @@ load helpers
   skip_if_no_runtime
 
   _prefetch alpine
-  run_buildah from --quiet --volume=${TESTDIR}:/myvol:ro --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --volume=${TESTDIR}:/myvol:ro --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah run $cid -- cat /proc/mounts
   expect_output --substring " /myvol "
@@ -315,7 +315,7 @@ load helpers
 
   # Create a container that uses that mapping and U volume flag.
   _prefetch alpine
-  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json --userns-uid-map 0:$uidbase:$uidsize --userns-gid-map 0:$gidbase:$gidsize --volume ${TESTDIR}/testdata:/mnt:z,U alpine
+  run_buildah from --pull=false $WITH_POLICY_JSON --userns-uid-map 0:$uidbase:$uidsize --userns-gid-map 0:$gidbase:$gidsize --volume ${TESTDIR}/testdata:/mnt:z,U alpine
   ctr="$output"
 
   # Test mounted volume has correct UID and GID ownership.
@@ -335,7 +335,7 @@ load helpers
   skip_if_no_runtime
 
   _prefetch alpine
-  run_buildah from --quiet --shm-size=80m --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --shm-size=80m --pull $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah run $cid -- df -h /dev/shm
   expect_output --substring " 80.0M "
@@ -345,7 +345,7 @@ load helpers
   skip_if_no_runtime
 
   _prefetch alpine
-  run_buildah from --quiet --add-host=localhost:127.0.0.1 --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --add-host=localhost:127.0.0.1 --pull $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah run --net=container $cid -- cat /etc/hosts
   expect_output --substring "127.0.0.1[[:blank:]]*localhost"
@@ -354,28 +354,28 @@ load helpers
 @test "from name test" {
   _prefetch alpine
   container_name=mycontainer
-  run_buildah from --quiet --name=${container_name} --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --name=${container_name} --pull $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah inspect --format '{{.Container}}' ${container_name}
 }
 
 @test "from cidfile test" {
   _prefetch alpine
-  run_buildah from --cidfile ${TESTDIR}/output.cid --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --cidfile ${TESTDIR}/output.cid --pull=false $WITH_POLICY_JSON alpine
   cid=$(< ${TESTDIR}/output.cid)
   run_buildah containers -f id=${cid}
 }
 
 @test "from pull never" {
-  run_buildah 125 from --signature-policy ${TESTSDIR}/policy.json --pull-never busybox
+  run_buildah 125 from $WITH_POLICY_JSON --pull-never busybox
   echo "$output"
   expect_output --substring "busybox: image not known"
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --pull=false busybox
+  run_buildah from $WITH_POLICY_JSON --pull=false busybox
   echo "$output"
   expect_output --substring "busybox-working-container"
 
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --pull=never busybox
+  run_buildah from $WITH_POLICY_JSON --pull=never busybox
   echo "$output"
   expect_output --substring "busybox-working-container"
 }
@@ -383,13 +383,13 @@ load helpers
 @test "from pull false no local image" {
   _prefetch busybox
   target=my-busybox
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --pull=false busybox
+  run_buildah from $WITH_POLICY_JSON --pull=false busybox
   echo "$output"
   expect_output --substring "busybox-working-container"
 }
 
 @test "from with nonexistent authfile: fails" {
-  run_buildah 125 from --authfile /no/such/file --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah 125 from --authfile /no/such/file --pull $WITH_POLICY_JSON alpine
   expect_output "checking authfile: stat /no/such/file: no such file or directory"
 }
 
@@ -397,11 +397,11 @@ load helpers
   _prefetch docker.io/busybox
   run_buildah inspect --format "{{.FromImageDigest}}" docker.io/busybox
   fromDigest="$output"
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json docker.io/busybox
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc --pull-always docker.io/busybox
+  run_buildah pull $WITH_POLICY_JSON docker.io/busybox
+  run_buildah from $WITH_POLICY_JSON --name busyboxc --pull-always docker.io/busybox
   expect_output --substring "Getting"
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json busyboxc fakename-img
-  run_buildah 125 from --signature-policy ${TESTSDIR}/policy.json --pull=always fakename-img
+  run_buildah commit $WITH_POLICY_JSON busyboxc fakename-img
+  run_buildah 125 from $WITH_POLICY_JSON --pull=always fakename-img
 
   # Also check for base-image annotations.
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' fakename-img
@@ -414,7 +414,7 @@ load helpers
   # Force a pull. Normally this would say 'Getting image ...' and other
   # progress messages. With --quiet, we should see only the container name.
   run_buildah '?' rmi busybox
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet docker.io/busybox
+  run_buildah from $WITH_POLICY_JSON --quiet docker.io/busybox
   expect_output "busybox-working-container"
 }
 
@@ -424,7 +424,7 @@ load helpers
   openssl genrsa -out ${TESTDIR}/tmp/mykey.pem 1024
   openssl genrsa -out ${TESTDIR}/tmp/mykey2.pem 1024
   openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword --encryption-key jwe:${TESTDIR}/tmp/mykey.pub busybox oci:${TESTDIR}/tmp/busybox_enc
+  run_buildah push $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword --encryption-key jwe:${TESTDIR}/tmp/mykey.pub busybox oci:${TESTDIR}/tmp/busybox_enc
 
   # Try encrypted image without key should fail
   run_buildah 125 from oci:${TESTDIR}/tmp/busybox_enc
@@ -447,7 +447,7 @@ load helpers
   openssl genrsa -out ${TESTDIR}/tmp/mykey2.pem 2048
   openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
   start_registry
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword --encryption-key jwe:${TESTDIR}/tmp/mykey.pub busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah push $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword --encryption-key jwe:${TESTDIR}/tmp/mykey.pub busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
 
   # Try encrypted image without key should fail
   run_buildah 125 from --tls-verify=false --creds testuser:testpassword docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
@@ -471,7 +471,7 @@ load helpers
 
   _prefetch busybox
   podman create --net=host --name busyboxc-podman busybox top
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --name busyboxc busybox
+  run_buildah from $WITH_POLICY_JSON --name busyboxc busybox
   expect_output --substring "busyboxc"
   podman rm -f busyboxc-podman
   run_buildah rm busyboxc
@@ -481,15 +481,15 @@ load helpers
   skip_if_no_runtime
 
   _prefetch alpine
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json --arch=arm64 alpine
+  run_buildah from --quiet --pull $WITH_POLICY_JSON --arch=arm64 alpine
   other=$output
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json --arch=$(go env GOARCH) alpine
+  run_buildah from --quiet --pull $WITH_POLICY_JSON --arch=$(go env GOARCH) alpine
   cid=$output
   run_buildah copy --from $other $cid /etc/apk/arch /root/other-arch
   run_buildah run $cid cat /root/other-arch
   expect_output "aarch64"
 
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json --arch=s390x alpine
+  run_buildah from --quiet --pull $WITH_POLICY_JSON --arch=s390x alpine
   other=$output
   run_buildah copy --from $other $cid /etc/apk/arch /root/other-arch
   run_buildah run $cid cat /root/other-arch
@@ -506,15 +506,15 @@ load helpers
   echo "$platform"
 
   _prefetch alpine
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json --platform=linux/arm64 alpine
+  run_buildah from --quiet --pull $WITH_POLICY_JSON --platform=linux/arm64 alpine
   other=$output
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json --platform=${platform} alpine
+  run_buildah from --quiet --pull $WITH_POLICY_JSON --platform=${platform} alpine
   cid=$output
   run_buildah copy --from $other $cid /etc/apk/arch /root/other-arch
   run_buildah run $cid cat /root/other-arch
   expect_output "aarch64"
 
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json --platform=linux/s390x alpine
+  run_buildah from --quiet --pull $WITH_POLICY_JSON --platform=linux/s390x alpine
   other=$output
   run_buildah copy --from $other $cid /etc/apk/arch /root/other-arch
   run_buildah run $cid cat /root/other-arch
@@ -525,9 +525,9 @@ load helpers
   _prefetch busybox
   start_registry
   run_buildah login --tls-verify=false --authfile ${TESTDIR}/test.auth --username testuser --password testpassword localhost:${REGISTRY_PORT}
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --authfile ${TESTDIR}/test.auth busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox:latest
+  run_buildah push $WITH_POLICY_JSON --tls-verify=false --authfile ${TESTDIR}/test.auth busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox:latest
   target=busybox-image
-  run_buildah from -q --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --authfile ${TESTDIR}/test.auth docker://localhost:${REGISTRY_PORT}/buildah/busybox:latest
+  run_buildah from -q $WITH_POLICY_JSON --tls-verify=false --authfile ${TESTDIR}/test.auth docker://localhost:${REGISTRY_PORT}/buildah/busybox:latest
   run_buildah rm $output
   run_buildah rmi localhost:${REGISTRY_PORT}/buildah/busybox:latest
 }
@@ -537,14 +537,14 @@ load helpers
   CAP_DAC_OVERRIDE=2  # unlikely to change
 
   # Try with default caps.
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah run $cid awk '/^CapEff/{print $2;}' /proc/self/status
   defaultcaps="$output"
   run_buildah rm $cid
 
   if ((0x$defaultcaps & 0x$CAP_DAC_OVERRIDE)); then
-    run_buildah from --quiet --cap-drop CAP_DAC_OVERRIDE --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+    run_buildah from --quiet --cap-drop CAP_DAC_OVERRIDE --pull=false $WITH_POLICY_JSON alpine
     cid=$output
     run_buildah run $cid awk '/^CapEff/{print $2;}' /proc/self/status
     droppedcaps="$output"
@@ -553,7 +553,7 @@ load helpers
       die "--cap-drop did not drop DAC_OVERRIDE: $droppedcaps"
     fi
   else
-    run_buildah from --quiet --cap-add CAP_DAC_OVERRIDE --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+    run_buildah from --quiet --cap-add CAP_DAC_OVERRIDE --pull=false $WITH_POLICY_JSON alpine
     cid=$output
     run_buildah run $cid awk '/^CapEff/{print $2;}' /proc/self/status
     addedcaps="$output"
@@ -566,7 +566,7 @@ load helpers
 
 @test "from ulimit test" {
   _prefetch alpine
-  run_buildah from -q --ulimit cpu=300 --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from -q --ulimit cpu=300 $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah run $cid /bin/sh -c "ulimit -t"
   expect_output "300" "ulimit -t"
@@ -575,7 +575,7 @@ load helpers
 @test "from isolation test" {
   skip_if_rootless_environment
   _prefetch alpine
-  run_buildah from -q --isolation chroot --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from -q --isolation chroot $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah inspect $cid
   expect_output --substring '"Isolation": "chroot"'
@@ -595,13 +595,13 @@ load helpers
 
   _prefetch alpine
   # with cgroup-parent
-  run_buildah from -q --cgroupns=host --cgroup-parent test-cgroup --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from -q --cgroupns=host --cgroup-parent test-cgroup $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah --cgroup-manager cgroupfs run $cid /bin/sh -c 'cat /proc/$$/cgroup'
   expect_output --substring "test-cgroup"
 
   # without cgroup-parent
-  run_buildah from -q --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from -q $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah --cgroup-manager cgroupfs run $cid /bin/sh -c 'cat /proc/$$/cgroup'
   if [ -n "$(grep "test-cgroup" <<< "$output")" ]; then
@@ -616,7 +616,7 @@ load helpers
   cni_plugin_path=${TESTDIR}/no-cni-plugin
   mkdir -p ${cni_config_dir}
   mkdir -p ${cni_plugin_path}
-  run_buildah from -q --cni-config-dir=${cni_config_dir} --cni-plugin-path=${cni_plugin_path} --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from -q --cni-config-dir=${cni_config_dir} --cni-plugin-path=${cni_plugin_path} $WITH_POLICY_JSON alpine
   cid=$output
 
   run_buildah inspect --format '{{.CNIConfigDir}}' $cid
@@ -635,7 +635,7 @@ load helpers
 
   _prefetch alpine
   tmp=$RANDOM
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull $WITH_POLICY_JSON alpine
   cid=$output
   FTP_PROXY=$tmp run_buildah run $cid printenv FTP_PROXY
   expect_output "$tmp"

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -32,7 +32,7 @@ load helpers
 }
 
 @test "commit-to-from-elsewhere" {
-  elsewhere=${TESTDIR}/elsewhere-img
+  elsewhere=${TEST_SCRATCH_DIR}/elsewhere-img
   mkdir -p ${elsewhere}
 
   run_buildah from --pull $WITH_POLICY_JSON scratch
@@ -123,22 +123,22 @@ load helpers
   run_buildah from --quiet --pull=true $WITH_POLICY_JSON docker:latest
   run_buildah rm $output
 
-  run_buildah push $WITH_POLICY_JSON alpine docker-archive:${TESTDIR}/docker-alp.tar:alpine
-  run_buildah push $WITH_POLICY_JSON alpine    oci-archive:${TESTDIR}/oci-alp.tar:alpine
-  run_buildah push $WITH_POLICY_JSON alpine            dir:${TESTDIR}/alp-dir
+  run_buildah push $WITH_POLICY_JSON alpine docker-archive:${TEST_SCRATCH_DIR}/docker-alp.tar:alpine
+  run_buildah push $WITH_POLICY_JSON alpine    oci-archive:${TEST_SCRATCH_DIR}/oci-alp.tar:alpine
+  run_buildah push $WITH_POLICY_JSON alpine            dir:${TEST_SCRATCH_DIR}/alp-dir
   run_buildah rmi alpine
 
-  run_buildah from --quiet $WITH_POLICY_JSON docker-archive:${TESTDIR}/docker-alp.tar
+  run_buildah from --quiet $WITH_POLICY_JSON docker-archive:${TEST_SCRATCH_DIR}/docker-alp.tar
   expect_output "alpine-working-container"
   run_buildah rm ${output}
   run_buildah rmi alpine
 
-  run_buildah from --quiet $WITH_POLICY_JSON oci-archive:${TESTDIR}/oci-alp.tar
+  run_buildah from --quiet $WITH_POLICY_JSON oci-archive:${TEST_SCRATCH_DIR}/oci-alp.tar
   expect_output "alpine-working-container"
   run_buildah rm ${output}
   run_buildah rmi alpine
 
-  run_buildah from --quiet $WITH_POLICY_JSON dir:${TESTDIR}/alp-dir
+  run_buildah from --quiet $WITH_POLICY_JSON dir:${TEST_SCRATCH_DIR}/alp-dir
   expect_output "dir-working-container"
 }
 
@@ -147,16 +147,16 @@ load helpers
   run_buildah from --quiet --pull=true $WITH_POLICY_JSON alpine
   run_buildah rm $output
 
-  run_buildah push $WITH_POLICY_JSON alpine docker-archive:${TESTDIR}/docker-alp.tar
-  run_buildah push $WITH_POLICY_JSON alpine    oci-archive:${TESTDIR}/oci-alp.tar
+  run_buildah push $WITH_POLICY_JSON alpine docker-archive:${TEST_SCRATCH_DIR}/docker-alp.tar
+  run_buildah push $WITH_POLICY_JSON alpine    oci-archive:${TEST_SCRATCH_DIR}/oci-alp.tar
   run_buildah rmi alpine
 
-  run_buildah from --quiet $WITH_POLICY_JSON docker-archive:${TESTDIR}/docker-alp.tar
+  run_buildah from --quiet $WITH_POLICY_JSON docker-archive:${TEST_SCRATCH_DIR}/docker-alp.tar
   expect_output "alpine-working-container"
   run_buildah rm $output
   run_buildah rmi -a
 
-  run_buildah from --quiet $WITH_POLICY_JSON oci-archive:${TESTDIR}/oci-alp.tar
+  run_buildah from --quiet $WITH_POLICY_JSON oci-archive:${TEST_SCRATCH_DIR}/oci-alp.tar
   expect_output "oci-archive-working-container"
   run_buildah rm $output
   run_buildah rmi -a
@@ -277,7 +277,7 @@ load helpers
   skip_if_no_runtime
 
   _prefetch alpine
-  run_buildah from --quiet --volume=${TESTDIR}:/myvol --pull $WITH_POLICY_JSON alpine
+  run_buildah from --quiet --volume=${TEST_SCRATCH_DIR}:/myvol --pull $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah run $cid -- cat /proc/mounts
   expect_output --substring " /myvol "
@@ -288,7 +288,7 @@ load helpers
   skip_if_no_runtime
 
   _prefetch alpine
-  run_buildah from --quiet --volume=${TESTDIR}:/myvol:ro --pull=false $WITH_POLICY_JSON alpine
+  run_buildah from --quiet --volume=${TEST_SCRATCH_DIR}:/myvol:ro --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah run $cid -- cat /proc/mounts
   expect_output --substring " /myvol "
@@ -310,12 +310,12 @@ load helpers
   gidsize=$((${RANDOM}+1024))
 
   # Create source volume.
-  mkdir ${TESTDIR}/testdata
-  touch ${TESTDIR}/testdata/testfile1.txt
+  mkdir ${TEST_SCRATCH_DIR}/testdata
+  touch ${TEST_SCRATCH_DIR}/testdata/testfile1.txt
 
   # Create a container that uses that mapping and U volume flag.
   _prefetch alpine
-  run_buildah from --pull=false $WITH_POLICY_JSON --userns-uid-map 0:$uidbase:$uidsize --userns-gid-map 0:$gidbase:$gidsize --volume ${TESTDIR}/testdata:/mnt:z,U alpine
+  run_buildah from --pull=false $WITH_POLICY_JSON --userns-uid-map 0:$uidbase:$uidsize --userns-gid-map 0:$gidbase:$gidsize --volume ${TEST_SCRATCH_DIR}/testdata:/mnt:z,U alpine
   ctr="$output"
 
   # Test mounted volume has correct UID and GID ownership.
@@ -361,8 +361,8 @@ load helpers
 
 @test "from cidfile test" {
   _prefetch alpine
-  run_buildah from --cidfile ${TESTDIR}/output.cid --pull=false $WITH_POLICY_JSON alpine
-  cid=$(< ${TESTDIR}/output.cid)
+  run_buildah from --cidfile ${TEST_SCRATCH_DIR}/output.cid --pull=false $WITH_POLICY_JSON alpine
+  cid=$(< ${TEST_SCRATCH_DIR}/output.cid)
   run_buildah containers -f id=${cid}
 }
 
@@ -420,49 +420,49 @@ load helpers
 
 @test "from encrypted local image" {
   _prefetch busybox
-  mkdir ${TESTDIR}/tmp
-  openssl genrsa -out ${TESTDIR}/tmp/mykey.pem 1024
-  openssl genrsa -out ${TESTDIR}/tmp/mykey2.pem 1024
-  openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
-  run_buildah push $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword --encryption-key jwe:${TESTDIR}/tmp/mykey.pub busybox oci:${TESTDIR}/tmp/busybox_enc
+  mkdir ${TEST_SCRATCH_DIR}/tmp
+  openssl genrsa -out ${TEST_SCRATCH_DIR}/tmp/mykey.pem 1024
+  openssl genrsa -out ${TEST_SCRATCH_DIR}/tmp/mykey2.pem 1024
+  openssl rsa -in ${TEST_SCRATCH_DIR}/tmp/mykey.pem -pubout > ${TEST_SCRATCH_DIR}/tmp/mykey.pub
+  run_buildah push $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword --encryption-key jwe:${TEST_SCRATCH_DIR}/tmp/mykey.pub busybox oci:${TEST_SCRATCH_DIR}/tmp/busybox_enc
 
   # Try encrypted image without key should fail
-  run_buildah 125 from oci:${TESTDIR}/tmp/busybox_enc
+  run_buildah 125 from oci:${TEST_SCRATCH_DIR}/tmp/busybox_enc
   expect_output --substring "decrypting layer .* missing private key needed for decryption"
 
   # Try encrypted image with wrong key should fail
-  run_buildah 125 from --decryption-key ${TESTDIR}/tmp/mykey2.pem oci:${TESTDIR}/tmp/busybox_enc
+  run_buildah 125 from --decryption-key ${TEST_SCRATCH_DIR}/tmp/mykey2.pem oci:${TEST_SCRATCH_DIR}/tmp/busybox_enc
   expect_output --substring "decrypting layer .* no suitable key unwrapper found or none of the private keys could be used for decryption"
 
   # Providing the right key should succeed
-  run_buildah from  --decryption-key ${TESTDIR}/tmp/mykey.pem oci:${TESTDIR}/tmp/busybox_enc
+  run_buildah from  --decryption-key ${TEST_SCRATCH_DIR}/tmp/mykey.pem oci:${TEST_SCRATCH_DIR}/tmp/busybox_enc
 
-  rm -rf ${TESTDIR}/tmp
+  rm -rf ${TEST_SCRATCH_DIR}/tmp
 }
 
 @test "from encrypted registry image" {
   _prefetch busybox
-  mkdir ${TESTDIR}/tmp
-  openssl genrsa -out ${TESTDIR}/tmp/mykey.pem 2048
-  openssl genrsa -out ${TESTDIR}/tmp/mykey2.pem 2048
-  openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
+  mkdir ${TEST_SCRATCH_DIR}/tmp
+  openssl genrsa -out ${TEST_SCRATCH_DIR}/tmp/mykey.pem 2048
+  openssl genrsa -out ${TEST_SCRATCH_DIR}/tmp/mykey2.pem 2048
+  openssl rsa -in ${TEST_SCRATCH_DIR}/tmp/mykey.pem -pubout > ${TEST_SCRATCH_DIR}/tmp/mykey.pub
   start_registry
-  run_buildah push $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword --encryption-key jwe:${TESTDIR}/tmp/mykey.pub busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah push $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword --encryption-key jwe:${TEST_SCRATCH_DIR}/tmp/mykey.pub busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
 
   # Try encrypted image without key should fail
   run_buildah 125 from --tls-verify=false --creds testuser:testpassword docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
   expect_output --substring "decrypting layer .* missing private key needed for decryption"
 
   # Try encrypted image with wrong key should fail
-  run_buildah 125 from --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey2.pem docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah 125 from --tls-verify=false --creds testuser:testpassword --decryption-key ${TEST_SCRATCH_DIR}/tmp/mykey2.pem docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
   expect_output --substring "decrypting layer .* no suitable key unwrapper found or none of the private keys could be used for decryption"
 
   # Providing the right key should succeed
-  run_buildah from --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey.pem docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah from --tls-verify=false --creds testuser:testpassword --decryption-key ${TEST_SCRATCH_DIR}/tmp/mykey.pem docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
   run_buildah rm -a
   run_buildah rmi localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
 
-  rm -rf ${TESTDIR}/tmp
+  rm -rf ${TEST_SCRATCH_DIR}/tmp
 }
 
 @test "from with non buildah container" {
@@ -524,10 +524,10 @@ load helpers
 @test "from --authfile test" {
   _prefetch busybox
   start_registry
-  run_buildah login --tls-verify=false --authfile ${TESTDIR}/test.auth --username testuser --password testpassword localhost:${REGISTRY_PORT}
-  run_buildah push $WITH_POLICY_JSON --tls-verify=false --authfile ${TESTDIR}/test.auth busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox:latest
+  run_buildah login --tls-verify=false --authfile ${TEST_SCRATCH_DIR}/test.auth --username testuser --password testpassword localhost:${REGISTRY_PORT}
+  run_buildah push $WITH_POLICY_JSON --tls-verify=false --authfile ${TEST_SCRATCH_DIR}/test.auth busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox:latest
   target=busybox-image
-  run_buildah from -q $WITH_POLICY_JSON --tls-verify=false --authfile ${TESTDIR}/test.auth docker://localhost:${REGISTRY_PORT}/buildah/busybox:latest
+  run_buildah from -q $WITH_POLICY_JSON --tls-verify=false --authfile ${TEST_SCRATCH_DIR}/test.auth docker://localhost:${REGISTRY_PORT}/buildah/busybox:latest
   run_buildah rm $output
   run_buildah rmi localhost:${REGISTRY_PORT}/buildah/busybox:latest
 }
@@ -612,8 +612,8 @@ load helpers
 @test "from cni config test" {
   _prefetch alpine
 
-  cni_config_dir=${TESTDIR}/no-cni-configs
-  cni_plugin_path=${TESTDIR}/no-cni-plugin
+  cni_config_dir=${TEST_SCRATCH_DIR}/no-cni-configs
+  cni_plugin_path=${TEST_SCRATCH_DIR}/no-cni-plugin
   mkdir -p ${cni_config_dir}
   mkdir -p ${cni_plugin_path}
   run_buildah from -q --cni-config-dir=${cni_config_dir} --cni-plugin-path=${cni_plugin_path} $WITH_POLICY_JSON alpine
@@ -626,8 +626,8 @@ load helpers
 }
 
 @test "from-image-with-zstd-compression" {
-  copy --format oci --dest-compress --dest-compress-format zstd docker://quay.io/libpod/alpine_nginx:latest dir:${TESTDIR}/base-image
-  run_buildah from dir:${TESTDIR}/base-image
+  copy --format oci --dest-compress --dest-compress-format zstd docker://quay.io/libpod/alpine_nginx:latest dir:${TEST_SCRATCH_DIR}/base-image
+  run_buildah from dir:${TEST_SCRATCH_DIR}/base-image
 }
 
 @test "from proxy test" {
@@ -653,14 +653,14 @@ load helpers
   skip_if_no_runtime
 
   _prefetch busybox
-  run_buildah from --cidfile ${TESTDIR}/cid busybox
-  cid=$(cat ${TESTDIR}/cid)
-  createrandom ${TESTDIR}/randomfile
-  run_buildah copy ${cid} ${TESTDIR}/randomfile /
-  run_buildah commit --iidfile ${TESTDIR}/iid ${cid}
-  iid=$(cat ${TESTDIR}/iid)
-  run_buildah from --cidfile ${TESTDIR}/cid2 ${iid}
-  cid2=$(cat ${TESTDIR}/cid2)
+  run_buildah from --cidfile ${TEST_SCRATCH_DIR}/cid busybox
+  cid=$(cat ${TEST_SCRATCH_DIR}/cid)
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
+  run_buildah copy ${cid} ${TEST_SCRATCH_DIR}/randomfile /
+  run_buildah commit --iidfile ${TEST_SCRATCH_DIR}/iid ${cid}
+  iid=$(cat ${TEST_SCRATCH_DIR}/iid)
+  run_buildah from --cidfile ${TEST_SCRATCH_DIR}/cid2 ${iid}
+  cid2=$(cat ${TEST_SCRATCH_DIR}/cid2)
   run_buildah run ${cid2} cat /etc/hosts
   truncated=${iid##*:}
   truncated="${truncated:0:12}"

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -10,6 +10,9 @@ OCI=$(${BUILDAH_BINARY} info --format '{{.host.OCIRuntime}}' || command -v runc 
 # Default timeout for a buildah command.
 BUILDAH_TIMEOUT=${BUILDAH_TIMEOUT:-300}
 
+# Used hundreds of times throughout all the tests
+WITH_POLICY_JSON="--signature-policy ${TESTSDIR}/policy.json"
+
 # We don't invoke gnupg directly in many places, but this avoids ENOTTY errors
 # when we invoke it directly in batch mode, and CI runs us without a terminal
 # attached.

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-BUILDAH_BINARY=${BUILDAH_BINARY:-$(dirname ${BASH_SOURCE})/../bin/buildah}
-IMGTYPE_BINARY=${IMGTYPE_BINARY:-$(dirname ${BASH_SOURCE})/../bin/imgtype}
-COPY_BINARY=${COPY_BINARY:-$(dirname ${BASH_SOURCE})/../bin/copy}
-TESTSDIR=${TESTSDIR:-$(dirname ${BASH_SOURCE})}
+# Directory in which tests live
+TEST_SOURCES=${TEST_SOURCES:-$(dirname ${BASH_SOURCE})}
+
+BUILDAH_BINARY=${BUILDAH_BINARY:-$TEST_SOURCES/../bin/buildah}
+IMGTYPE_BINARY=${IMGTYPE_BINARY:-$TEST_SOURCES/../bin/imgtype}
+COPY_BINARY=${COPY_BINARY:-$TEST_SOURCES/../bin/copy}
 STORAGE_DRIVER=${STORAGE_DRIVER:-vfs}
 PATH=$(dirname ${BASH_SOURCE})/../bin:${PATH}
 OCI=$(${BUILDAH_BINARY} info --format '{{.host.OCIRuntime}}' || command -v runc || command -v crun)
@@ -11,10 +13,10 @@ OCI=$(${BUILDAH_BINARY} info --format '{{.host.OCIRuntime}}' || command -v runc 
 BUILDAH_TIMEOUT=${BUILDAH_TIMEOUT:-300}
 
 # Shortcut for directory containing Containerfiles for bud.bats
-BUDFILES=${TESTSDIR}/bud
+BUDFILES=${TEST_SOURCES}/bud
 
 # Used hundreds of times throughout all the tests
-WITH_POLICY_JSON="--signature-policy ${TESTSDIR}/policy.json"
+WITH_POLICY_JSON="--signature-policy ${TEST_SOURCES}/policy.json"
 
 # We don't invoke gnupg directly in many places, but this avoids ENOTTY errors
 # when we invoke it directly in batch mode, and CI runs us without a terminal
@@ -47,13 +49,13 @@ EOF
 
     # Common options for all buildah and podman invocations
     ROOTDIR_OPTS="--root ${TESTDIR}/root --runroot ${TESTDIR}/runroot --storage-driver ${STORAGE_DRIVER}"
-    BUILDAH_REGISTRY_OPTS="--registries-conf ${TESTSDIR}/registries.conf --registries-conf-dir ${TESTDIR}/registries.d --short-name-alias-conf ${TESTDIR}/cache/shortnames.conf"
-    PODMAN_REGISTRY_OPTS="--registries-conf ${TESTSDIR}/registries.conf"
+    BUILDAH_REGISTRY_OPTS="--registries-conf ${TEST_SOURCES}/registries.conf --registries-conf-dir ${TESTDIR}/registries.d --short-name-alias-conf ${TESTDIR}/cache/shortnames.conf"
+    PODMAN_REGISTRY_OPTS="--registries-conf ${TEST_SOURCES}/registries.conf"
 }
 
 function starthttpd() {
     pushd ${2:-${TESTDIR}} > /dev/null
-    go build -o serve ${TESTSDIR}/serve/serve.go
+    go build -o serve ${TEST_SOURCES}/serve/serve.go
     portfile=$(mktemp)
     if test -z "${portfile}"; then
         echo error creating temporaty file
@@ -596,7 +598,7 @@ function skip_if_no_docker() {
 function start_git_daemon() {
   daemondir=${TESTDIR}/git-daemon
   mkdir -p ${daemondir}/repo
-  gzip -dc < ${1:-${TESTSDIR}/git-daemon/repo.tar.gz} | tar x -C ${daemondir}/repo
+  gzip -dc < ${1:-${TEST_SOURCES}/git-daemon/repo.tar.gz} | tar x -C ${daemondir}/repo
   GITPORT=$(($RANDOM + 32768))
   git daemon --detach --pid-file=${TESTDIR}/git-daemon/pid --reuseaddr --port=${GITPORT} --base-path=${daemondir} ${daemondir}
 }

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -10,6 +10,9 @@ OCI=$(${BUILDAH_BINARY} info --format '{{.host.OCIRuntime}}' || command -v runc 
 # Default timeout for a buildah command.
 BUILDAH_TIMEOUT=${BUILDAH_TIMEOUT:-300}
 
+# Shortcut for directory containing Containerfiles for bud.bats
+BUDFILES=${TESTSDIR}/bud
+
 # Used hundreds of times throughout all the tests
 WITH_POLICY_JSON="--signature-policy ${TESTSDIR}/policy.json"
 

--- a/tests/history.bats
+++ b/tests/history.bats
@@ -9,7 +9,7 @@ function testconfighistory() {
   image=$(echo "i$config" | sed -E -e 's|[[:blank:]]|_|g' -e "s,[-=/:'],_,g" | tr '[A-Z]' '[a-z]')
   run_buildah from --name "$container" --format docker scratch
   run_buildah config $config --add-history "$container"
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json "$container" "$image"
+  run_buildah commit $WITH_POLICY_JSON "$container" "$image"
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image"
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image"
   expect_output --substring "$expected"
@@ -34,7 +34,7 @@ function testconfighistory() {
 @test "history-healthcheck" {
   run_buildah from --name healthcheckctr --format docker scratch
   run_buildah config --healthcheck "CMD /foo" --healthcheck-timeout=10s --healthcheck-interval=20s --healthcheck-retries=7 --healthcheck-start-period=30s --add-history healthcheckctr
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json healthcheckctr healthcheckimg
+  run_buildah commit $WITH_POLICY_JSON healthcheckctr healthcheckimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg
   expect_output --substring "HEALTHCHECK --interval=20s --retries=7 --start-period=30s --timeout=10s CMD /foo"
@@ -47,7 +47,7 @@ function testconfighistory() {
 @test "history-onbuild" {
   run_buildah from --name onbuildctr --format docker scratch
   run_buildah config --onbuild "CMD /foo" --add-history onbuildctr
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json onbuildctr onbuildimg
+  run_buildah commit $WITH_POLICY_JSON onbuildctr onbuildimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg
   expect_output --substring "ONBUILD CMD /foo"
@@ -82,7 +82,7 @@ function testconfighistory() {
   run_buildah from --name addctr --format docker scratch
   run_buildah add --add-history addctr ${TESTDIR}/randomfile
   digest="$output"
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json addctr addimg
+  run_buildah commit $WITH_POLICY_JSON addctr addimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg
   expect_output --substring "ADD file:$digest"
@@ -93,7 +93,7 @@ function testconfighistory() {
   run_buildah from --name copyctr --format docker scratch
   run_buildah copy --add-history copyctr ${TESTDIR}/randomfile
   digest="$output"
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json copyctr copyimg
+  run_buildah commit $WITH_POLICY_JSON copyctr copyimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg
   expect_output --substring "COPY file:$digest"
@@ -101,9 +101,9 @@ function testconfighistory() {
 
 @test "history-run" {
   _prefetch busybox
-  run_buildah from --name runctr --format docker --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --name runctr --format docker $WITH_POLICY_JSON busybox
   run_buildah run --add-history runctr -- uname -a
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json runctr runimg
+  run_buildah commit $WITH_POLICY_JSON runctr runimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg
   expect_output --substring "/bin/sh -c uname -a"
@@ -118,7 +118,7 @@ FROM busybox
 RUN echo \$HTTP_PROXY
 EOF
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t test --build-arg HTTP_PROXY="helloworld" ${ctxdir}
+  run_buildah build $WITH_POLICY_JSON -t test --build-arg HTTP_PROXY="helloworld" ${ctxdir}
   expect_output --substring 'helloworld'
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' test
   # history should not contain value for HTTP_PROXY since it was not in Containerfile
@@ -136,7 +136,7 @@ ARG HTTP_PROXY
 RUN echo \$HTTP_PROXY
 EOF
 
-  run_buildah build --signature-policy ${TESTSDIR}/policy.json -t test --build-arg HTTP_PROXY="helloworld" ${ctxdir}
+  run_buildah build $WITH_POLICY_JSON -t test --build-arg HTTP_PROXY="helloworld" ${ctxdir}
   expect_output --substring 'helloworld'
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' test
   # history should not contain value for HTTP_PROXY since it was not in Containerfile

--- a/tests/history.bats
+++ b/tests/history.bats
@@ -78,9 +78,9 @@ function testconfighistory() {
 }
 
 @test "history-add" {
-  createrandom ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
   run_buildah from --name addctr --format docker scratch
-  run_buildah add --add-history addctr ${TESTDIR}/randomfile
+  run_buildah add --add-history addctr ${TEST_SCRATCH_DIR}/randomfile
   digest="$output"
   run_buildah commit $WITH_POLICY_JSON addctr addimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg
@@ -89,9 +89,9 @@ function testconfighistory() {
 }
 
 @test "history-copy" {
-  createrandom ${TESTDIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
   run_buildah from --name copyctr --format docker scratch
-  run_buildah copy --add-history copyctr ${TESTDIR}/randomfile
+  run_buildah copy --add-history copyctr ${TEST_SCRATCH_DIR}/randomfile
   digest="$output"
   run_buildah commit $WITH_POLICY_JSON copyctr copyimg
   run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg
@@ -111,7 +111,7 @@ function testconfighistory() {
 
 @test "history should not contain vars in allowlist unless set in ARG" {
   _prefetch busybox
-  ctxdir=${TESTDIR}/bud
+  ctxdir=${TEST_SCRATCH_DIR}/bud
   mkdir -p $ctxdir
   cat >$ctxdir/Dockerfile <<EOF
 FROM busybox
@@ -128,7 +128,7 @@ EOF
 
 @test "history should contain vars in allowlist when set in ARG" {
   _prefetch busybox
-  ctxdir=${TESTDIR}/bud
+  ctxdir=${TEST_SCRATCH_DIR}/bud
   mkdir -p $ctxdir
   cat >$ctxdir/Dockerfile <<EOF
 FROM busybox

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -182,18 +182,18 @@ load helpers
 }
 
 @test "images in OCI format with no creation dates" {
-  mkdir -p $TESTDIR/blobs/sha256
+  mkdir -p $TEST_SCRATCH_DIR/blobs/sha256
 
   # Create a layer.
-  dd if=/dev/zero bs=512 count=2 of=$TESTDIR/blob
-  layerdigest=$(sha256sum $TESTDIR/blob | awk '{print $1}')
-  layersize=$(stat -c %s $TESTDIR/blob)
-  mv $TESTDIR/blob $TESTDIR/blobs/sha256/${layerdigest}
+  dd if=/dev/zero bs=512 count=2 of=$TEST_SCRATCH_DIR/blob
+  layerdigest=$(sha256sum $TEST_SCRATCH_DIR/blob | awk '{print $1}')
+  layersize=$(stat -c %s $TEST_SCRATCH_DIR/blob)
+  mv $TEST_SCRATCH_DIR/blob $TEST_SCRATCH_DIR/blobs/sha256/${layerdigest}
 
   # Create a configuration blob that doesn't include a "created" date.
   now=$(TZ=UTC date +%Y-%m-%dT%H:%M:%S.%NZ)
   arch=$(go env GOARCH)
-  cat > $TESTDIR/blob << EOF
+  cat > $TEST_SCRATCH_DIR/blob << EOF
   {
     "architecture": "$arch",
     "os": "linux",
@@ -219,12 +219,12 @@ load helpers
     ]
   }
 EOF
-  configdigest=$(sha256sum $TESTDIR/blob | awk '{print $1}')
-  configsize=$(stat -c %s $TESTDIR/blob)
-  mv $TESTDIR/blob $TESTDIR/blobs/sha256/${configdigest}
+  configdigest=$(sha256sum $TEST_SCRATCH_DIR/blob | awk '{print $1}')
+  configsize=$(stat -c %s $TEST_SCRATCH_DIR/blob)
+  mv $TEST_SCRATCH_DIR/blob $TEST_SCRATCH_DIR/blobs/sha256/${configdigest}
 
   # Create a manifest for that configuration blob and layer.
-  cat > $TESTDIR/blob << EOF
+  cat > $TEST_SCRATCH_DIR/blob << EOF
   {
     "schemaVersion": 2,
     "config": {
@@ -241,12 +241,12 @@ EOF
     ]
   }
 EOF
-  manifestdigest=$(sha256sum $TESTDIR/blob | awk '{print $1}')
-  manifestsize=$(stat -c %s $TESTDIR/blob)
-  mv $TESTDIR/blob $TESTDIR/blobs/sha256/${manifestdigest}
+  manifestdigest=$(sha256sum $TEST_SCRATCH_DIR/blob | awk '{print $1}')
+  manifestsize=$(stat -c %s $TEST_SCRATCH_DIR/blob)
+  mv $TEST_SCRATCH_DIR/blob $TEST_SCRATCH_DIR/blobs/sha256/${manifestdigest}
 
   # Add the manifest to the image index.
-  cat > $TESTDIR/index.json << EOF
+  cat > $TEST_SCRATCH_DIR/index.json << EOF
   {
     "schemaVersion": 2,
     "manifests": [
@@ -260,10 +260,10 @@ EOF
 EOF
 
   # Mark the directory as a layout directory.
-  echo -n '{"imageLayoutVersion": "1.0.0"}' > $TESTDIR/oci-layout
+  echo -n '{"imageLayoutVersion": "1.0.0"}' > $TEST_SCRATCH_DIR/oci-layout
 
   # Import the image.
-  run_buildah pull oci:$TESTDIR
+  run_buildah pull oci:$TEST_SCRATCH_DIR
 
   # Inspect the image.  We shouldn't crash.
   run_buildah inspect ${configdigest}

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -27,7 +27,7 @@ load helpers
 
 @test "images all test" {
   _prefetch alpine
-  run_buildah bud $WITH_POLICY_JSON --layers -t test ${TESTSDIR}/bud/use-layers
+  run_buildah bud $WITH_POLICY_JSON --layers -t test $BUDFILES/use-layers
   run_buildah images
   expect_line_count 3
 
@@ -35,7 +35,7 @@ load helpers
   expect_line_count 8
 
   # create a no name image which should show up when doing buildah images without the --all flag
-  run_buildah bud $WITH_POLICY_JSON ${TESTSDIR}/bud/use-layers
+  run_buildah bud $WITH_POLICY_JSON $BUDFILES/use-layers
   run_buildah images
   expect_line_count 4
 }

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -17,9 +17,9 @@ load helpers
 
 @test "images" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid2=$output
   run_buildah images
   expect_line_count 3
@@ -27,7 +27,7 @@ load helpers
 
 @test "images all test" {
   _prefetch alpine
-  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test ${TESTSDIR}/bud/use-layers
+  run_buildah bud $WITH_POLICY_JSON --layers -t test ${TESTSDIR}/bud/use-layers
   run_buildah images
   expect_line_count 3
 
@@ -35,16 +35,16 @@ load helpers
   expect_line_count 8
 
   # create a no name image which should show up when doing buildah images without the --all flag
-  run_buildah bud --signature-policy ${TESTSDIR}/policy.json ${TESTSDIR}/bud/use-layers
+  run_buildah bud $WITH_POLICY_JSON ${TESTSDIR}/bud/use-layers
   run_buildah images
   expect_line_count 4
 }
 
 @test "images filter test" {
   _prefetch k8s.gcr.io/pause busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json k8s.gcr.io/pause
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON k8s.gcr.io/pause
   cid1=$output
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid2=$output
 
   run_buildah 125 images --noheading --filter since k8s.gcr.io/pause
@@ -62,9 +62,9 @@ load helpers
 
 @test "images format test" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid2=$output
   run_buildah images --format "{{.Name}}"
   expect_line_count 2
@@ -72,9 +72,9 @@ load helpers
 
 @test "images noheading test" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid2=$output
   run_buildah images --noheading
   expect_line_count 2
@@ -82,9 +82,9 @@ load helpers
 
 @test "images quiet test" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid2=$output
   run_buildah images --quiet
   expect_line_count 2
@@ -92,9 +92,9 @@ load helpers
 
 @test "images no-trunc test" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid2=$output
   run_buildah images -q --no-trunc
   expect_line_count 2
@@ -103,8 +103,8 @@ load helpers
 
 @test "images json test" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
 
   for img in '' alpine busybox; do
       # e.g. [ { "id": "xx", ... },{ "id": "yy", ... } ]
@@ -119,9 +119,9 @@ load helpers
 }
 
 @test "images json dup test" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
+  run_buildah commit $WITH_POLICY_JSON $cid test
   run_buildah tag test new-name
 
   run_buildah images --json
@@ -129,12 +129,12 @@ load helpers
 }
 
 @test "images json valid" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid1=$output
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid2=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid1 test
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid2 test2
+  run_buildah commit $WITH_POLICY_JSON $cid1 test
+  run_buildah commit $WITH_POLICY_JSON $cid2 test2
 
   run_buildah images --json
   run python3 -m json.tool <<< "$output"
@@ -143,9 +143,9 @@ load helpers
 
 @test "specify an existing image" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid2=$output
   run_buildah images alpine
   expect_line_count 2
@@ -158,10 +158,10 @@ load helpers
 }
 
 @test "Test dangling images" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid test
+  run_buildah commit $WITH_POLICY_JSON $cid test
+  run_buildah commit $WITH_POLICY_JSON $cid test
   run_buildah images
   expect_line_count 3
 
@@ -176,7 +176,7 @@ load helpers
 
 @test "image digest test" {
   _prefetch busybox
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah pull $WITH_POLICY_JSON busybox
   run_buildah images --digests
   expect_output --substring "sha256:"
 }

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -15,9 +15,9 @@ load helpers
 
 @test "inspect" {
   _prefetch alpine
-  run_buildah from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull $WITH_POLICY_JSON alpine
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json "$cid" alpine-image
+  run_buildah commit $WITH_POLICY_JSON "$cid" alpine-image
 
   # e.g. { map[] [PATH=/....] [] [/bin/sh] map[]  map[] }
   run_buildah inspect --format '{{.OCIv1.Config}}' alpine
@@ -52,7 +52,7 @@ load helpers
 
 @test "inspect-config-is-json" {
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah inspect alpine
         expect_output --substring 'Config.*\{'
@@ -60,7 +60,7 @@ load helpers
 
 @test "inspect-manifest-is-json" {
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah inspect alpine
         expect_output --substring 'Manifest.*\{'
@@ -68,7 +68,7 @@ load helpers
 
 @test "inspect-ociv1-is-json" {
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah inspect alpine
         expect_output --substring 'OCIv1.*\{'
@@ -76,7 +76,7 @@ load helpers
 
 @test "inspect-docker-is-json" {
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah inspect alpine
         expect_output --substring 'Docker.*\{'
@@ -84,7 +84,7 @@ load helpers
 
 @test "inspect-format-config-is-json" {
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah inspect --format "{{.Config}}" alpine
         expect_output --substring '\{'
@@ -92,7 +92,7 @@ load helpers
 
 @test "inspect-format-manifest-is-json" {
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah inspect --format "{{.Manifest}}" alpine
         expect_output --substring '\{'
@@ -100,7 +100,7 @@ load helpers
 
 @test "inspect-format-ociv1-is-json" {
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah inspect --format "{{.OCIv1}}" alpine
         expect_output --substring '\{'
@@ -108,7 +108,7 @@ load helpers
 
 @test "inspect-format-docker-is-json" {
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah inspect --format "{{.Docker}}" alpine
         expect_output --substring '\{'
@@ -117,7 +117,7 @@ load helpers
 @test "inspect-format-docker-variant" {
 	# github.com/containerd/containerd/platforms.Normalize() converts Arch:"armhf" to Arch:"arm"+Variant:"v7",
 	# so check that platform normalization happens at least for that one
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json --arch=armhf scratch
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON --arch=armhf scratch
 	cid=$output
 	run_buildah inspect --format "{{.Docker.Architecture}}" $cid
 	[[ "$output" == "arm" ]]

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -86,7 +86,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 @test "manifest-push" {
     run_buildah manifest create foo
     run_buildah manifest add --all foo ${IMAGE_LIST}
-    run_buildah manifest push $WITH_POLICY_JSON foo dir:${TESTDIR}/pushed
+    run_buildah manifest push $WITH_POLICY_JSON foo dir:${TEST_SCRATCH_DIR}/pushed
     case "$(go env GOARCH 2> /dev/null)" in
 	    amd64) IMAGE_LIST_EXPECTED_INSTANCE_DIGEST=${IMAGE_LIST_AMD64_INSTANCE_DIGEST} ;;
 	    arm64) IMAGE_LIST_EXPECTED_INSTANCE_DIGEST=${IMAGE_LIST_ARM64_INSTANCE_DIGEST} ;;
@@ -95,15 +95,15 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 	    s390x) IMAGE_LIST_EXPECTED_INSTANCE_DIGEST=${IMAGE_LIST_S390X_INSTANCE_DIGEST} ;;
 	    *) skip "current arch \"$(go env GOARCH 2> /dev/null)\" not present in manifest list" ;;
     esac
-    run grep ${IMAGE_LIST_EXPECTED_INSTANCE_DIGEST##sha256} ${TESTDIR}/pushed/manifest.json
+    run grep ${IMAGE_LIST_EXPECTED_INSTANCE_DIGEST##sha256} ${TEST_SCRATCH_DIR}/pushed/manifest.json
     [ $status -eq 0 ]
 }
 
 @test "manifest-push-all" {
     run_buildah manifest create foo
     run_buildah manifest add --all foo ${IMAGE_LIST}
-    run_buildah manifest push $WITH_POLICY_JSON --all foo dir:${TESTDIR}/pushed
-    run sha256sum ${TESTDIR}/pushed/*
+    run_buildah manifest push $WITH_POLICY_JSON --all foo dir:${TEST_SCRATCH_DIR}/pushed
+    run sha256sum ${TEST_SCRATCH_DIR}/pushed/*
     expect_output --substring ${IMAGE_LIST_AMD64_INSTANCE_DIGEST##sha256:}
     expect_output --substring ${IMAGE_LIST_ARM_INSTANCE_DIGEST##sha256:}
     expect_output --substring ${IMAGE_LIST_ARM64_INSTANCE_DIGEST##sha256:}
@@ -115,7 +115,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest create foo
     run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST}
     run_buildah manifest inspect foo
-    run_buildah manifest push $WITH_POLICY_JSON --purge foo dir:${TESTDIR}/pushed
+    run_buildah manifest push $WITH_POLICY_JSON --purge foo dir:${TEST_SCRATCH_DIR}/pushed
     run_buildah 125 manifest inspect foo
 }
 
@@ -123,7 +123,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest create foo
     run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST}
     run_buildah manifest inspect foo
-    run_buildah manifest push $WITH_POLICY_JSON --rm foo dir:${TESTDIR}/pushed
+    run_buildah manifest push $WITH_POLICY_JSON --rm foo dir:${TEST_SCRATCH_DIR}/pushed
     run_buildah 125 manifest inspect foo
 }
 
@@ -131,7 +131,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest create foo
     run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST}
     run_buildah manifest inspect foo
-    run_buildah 125 manifest push --authfile /tmp/nonexistent $WITH_POLICY_JSON --purge foo dir:${TESTDIR}/pushed
+    run_buildah 125 manifest push --authfile /tmp/nonexistent $WITH_POLICY_JSON --purge foo dir:${TEST_SCRATCH_DIR}/pushed
 
 }
 
@@ -172,13 +172,13 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     archinstance=$(jq -r '.manifests|map(select(.platform.architecture=="'$arch'"))[].digest' <<< "$output")
     run_buildah manifest remove test-list $archinstance
     # Try to build using the build cache.
-    mkdir ${TESTDIR}/build
-    echo 'much content, wow.' > ${TESTDIR}/build/content.txt
-    echo 'FROM scratch' > ${TESTDIR}/build/Dockerfile
-    echo 'ADD content.txt /' >> ${TESTDIR}/build/Dockerfile
-    run_buildah bud --layers --iidfile ${TESTDIR}/image-id.txt ${TESTDIR}/build
+    mkdir ${TEST_SCRATCH_DIR}/build
+    echo 'much content, wow.' > ${TEST_SCRATCH_DIR}/build/content.txt
+    echo 'FROM scratch' > ${TEST_SCRATCH_DIR}/build/Dockerfile
+    echo 'ADD content.txt /' >> ${TEST_SCRATCH_DIR}/build/Dockerfile
+    run_buildah bud --layers --iidfile ${TEST_SCRATCH_DIR}/image-id.txt ${TEST_SCRATCH_DIR}/build
     # Make sure we can add the new image to the list.
-    run_buildah manifest add test-list $(< ${TESTDIR}/image-id.txt)
+    run_buildah manifest add test-list $(< ${TEST_SCRATCH_DIR}/image-id.txt)
 }
 
 @test "manifest-add-to-list-from-storage" {

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -29,7 +29,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 
 @test "manifest-add local image" {
     target=scratch-image
-    run_buildah bud $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
+    run_buildah bud $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
     run_buildah manifest create foo
     run_buildah manifest add foo ${target}
     run_buildah manifest rm foo

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -29,7 +29,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 
 @test "manifest-add local image" {
     target=scratch-image
-    run_buildah bud --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/from-scratch
+    run_buildah bud $WITH_POLICY_JSON -t ${target} ${TESTSDIR}/bud/from-scratch
     run_buildah manifest create foo
     run_buildah manifest add foo ${target}
     run_buildah manifest rm foo
@@ -86,7 +86,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 @test "manifest-push" {
     run_buildah manifest create foo
     run_buildah manifest add --all foo ${IMAGE_LIST}
-    run_buildah manifest push --signature-policy ${TESTSDIR}/policy.json foo dir:${TESTDIR}/pushed
+    run_buildah manifest push $WITH_POLICY_JSON foo dir:${TESTDIR}/pushed
     case "$(go env GOARCH 2> /dev/null)" in
 	    amd64) IMAGE_LIST_EXPECTED_INSTANCE_DIGEST=${IMAGE_LIST_AMD64_INSTANCE_DIGEST} ;;
 	    arm64) IMAGE_LIST_EXPECTED_INSTANCE_DIGEST=${IMAGE_LIST_ARM64_INSTANCE_DIGEST} ;;
@@ -102,7 +102,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 @test "manifest-push-all" {
     run_buildah manifest create foo
     run_buildah manifest add --all foo ${IMAGE_LIST}
-    run_buildah manifest push --signature-policy ${TESTSDIR}/policy.json --all foo dir:${TESTDIR}/pushed
+    run_buildah manifest push $WITH_POLICY_JSON --all foo dir:${TESTDIR}/pushed
     run sha256sum ${TESTDIR}/pushed/*
     expect_output --substring ${IMAGE_LIST_AMD64_INSTANCE_DIGEST##sha256:}
     expect_output --substring ${IMAGE_LIST_ARM_INSTANCE_DIGEST##sha256:}
@@ -115,7 +115,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest create foo
     run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST}
     run_buildah manifest inspect foo
-    run_buildah manifest push --signature-policy ${TESTSDIR}/policy.json --purge foo dir:${TESTDIR}/pushed
+    run_buildah manifest push $WITH_POLICY_JSON --purge foo dir:${TESTDIR}/pushed
     run_buildah 125 manifest inspect foo
 }
 
@@ -123,7 +123,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest create foo
     run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST}
     run_buildah manifest inspect foo
-    run_buildah manifest push --signature-policy ${TESTSDIR}/policy.json --rm foo dir:${TESTDIR}/pushed
+    run_buildah manifest push $WITH_POLICY_JSON --rm foo dir:${TESTDIR}/pushed
     run_buildah 125 manifest inspect foo
 }
 
@@ -131,12 +131,12 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest create foo
     run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST}
     run_buildah manifest inspect foo
-    run_buildah 125 manifest push --authfile /tmp/nonexistent --signature-policy ${TESTSDIR}/policy.json --purge foo dir:${TESTDIR}/pushed
+    run_buildah 125 manifest push --authfile /tmp/nonexistent $WITH_POLICY_JSON --purge foo dir:${TESTDIR}/pushed
 
 }
 
 @test "manifest-from-tag" {
-    run_buildah from --signature-policy ${TESTSDIR}/policy.json --name test-container ${IMAGE_LIST}
+    run_buildah from $WITH_POLICY_JSON --name test-container ${IMAGE_LIST}
     run_buildah inspect --format ''{{.OCIv1.Architecture}}' ${IMAGE_LIST}
     expect_output --substring $(go env GOARCH)
     run_buildah inspect --format ''{{.OCIv1.Architecture}}' test-container
@@ -144,7 +144,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 }
 
 @test "manifest-from-digest" {
-    run_buildah from --signature-policy ${TESTSDIR}/policy.json --name test-container ${IMAGE_LIST_DIGEST}
+    run_buildah from $WITH_POLICY_JSON --name test-container ${IMAGE_LIST_DIGEST}
     run_buildah inspect --format ''{{.OCIv1.Architecture}}' ${IMAGE_LIST_DIGEST}
     expect_output --substring $(go env GOARCH)
     run_buildah inspect --format ''{{.OCIv1.Architecture}}' test-container
@@ -152,7 +152,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 }
 
 @test "manifest-from-instance" {
-    run_buildah from --signature-policy ${TESTSDIR}/policy.json --name test-container ${IMAGE_LIST_INSTANCE}
+    run_buildah from $WITH_POLICY_JSON --name test-container ${IMAGE_LIST_INSTANCE}
     run_buildah inspect --format ''{{.OCIv1.Architecture}}' ${IMAGE_LIST_INSTANCE}
     expect_output --substring arm64
     run_buildah inspect --format ''{{.OCIv1.Architecture}}' test-container

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -15,7 +15,7 @@ load helpers
 
 @test "mount one container" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah mount "$cid"
 }
@@ -26,35 +26,35 @@ load helpers
 
 @test "mount multi images" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
-  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull-never $WITH_POLICY_JSON alpine
   cid2=$output
-  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull-never $WITH_POLICY_JSON alpine
   cid3=$output
   run_buildah mount "$cid1" "$cid2" "$cid3"
 }
 
 @test "mount multi images one bad" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
-  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull-never $WITH_POLICY_JSON alpine
   cid2=$output
-  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull-never $WITH_POLICY_JSON alpine
   cid3=$output
   run_buildah 125 mount "$cid1" badcontainer "$cid2" "$cid3"
 }
 
 @test "list currently mounted containers" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
   run_buildah mount "$cid1"
-  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull-never $WITH_POLICY_JSON alpine
   cid2=$output
   run_buildah mount "$cid2"
-  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull-never $WITH_POLICY_JSON alpine
   cid3=$output
   run_buildah mount "$cid3"
   run_buildah mount

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -8,7 +8,7 @@ load helpers
   fi
 
   _prefetch alpine
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet alpine
+  run_buildah from $WITH_POLICY_JSON --quiet alpine
   expect_output "alpine-working-container"
   ctr="$output"
 
@@ -40,7 +40,7 @@ load helpers
 
   # Create a container that uses that mapping.
   _prefetch alpine
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet --userns-uid-map 0:$uidbase:$uidsize --userns-gid-map 0:$gidbase:$gidsize alpine
+  run_buildah from $WITH_POLICY_JSON --quiet --userns-uid-map 0:$uidbase:$uidsize --userns-gid-map 0:$gidbase:$gidsize alpine
   ctr="$output"
 
   # Check that with settings that require a user namespace, we also get a new network namespace by default.
@@ -57,7 +57,7 @@ load helpers
   assert "$output" != "$host_sys"
 
   # Create a container that doesn't use that mapping.
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet alpine
+  run_buildah from $WITH_POLICY_JSON --quiet alpine
   ctr="$output"
 
   run_buildah run $RUNOPTS --net=host "$ctr" readlink /proc/self/ns/net
@@ -201,9 +201,9 @@ idmapping_check_permission() {
     }
 
     # Create a container using these mappings.
-    echo "Building container with --signature-policy ${TESTSDIR}/policy.json --quiet ${uidmapargs[$i]} ${gidmapargs[$i]} alpine"
+    echo "Building container with $WITH_POLICY_JSON --quiet ${uidmapargs[$i]} ${gidmapargs[$i]} alpine"
     _prefetch alpine
-    run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet ${uidmapargs[$i]} ${gidmapargs[$i]} alpine
+    run_buildah from $WITH_POLICY_JSON --quiet ${uidmapargs[$i]} ${gidmapargs[$i]} alpine
     ctr="$output"
 
     # If we specified mappings, expect to be in a different namespace by default.
@@ -246,7 +246,7 @@ idmapping_check_permission() {
     # Also test bud command
     # Build an image using these mappings.
     echo "Building image with ${uidmapargs[$i]} ${gidmapargs[$i]}"
-    run_buildah bud ${uidmapargs[$i]} ${gidmapargs[$i]} $RUNOPTS --signature-policy ${TESTSDIR}/policy.json \
+    run_buildah bud ${uidmapargs[$i]} ${gidmapargs[$i]} $RUNOPTS $WITH_POLICY_JSON \
                     -t localhost/alpine-bud:$i -f ${TESTSDIR}/bud/namespaces/Containerfile $TESTDIR
     # If we specified mappings, expect to be in a different namespace by default.
     output_namespace="$(grep -A1 'ReadlinkResult' <<< "$output" | tail -n1)"
@@ -298,7 +298,7 @@ general_namespace() {
   _prefetch alpine
   for namespace in "${types[@]}" ; do
     # Specify the setting for this namespace for this container.
-    run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet --"$nsflag"=$namespace alpine
+    run_buildah from $WITH_POLICY_JSON --quiet --"$nsflag"=$namespace alpine
     [ "$output" != "" ]
     ctr="$output"
 
@@ -342,7 +342,7 @@ general_namespace() {
 FROM alpine
 RUN echo "TargetOutput" && readlink /proc/self/ns/$nstype
 _EOF
-    run_buildah bud --"$nsflag"=$namespace $RUNOPTS --signature-policy ${TESTSDIR}/policy.json --file ${mytmpdir} .
+    run_buildah bud --"$nsflag"=$namespace $RUNOPTS $WITH_POLICY_JSON --file ${mytmpdir} .
     result=$(grep -A1 "TargetOutput" <<< "$output" | tail -n1)
     case "$namespace" in
     ""|container|private)
@@ -420,8 +420,8 @@ _EOF
           for uts in host private; do
             for cgroupns in host private; do
 
-              echo "buildah from --signature-policy ${TESTSDIR}/policy.json --ipc=$ipc --net=$net --pid=$pid --userns=$userns --uts=$uts --cgroupns=$cgroupns alpine"
-              run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet --ipc=$ipc --net=$net --pid=$pid --userns=$userns --uts=$uts --cgroupns=$cgroupns alpine
+              echo "buildah from $WITH_POLICY_JSON --ipc=$ipc --net=$net --pid=$pid --userns=$userns --uts=$uts --cgroupns=$cgroupns alpine"
+              run_buildah from $WITH_POLICY_JSON --quiet --ipc=$ipc --net=$net --pid=$pid --userns=$userns --uts=$uts --cgroupns=$cgroupns alpine
               [ "$output" != "" ]
               ctr="$output"
               run_buildah run $ctr pwd
@@ -445,7 +445,7 @@ _EOF
 	cid=$output
 	run_buildah copy "$cid" ${TESTDIR}/randomfile /
 	run_buildah copy --chown 1:1 "$cid" ${TESTDIR}/randomfile /randomfile2
-	run_buildah commit --squash --signature-policy ${TESTSDIR}/policy.json --rm "$cid" squashed
+	run_buildah commit --squash $WITH_POLICY_JSON --rm "$cid" squashed
 	run_buildah from --quiet squashed
 	cid=$output
 	run_buildah mount $cid
@@ -476,9 +476,9 @@ _EOF
 }
 
 @test "idmapping-syntax" {
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet --userns-uid-map=0:10000:65536 alpine
+  run_buildah from $WITH_POLICY_JSON --quiet --userns-uid-map=0:10000:65536 alpine
 
-  run_buildah 125 from --signature-policy ${TESTSDIR}/policy.json --quiet --userns-gid-map=0:10000:65536 alpine
+  run_buildah 125 from $WITH_POLICY_JSON --quiet --userns-gid-map=0:10000:65536 alpine
   expect_output --substring "userns-gid-map can not be used without --userns-uid-map"
 }
 
@@ -499,7 +499,7 @@ ipcns = "$mode"
 utsns = "$mode"
 EOF
 
-    CONTAINERS_CONF="$containers_conf_file" run_buildah from --signature-policy ${TESTSDIR}/policy.json --quiet alpine
+    CONTAINERS_CONF="$containers_conf_file" run_buildah from $WITH_POLICY_JSON --quiet alpine
     [ "$output" != "" ]
     ctr="$output"
 

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -21,8 +21,8 @@ load helpers
   skip_if_chroot
   skip_if_rootless
 
-  mkdir -p $TESTDIR/no-cni-configs
-  RUNOPTS="--cni-config-dir=${TESTDIR}/no-cni-configs ${RUNC_BINARY:+--runtime $RUNC_BINARY}"
+  mkdir -p $TEST_SCRATCH_DIR/no-cni-configs
+  RUNOPTS="--cni-config-dir=${TEST_SCRATCH_DIR}/no-cni-configs ${RUNC_BINARY:+--runtime $RUNC_BINARY}"
   # Check if we're running in an environment that can even test this.
   run readlink /proc/self/ns/user
   echo "readlink /proc/self/ns/user -> $output"
@@ -103,8 +103,8 @@ idmapping_check_permission() {
 
 @test "idmapping" {
   skip_if_rootless_environment
-  mkdir -p $TESTDIR/no-cni-configs
-  RUNOPTS="--cni-config-dir=${TESTDIR}/no-cni-configs ${RUNC_BINARY:+--runtime $RUNC_BINARY}"
+  mkdir -p $TEST_SCRATCH_DIR/no-cni-configs
+  RUNOPTS="--cni-config-dir=${TEST_SCRATCH_DIR}/no-cni-configs ${RUNC_BINARY:+--runtime $RUNC_BINARY}"
 
   # Check if we're running in an environment that can even test this.
   run readlink /proc/self/ns/user
@@ -178,11 +178,11 @@ idmapping_check_permission() {
     fi
   fi
 
-  touch ${TESTDIR}/somefile
-  mkdir ${TESTDIR}/somedir
-  touch ${TESTDIR}/somedir/someotherfile
-  chmod 700 ${TESTDIR}/somedir/someotherfile
-  chmod u+s ${TESTDIR}/somedir/someotherfile
+  touch ${TEST_SCRATCH_DIR}/somefile
+  mkdir ${TEST_SCRATCH_DIR}/somedir
+  touch ${TEST_SCRATCH_DIR}/somedir/someotherfile
+  chmod 700 ${TEST_SCRATCH_DIR}/somedir/someotherfile
+  chmod u+s ${TEST_SCRATCH_DIR}/somedir/someotherfile
 
   for i in $(seq 0 "$((${#uidmaps[*]}-1))") ; do
     # local helper function for checking /proc/self/ns/user
@@ -220,11 +220,11 @@ idmapping_check_permission() {
     rootgid=$rootxid
 
     # Check that if we copy a file into the container, it gets the right permissions.
-    run_buildah copy --chown 1:1 "$ctr" ${TESTDIR}/somefile /
+    run_buildah copy --chown 1:1 "$ctr" ${TEST_SCRATCH_DIR}/somefile /
     run_buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somefile
     output_file_stat="$output"
     # Check that if we copy a directory into the container, its contents get the right permissions.
-    run_buildah copy "$ctr" ${TESTDIR}/somedir /somedir
+    run_buildah copy "$ctr" ${TEST_SCRATCH_DIR}/somedir /somedir
     run_buildah run $RUNOPTS "$ctr" stat -c '%u:%g' /somedir
     output_dir_stat="$output"
     idmapping_check_permission "$output_file_stat" "$output_dir_stat"
@@ -247,7 +247,7 @@ idmapping_check_permission() {
     # Build an image using these mappings.
     echo "Building image with ${uidmapargs[$i]} ${gidmapargs[$i]}"
     run_buildah bud ${uidmapargs[$i]} ${gidmapargs[$i]} $RUNOPTS $WITH_POLICY_JSON \
-                    -t localhost/alpine-bud:$i -f $BUDFILES/namespaces/Containerfile $TESTDIR
+                    -t localhost/alpine-bud:$i -f $BUDFILES/namespaces/Containerfile $TEST_SCRATCH_DIR
     # If we specified mappings, expect to be in a different namespace by default.
     output_namespace="$(grep -A1 'ReadlinkResult' <<< "$output" | tail -n1)"
     idmapping_check_namespace "${output_namespace}" "bud"
@@ -271,9 +271,9 @@ idmapping_check_permission() {
 }
 
 general_namespace() {
-  mkdir -p $TESTDIR/no-cni-configs
-  RUNOPTS="--cni-config-dir=${TESTDIR}/no-cni-configs ${RUNC_BINARY:+--runtime $RUNC_BINARY}"
-  mytmpdir=$TESTDIR/my-dir
+  mkdir -p $TEST_SCRATCH_DIR/no-cni-configs
+  RUNOPTS="--cni-config-dir=${TEST_SCRATCH_DIR}/no-cni-configs ${RUNC_BINARY:+--runtime $RUNC_BINARY}"
+  mytmpdir=$TEST_SCRATCH_DIR/my-dir
   mkdir -p ${mytmpdir}
 
   # The name of the /proc/self/ns/$link.
@@ -440,11 +440,11 @@ _EOF
 
 @test "idmapping-and-squash" {
         skip_if_rootless_environment
-	createrandom ${TESTDIR}/randomfile
+	createrandom ${TEST_SCRATCH_DIR}/randomfile
 	run_buildah from --userns-uid-map 0:32:16 --userns-gid-map 0:48:16 scratch
 	cid=$output
-	run_buildah copy "$cid" ${TESTDIR}/randomfile /
-	run_buildah copy --chown 1:1 "$cid" ${TESTDIR}/randomfile /randomfile2
+	run_buildah copy "$cid" ${TEST_SCRATCH_DIR}/randomfile /
+	run_buildah copy --chown 1:1 "$cid" ${TEST_SCRATCH_DIR}/randomfile /randomfile2
 	run_buildah commit --squash $WITH_POLICY_JSON --rm "$cid" squashed
 	run_buildah from --quiet squashed
 	cid=$output
@@ -486,7 +486,7 @@ _EOF
   skip_if_chroot
 
   _prefetch alpine
-  containers_conf_file="$TESTDIR/containers-namespaces.conf"
+  containers_conf_file="$TEST_SCRATCH_DIR/containers-namespaces.conf"
 
   for mode in host private; do
     cat > "$containers_conf_file" << EOF

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -247,7 +247,7 @@ idmapping_check_permission() {
     # Build an image using these mappings.
     echo "Building image with ${uidmapargs[$i]} ${gidmapargs[$i]}"
     run_buildah bud ${uidmapargs[$i]} ${gidmapargs[$i]} $RUNOPTS $WITH_POLICY_JSON \
-                    -t localhost/alpine-bud:$i -f ${TESTSDIR}/bud/namespaces/Containerfile $TESTDIR
+                    -t localhost/alpine-bud:$i -f $BUDFILES/namespaces/Containerfile $TESTDIR
     # If we specified mappings, expect to be in a different namespace by default.
     output_namespace="$(grep -A1 'ReadlinkResult' <<< "$output" | tail -n1)"
     idmapping_check_namespace "${output_namespace}" "bud"

--- a/tests/overlay.bats
+++ b/tests/overlay.bats
@@ -12,7 +12,7 @@ load helpers
   mkdir ${TESTDIR}/lower
   touch ${TESTDIR}/lower/foo
 
-  run_buildah from --quiet -v ${TESTDIR}/lower:/lower:O --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet -v ${TESTDIR}/lower:/lower:O --quiet $WITH_POLICY_JSON $image
   cid=$output
 
   # This should succeed
@@ -41,7 +41,7 @@ load helpers
   mkdir -m 770 ${TESTDIR}/lower
   chown 1:1 ${TESTDIR}/lower
   permission=$(stat -c "%a %u %g" ${TESTDIR}/lower)
-  run_buildah from --quiet -v ${TESTDIR}/lower:/tmp/test:O --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet -v ${TESTDIR}/lower:/tmp/test:O --quiet $WITH_POLICY_JSON $image
   cid=$output
 
   # This should succeed
@@ -73,7 +73,7 @@ load helpers
 
   # This should succeed.
   # Add double backslash, because shell will escape.
-  run_buildah from --quiet -v ${TESTDIR}/a\\:lower:/a\\:lower:O --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet -v ${TESTDIR}/a\\:lower:/a\\:lower:O --quiet $WITH_POLICY_JSON $image
   cid=$output
 
   # This should succeed

--- a/tests/overlay.bats
+++ b/tests/overlay.bats
@@ -9,10 +9,10 @@ load helpers
     skip "skipping overlay test because \$STORAGE_DRIVER = $STORAGE_DRIVER"
   fi
   image=alpine
-  mkdir ${TESTDIR}/lower
-  touch ${TESTDIR}/lower/foo
+  mkdir ${TEST_SCRATCH_DIR}/lower
+  touch ${TEST_SCRATCH_DIR}/lower/foo
 
-  run_buildah from --quiet -v ${TESTDIR}/lower:/lower:O --quiet $WITH_POLICY_JSON $image
+  run_buildah from --quiet -v ${TEST_SCRATCH_DIR}/lower:/lower:O --quiet $WITH_POLICY_JSON $image
   cid=$output
 
   # This should succeed
@@ -27,7 +27,7 @@ load helpers
   run_buildah 1 run $cid ls /lower/bar
 
   # This should fail
-  run ls ${TESTDIR}/lower/bar
+  run ls ${TEST_SCRATCH_DIR}/lower/bar
   [ "$status" -ne 0 ]
 }
 
@@ -38,10 +38,10 @@ load helpers
     skip "skipping overlay test because \$STORAGE_DRIVER = $STORAGE_DRIVER"
   fi
   image=alpine
-  mkdir -m 770 ${TESTDIR}/lower
-  chown 1:1 ${TESTDIR}/lower
-  permission=$(stat -c "%a %u %g" ${TESTDIR}/lower)
-  run_buildah from --quiet -v ${TESTDIR}/lower:/tmp/test:O --quiet $WITH_POLICY_JSON $image
+  mkdir -m 770 ${TEST_SCRATCH_DIR}/lower
+  chown 1:1 ${TEST_SCRATCH_DIR}/lower
+  permission=$(stat -c "%a %u %g" ${TEST_SCRATCH_DIR}/lower)
+  run_buildah from --quiet -v ${TEST_SCRATCH_DIR}/lower:/tmp/test:O --quiet $WITH_POLICY_JSON $image
   cid=$output
 
   # This should succeed
@@ -49,7 +49,7 @@ load helpers
   expect_output "$permission"
 
   # Create and remove content in the overlay directory, should succeed
-  touch ${TESTDIR}/lower/foo
+  touch ${TEST_SCRATCH_DIR}/lower/foo
   run_buildah run $cid touch /tmp/test/bar
   run_buildah run $cid rm /tmp/test/foo
 
@@ -57,7 +57,7 @@ load helpers
   run_buildah 1 run $cid ls /tmp/test/bar
 
   # This should fail since /tmp/test was an overlay, not a bind mount
-  run ls ${TESTDIR}/lower/bar
+  run ls ${TEST_SCRATCH_DIR}/lower/bar
   [ "$status" -ne 0 ]
 }
 
@@ -68,19 +68,19 @@ load helpers
     skip "skipping overlay test because \$STORAGE_DRIVER = $STORAGE_DRIVER"
   fi
   image=alpine
-  mkdir ${TESTDIR}/a:lower
-  touch ${TESTDIR}/a:lower/foo
+  mkdir ${TEST_SCRATCH_DIR}/a:lower
+  touch ${TEST_SCRATCH_DIR}/a:lower/foo
 
   # This should succeed.
   # Add double backslash, because shell will escape.
-  run_buildah from --quiet -v ${TESTDIR}/a\\:lower:/a\\:lower:O --quiet $WITH_POLICY_JSON $image
+  run_buildah from --quiet -v ${TEST_SCRATCH_DIR}/a\\:lower:/a\\:lower:O --quiet $WITH_POLICY_JSON $image
   cid=$output
 
   # This should succeed
   run_buildah run $cid ls /a:lower/foo
 
   # Mount volume when run
-  run_buildah run -v ${TESTDIR}/a\\:lower:/b\\:lower:O $cid ls /b:lower/foo
+  run_buildah run -v ${TEST_SCRATCH_DIR}/a\\:lower:/b\\:lower:O $cid ls /b:lower/foo
 
   # Create and remove content in the overlay directory, should succeed,
   # resetting the contents between each run.
@@ -91,6 +91,6 @@ load helpers
   run_buildah 1 run $cid ls /a:lower/bar
 
   # This should fail
-  run ls ${TESTDIR}/a:lower/bar
+  run ls ${TEST_SCRATCH_DIR}/a:lower/bar
   [ "$status" -ne 0 ]
 }

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -29,32 +29,32 @@ load helpers
 }
 
 @test "pull-blocked" {
-  run_buildah 125 --registries-conf ${TESTSDIR}/registries.conf.block pull $WITH_POLICY_JSON docker.io/alpine
+  run_buildah 125 --registries-conf ${TEST_SOURCES}/registries.conf.block pull $WITH_POLICY_JSON docker.io/alpine
   expect_output --substring "registry docker.io is blocked in"
 
-  run_buildah --retry --registries-conf ${TESTSDIR}/registries.conf       pull $WITH_POLICY_JSON docker.io/alpine
+  run_buildah --retry --registries-conf ${TEST_SOURCES}/registries.conf       pull $WITH_POLICY_JSON docker.io/alpine
 }
 
 @test "pull-from-registry" {
-  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf $WITH_POLICY_JSON busybox:glibc
-  run_buildah pull --registries-conf ${TESTSDIR}/registries.conf $WITH_POLICY_JSON busybox:latest
+  run_buildah --retry pull --registries-conf ${TEST_SOURCES}/registries.conf $WITH_POLICY_JSON busybox:glibc
+  run_buildah pull --registries-conf ${TEST_SOURCES}/registries.conf $WITH_POLICY_JSON busybox:latest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "busybox:glibc"
   expect_output --substring "busybox:latest"
   # We need to see if this file is created after first pull in at least one test
   [ -f ${TESTDIR}/root/defaultNetworkBackend ]
 
-  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf $WITH_POLICY_JSON quay.io/libpod/alpine_nginx:latest
+  run_buildah --retry pull --registries-conf ${TEST_SOURCES}/registries.conf $WITH_POLICY_JSON quay.io/libpod/alpine_nginx:latest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine_nginx:latest"
 
   run_buildah rmi quay.io/libpod/alpine_nginx:latest
-  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf $WITH_POLICY_JSON quay.io/libpod/alpine_nginx
+  run_buildah --retry pull --registries-conf ${TEST_SOURCES}/registries.conf $WITH_POLICY_JSON quay.io/libpod/alpine_nginx
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine_nginx:latest"
 
-  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf $WITH_POLICY_JSON alpine@sha256:e9a2035f9d0d7cee1cdd445f5bfa0c5c646455ee26f14565dce23cf2d2de7570
-  run_buildah 125 pull --registries-conf ${TESTSDIR}/registries.conf $WITH_POLICY_JSON fakeimage/fortest
+  run_buildah --retry pull --registries-conf ${TEST_SOURCES}/registries.conf $WITH_POLICY_JSON alpine@sha256:e9a2035f9d0d7cee1cdd445f5bfa0c5c646455ee26f14565dce23cf2d2de7570
+  run_buildah 125 pull --registries-conf ${TEST_SOURCES}/registries.conf $WITH_POLICY_JSON fakeimage/fortest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   [[ ! "$output" =~ "fakeimage/fortest" ]]
 }
@@ -114,7 +114,7 @@ load helpers
   declare -a tags=(0.9 0.9.1 1.1 alpha beta gamma2.0 latest)
 
   # setup: pull alpine, and push it repeatedly to localhost using those tags
-  opts="--signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword"
+  opts="--signature-policy ${TEST_SOURCES}/policy.json --tls-verify=false --creds testuser:testpassword"
   run_buildah --retry pull --quiet $WITH_POLICY_JSON alpine
   for tag in "${tags[@]}"; do
       run_buildah push $opts alpine localhost:${REGISTRY_PORT}/myalpine:$tag
@@ -162,18 +162,18 @@ load helpers
 @test "pull-denied-by-registry-sources" {
   export BUILD_REGISTRY_SOURCES='{"blockedRegistries": ["docker.io"]}'
 
-  run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
+  run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TEST_SOURCES}/registries.conf.hub --quiet busybox
   expect_output --substring 'registry "docker.io" denied by policy: it is in the blocked registries list'
 
-  run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
+  run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TEST_SOURCES}/registries.conf.hub --quiet busybox
   expect_output --substring 'registry "docker.io" denied by policy: it is in the blocked registries list'
 
   export BUILD_REGISTRY_SOURCES='{"allowedRegistries": ["some-other-registry.example.com"]}'
 
-  run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
+  run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TEST_SOURCES}/registries.conf.hub --quiet busybox
   expect_output --substring 'registry "docker.io" denied by policy: not in allowed registries list'
 
-  run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
+  run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TEST_SOURCES}/registries.conf.hub --quiet busybox
   expect_output --substring 'registry "docker.io" denied by policy: not in allowed registries list'
 }
 

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -29,69 +29,69 @@ load helpers
 }
 
 @test "pull-blocked" {
-  run_buildah 125 --registries-conf ${TESTSDIR}/registries.conf.block pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
+  run_buildah 125 --registries-conf ${TESTSDIR}/registries.conf.block pull $WITH_POLICY_JSON docker.io/alpine
   expect_output --substring "registry docker.io is blocked in"
 
-  run_buildah --retry --registries-conf ${TESTSDIR}/registries.conf       pull --signature-policy ${TESTSDIR}/policy.json docker.io/alpine
+  run_buildah --retry --registries-conf ${TESTSDIR}/registries.conf       pull $WITH_POLICY_JSON docker.io/alpine
 }
 
 @test "pull-from-registry" {
-  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json busybox:glibc
-  run_buildah pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json busybox:latest
+  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf $WITH_POLICY_JSON busybox:glibc
+  run_buildah pull --registries-conf ${TESTSDIR}/registries.conf $WITH_POLICY_JSON busybox:latest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "busybox:glibc"
   expect_output --substring "busybox:latest"
   # We need to see if this file is created after first pull in at least one test
   [ -f ${TESTDIR}/root/defaultNetworkBackend ]
 
-  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/alpine_nginx:latest
+  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf $WITH_POLICY_JSON quay.io/libpod/alpine_nginx:latest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine_nginx:latest"
 
   run_buildah rmi quay.io/libpod/alpine_nginx:latest
-  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/alpine_nginx
+  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf $WITH_POLICY_JSON quay.io/libpod/alpine_nginx
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine_nginx:latest"
 
-  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json alpine@sha256:e9a2035f9d0d7cee1cdd445f5bfa0c5c646455ee26f14565dce23cf2d2de7570
-  run_buildah 125 pull --registries-conf ${TESTSDIR}/registries.conf --signature-policy ${TESTSDIR}/policy.json fakeimage/fortest
+  run_buildah --retry pull --registries-conf ${TESTSDIR}/registries.conf $WITH_POLICY_JSON alpine@sha256:e9a2035f9d0d7cee1cdd445f5bfa0c5c646455ee26f14565dce23cf2d2de7570
+  run_buildah 125 pull --registries-conf ${TESTSDIR}/registries.conf $WITH_POLICY_JSON fakeimage/fortest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   [[ ! "$output" =~ "fakeimage/fortest" ]]
 }
 
 @test "pull-from-docker-archive" {
-  run_buildah --retry pull --signature-policy ${TESTSDIR}/policy.json alpine
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json docker.io/library/alpine:latest docker-archive:${TESTDIR}/alp.tar:alpine:latest
+  run_buildah --retry pull $WITH_POLICY_JSON alpine
+  run_buildah push $WITH_POLICY_JSON docker.io/library/alpine:latest docker-archive:${TESTDIR}/alp.tar:alpine:latest
   run_buildah rmi alpine
-  run_buildah --retry pull --signature-policy ${TESTSDIR}/policy.json docker-archive:${TESTDIR}/alp.tar
+  run_buildah --retry pull $WITH_POLICY_JSON docker-archive:${TESTDIR}/alp.tar
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine"
-  run_buildah 125 pull --all-tags --signature-policy ${TESTSDIR}/policy.json docker-archive:${TESTDIR}/alp.tar
+  run_buildah 125 pull --all-tags $WITH_POLICY_JSON docker-archive:${TESTDIR}/alp.tar
   expect_output --substring "pulling all tags is not supported for docker-archive transport"
 }
 
 @test "pull-from-oci-archive" {
-  run_buildah --retry pull --signature-policy ${TESTSDIR}/policy.json alpine
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json docker.io/library/alpine:latest oci-archive:${TESTDIR}/alp.tar:alpine
+  run_buildah --retry pull $WITH_POLICY_JSON alpine
+  run_buildah push $WITH_POLICY_JSON docker.io/library/alpine:latest oci-archive:${TESTDIR}/alp.tar:alpine
   run_buildah rmi alpine
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json oci-archive:${TESTDIR}/alp.tar
+  run_buildah pull $WITH_POLICY_JSON oci-archive:${TESTDIR}/alp.tar
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine"
-  run_buildah 125 pull --all-tags --signature-policy ${TESTSDIR}/policy.json oci-archive:${TESTDIR}/alp.tar
+  run_buildah 125 pull --all-tags $WITH_POLICY_JSON oci-archive:${TESTDIR}/alp.tar
   expect_output --substring "pulling all tags is not supported for oci-archive transport"
 }
 
 @test "pull-from-local-directory" {
   mkdir ${TESTDIR}/buildahtest
-  run_buildah --retry pull --signature-policy ${TESTSDIR}/policy.json alpine
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json docker.io/library/alpine:latest dir:${TESTDIR}/buildahtest
+  run_buildah --retry pull $WITH_POLICY_JSON alpine
+  run_buildah push $WITH_POLICY_JSON docker.io/library/alpine:latest dir:${TESTDIR}/buildahtest
   run_buildah rmi alpine
-  run_buildah pull --quiet --signature-policy ${TESTSDIR}/policy.json dir:${TESTDIR}/buildahtest
+  run_buildah pull --quiet $WITH_POLICY_JSON dir:${TESTDIR}/buildahtest
   imageID="$output"
   # Images pulled via the dir transport are untagged.
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "<none>:<none>"
-  run_buildah 125 pull --all-tags --signature-policy ${TESTSDIR}/policy.json dir:$imageID
+  run_buildah 125 pull --all-tags $WITH_POLICY_JSON dir:$imageID
   expect_output --substring "pulling all tags is not supported for dir transport"
 }
 
@@ -101,11 +101,11 @@ load helpers
   run docker pull alpine
   echo "$output"
   [ "$status" -eq 0 ]
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json docker-daemon:docker.io/library/alpine:latest
+  run_buildah pull $WITH_POLICY_JSON docker-daemon:docker.io/library/alpine:latest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine:latest"
   run_buildah rmi alpine
-  run_buildah 125 pull --all-tags --signature-policy ${TESTSDIR}/policy.json docker-daemon:docker.io/library/alpine:latest
+  run_buildah 125 pull --all-tags $WITH_POLICY_JSON docker-daemon:docker.io/library/alpine:latest
   expect_output --substring "pulling all tags is not supported for docker-daemon transport"
 }
 
@@ -115,7 +115,7 @@ load helpers
 
   # setup: pull alpine, and push it repeatedly to localhost using those tags
   opts="--signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword"
-  run_buildah --retry pull --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah --retry pull --quiet $WITH_POLICY_JSON alpine
   for tag in "${tags[@]}"; do
       run_buildah push $opts alpine localhost:${REGISTRY_PORT}/myalpine:$tag
   done
@@ -149,36 +149,36 @@ load helpers
 }
 
 @test "pull-from-oci-directory" {
-  run_buildah --retry pull --signature-policy ${TESTSDIR}/policy.json alpine
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json docker.io/library/alpine:latest oci:${TESTDIR}/alpine
+  run_buildah --retry pull $WITH_POLICY_JSON alpine
+  run_buildah push $WITH_POLICY_JSON docker.io/library/alpine:latest oci:${TESTDIR}/alpine
   run_buildah rmi alpine
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json oci:${TESTDIR}/alpine
+  run_buildah pull $WITH_POLICY_JSON oci:${TESTDIR}/alpine
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "localhost${TESTDIR}/alpine:latest"
-  run_buildah 125 pull --all-tags --signature-policy ${TESTSDIR}/policy.json oci:${TESTDIR}/alpine
+  run_buildah 125 pull --all-tags $WITH_POLICY_JSON oci:${TESTDIR}/alpine
   expect_output --substring "pulling all tags is not supported for oci transport"
 }
 
 @test "pull-denied-by-registry-sources" {
   export BUILD_REGISTRY_SOURCES='{"blockedRegistries": ["docker.io"]}'
 
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
+  run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
   expect_output --substring 'registry "docker.io" denied by policy: it is in the blocked registries list'
 
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
+  run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
   expect_output --substring 'registry "docker.io" denied by policy: it is in the blocked registries list'
 
   export BUILD_REGISTRY_SOURCES='{"allowedRegistries": ["some-other-registry.example.com"]}'
 
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
+  run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
   expect_output --substring 'registry "docker.io" denied by policy: not in allowed registries list'
 
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
+  run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TESTSDIR}/registries.conf.hub --quiet busybox
   expect_output --substring 'registry "docker.io" denied by policy: not in allowed registries list'
 }
 
 @test "pull should fail with nonexistent authfile" {
-  run_buildah 125 pull --authfile /tmp/nonexistent --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah 125 pull --authfile /tmp/nonexistent $WITH_POLICY_JSON alpine
 }
 
 @test "pull encrypted local image" {
@@ -187,18 +187,18 @@ load helpers
   openssl genrsa -out ${TESTDIR}/tmp/mykey.pem 1024
   openssl genrsa -out ${TESTDIR}/tmp/mykey2.pem 1024
   openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json --encryption-key jwe:${TESTDIR}/tmp/mykey.pub busybox  oci:${TESTDIR}/tmp/busybox_enc
+  run_buildah push $WITH_POLICY_JSON --encryption-key jwe:${TESTDIR}/tmp/mykey.pub busybox  oci:${TESTDIR}/tmp/busybox_enc
 
   # Try to pull encrypted image without key should fail
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json oci:${TESTDIR}/tmp/busybox_enc
+  run_buildah 125 pull $WITH_POLICY_JSON oci:${TESTDIR}/tmp/busybox_enc
   expect_output --substring "decrypting layer .* missing private key needed for decryption"
 
   # Try to pull encrypted image with wrong key should fail
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --decryption-key ${TESTDIR}/tmp/mykey2.pem oci:${TESTDIR}/tmp/busybox_enc
+  run_buildah 125 pull $WITH_POLICY_JSON --decryption-key ${TESTDIR}/tmp/mykey2.pem oci:${TESTDIR}/tmp/busybox_enc
   expect_output --substring "decrypting layer .* no suitable key unwrapper found or none of the private keys could be used for decryption"
 
   # Providing the right key should succeed
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json --decryption-key ${TESTDIR}/tmp/mykey.pem oci:${TESTDIR}/tmp/busybox_enc
+  run_buildah pull $WITH_POLICY_JSON --decryption-key ${TESTDIR}/tmp/mykey.pem oci:${TESTDIR}/tmp/busybox_enc
 
   rm -rf ${TESTDIR}/tmp
 }
@@ -210,18 +210,18 @@ load helpers
   openssl genrsa -out ${TESTDIR}/tmp/mykey.pem 1024
   openssl genrsa -out ${TESTDIR}/tmp/mykey2.pem 1024
   openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword --encryption-key jwe:${TESTDIR}/tmp/mykey.pub busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah push $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword --encryption-key jwe:${TESTDIR}/tmp/mykey.pub busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
 
   # Try to pull encrypted image without key should fail
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah 125 pull $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
   expect_output --substring "decrypting layer .* missing private key needed for decryption"
 
   # Try to pull encrypted image with wrong key should fail, with diff. msg
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey2.pem docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah 125 pull $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey2.pem docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
   expect_output --substring "decrypting layer .* no suitable key unwrapper found or none of the private keys could be used for decryption"
 
   # Providing the right key should succeed
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey.pem docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah pull $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey.pem docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
 
   run_buildah rmi localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
 
@@ -235,20 +235,20 @@ load helpers
   openssl genrsa -out ${TESTDIR}/tmp/mykey.pem 1024
   openssl genrsa -out ${TESTDIR}/tmp/mykey2.pem 1024
   openssl rsa -in ${TESTDIR}/tmp/mykey.pem -pubout > ${TESTDIR}/tmp/mykey.pub
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid=$output
-  run_buildah commit --iidfile /dev/null --tls-verify=false --creds testuser:testpassword --signature-policy ${TESTSDIR}/policy.json --encryption-key jwe:${TESTDIR}/tmp/mykey.pub -q $cid docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah commit --iidfile /dev/null --tls-verify=false --creds testuser:testpassword $WITH_POLICY_JSON --encryption-key jwe:${TESTDIR}/tmp/mykey.pub -q $cid docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
 
   # Try to pull encrypted image without key should fail
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah 125 pull $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
   expect_output --substring "decrypting layer .* missing private key needed for decryption"
 
   # Try to pull encrypted image with wrong key should fail
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey2.pem docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah 125 pull $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey2.pem docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
   expect_output --substring "decrypting layer .* no suitable key unwrapper found or none of the private keys could be used for decryption"
 
   # Providing the right key should succeed
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey.pem docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
+  run_buildah pull $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword --decryption-key ${TESTDIR}/tmp/mykey.pem docker://localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
 
   run_buildah rmi localhost:${REGISTRY_PORT}/buildah/busybox_encrypted:latest
 
@@ -260,7 +260,7 @@ load helpers
   mkdir /tmp/buildah-test
   mount -t tmpfs -o size=5M tmpfs /tmp/buildah-test
   run dd if=/dev/urandom of=/tmp/buildah-test/full
-  run_buildah 125 --root=/tmp/buildah-test pull --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah 125 --root=/tmp/buildah-test pull $WITH_POLICY_JSON alpine
   expect_output --substring "no space left on device"
   umount /tmp/buildah-test
   rm -rf /tmp/buildah-test
@@ -286,27 +286,27 @@ load helpers
 
 @test "pull-policy" {
   mkdir ${TESTDIR}/buildahtest
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --policy bogus alpine
+  run_buildah 125 pull $WITH_POLICY_JSON --policy bogus alpine
   expect_output --substring "unsupported pull policy \"bogus\""
 
   #  If image does not exist the never will fail
-  run_buildah 125 pull -q --signature-policy ${TESTSDIR}/policy.json --policy never alpine
+  run_buildah 125 pull -q $WITH_POLICY_JSON --policy never alpine
   expect_output --substring "image not known"
   run_buildah 125 inspect --type image alpine
   expect_output --substring "image not known"
 
   # create bogus alpine image
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
   run_buildah commit -q $cid docker.io/library/alpine
   iid=$output
 
   #  If image does not exist the never will succeed, but iid should not change
-  run_buildah pull -q --signature-policy ${TESTSDIR}/policy.json --policy never alpine
+  run_buildah pull -q $WITH_POLICY_JSON --policy never alpine
   expect_output $iid
 
   # Pull image by default should change the image id
-  run_buildah pull -q --policy always --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah pull -q --policy always $WITH_POLICY_JSON alpine
   assert "$output" != "$iid" "pulled image should have a new IID"
 
   # Recreate image
@@ -314,15 +314,15 @@ load helpers
   iid=$output
 
   # Make sure missing image works
-  run_buildah pull -q --signature-policy ${TESTSDIR}/policy.json --policy missing alpine
+  run_buildah pull -q $WITH_POLICY_JSON --policy missing alpine
   expect_output $iid
 
   run_buildah rmi alpine
-  run_buildah pull -q --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah pull -q $WITH_POLICY_JSON alpine
   run_buildah inspect alpine
 
   run_buildah rmi alpine
-  run_buildah pull -q --signature-policy ${TESTSDIR}/policy.json --policy missing alpine
+  run_buildah pull -q $WITH_POLICY_JSON --policy missing alpine
   run_buildah inspect alpine
 
   run_buildah rmi alpine
@@ -330,11 +330,11 @@ load helpers
 
 @test "pull --arch" {
   mkdir ${TESTDIR}/buildahtest
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --arch bogus alpine
+  run_buildah 125 pull $WITH_POLICY_JSON --arch bogus alpine
   expect_output --substring "no image found in manifest list"
 
   # Make sure missing image works
-  run_buildah pull -q --signature-policy ${TESTSDIR}/policy.json --arch arm64 alpine
+  run_buildah pull -q $WITH_POLICY_JSON --arch arm64 alpine
 
   run_buildah inspect --format "{{ .Docker.Architecture }}" alpine
   expect_output arm64
@@ -347,11 +347,11 @@ load helpers
 
 @test "pull --platform" {
   mkdir ${TESTDIR}/buildahtest
-  run_buildah 125 pull --signature-policy ${TESTSDIR}/policy.json --platform linux/bogus alpine
+  run_buildah 125 pull $WITH_POLICY_JSON --platform linux/bogus alpine
   expect_output --substring "no image found in manifest list"
 
   # Make sure missing image works
-  run_buildah pull -q --signature-policy ${TESTSDIR}/policy.json --platform linux/arm64 alpine
+  run_buildah pull -q $WITH_POLICY_JSON --platform linux/arm64 alpine
 
   run_buildah inspect --format "{{ .Docker.Architecture }}" alpine
   expect_output arm64
@@ -368,20 +368,20 @@ load helpers
   mkdir -p $testdir
   mount -t tmpfs -o size=1M tmpfs $testdir
 
-  TMPDIR=$testdir run_buildah 125 pull --policy always --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/alpine_nginx:latest
+  TMPDIR=$testdir run_buildah 125 pull --policy always $WITH_POLICY_JSON quay.io/libpod/alpine_nginx:latest
   expect_output --substring "no space left on device"
 
-  run_buildah pull --policy always --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/alpine_nginx:latest
+  run_buildah pull --policy always $WITH_POLICY_JSON quay.io/libpod/alpine_nginx:latest
   umount $testdir
   rm -rf $testdir
 }
 
 @test "pull-policy --missing --arch" {
   # Make sure missing image works
-  run_buildah pull -q --signature-policy ${TESTSDIR}/policy.json --policy missing --arch amd64 alpine
+  run_buildah pull -q $WITH_POLICY_JSON --policy missing --arch amd64 alpine
   amdiid=$output
 
-  run_buildah pull -q --signature-policy ${TESTSDIR}/policy.json --policy missing --arch arm64 alpine
+  run_buildah pull -q $WITH_POLICY_JSON --policy missing --arch arm64 alpine
   armiid=$output
 
   assert "$amdiid" != "$armiid" "AMD and ARM ids should differ"

--- a/tests/registries.bats
+++ b/tests/registries.bats
@@ -8,11 +8,11 @@ load helpers
     image2=$2
 
     # Create a container by specifying the image with one name.
-    run_buildah --retry from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image1
+    run_buildah --retry from --quiet --pull=false $WITH_POLICY_JSON $image1
     cid1=$output
 
     # Create a container by specifying the image with another name.
-    run_buildah --retry from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json $image2
+    run_buildah --retry from --quiet --pull=false $WITH_POLICY_JSON $image2
     cid2=$output
 
     # Get their image IDs.  They should be the same one.

--- a/tests/rename.bats
+++ b/tests/rename.bats
@@ -5,7 +5,7 @@ load helpers
 @test "rename" {
   _prefetch alpine
   new_name=test-container
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah containers --format "{{.ContainerName}}"
   old_name=$output
@@ -20,7 +20,7 @@ load helpers
 
 @test "rename same name as current name" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah 125 rename ${cid} ${cid}
   expect_output 'renaming a container with the same name as its current name'
@@ -28,9 +28,9 @@ load helpers
 
 @test "rename same name as other container name" {
   _prefetch alpine busybox
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
   cid2=$output
   run_buildah 125 rename ${cid1} ${cid2}
   expect_output --substring " already in use by "

--- a/tests/rm.bats
+++ b/tests/rm.bats
@@ -20,34 +20,34 @@ load helpers
 
 @test "remove one container" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah rm "$cid"
 }
 
 @test "remove multiple containers" {
   _prefetch alpine busybox
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet $WITH_POLICY_JSON alpine
   cid2=$output
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid3=$output
   run_buildah rm "$cid2" "$cid3"
 }
 
 @test "remove all containers" {
   _prefetch alpine busybox
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid1=$output
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet $WITH_POLICY_JSON alpine
   cid2=$output
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid3=$output
   run_buildah rm -a
 }
 
 @test "use conflicting commands to remove containers" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah 125 rm -a "$cid"
   expect_output --substring "when using the --all switch, you may not pass any containers names or IDs"

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -76,8 +76,8 @@ load helpers
 @test "use prune to remove dangling images" {
   _prefetch busybox
 
-  createrandom ${TESTDIR}/randomfile
-  createrandom ${TESTDIR}/other-randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/other-randomfile
 
   run_buildah from --pull=false --quiet $WITH_POLICY_JSON busybox
   cid=$output
@@ -87,7 +87,7 @@ load helpers
 
   run_buildah mount $cid
   root=$output
-  cp ${TESTDIR}/randomfile $root/randomfile
+  cp ${TEST_SCRATCH_DIR}/randomfile $root/randomfile
   run_buildah unmount $cid
   run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
 
@@ -96,7 +96,7 @@ load helpers
 
   run_buildah mount $cid
   root=$output
-  cp ${TESTDIR}/other-randomfile $root/other-randomfile
+  cp ${TEST_SCRATCH_DIR}/other-randomfile $root/other-randomfile
   run_buildah unmount $cid
   run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
 
@@ -114,8 +114,8 @@ load helpers
 }
 
 @test "use prune to remove dangling images with parent" {
-  createrandom ${TESTDIR}/randomfile
-  createrandom ${TESTDIR}/other-randomfile
+  createrandom ${TEST_SCRATCH_DIR}/randomfile
+  createrandom ${TEST_SCRATCH_DIR}/other-randomfile
 
   run_buildah from --quiet $WITH_POLICY_JSON scratch
   cid=$output
@@ -125,7 +125,7 @@ load helpers
 
   run_buildah mount $cid
   root=$output
-  cp ${TESTDIR}/randomfile $root/randomfile
+  cp ${TEST_SCRATCH_DIR}/randomfile $root/randomfile
   run_buildah unmount $cid
   run_buildah commit --quiet $WITH_POLICY_JSON $cid
   image=$output
@@ -138,7 +138,7 @@ load helpers
   cid=$output
   run_buildah mount $cid
   root=$output
-  cp ${TESTDIR}/other-randomfile $root/other-randomfile
+  cp ${TEST_SCRATCH_DIR}/other-randomfile $root/other-randomfile
   run_buildah unmount $cid
   run_buildah commit $WITH_POLICY_JSON $cid
   run_buildah rm $cid
@@ -157,7 +157,7 @@ load helpers
 
 @test "attempt to prune non-dangling empty images" {
   # Regression test for containers/podman/issues/10832
-  ctxdir=${TESTDIR}/bud
+  ctxdir=${TEST_SCRATCH_DIR}/bud
   mkdir -p $ctxdir
   cat >$ctxdir/Dockerfile <<EOF
 FROM scratch

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -15,7 +15,7 @@ load helpers
 
 @test "remove one image" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah rm "$cid"
   run_buildah rmi alpine
@@ -25,9 +25,9 @@ load helpers
 
 @test "remove multiple images" {
   _prefetch alpine busybox
-  run_buildah from --pull=false --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --pull=false --quiet $WITH_POLICY_JSON alpine
   cid2=$output
-  run_buildah from --pull=false --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --pull=false --quiet $WITH_POLICY_JSON busybox
   cid3=$output
   run_buildah 125 rmi alpine busybox
   run_buildah images -q
@@ -47,22 +47,22 @@ load helpers
 
 @test "remove all images" {
   _prefetch alpine busybox
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid1=$output
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet $WITH_POLICY_JSON alpine
   cid2=$output
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid3=$output
   run_buildah rmi -a -f
   run_buildah images -q
   expect_output ""
 
   _prefetch alpine busybox
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from $WITH_POLICY_JSON scratch
   cid1=$output
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet $WITH_POLICY_JSON alpine
   cid2=$output
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid3=$output
   run_buildah 125 rmi --all
   run_buildah images -q
@@ -79,7 +79,7 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  run_buildah from --pull=false --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah from --pull=false --quiet $WITH_POLICY_JSON busybox
   cid=$output
 
   run_buildah images -q
@@ -89,7 +89,7 @@ load helpers
   root=$output
   cp ${TESTDIR}/randomfile $root/randomfile
   run_buildah unmount $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
 
   run_buildah images -q
   expect_line_count 2
@@ -98,7 +98,7 @@ load helpers
   root=$output
   cp ${TESTDIR}/other-randomfile $root/other-randomfile
   run_buildah unmount $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid containers-storage:new-image
+  run_buildah commit $WITH_POLICY_JSON $cid containers-storage:new-image
 
   run_buildah images -q
   expect_line_count 3
@@ -117,7 +117,7 @@ load helpers
   createrandom ${TESTDIR}/randomfile
   createrandom ${TESTDIR}/other-randomfile
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --quiet $WITH_POLICY_JSON scratch
   cid=$output
 
   run_buildah images -q -a
@@ -127,20 +127,20 @@ load helpers
   root=$output
   cp ${TESTDIR}/randomfile $root/randomfile
   run_buildah unmount $cid
-  run_buildah commit --quiet --signature-policy ${TESTSDIR}/policy.json $cid
+  run_buildah commit --quiet $WITH_POLICY_JSON $cid
   image=$output
   run_buildah rm $cid
 
   run_buildah images -q -a
   expect_line_count 1
 
-  run_buildah from --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet $WITH_POLICY_JSON $image
   cid=$output
   run_buildah mount $cid
   root=$output
   cp ${TESTDIR}/other-randomfile $root/other-randomfile
   run_buildah unmount $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid
+  run_buildah commit $WITH_POLICY_JSON $cid
   run_buildah rm $cid
 
   run_buildah images -q -a
@@ -172,19 +172,19 @@ EOF
 
 @test "use conflicting commands to remove images" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah rm "$cid"
   run_buildah 125 rmi -a alpine
   expect_output --substring "when using the --all switch, you may not pass any images names or IDs"
 
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah rm "$cid"
   run_buildah 125 rmi -p alpine
   expect_output --substring "when using the --prune switch, you may not pass any images names or IDs"
 
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah rm "$cid"
   run_buildah 125 rmi -a -p
@@ -194,10 +194,10 @@ EOF
 
 @test "remove image that is a parent of another image" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid new-image
+  run_buildah commit $WITH_POLICY_JSON $cid new-image
   run_buildah rm -a
 
   # Since it has children, alpine will only be untagged (Podman compat) but not
@@ -212,10 +212,10 @@ EOF
 
 @test "rmi with cached images" {
   _prefetch alpine
-  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test1 ${TESTSDIR}/bud/use-layers
+  run_buildah bud $WITH_POLICY_JSON --layers -t test1 ${TESTSDIR}/bud/use-layers
   run_buildah images -a -q
   expect_line_count 7
-  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
+  run_buildah bud $WITH_POLICY_JSON --layers -t test2 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
   run_buildah images -a -q
   expect_line_count 9
   run_buildah rmi test2
@@ -224,7 +224,7 @@ EOF
   run_buildah rmi test1
   run_buildah images -a -q
   expect_line_count 1
-  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
+  run_buildah bud $WITH_POLICY_JSON --layers -t test3 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
   run_buildah rmi alpine
   run_buildah rmi test3
   run_buildah images -a -q
@@ -233,14 +233,14 @@ EOF
 
 @test "rmi image that is created from another named image" {
   _prefetch alpine
-  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid new-image
-  run_buildah from --quiet --pull=true --signature-policy ${TESTSDIR}/policy.json new-image
+  run_buildah commit $WITH_POLICY_JSON $cid new-image
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON new-image
   cid=$output
   run_buildah config --env 'foo=bar' $cid
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid new-image-2
+  run_buildah commit $WITH_POLICY_JSON $cid new-image-2
   run_buildah rm -a
   run_buildah rmi new-image-2
   run_buildah images -q

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -212,10 +212,10 @@ EOF
 
 @test "rmi with cached images" {
   _prefetch alpine
-  run_buildah bud $WITH_POLICY_JSON --layers -t test1 ${TESTSDIR}/bud/use-layers
+  run_buildah bud $WITH_POLICY_JSON --layers -t test1 $BUDFILES/use-layers
   run_buildah images -a -q
   expect_line_count 7
-  run_buildah bud $WITH_POLICY_JSON --layers -t test2 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
+  run_buildah bud $WITH_POLICY_JSON --layers -t test2 -f Dockerfile.2 $BUDFILES/use-layers
   run_buildah images -a -q
   expect_line_count 9
   run_buildah rmi test2
@@ -224,7 +224,7 @@ EOF
   run_buildah rmi test1
   run_buildah images -a -q
   expect_line_count 1
-  run_buildah bud $WITH_POLICY_JSON --layers -t test3 -f Dockerfile.2 ${TESTSDIR}/bud/use-layers
+  run_buildah bud $WITH_POLICY_JSON --layers -t test3 -f Dockerfile.2 $BUDFILES/use-layers
   run_buildah rmi alpine
   run_buildah rmi test3
   run_buildah images -a -q

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -467,7 +467,7 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	# we need to not use the list of limits that are set in our default
-	# ${TESTSDIR}/containers.conf for the sake of other tests, and override
+	# ${TEST_SOURCES}/containers.conf for the sake of other tests, and override
 	# any that might be picked up from system-wide configuration
 	echo '[containers]' > ${TESTDIR}/containers.conf
 	echo 'default_ulimits = []' >> ${TESTDIR}/containers.conf

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -8,7 +8,7 @@ load helpers
 	_prefetch alpine
 	${OCI} --version
 	createrandom ${TESTDIR}/randomfile
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah mount $cid
 	root=$output
@@ -30,7 +30,7 @@ load helpers
 	skip_if_no_runtime
 
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 
 	# This should fail, because buildah run doesn't have a -n flag.
@@ -57,7 +57,7 @@ load helpers
 	skip_if_no_runtime
 
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah config --workingdir /tmp $cid
 
@@ -189,7 +189,7 @@ function configure_and_check_user() {
 		skip "CGO_ENABLED = '$CGO_ENABLED'"
 	fi
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah mount $cid
 	root=$output
@@ -231,7 +231,7 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah config --env foo=foo $cid
 	# Ensure foo=foo from `buildah config`
@@ -250,7 +250,7 @@ function configure_and_check_user() {
 
 	_prefetch alpine
 	${OCI} --version
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run $cid hostname
 	[ "$output" != "foobar" ]
@@ -263,7 +263,7 @@ function configure_and_check_user() {
 
 	_prefetch alpine
 	${OCI} --version
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run --hostname foobar $cid hostname
 	expect_output "foobar"
@@ -283,7 +283,7 @@ function configure_and_check_user() {
 	fi
 	${OCI} --version
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	mkdir -p ${TESTDIR}/was-empty
 	# As a baseline, this should succeed.
@@ -312,7 +312,7 @@ function configure_and_check_user() {
 	fi
 	${OCI} --version
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	mkdir -p ${TESTDIR}/upperdir
 	mkdir -p ${TESTDIR}/workdir
@@ -338,7 +338,7 @@ function configure_and_check_user() {
 
   # Create the container.
   _prefetch alpine
-  run_buildah from --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from $WITH_POLICY_JSON alpine
   ctr="$output"
 
   # Test user can create file in the mounted volume.
@@ -353,7 +353,7 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run $cid pwd
 	expect_output "/"
@@ -375,7 +375,7 @@ function configure_and_check_user() {
 	fi
 	${OCI} --version
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	mkdir -p ${TESTDIR}/was:empty
 	# As a baseline, this should succeed.
@@ -397,9 +397,9 @@ function configure_and_check_user() {
 			skip "skip if selinux enabled, since stages have different selinux label"
 		fi
 	fi
-	run_buildah build -t buildkitbase --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTSDIR}/bud/buildkit-mount-from/
+	run_buildah build -t buildkitbase $WITH_POLICY_JSON -f ${TESTSDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTSDIR}/bud/buildkit-mount-from/
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run --mount type=bind,source=.,from=buildkitbase,target=/test,z  $cid cat /test/hello
 	expect_output --substring "hello"
@@ -415,7 +415,7 @@ function configure_and_check_user() {
 		fi
 	fi
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run --mount type=cache,target=/test,z  $cid sh -c 'echo "hello" > /test/hello && cat /test/hello'
 	run_buildah run --mount type=cache,target=/test,z  $cid cat /test/hello
@@ -427,7 +427,7 @@ function configure_and_check_user() {
 
 	${OCI} --version
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	mkdir -p ${TESTDIR}/tmp
 	ln -s tmp ${TESTDIR}/tmp2
@@ -440,7 +440,7 @@ function configure_and_check_user() {
 
 	${OCI} --version
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	# Try with default caps.
 	run_buildah run $cid grep ^CapEff /proc/self/status
@@ -475,7 +475,7 @@ function configure_and_check_user() {
 
 	_prefetch alpine
 	maxpids=$(cat /proc/sys/kernel/pid_max)
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output 1024 "limits: open files (unlimited)"
@@ -483,7 +483,7 @@ function configure_and_check_user() {
 	expect_output ${maxpids} "limits: processes (unlimited)"
 	run_buildah rm $cid
 
-	run_buildah from --quiet --ulimit nofile=300:400 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --ulimit nofile=300:400 --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output "300" "limits: open files (w/file limit)"
@@ -491,7 +491,7 @@ function configure_and_check_user() {
 	expect_output ${maxpids} "limits: processes (w/file limit)"
 	run_buildah rm $cid
 
-	run_buildah from --quiet --ulimit nproc=100:200 --ulimit nofile=300:400 --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --ulimit nproc=100:200 --ulimit nofile=300:400 --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run $cid awk '/open files/{print $4}' /proc/self/limits
 	expect_output "300" "limits: open files (w/file & proc limits)"
@@ -504,7 +504,7 @@ function configure_and_check_user() {
 @test "run-builtin-volume-omitted" {
 	# This image is known to include a volume, but not include the mountpoint
 	# in the image.
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json quay.io/libpod/registry:volume_omitted
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON quay.io/libpod/registry:volume_omitted
 	cid=$output
 	run_buildah mount $cid
 	mnt=$output
@@ -524,7 +524,7 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah 42 run ${cid} sh -c 'exit 42'
 }
@@ -533,7 +533,7 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah 1 run ${cid} /etc
 }
@@ -543,7 +543,7 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	# test a standard mount to /run/.containerenv
 	run_buildah run $cid ls -1 /run/.containerenv
@@ -571,15 +571,15 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --device /dev/fuse --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false --device /dev/fuse $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah 0 run ${cid} ls /dev/fuse
 
-	run_buildah from --quiet --pull=false --device /dev/fuse:/dev/fuse:rm --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false --device /dev/fuse:/dev/fuse:rm $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah 0 run ${cid} ls /dev/fuse
 
-	run_buildah from --quiet --pull=false --device /dev/fuse:/dev/fuse:rwm --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false --device /dev/fuse:/dev/fuse:rwm $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah 0 run ${cid} ls /dev/fuse
 
@@ -592,7 +592,7 @@ function configure_and_check_user() {
 	skip_if_rootless
 
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --device /dev/fuse:/dev/fuse1 --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false --device /dev/fuse:/dev/fuse1 $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah 0 run ${cid} ls /dev/fuse1
 }
@@ -607,7 +607,7 @@ function configure_and_check_user() {
 
 	local hostname=h-$(random_string)
 
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json debian
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON debian
 	cid=$output
 	run_buildah 125 run --network=bogus $cid cat /etc/hosts
 	expect_output --substring "unable to find network with name or ID bogus: network not found"
@@ -641,7 +641,7 @@ function configure_and_check_user() {
 	expect_output --substring ""
 	run_buildah rm -a
 
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json debian
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON debian
 	cid=$output
 	run_buildah run --network=host $cid cat /etc/hosts
 	hostOutput=$output
@@ -653,7 +653,7 @@ function configure_and_check_user() {
 	[ "$output" != "$hostOutput" ]
 	run_buildah rm -a
 
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json debian
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON debian
 	cid=$output
 	run_buildah run --network=none $cid sh -c 'echo "110.110.110.0 fake_host" >> /etc/hosts; cat /etc/hosts'
 	expect_output "110.110.110.0 fake_host"
@@ -686,7 +686,7 @@ function configure_and_check_user() {
 		nameservers="nameserver 10.0.2.3
 $output"
 	fi
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run --network=private $cid grep nameserver /etc/resolv.conf
 	# check that no 127... nameserver is in resolv.conf
@@ -701,7 +701,7 @@ $output"
 
 	run grep nameserver /etc/resolv.conf
 	nameservers="$output"
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run --isolation=chroot --network=host $cid grep nameserver /etc/resolv.conf
 	assert "$nameservers" "Container nameservers match the host nameservers"
@@ -712,7 +712,7 @@ $output"
 	fi
 	run_buildah rm -a
 
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run --isolation=chroot --network=none $cid sh -c 'echo "nameserver 110.110.0.110" >> /etc/resolv.conf; cat /etc/resolv.conf'
 	expect_output "nameserver 110.110.0.110"
@@ -727,7 +727,7 @@ $output"
 @test "run --network should override build --network" {
 	skip_if_no_runtime
 
-	run_buildah from --network=none --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --network=none --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	# should fail by default
 	run_buildah 1 run $cid wget google.com
@@ -742,7 +742,7 @@ $output"
 	skip_if_no_runtime
 
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run --user sync $cid whoami
 	expect_output "sync"
@@ -768,7 +768,7 @@ $output"
     ]
 }
 _EOF
-	run_buildah from --security-opt seccomp=${TESTDIR}/seccomp.json --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --security-opt seccomp=${TESTDIR}/seccomp.json --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 
 	local found_runtime=
@@ -801,7 +801,7 @@ _EOF
 	skip_if_no_runtime
 
 	_prefetch alpine
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run --terminal=true $cid ls --color=auto
 	colored="$output"
@@ -820,7 +820,7 @@ _EOF
 	fi
 	_prefetch alpine
 
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run --cgroupns=host $cid cat /proc/self/cgroup
 	expect_output --substring "/user.slice/"
@@ -831,7 +831,7 @@ _EOF
 
 	_prefetch alpine
 
-	run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah run $cid grep ^CapInh: /proc/self/status
 	expect_output "CapInh:	0000000000000000"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -397,7 +397,7 @@ function configure_and_check_user() {
 			skip "skip if selinux enabled, since stages have different selinux label"
 		fi
 	fi
-	run_buildah build -t buildkitbase $WITH_POLICY_JSON -f ${TESTSDIR}/bud/buildkit-mount-from/Dockerfilebuildkitbase ${TESTSDIR}/bud/buildkit-mount-from/
+	run_buildah build -t buildkitbase $WITH_POLICY_JSON -f $BUDFILES/buildkit-mount-from/Dockerfilebuildkitbase $BUDFILES/buildkit-mount-from/
 	_prefetch alpine
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output

--- a/tests/selinux.bats
+++ b/tests/selinux.bats
@@ -13,7 +13,7 @@ load helpers
   _prefetch $image
 
   # Create a container and read its context as a baseline.
-  run_buildah from --quiet --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet --quiet $WITH_POLICY_JSON $image
   cid=$output
   run_buildah run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   [ "$output" != "" ]
@@ -24,7 +24,7 @@ load helpers
   expect_output "$firstlabel" "label of second container == first"
 
   # Ensure that different containers get different labels.
-  run_buildah from --quiet --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet --quiet $WITH_POLICY_JSON $image
   cid1=$output
   run_buildah run $cid1 sh -c 'tr \\0 \\n < /proc/self/attr/current'
   assert "$output" != "$firstlabel" \
@@ -42,7 +42,7 @@ load helpers
   _prefetch $image
 
   # Create a container and read its context as a baseline.
-  run_buildah from --quiet --security-opt label=disable --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet --security-opt label=disable --quiet $WITH_POLICY_JSON $image
   cid=$output
   run_buildah run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
   context=$output
@@ -72,7 +72,7 @@ load helpers
 
   firstlabel="system_u:system_r:container_t:s0:c1,c2"
   # Create a container and read its context as a baseline.
-  run_buildah from --quiet --security-opt label="level:s0:c1,c2" --quiet --signature-policy ${TESTSDIR}/policy.json $image
+  run_buildah from --quiet --security-opt label="level:s0:c1,c2" --quiet $WITH_POLICY_JSON $image
   cid=$output
 
   # Inspect image

--- a/tests/sign.bats
+++ b/tests/sign.bats
@@ -38,23 +38,23 @@ function _gpg_setup() {
 
   mkdir -p ${TESTDIR}/signed-image ${TESTDIR}/unsigned-image
 
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json --sign-by amanda@localhost $cid signed-alpine-image
+  run_buildah commit $WITH_POLICY_JSON --sign-by amanda@localhost $cid signed-alpine-image
 
   # Pushing should preserve the signature.
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json signed-alpine-image dir:${TESTDIR}/signed-image
+  run_buildah push $WITH_POLICY_JSON signed-alpine-image dir:${TESTDIR}/signed-image
   ls -l ${TESTDIR}/signed-image/
   test -s ${TESTDIR}/signed-image/signature-1
 
   # Pushing with --remove-signatures should remove the signature.
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json --remove-signatures signed-alpine-image dir:${TESTDIR}/unsigned-image
+  run_buildah push $WITH_POLICY_JSON --remove-signatures signed-alpine-image dir:${TESTDIR}/unsigned-image
   ls -l ${TESTDIR}/unsigned-image/
   ! test -s ${TESTDIR}/unsigned-image/signature-1
 
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json $cid unsigned-alpine-image
+  run_buildah commit $WITH_POLICY_JSON $cid unsigned-alpine-image
   # Pushing with --sign-by should fail add the signature to a dir: location, if it tries to add them.
-  run_buildah 125 push --signature-policy ${TESTSDIR}/policy.json --sign-by amanda@localhost unsigned-alpine-image dir:${TESTDIR}/signed-image
+  run_buildah 125 push $WITH_POLICY_JSON --sign-by amanda@localhost unsigned-alpine-image dir:${TESTDIR}/signed-image
   expect_output --substring "Cannot determine canonical Docker reference"
 
   # Clear out images, so that we don't have leftover signatures when we pull in an image that will end up
@@ -62,18 +62,18 @@ function _gpg_setup() {
   run_buildah rmi -a -f
 
   # Pulling with --remove-signatures should remove signatures, and pushing should have none to keep.
-  run_buildah pull --signature-policy ${TESTSDIR}/policy.json --quiet dir:${TESTDIR}/signed-image
+  run_buildah pull $WITH_POLICY_JSON --quiet dir:${TESTDIR}/signed-image
   imageID="$output"
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json "$imageID" dir:${TESTDIR}/unsigned-image
+  run_buildah push $WITH_POLICY_JSON "$imageID" dir:${TESTDIR}/unsigned-image
   ls -l ${TESTDIR}/unsigned-image/
   ! test -s ${TESTDIR}/unsigned-image/signature-1
 
   # Build a manifest list and try to push the list with signatures.
   run_buildah manifest create list
   run_buildah manifest add list $imageID
-  run_buildah 125 manifest push --signature-policy ${TESTSDIR}/policy.json --sign-by amanda@localhost --all list dir:${TESTDIR}/signed-image
+  run_buildah 125 manifest push $WITH_POLICY_JSON --sign-by amanda@localhost --all list dir:${TESTDIR}/signed-image
   expect_output --substring "Cannot determine canonical Docker reference"
-  run_buildah manifest push --signature-policy ${TESTSDIR}/policy.json --all list dir:${TESTDIR}/unsigned-image
+  run_buildah manifest push $WITH_POLICY_JSON --all list dir:${TESTDIR}/unsigned-image
 }
 
 @test "build-with-dockerfile-signatures" {
@@ -87,11 +87,11 @@ function _gpg_setup() {
 	EOF
 
   # We should be able to sign at build-time.
-  run_buildah bud --signature-policy ${TESTSDIR}/policy.json --sign-by amanda@localhost -t signed-scratch-image ${builddir}
+  run_buildah bud $WITH_POLICY_JSON --sign-by amanda@localhost -t signed-scratch-image ${builddir}
 
   mkdir -p ${TESTDIR}/signed-image
   # Pushing should preserve the signature.
-  run_buildah push --signature-policy ${TESTSDIR}/policy.json signed-scratch-image dir:${TESTDIR}/signed-image
+  run_buildah push $WITH_POLICY_JSON signed-scratch-image dir:${TESTDIR}/signed-image
   ls -l ${TESTDIR}/signed-image/
   test -s ${TESTDIR}/signed-image/signature-1
 }

--- a/tests/sign.bats
+++ b/tests/sign.bats
@@ -7,7 +7,7 @@ function _gpg_setup() {
     skip 'gpg command not found in $PATH'
   fi
 
-  export GNUPGHOME=${TESTDIR}/.gnupg
+  export GNUPGHOME=${TEST_SCRATCH_DIR}/.gnupg
   mkdir -p --mode=0700 $GNUPGHOME
 
   # gpg on f30 and above needs this, otherwise:
@@ -18,7 +18,7 @@ function _gpg_setup() {
       GPGOPTS=
   fi
 
-  cat > ${TESTDIR}/genkey-answers <<- EOF
+  cat > ${TEST_SCRATCH_DIR}/genkey-answers <<- EOF
 	%echo Generating a basic OpenPGP key
 	Key-Type: RSA
 	Key-Length: 2048
@@ -28,7 +28,7 @@ function _gpg_setup() {
 	%commit
 	%echo done
 	EOF
-  gpg --batch $GPGOPTS --gen-key --passphrase '' < ${TESTDIR}/genkey-answers
+  gpg --batch $GPGOPTS --gen-key --passphrase '' < ${TEST_SCRATCH_DIR}/genkey-answers
 }
 
 
@@ -36,25 +36,25 @@ function _gpg_setup() {
   _gpg_setup
   _prefetch alpine
 
-  mkdir -p ${TESTDIR}/signed-image ${TESTDIR}/unsigned-image
+  mkdir -p ${TEST_SCRATCH_DIR}/signed-image ${TEST_SCRATCH_DIR}/unsigned-image
 
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah commit $WITH_POLICY_JSON --sign-by amanda@localhost $cid signed-alpine-image
 
   # Pushing should preserve the signature.
-  run_buildah push $WITH_POLICY_JSON signed-alpine-image dir:${TESTDIR}/signed-image
-  ls -l ${TESTDIR}/signed-image/
-  test -s ${TESTDIR}/signed-image/signature-1
+  run_buildah push $WITH_POLICY_JSON signed-alpine-image dir:${TEST_SCRATCH_DIR}/signed-image
+  ls -l ${TEST_SCRATCH_DIR}/signed-image/
+  test -s ${TEST_SCRATCH_DIR}/signed-image/signature-1
 
   # Pushing with --remove-signatures should remove the signature.
-  run_buildah push $WITH_POLICY_JSON --remove-signatures signed-alpine-image dir:${TESTDIR}/unsigned-image
-  ls -l ${TESTDIR}/unsigned-image/
-  ! test -s ${TESTDIR}/unsigned-image/signature-1
+  run_buildah push $WITH_POLICY_JSON --remove-signatures signed-alpine-image dir:${TEST_SCRATCH_DIR}/unsigned-image
+  ls -l ${TEST_SCRATCH_DIR}/unsigned-image/
+  ! test -s ${TEST_SCRATCH_DIR}/unsigned-image/signature-1
 
   run_buildah commit $WITH_POLICY_JSON $cid unsigned-alpine-image
   # Pushing with --sign-by should fail add the signature to a dir: location, if it tries to add them.
-  run_buildah 125 push $WITH_POLICY_JSON --sign-by amanda@localhost unsigned-alpine-image dir:${TESTDIR}/signed-image
+  run_buildah 125 push $WITH_POLICY_JSON --sign-by amanda@localhost unsigned-alpine-image dir:${TEST_SCRATCH_DIR}/signed-image
   expect_output --substring "Cannot determine canonical Docker reference"
 
   # Clear out images, so that we don't have leftover signatures when we pull in an image that will end up
@@ -62,24 +62,24 @@ function _gpg_setup() {
   run_buildah rmi -a -f
 
   # Pulling with --remove-signatures should remove signatures, and pushing should have none to keep.
-  run_buildah pull $WITH_POLICY_JSON --quiet dir:${TESTDIR}/signed-image
+  run_buildah pull $WITH_POLICY_JSON --quiet dir:${TEST_SCRATCH_DIR}/signed-image
   imageID="$output"
-  run_buildah push $WITH_POLICY_JSON "$imageID" dir:${TESTDIR}/unsigned-image
-  ls -l ${TESTDIR}/unsigned-image/
-  ! test -s ${TESTDIR}/unsigned-image/signature-1
+  run_buildah push $WITH_POLICY_JSON "$imageID" dir:${TEST_SCRATCH_DIR}/unsigned-image
+  ls -l ${TEST_SCRATCH_DIR}/unsigned-image/
+  ! test -s ${TEST_SCRATCH_DIR}/unsigned-image/signature-1
 
   # Build a manifest list and try to push the list with signatures.
   run_buildah manifest create list
   run_buildah manifest add list $imageID
-  run_buildah 125 manifest push $WITH_POLICY_JSON --sign-by amanda@localhost --all list dir:${TESTDIR}/signed-image
+  run_buildah 125 manifest push $WITH_POLICY_JSON --sign-by amanda@localhost --all list dir:${TEST_SCRATCH_DIR}/signed-image
   expect_output --substring "Cannot determine canonical Docker reference"
-  run_buildah manifest push $WITH_POLICY_JSON --all list dir:${TESTDIR}/unsigned-image
+  run_buildah manifest push $WITH_POLICY_JSON --all list dir:${TEST_SCRATCH_DIR}/unsigned-image
 }
 
 @test "build-with-dockerfile-signatures" {
   _gpg_setup
 
-  builddir=${TESTDIR}/builddir
+  builddir=${TEST_SCRATCH_DIR}/builddir
   mkdir -p $builddir
   cat > ${builddir}/Dockerfile <<- EOF
 	FROM scratch
@@ -89,9 +89,9 @@ function _gpg_setup() {
   # We should be able to sign at build-time.
   run_buildah bud $WITH_POLICY_JSON --sign-by amanda@localhost -t signed-scratch-image ${builddir}
 
-  mkdir -p ${TESTDIR}/signed-image
+  mkdir -p ${TEST_SCRATCH_DIR}/signed-image
   # Pushing should preserve the signature.
-  run_buildah push $WITH_POLICY_JSON signed-scratch-image dir:${TESTDIR}/signed-image
-  ls -l ${TESTDIR}/signed-image/
-  test -s ${TESTDIR}/signed-image/signature-1
+  run_buildah push $WITH_POLICY_JSON signed-scratch-image dir:${TEST_SCRATCH_DIR}/signed-image
+  ls -l ${TEST_SCRATCH_DIR}/signed-image/
+  test -s ${TEST_SCRATCH_DIR}/signed-image/signature-1
 }

--- a/tests/source.bats
+++ b/tests/source.bats
@@ -4,7 +4,7 @@ load helpers
 
 @test "source create" {
   # Create an empty source image and make sure it's properly initialized
-  srcdir=${TESTDIR}/newsource
+  srcdir=${TEST_SCRATCH_DIR}/newsource
   run_buildah source create --author="Buildah authors" $srcdir
 
   # Inspect the index.json
@@ -52,7 +52,7 @@ load helpers
 
 @test "source add" {
   # Create an empty source image and make sure it's properly initialized.
-  srcdir=${TESTDIR}/newsource
+  srcdir=${TEST_SCRATCH_DIR}/newsource
   run_buildah source create $srcdir
 
   # Digest of initial manifest
@@ -62,8 +62,8 @@ load helpers
   [ "$status" -eq 0 ]
 
   # Add layer 1
-  echo 111 > ${TESTDIR}/file1
-  run_buildah source add $srcdir ${TESTDIR}/file1
+  echo 111 > ${TEST_SCRATCH_DIR}/file1
+  run_buildah source add $srcdir ${TEST_SCRATCH_DIR}/file1
   # Make sure the digest of the manifest changed
   run jq -r .manifests[0].digest $srcdir/index.json
   manifestDigestFile1=${output//sha256:/} # strip off the sha256 prefix
@@ -82,8 +82,8 @@ load helpers
   expect_output --substring "$layer1Size"
 
   # Add layer 2
-  echo 222222aBitLongerForAdifferentSize > ${TESTDIR}/file2
-  run_buildah source add $srcdir ${TESTDIR}/file2
+  echo 222222aBitLongerForAdifferentSize > ${TEST_SCRATCH_DIR}/file2
+  run_buildah source add $srcdir ${TEST_SCRATCH_DIR}/file2
   # Make sure the digest of the manifest changed
   run jq -r .manifests[0].digest $srcdir/index.json
   manifestDigestFile2=${output//sha256:/} # strip off the sha256 prefix
@@ -115,20 +115,20 @@ load helpers
 
 @test "source push/pull" {
   # Create an empty source image and make sure it's properly initialized.
-  srcdir=${TESTDIR}/newsource
+  srcdir=${TEST_SCRATCH_DIR}/newsource
   run_buildah source create $srcdir
 
   # Add two layers
-  echo 111 > ${TESTDIR}/file1
-  run_buildah source add $srcdir ${TESTDIR}/file1
-  echo 222... > ${TESTDIR}/file2
-  run_buildah source add $srcdir ${TESTDIR}/file2
+  echo 111 > ${TEST_SCRATCH_DIR}/file1
+  run_buildah source add $srcdir ${TEST_SCRATCH_DIR}/file1
+  echo 222... > ${TEST_SCRATCH_DIR}/file2
+  run_buildah source add $srcdir ${TEST_SCRATCH_DIR}/file2
 
   start_registry
 
   run_buildah source push --tls-verify=false --creds testuser:testpassword $srcdir localhost:${REGISTRY_PORT}/source:test
 
-  pulldir=${TESTDIR}/pulledsource
+  pulldir=${TEST_SCRATCH_DIR}/pulledsource
   run_buildah source pull --tls-verify=false --creds testuser:testpassword localhost:${REGISTRY_PORT}/source:test $pulldir
 
   run diff -r $srcdir $pulldir

--- a/tests/squash.bats
+++ b/tests/squash.bats
@@ -131,10 +131,10 @@ function check_lengths() {
 @test "bud-squash-should-use-cache" {
   _prefetch alpine
   # populate cache from simple build
-  run_buildah build --layers -t test $WITH_POLICY_JSON -f ${TESTSDIR}/bud/layers-squash/Dockerfile.multi-stage
+  run_buildah build --layers -t test $WITH_POLICY_JSON -f $BUDFILES/layers-squash/Dockerfile.multi-stage
   # create another squashed build and check if we are using cache for everything.
   # instead of last instruction in last stage
-  run_buildah build --layers --squash -t testsquash $WITH_POLICY_JSON -f ${TESTSDIR}/bud/layers-squash/Dockerfile.multi-stage
+  run_buildah build --layers --squash -t testsquash $WITH_POLICY_JSON -f $BUDFILES/layers-squash/Dockerfile.multi-stage
   expect_output --substring "Using cache"
   run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' testsquash
   expect_output "1" "should only container 1 diff"

--- a/tests/squash.bats
+++ b/tests/squash.bats
@@ -17,13 +17,13 @@ function check_lengths() {
 }
 
 @test "squash" {
-	createrandom ${TESTDIR}/randomfile
+	createrandom ${TEST_SCRATCH_DIR}/randomfile
 	run_buildah from scratch
 	cid=$output
 	image=stage0
 	remove=(8 5)
 	for stage in $(seq 10) ; do
-		run_buildah copy "$cid" ${TESTDIR}/randomfile /layer${stage}
+		run_buildah copy "$cid" ${TEST_SCRATCH_DIR}/randomfile /layer${stage}
 		image=stage${stage}
 		if test $stage -eq ${remove[0]} ; then
 			run_buildah mount "$cid"
@@ -51,30 +51,30 @@ function check_lengths() {
 			fi
 			continue
 		fi
-		cmp $mountpoint/layer${stage} ${TESTDIR}/randomfile
+		cmp $mountpoint/layer${stage} ${TEST_SCRATCH_DIR}/randomfile
 	done
 }
 
 @test "squash-using-dockerfile" {
-	createrandom ${TESTDIR}/randomfile
+	createrandom ${TEST_SCRATCH_DIR}/randomfile
 	image=stage0
 	from=scratch
 	for stage in $(seq 10) ; do
-		mkdir -p ${TESTDIR}/stage${stage}
-		echo FROM ${from} > ${TESTDIR}/stage${stage}/Dockerfile
-		cp ${TESTDIR}/randomfile ${TESTDIR}/stage${stage}/
-		echo COPY randomfile /layer${stage} >> ${TESTDIR}/stage${stage}/Dockerfile
+		mkdir -p ${TEST_SCRATCH_DIR}/stage${stage}
+		echo FROM ${from} > ${TEST_SCRATCH_DIR}/stage${stage}/Dockerfile
+		cp ${TEST_SCRATCH_DIR}/randomfile ${TEST_SCRATCH_DIR}/stage${stage}/
+		echo COPY randomfile /layer${stage} >> ${TEST_SCRATCH_DIR}/stage${stage}/Dockerfile
 		image=stage${stage}
 		from=${image}
-		run_buildah build-using-dockerfile $WITH_POLICY_JSON -t ${image} ${TESTDIR}/stage${stage}
+		run_buildah build-using-dockerfile $WITH_POLICY_JSON -t ${image} ${TEST_SCRATCH_DIR}/stage${stage}
                 check_lengths $image $stage
 	done
 
-	mkdir -p ${TESTDIR}/squashed
-	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
-	cp ${TESTDIR}/randomfile ${TESTDIR}/squashed/
-	echo COPY randomfile /layer-squashed >> ${TESTDIR}/stage${stage}/Dockerfile
-	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash -t squashed ${TESTDIR}/squashed
+	mkdir -p ${TEST_SCRATCH_DIR}/squashed
+	echo FROM ${from} > ${TEST_SCRATCH_DIR}/squashed/Dockerfile
+	cp ${TEST_SCRATCH_DIR}/randomfile ${TEST_SCRATCH_DIR}/squashed/
+	echo COPY randomfile /layer-squashed >> ${TEST_SCRATCH_DIR}/stage${stage}/Dockerfile
+	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash -t squashed ${TEST_SCRATCH_DIR}/squashed
 
         check_lengths squashed 1
 
@@ -83,46 +83,46 @@ function check_lengths() {
 	run_buildah mount $cid
 	mountpoint=$output
 	for stage in $(seq 10) ; do
-		cmp $mountpoint/layer${stage} ${TESTDIR}/randomfile
+		cmp $mountpoint/layer${stage} ${TEST_SCRATCH_DIR}/randomfile
 	done
 
-	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash --layers -t squashed ${TESTDIR}/squashed
+	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash --layers -t squashed ${TEST_SCRATCH_DIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
         expect_output "1" "len(DiffIDs) - simple image"
 
-	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
-	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash -t squashed ${TESTDIR}/squashed
+	echo FROM ${from} > ${TEST_SCRATCH_DIR}/squashed/Dockerfile
+	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash -t squashed ${TEST_SCRATCH_DIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
         expect_output "1" "len(DiffIDs) - image with FROM"
 
-	echo USER root >> ${TESTDIR}/squashed/Dockerfile
-	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash -t squashed ${TESTDIR}/squashed
+	echo USER root >> ${TEST_SCRATCH_DIR}/squashed/Dockerfile
+	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash -t squashed ${TEST_SCRATCH_DIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
         expect_output "1" "len(DiffIDs) - image with FROM and USER"
 
-	echo COPY file / >> ${TESTDIR}/squashed/Dockerfile
-	echo COPY file / > ${TESTDIR}/squashed/file
-	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash -t squashed ${TESTDIR}/squashed
+	echo COPY file / >> ${TEST_SCRATCH_DIR}/squashed/Dockerfile
+	echo COPY file / > ${TEST_SCRATCH_DIR}/squashed/file
+	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash -t squashed ${TEST_SCRATCH_DIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
         expect_output "1" "len(DiffIDs) - image with FROM, USER, and 2xCOPY"
 
-	echo FROM ${from} > ${TESTDIR}/squashed/Dockerfile
-	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash --layers -t squashed ${TESTDIR}/squashed
+	echo FROM ${from} > ${TEST_SCRATCH_DIR}/squashed/Dockerfile
+	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash --layers -t squashed ${TEST_SCRATCH_DIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
         expect_output "1" "len(DiffIDs) - image with FROM (--layers)"
 
-	echo USER root >> ${TESTDIR}/squashed/Dockerfile
-	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash -t squashed ${TESTDIR}/squashed
+	echo USER root >> ${TEST_SCRATCH_DIR}/squashed/Dockerfile
+	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash -t squashed ${TEST_SCRATCH_DIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
         expect_output "1" "len(DiffIDs) - image with FROM and USER (--layers)"
 
-	echo COPY file / >> ${TESTDIR}/squashed/Dockerfile
-	echo COPY file / > ${TESTDIR}/squashed/file
-	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash -t squashed ${TESTDIR}/squashed
+	echo COPY file / >> ${TEST_SCRATCH_DIR}/squashed/Dockerfile
+	echo COPY file / > ${TEST_SCRATCH_DIR}/squashed/file
+	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash -t squashed ${TEST_SCRATCH_DIR}/squashed
 	run_buildah inspect -t image -f '{{len .Docker.RootFS.DiffIDs}}' squashed
         expect_output "1" "len(DiffIDs) - image with FROM, USER, and 2xCOPY (--layers)"
 
-	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash --format docker -t squashed ${TESTDIR}/squashed
+	run_buildah build-using-dockerfile $WITH_POLICY_JSON --squash --format docker -t squashed ${TEST_SCRATCH_DIR}/squashed
 	run_buildah inspect -t image -f '{{.Docker.Parent}}' squashed
         expect_output "" "should have no parent image set"
 }

--- a/tests/ssh.bats
+++ b/tests/ssh.bats
@@ -21,7 +21,7 @@ function teardown(){
   ssh-keygen -b 2048 -t rsa -f $mytmpdir/sshkey -q -N ""
   fingerprint=$(ssh-keygen -l -f $mytmpdir/sshkey -E md5 | awk '{ print $2; }')
 
-  run_buildah bud --ssh default=$mytmpdir/sshkey --signature-policy ${TESTSDIR}/policy.json  -t sshimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.ssh ${TESTSDIR}/bud/run-mounts
+  run_buildah bud --ssh default=$mytmpdir/sshkey $WITH_POLICY_JSON  -t sshimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.ssh ${TESTSDIR}/bud/run-mounts
   expect_output --substring $fingerprint
 
   run_buildah from sshimg
@@ -38,7 +38,7 @@ function teardown(){
   ssh-keygen -b 2048 -t rsa -f $mytmpdir/sshkey -q -N ""
   fingerprint=$(ssh-keygen -l -f $mytmpdir/sshkey -E md5 | awk '{ print $2; }')
 
-  run_buildah 2 bud --ssh default=$mytmpdir/sshkey --signature-policy ${TESTSDIR}/policy.json  -t sshimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.ssh_access ${TESTSDIR}/bud/run-mounts
+  run_buildah 2 bud --ssh default=$mytmpdir/sshkey $WITH_POLICY_JSON  -t sshimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.ssh_access ${TESTSDIR}/bud/run-mounts
   expect_output --substring "Could not open a connection to your authentication agent."
 }
 
@@ -50,7 +50,7 @@ function teardown(){
   ssh-keygen -b 2048 -t rsa -f $mytmpdir/sshkey -q -N ""
   fingerprint=$(ssh-keygen -l -f $mytmpdir/sshkey -E md5 | awk '{ print $2; }')
 
-  run_buildah bud --ssh default=$mytmpdir/sshkey --signature-policy ${TESTSDIR}/policy.json  -t secretopts -f ${TESTSDIR}/bud/run-mounts/Dockerfile.ssh_options ${TESTSDIR}/bud/run-mounts
+  run_buildah bud --ssh default=$mytmpdir/sshkey $WITH_POLICY_JSON  -t secretopts -f ${TESTSDIR}/bud/run-mounts/Dockerfile.ssh_options ${TESTSDIR}/bud/run-mounts
   expect_output --substring "444"
   expect_output --substring "1000"
   expect_output --substring "1001"
@@ -66,7 +66,7 @@ function teardown(){
   eval "$(ssh-agent -s)"
   ssh-add $mytmpdir/sshkey
 
-  run_buildah bud --ssh default=$mytmpdir/sshkey --signature-policy ${TESTSDIR}/policy.json  -t sshimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.ssh ${TESTSDIR}/bud/run-mounts
+  run_buildah bud --ssh default=$mytmpdir/sshkey $WITH_POLICY_JSON  -t sshimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.ssh ${TESTSDIR}/bud/run-mounts
   expect_output --substring $fingerprint
 
   run_buildah from sshimg

--- a/tests/ssh.bats
+++ b/tests/ssh.bats
@@ -21,7 +21,7 @@ function teardown(){
   ssh-keygen -b 2048 -t rsa -f $mytmpdir/sshkey -q -N ""
   fingerprint=$(ssh-keygen -l -f $mytmpdir/sshkey -E md5 | awk '{ print $2; }')
 
-  run_buildah bud --ssh default=$mytmpdir/sshkey $WITH_POLICY_JSON  -t sshimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.ssh ${TESTSDIR}/bud/run-mounts
+  run_buildah bud --ssh default=$mytmpdir/sshkey $WITH_POLICY_JSON  -t sshimg -f $BUDFILES/run-mounts/Dockerfile.ssh $BUDFILES/run-mounts
   expect_output --substring $fingerprint
 
   run_buildah from sshimg
@@ -38,7 +38,7 @@ function teardown(){
   ssh-keygen -b 2048 -t rsa -f $mytmpdir/sshkey -q -N ""
   fingerprint=$(ssh-keygen -l -f $mytmpdir/sshkey -E md5 | awk '{ print $2; }')
 
-  run_buildah 2 bud --ssh default=$mytmpdir/sshkey $WITH_POLICY_JSON  -t sshimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.ssh_access ${TESTSDIR}/bud/run-mounts
+  run_buildah 2 bud --ssh default=$mytmpdir/sshkey $WITH_POLICY_JSON  -t sshimg -f $BUDFILES/run-mounts/Dockerfile.ssh_access $BUDFILES/run-mounts
   expect_output --substring "Could not open a connection to your authentication agent."
 }
 
@@ -50,7 +50,7 @@ function teardown(){
   ssh-keygen -b 2048 -t rsa -f $mytmpdir/sshkey -q -N ""
   fingerprint=$(ssh-keygen -l -f $mytmpdir/sshkey -E md5 | awk '{ print $2; }')
 
-  run_buildah bud --ssh default=$mytmpdir/sshkey $WITH_POLICY_JSON  -t secretopts -f ${TESTSDIR}/bud/run-mounts/Dockerfile.ssh_options ${TESTSDIR}/bud/run-mounts
+  run_buildah bud --ssh default=$mytmpdir/sshkey $WITH_POLICY_JSON  -t secretopts -f $BUDFILES/run-mounts/Dockerfile.ssh_options $BUDFILES/run-mounts
   expect_output --substring "444"
   expect_output --substring "1000"
   expect_output --substring "1001"
@@ -66,7 +66,7 @@ function teardown(){
   eval "$(ssh-agent -s)"
   ssh-add $mytmpdir/sshkey
 
-  run_buildah bud --ssh default=$mytmpdir/sshkey $WITH_POLICY_JSON  -t sshimg -f ${TESTSDIR}/bud/run-mounts/Dockerfile.ssh ${TESTSDIR}/bud/run-mounts
+  run_buildah bud --ssh default=$mytmpdir/sshkey $WITH_POLICY_JSON  -t sshimg -f $BUDFILES/run-mounts/Dockerfile.ssh $BUDFILES/run-mounts
   expect_output --substring $fingerprint
 
   run_buildah from sshimg

--- a/tests/ssh.bats
+++ b/tests/ssh.bats
@@ -16,7 +16,7 @@ function teardown(){
 @test "bud with ssh key" {
   _prefetch alpine
 
-  mytmpdir=${TESTDIR}/my-dir1
+  mytmpdir=${TEST_SCRATCH_DIR}/my-dir1
   mkdir -p ${mytmpdir}
   ssh-keygen -b 2048 -t rsa -f $mytmpdir/sshkey -q -N ""
   fingerprint=$(ssh-keygen -l -f $mytmpdir/sshkey -E md5 | awk '{ print $2; }')
@@ -33,7 +33,7 @@ function teardown(){
 @test "bud with ssh key secret accessed on second RUN" {
  _prefetch alpine
 
-  mytmpdir=${TESTDIR}/my-dir1
+  mytmpdir=${TEST_SCRATCH_DIR}/my-dir1
   mkdir -p ${mytmpdir}
   ssh-keygen -b 2048 -t rsa -f $mytmpdir/sshkey -q -N ""
   fingerprint=$(ssh-keygen -l -f $mytmpdir/sshkey -E md5 | awk '{ print $2; }')
@@ -45,7 +45,7 @@ function teardown(){
 @test "bud with containerfile ssh options" {
   _prefetch alpine
 
-  mytmpdir=${TESTDIR}/my-dir1
+  mytmpdir=${TEST_SCRATCH_DIR}/my-dir1
   mkdir -p ${mytmpdir}
   ssh-keygen -b 2048 -t rsa -f $mytmpdir/sshkey -q -N ""
   fingerprint=$(ssh-keygen -l -f $mytmpdir/sshkey -E md5 | awk '{ print $2; }')
@@ -59,7 +59,7 @@ function teardown(){
 @test "bud with ssh sock" {
   _prefetch alpine
 
-  mytmpdir=${TESTDIR}/my-dir1
+  mytmpdir=${TEST_SCRATCH_DIR}/my-dir1
   mkdir -p ${mytmpdir}
   ssh-keygen -b 2048 -t rsa -f $mytmpdir/sshkey -q -N ""
   fingerprint=$(ssh-keygen -l -f $mytmpdir/sshkey -E md5 | awk '{ print $2; }')

--- a/tests/subscriptions.bats
+++ b/tests/subscriptions.bats
@@ -6,7 +6,7 @@ load helpers
     skip_if_no_runtime
 
     # Setup
-    SECRETS_DIR=$TESTDIR/rhel/secrets
+    SECRETS_DIR=$TEST_SCRATCH_DIR/rhel/secrets
     mkdir -p $SECRETS_DIR
 
     TESTFILE1=$SECRETS_DIR/test.txt
@@ -17,20 +17,20 @@ load helpers
     touch     $TESTFILE2
     chmod 604 $TESTFILE2
 
-    TESTDIR1=$SECRETS_DIR/test-dir
-    mkdir -m704 $TESTDIR1
+    TEST_SCRATCH_DIR1=$SECRETS_DIR/test-dir
+    mkdir -m704 $TEST_SCRATCH_DIR1
 
-    TESTFILE3=$TESTDIR1/file.txt
+    TESTFILE3=$TEST_SCRATCH_DIR1/file.txt
     touch     $TESTFILE3
     chmod 777 $TESTFILE3
 
-    mkdir -p $TESTDIR/symlink/target
-    touch    $TESTDIR/symlink/target/key.pem
-    ln -s    $TESTDIR/symlink/target $SECRETS_DIR/mysymlink
+    mkdir -p $TEST_SCRATCH_DIR/symlink/target
+    touch    $TEST_SCRATCH_DIR/symlink/target/key.pem
+    ln -s    $TEST_SCRATCH_DIR/symlink/target $SECRETS_DIR/mysymlink
 
     # prepare the test mounts file
-    mkdir $TESTDIR/containers
-    MOUNTS_PATH=$TESTDIR/containers/mounts.conf
+    mkdir $TEST_SCRATCH_DIR/containers
+    MOUNTS_PATH=$TEST_SCRATCH_DIR/containers/mounts.conf
 
     # add the mounts entries
     echo "$SECRETS_DIR:/run/secrets"  > $MOUNTS_PATH
@@ -49,7 +49,7 @@ load helpers
     expect_output --substring "test.txt"
 
     # test a mount without destination
-    run_buildah run $cid ls "$TESTDIR"/rhel/secrets
+    run_buildah run $cid ls "$TEST_SCRATCH_DIR"/rhel/secrets
     expect_output --substring "test.txt"
 
     # test a file-based mount
@@ -68,14 +68,14 @@ load helpers
     run_buildah run $cid stat -c %a /run/secrets/test-dir/file.txt
     expect_output 777
 
-    cat > $TESTDIR/Containerfile << _EOF
+    cat > $TEST_SCRATCH_DIR/Containerfile << _EOF
 from alpine
 run stat -c %a /run/secrets/file.txt
 run stat -c %a /run/secrets/test-dir
 run stat -c %a /run/secrets/test-dir/file.txt
 _EOF
 
-    run_buildah --default-mounts-file "$MOUNTS_PATH" bud $TESTDIR
+    run_buildah --default-mounts-file "$MOUNTS_PATH" bud $TEST_SCRATCH_DIR
     expect_output --substring "604"
     expect_output --substring "704"
     expect_output --substring "777"

--- a/tests/subscriptions.bats
+++ b/tests/subscriptions.bats
@@ -41,7 +41,7 @@ load helpers
     # setup the test container
     _prefetch alpine
     run_buildah --default-mounts-file "$MOUNTS_PATH" \
-		from --quiet --pull --signature-policy ${TESTSDIR}/policy.json alpine
+		from --quiet --pull $WITH_POLICY_JSON alpine
     cid=$output
 
     # test a standard mount to /run/secrets

--- a/tests/tag.bats
+++ b/tests/tag.bats
@@ -3,9 +3,9 @@
 load helpers
 
 @test "tag by name" {
-  run_buildah from --pull=false --signature-policy ${TESTSDIR}/policy.json scratch
+  run_buildah from --pull=false $WITH_POLICY_JSON scratch
   cid=$output
-  run_buildah commit --signature-policy ${TESTSDIR}/policy.json "$cid" scratch-image
+  run_buildah commit $WITH_POLICY_JSON "$cid" scratch-image
   run_buildah 125 inspect --type image tagged-image
   run_buildah tag scratch-image tagged-image tagged-also-image named-image
   run_buildah inspect --type image tagged-image
@@ -15,7 +15,7 @@ load helpers
 
 @test "tag by id" {
   _prefetch busybox
-  run_buildah pull --quiet --signature-policy ${TESTSDIR}/policy.json busybox
+  run_buildah pull --quiet $WITH_POLICY_JSON busybox
   id=$output
 
   # Tag by ID, then make a container from that tag

--- a/tests/test_buildah_build_rpm.sh
+++ b/tests/test_buildah_build_rpm.sh
@@ -18,7 +18,7 @@ SBOX=/tmp/sandbox
 PACKAGES=/tmp/packages
 mkdir -p ${SBOX}/buildah
 GITROOT=${SBOX}/buildah
-TESTSDIR=${GITROOT}/tests
+TEST_SOURCES=${GITROOT}/tests
 
 # Change packager as appropriate for the platform
 PACKAGER=dnf
@@ -36,7 +36,7 @@ cd $GITROOT
 ########
 # Build a container to use for building the binaries.
 ########
-CTRID=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $IMAGE)
+CTRID=$(buildah from --pull --signature-policy ${TEST_SOURCES}/policy.json $IMAGE)
 ROOTMNT=$(buildah mount $CTRID)
 COMMIT=$(git log --format=%H -n 1)
 SHORTCOMMIT=$(echo ${COMMIT} | cut -c-7)
@@ -62,7 +62,7 @@ buildah run $CTRID -- rpmbuild --define "_topdir /rpmbuild" -ba /rpmbuild/SPECS/
 ########
 # Build a second new container.
 ########
-CTRID2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $IMAGE)
+CTRID2=$(buildah from --pull --signature-policy ${TEST_SOURCES}/policy.json $IMAGE)
 ROOTMNT2=$(buildah mount $CTRID2)
 
 ########
@@ -105,14 +105,14 @@ buildah rmi -f $(buildah images -q)
 ########
 # Kick off baseline testing against the installed Buildah 
 ########
-/bin/bash -v ${TESTSDIR}/test_buildah_baseline.sh
+/bin/bash -v ${TEST_SOURCES}/test_buildah_baseline.sh
 
 ########
 # Install the Buildah we just built locally and run 
 # the baseline tests again.
 ########
 ${PACKAGER} -y install ${PACKAGES}/*.rpm
-/bin/bash -v ${TESTSDIR}/test_buildah_baseline.sh
+/bin/bash -v ${TEST_SOURCES}/test_buildah_baseline.sh
 
 ########
 # Clean up 

--- a/tests/test_buildah_rpm.sh
+++ b/tests/test_buildah_rpm.sh
@@ -4,7 +4,7 @@ load helpers
 
 # Ensure that any updated/pushed rpm .spec files don't clobber the commit placeholder
 @test "rpm REPLACEWITHCOMMITID placeholder exists in .spec file" {
-	run grep -q "^%global[ ]\+commit[ ]\+REPLACEWITHCOMMITID$" ${TESTSDIR}/../contrib/rpm/buildah.spec
+	run grep -q "^%global[ ]\+commit[ ]\+REPLACEWITHCOMMITID$" ${TEST_SOURCES}/../contrib/rpm/buildah.spec
 	[ "$status" -eq 0 ]
 }
 
@@ -13,7 +13,7 @@ load helpers
 
         # Build a container to use for building the binaries.
         image=registry.centos.org/centos/centos:centos7
-        cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+        cid=$(buildah from --pull --signature-policy ${TEST_SOURCES}/policy.json $image)
         root=$(buildah mount $cid)
         commit=$(git log --format=%H -n 1)
         shortcommit=$(echo ${commit} | cut -c-7)
@@ -23,7 +23,7 @@ load helpers
         (cd ..; git archive --format tar.gz --prefix=buildah-${commit}/ ${commit}) > ${root}/rpmbuild/SOURCES/buildah-${shortcommit}.tar.gz
 
         # Update the .spec file with the commit ID.
-        sed s:REPLACEWITHCOMMITID:${commit}:g ${TESTSDIR}/../contrib/rpm/buildah.spec > ${root}/rpmbuild/SPECS/buildah.spec
+        sed s:REPLACEWITHCOMMITID:${commit}:g ${TEST_SOURCES}/../contrib/rpm/buildah.spec > ${root}/rpmbuild/SPECS/buildah.spec
 
         # Install build dependencies and build binary packages.
         buildah run $cid -- yum -y install rpm-build yum-utils
@@ -31,7 +31,7 @@ load helpers
         buildah run $cid -- rpmbuild --define "_topdir /rpmbuild" -ba /rpmbuild/SPECS/buildah.spec
 
         # Build a second new container.
-        cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+        cid2=$(buildah from --pull --signature-policy ${TEST_SOURCES}/policy.json $image)
         root2=$(buildah mount $cid2)
 
         # Copy the binary packages from the first container to the second one, and build a list of
@@ -66,7 +66,7 @@ load helpers
 
         # Build a container to use for building the binaries.
         image=registry.fedoraproject.org/fedora:latest
-        cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+        cid=$(buildah from --pull --signature-policy ${TEST_SOURCES}/policy.json $image)
         root=$(buildah mount $cid)
         commit=$(git log --format=%H -n 1)
         shortcommit=$(echo ${commit} | cut -c-7)
@@ -76,7 +76,7 @@ load helpers
         (cd ..; git archive --format tar.gz --prefix=buildah-${commit}/ ${commit}) > ${root}/rpmbuild/SOURCES/buildah-${shortcommit}.tar.gz
 
         # Update the .spec file with the commit ID.
-        sed s:REPLACEWITHCOMMITID:${commit}:g ${TESTSDIR}/../contrib/rpm/buildah.spec > ${root}/rpmbuild/SPECS/buildah.spec
+        sed s:REPLACEWITHCOMMITID:${commit}:g ${TEST_SOURCES}/../contrib/rpm/buildah.spec > ${root}/rpmbuild/SPECS/buildah.spec
 
         # Install build dependencies and build binary packages.
         buildah run $cid -- dnf -y install 'dnf-command(builddep)' rpm-build
@@ -84,7 +84,7 @@ load helpers
         buildah run $cid -- rpmbuild --define "_topdir /rpmbuild" -ba /rpmbuild/SPECS/buildah.spec
 
         # Build a second new container.
-        cid2=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image)
+        cid2=$(buildah from --pull --signature-policy ${TEST_SOURCES}/policy.json $image)
         root2=$(buildah mount $cid2)
 
         # Copy the binary packages from the first container to the second one, and build a list of

--- a/tests/umount.bats
+++ b/tests/umount.bats
@@ -15,7 +15,7 @@ load helpers
 
 @test "umount one image" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah mount "$cid"
   run_buildah umount "$cid"
@@ -27,13 +27,13 @@ load helpers
 
 @test "umount multi images" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
   run_buildah mount "$cid1"
-  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull-never $WITH_POLICY_JSON alpine
   cid2=$output
   run_buildah mount "$cid2"
-  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull-never $WITH_POLICY_JSON alpine
   cid3=$output
   run_buildah mount "$cid3"
   run_buildah umount "$cid1" "$cid2" "$cid3"
@@ -41,13 +41,13 @@ load helpers
 
 @test "umount all images" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
   run_buildah mount "$cid1"
-  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull-never $WITH_POLICY_JSON alpine
   cid2=$output
   run_buildah mount "$cid2"
-  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull-never $WITH_POLICY_JSON alpine
   cid3=$output
   run_buildah mount "$cid3"
   run_buildah umount --all
@@ -55,13 +55,13 @@ load helpers
 
 @test "umount multi images one bad" {
   _prefetch alpine
-  run_buildah from --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid1=$output
   run_buildah mount "$cid1"
-  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull-never $WITH_POLICY_JSON alpine
   cid2=$output
   run_buildah mount "$cid2"
-  run_buildah from --quiet --pull-never --signature-policy ${TESTSDIR}/policy.json alpine
+  run_buildah from --quiet --pull-never $WITH_POLICY_JSON alpine
   cid3=$output
   run_buildah mount "$cid3"
   run_buildah 125 umount "$cid1" badcontainer "$cid2" "$cid3"

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -7,24 +7,24 @@ load helpers
 }
 
 @test "buildah version current in .spec file Version" {
-	if [ ! -d "${TESTSDIR}/../contrib/rpm" ]; then
+	if [ ! -d "${TEST_SOURCES}/../contrib/rpm" ]; then
 		skip "No source dir available"
 	fi
 	run_buildah version
 	bversion=$(awk '/^Version:/ { print $NF }' <<< "$output")
-	rversion=$(awk '/^Version:/ { print $NF }' < ${TESTSDIR}/../contrib/rpm/buildah.spec)
+	rversion=$(awk '/^Version:/ { print $NF }' < ${TEST_SOURCES}/../contrib/rpm/buildah.spec)
 	echo "bversion=${bversion}"
 	echo "rversion=${rversion}"
 	test "${bversion}" = "${rversion}" -o "${bversion}" = "${rversion}-dev"
 }
 
 @test "buildah version current in .spec file changelog" {
-	if [ ! -d "${TESTSDIR}/../contrib/rpm" ]; then
+	if [ ! -d "${TEST_SOURCES}/../contrib/rpm" ]; then
 		skip "No source dir available"
 	fi
 	run_buildah version
 	bversion=$(awk '/^Version:/ { print $NF }' <<< "$output")
-	grep -A1 ^%changelog ${TESTSDIR}/../contrib/rpm/buildah.spec | grep -q " ${bversion}-"
+	grep -A1 ^%changelog ${TEST_SOURCES}/../contrib/rpm/buildah.spec | grep -q " ${bversion}-"
 }
 
 @test "buildah version current in package" {


### PR DESCRIPTION
They cause way too much confusion. Rename $TESTSDIR (plural) to $TEST_SOURCES
and $TESTDIR (singular) to $TEST_SCRATCH_DIR.

In the process, refactor two commonly-used expressions ($WITH_POLICY_JSON and $BUDFILES).

Split into four separate commits, for ease of review.