### PR TITLE
Fix docs build on FreeBSD

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,6 +3,11 @@ DATADIR := ${PREFIX}/share
 MANDIR := $(DATADIR)/man
 # Following go-md2man is guaranteed on host
 GOMD2MAN ?= ../tests/tools/build/go-md2man
+ifeq ($(shell uname -s),FreeBSD)
+SED=gsed
+else
+SED=sed
+endif
 
 docs: $(patsubst %.md,%,$(wildcard *.md))
 
@@ -10,7 +15,7 @@ docs: $(patsubst %.md,%,$(wildcard *.md))
 ### sed is used to filter http/s links as well as relative links
 ### replaces "\" at the end of a line with two spaces
 ### this ensures that manpages are rendered correctly
-	sed -e 's/\((buildah[^)]*\.md\(#.*\)\?)\)//g' \
+	$(SED) -e 's/\((buildah[^)]*\.md\(#.*\)\?)\)//g' \
 	 -e 's/\[\(buildah[^]]*\)\]/\1/g' \
 	 -e 's/\[\([^]]*\)](http[^)]\+)/\1/g' \
 	 -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g' \


### PR DESCRIPTION
The sed implementation has a strict interpretation of posix 'basic'
regular expressions. It would be better to re-implement this using
'extended' regular expressions but for now, just use GNU sed.

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### What type of PR is this?

> /kind cleanup

#### What this PR does / why we need it:

I'm porting buildah to FreeBSD

#### How to verify it

Run:
```
gmake -C docs
```
on a FreeBSD host - without this change all the manpages are zero length

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

None
