### PR TITLE
Cirrus: Update CI VMs to F36

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,11 +27,11 @@ env:
     ####
     # GCE project where images live
     IMAGE_PROJECT: "libpod-218412"
-    FEDORA_NAME: "fedora-35"
-    PRIOR_FEDORA_NAME: "fedora-34"
+    FEDORA_NAME: "fedora-36"
+    PRIOR_FEDORA_NAME: "fedora-35"
     UBUNTU_NAME: "ubuntu-2110"
 
-    IMAGE_SUFFIX: "c4764556961513472"
+    IMAGE_SUFFIX: "c4955393725038592"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -180,7 +180,6 @@ in_podman() {
         echo "$envarg" | tee -a $envfile | indent
     done
     showrun podman run -i --name="$IN_PODMAN_NAME" \
-                   --net=host \
                    --net="container:registry" \
                    --security-opt=label=disable \
                    --security-opt=seccomp=unconfined \

--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -39,6 +39,9 @@ case $1 in
         )
         case $OS_RELEASE_ID in
             fedora*)
+                if [[ "$OS_RELEASE_VER" -ge 36 ]]; then
+                    PKG_NAMES+=(aardvark-dns netavark)
+                fi
                 PKG_LST_CMD='rpm -q --qf=%{N}-%{V}-%{R}-%{ARCH}\n'
                 ;;
             ubuntu*)

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -10,7 +10,13 @@ source $(dirname $0)/lib.sh
 
 req_env_vars OS_RELEASE_ID OS_RELEASE_VER GOSRC IN_PODMAN_IMAGE
 
-echo "Setting up $OS_RELEASE_ID $OS_RELEASE_VER"
+msg "Disabling git repository owner-check system-wide."
+# Newer versions of git bark if repo. files are unexpectedly owned.
+# This mainly affects rootless and containerized testing.  But
+# the testing environment is disposable, so we don't care.=
+git config --system --add safe.directory $GOSRC
+
+msg "Setting up $OS_RELEASE_ID $OS_RELEASE_VER"
 cd $GOSRC
 case "$OS_RELEASE_ID" in
     fedora)

--- a/pkg/formats/templates.go
+++ b/pkg/formats/templates.go
@@ -20,6 +20,10 @@ var basicFunctions = template.FuncMap{
 	},
 	"split":    strings.Split,
 	"join":     strings.Join,
+	// strings.Title is deprecated since go 1.18
+	// However for our use case it is still fine. The recommended replacement
+	// is adding about 400kb binary size so lets keep using this for now.
+	//nolint:staticcheck
 	"title":    strings.Title,
 	"lower":    strings.ToLower,
 	"upper":    strings.ToUpper,


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Bump Fedora VM to version 36 and prior-Fedora to 35

#### How to verify it

All CI will pass

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Ref: https://github.com/containers/automation_images/pull/115

#### Does this PR introduce a user-facing change?

None

[NO NEW TESTS NEEDED]