### PR TITLE
imagebuildah, executor: process `ARG` variables while populating baseMap

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -603,11 +603,12 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 						}
 						base := child.Next.Value
 						if base != "scratch" {
-							// TODO: this didn't undergo variable and arg
-							// expansion, so if the AS clause in another
-							// FROM instruction uses argument values,
-							// we might not record the right value here.
-							b.baseMap[base] = true
+							userArgs := argsMapToSlice(stage.Builder.Args)
+							baseWithArg, err := imagebuilder.ProcessWord(base, userArgs)
+							if err != nil {
+								return "", nil, errors.Wrapf(err, "while replacing arg variables with values for format %q", base)
+							}
+							b.baseMap[baseWithArg] = true
 							logrus.Debugf("base for stage %d: %q", stageIndex, base)
 						}
 					}

--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -10,3 +10,13 @@ import (
 func InitReexec() bool {
 	return buildah.InitReexec()
 }
+
+// argsMapToSlice returns the contents of a map[string]string as a slice of keys
+// and values joined with "=".
+func argsMapToSlice(m map[string]string) []string {
+	s := make([]string, 0, len(m))
+	for k, v := range m {
+		s = append(s, k+"="+v)
+	}
+	return s
+}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3180,6 +3180,12 @@ _EOF
   assert "$output" !~ '--build-arg NEWSECRET=<VALUE>'
 }
 
+@test "bud with arg in from statement" {
+  _prefetch alpine
+  run_buildah build -t testbud $WITH_POLICY_JSON --build-arg app_type=x --build-arg another_app_type=m --file $BUDFILES/with-arg/Dockerfilefromarg .
+  expect_output --substring 'world'
+}
+
 @test "bud with --runtime and --runtime-flag" {
   # This Containerfile needs us to be able to handle a working RUN instruction.
   skip_if_no_runtime

--- a/tests/bud/with-arg/Dockerfilefromarg
+++ b/tests/bud/with-arg/Dockerfilefromarg
@@ -1,0 +1,16 @@
+ARG app_type
+ARG another_app_type
+ARG another_app_type_default=m
+
+FROM alpine as x
+RUN echo hello
+
+FROM ${app_type} as m
+RUN echo world
+
+# Do not supply this in cli, lets use default
+FROM ${another_app_type_default} as final
+RUN echo hello
+
+FROM ${another_app_type} as final
+RUN echo hello


### PR DESCRIPTION
While processing `FROM <token> as final` executor populates baseMap as
it is without resolving or processing for any ARG values. Following
commit ensures that we process resolve any ARG variables with ARG values
while populating baseMap so it can be used later to check if stage is
reused.

Fixes: https://github.com/containers/buildah/issues/3939