### PR TITLE
Add test for prevention of reusing encrypted layers

### DIFF
--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -229,6 +229,10 @@ load helpers
   # this test, just checks the ability to commit an image to a registry
   # there is no good way to test the details of the image unless with ./buildah pull, test will be in pull.bats
   rm -rf ${TEST_SCRATCH_DIR}/tmp
+
+  # verify that encrypted layers are not cached or reused for an non-encrypted image (See containers/image#1533)
+  run_buildah commit --iidfile /dev/null --tls-verify=false --creds testuser:testpassword $WITH_POLICY_JSON -q $cid docker://localhost:${REGISTRY_PORT}/buildah/busybox_not_encrypted:latest
+  run_buildah from $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword docker://localhost:${REGISTRY_PORT}/buildah/busybox_not_encrypted:latest
 }
 
 @test "commit omit-timestamp" {


### PR DESCRIPTION
Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

This fix modifies the test "commit oci encrypt to registry" to verify that encrypted layers are not reused for a non-encrypted image. This test verifies a fix in https://github.com/containers/image/pull/1533.


#### How to verify it
Run the modified test: `bats tests/commit.bats`

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
