### PR TITLE
Handle OS version and features flags

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -330,7 +330,7 @@ type BuilderOptions struct {
 	Format string
 	// Devices are the additional devices to add to the containers
 	Devices define.ContainerDevices
-	//DefaultEnv for containers
+	// DefaultEnv is deprecated and ignored.
 	DefaultEnv []string
 	// MaxPullRetries is the maximum number of attempts we'll make to pull
 	// any one image from the external registry if the first attempt fails.

--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -394,6 +394,7 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 		Timestamp:               timestamp,
 		Platforms:               platforms,
 		UnsetEnvs:               iopts.UnsetEnvs,
+		Envs:                    iopts.Envs,
 	}
 	if iopts.Quiet {
 		options.ReportWriter = ioutil.Discard

--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -395,6 +395,8 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 		Platforms:               platforms,
 		UnsetEnvs:               iopts.UnsetEnvs,
 		Envs:                    iopts.Envs,
+		OSFeatures:              iopts.OSFeatures,
+		OSVersion:               iopts.OSVersion,
 	}
 	if iopts.Quiet {
 		options.ReportWriter = ioutil.Discard

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -118,7 +118,7 @@ func commitListFlagSet(cmd *cobra.Command, opts *commitInputOptions) {
 	}
 
 	flags.BoolVar(&opts.squash, "squash", false, "produce an image with only one layer")
-	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
+	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
 
 	flags.StringSliceVar(&opts.unsetenvs, "unsetenv", nil, "unset env from final image")
 	_ = cmd.RegisterFlagCompletionFunc("unsetenv", completion.AutocompleteNone)

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -39,6 +39,8 @@ type configResults struct {
 	label                  []string
 	onbuild                []string
 	os                     string
+	osfeature              []string
+	osversion              string
 	ports                  []string
 	shell                  string
 	stopSignal             string
@@ -88,6 +90,8 @@ func init() {
 	flags.StringArrayVarP(&opts.label, "label", "l", []string{}, "add image configuration `label` e.g. label=value")
 	flags.StringSliceVar(&opts.onbuild, "onbuild", []string{}, "add onbuild command to be run on images based on this image. Only supported on 'docker' formatted images")
 	flags.StringVar(&opts.os, "os", "", "set `operating system` of the target image")
+	flags.StringArrayVar(&opts.osfeature, "os-feature", []string{}, "set required OS `feature` for the target image")
+	flags.StringVar(&opts.osversion, "os-version", "", "set required OS `version` for the target image")
 	flags.StringSliceVarP(&opts.ports, "port", "p", []string{}, "add `port` to expose when running containers based on image (default [])")
 	flags.StringVar(&opts.shell, "shell", "", "add `shell` to run in containers")
 	flags.StringVar(&opts.stopSignal, "stop-signal", "", "set `stop signal` for containers based on image")
@@ -176,6 +180,21 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 	}
 	if c.Flag("os").Changed {
 		builder.SetOS(iopts.os)
+	}
+	if c.Flag("os-feature").Changed {
+		for _, osFeatureSpec := range iopts.osfeature {
+			switch {
+			case osFeatureSpec == "-":
+				builder.ClearOSFeatures()
+			case strings.HasSuffix(osFeatureSpec, "-"):
+				builder.UnsetOSFeature(strings.TrimSuffix(osFeatureSpec, "-"))
+			default:
+				builder.SetOSFeature(osFeatureSpec)
+			}
+		}
+	}
+	if c.Flag("os-version").Changed {
+		builder.SetOSVersion(iopts.osversion)
 	}
 	if c.Flag("user").Changed {
 		builder.SetUser(iopts.user)

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -226,7 +226,6 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 			}
 			env[1] = os.Expand(env[1], getenv)
 			builder.SetEnv(env[0], env[1])
-
 		case env[0] == "-":
 			builder.ClearEnv()
 		case strings.HasSuffix(env[0], "-"):

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -319,7 +319,6 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 		Format:                format,
 		BlobDirectory:         iopts.BlobCache,
 		Devices:               devices,
-		DefaultEnv:            defaultContainerConfig.GetDefaultEnv(),
 		MaxPullRetries:        maxPullPushRetries,
 		PullRetryDelay:        pullPushRetryDelay,
 		OciDecryptConfig:      decConfig,

--- a/cmd/buildah/login.go
+++ b/cmd/buildah/login.go
@@ -40,7 +40,7 @@ func init() {
 	flags := loginCommand.Flags()
 	flags.SetInterspersed(false)
 	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
-	flags.BoolVar(&opts.getLogin, "get-login", true, "Return the current login user for the registry")
+	flags.BoolVar(&opts.getLogin, "get-login", true, "return the current login user for the registry")
 	flags.AddFlagSet(auth.GetLoginFlags(&opts.loginOpts))
 	rootCmd.AddCommand(loginCommand)
 }

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -73,7 +73,7 @@ func init() {
 	flags.BoolVar(&opts.noPivot, "no-pivot", false, "do not use pivot root to jail process inside rootfs")
 	flags.BoolVarP(&opts.terminal, "terminal", "t", false, "allocate a pseudo-TTY in the container")
 	flags.StringArrayVarP(&opts.volumes, "volume", "v", []string{}, "bind mount a host location into the container while running the command")
-	flags.StringArrayVar(&opts.mounts, "mount", []string{}, "Attach a filesystem mount to the container (default [])")
+	flags.StringArrayVar(&opts.mounts, "mount", []string{}, "attach a filesystem mount to the container (default [])")
 	flags.StringVar(&opts.workingDir, "workingdir", "", "temporarily set working directory for command (default to container's workingdir)")
 
 	userFlags := getUserFlags()

--- a/commit.go
+++ b/commit.go
@@ -102,6 +102,7 @@ type CommitOptions struct {
 	// indexing. i.e. 0 is the first layer, -1 is the last (top-most) layer.
 	OciEncryptLayers *[]int
 	// UnsetEnvs is a list of environments to not add to final image.
+	// Deprecated: use UnsetEnv() before committing instead.
 	UnsetEnvs []string
 }
 

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/docker"
+	"github.com/containers/buildah/util"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/transports"
@@ -200,6 +201,69 @@ func (b *Builder) OS() string {
 func (b *Builder) SetOS(os string) {
 	b.OCIv1.OS = os
 	b.Docker.OS = os
+}
+
+// OSVersion returns a version of the OS on which the container, or a container
+// built using an image built from this container, is intended to be run.
+func (b *Builder) OSVersion() string {
+	return b.OCIv1.OSVersion
+}
+
+// SetOSVersion sets the version of the OS on which the container, or a
+// container built using an image built from this container, is intended to be
+// run.
+func (b *Builder) SetOSVersion(version string) {
+	b.OCIv1.OSVersion = version
+	b.Docker.OSVersion = version
+}
+
+// OSFeatures returns a list of OS features which the container, or a container
+// built using an image built from this container, depends on the OS supplying.
+func (b *Builder) OSFeatures() []string {
+	return copyStringSlice(b.OCIv1.OSFeatures)
+}
+
+// SetOSFeature adds a feature of the OS which the container, or a container
+// built using an image built from this container, depends on the OS supplying.
+func (b *Builder) SetOSFeature(feature string) {
+	if !util.StringInSlice(feature, b.OCIv1.OSFeatures) {
+		b.OCIv1.OSFeatures = append(b.OCIv1.OSFeatures, feature)
+	}
+	if !util.StringInSlice(feature, b.Docker.OSFeatures) {
+		b.Docker.OSFeatures = append(b.Docker.OSFeatures, feature)
+	}
+}
+
+// UnsetOSFeature removes a feature of the OS which the container, or a
+// container built using an image built from this container, depends on the OS
+// supplying.
+func (b *Builder) UnsetOSFeature(feature string) {
+	if util.StringInSlice(feature, b.OCIv1.OSFeatures) {
+		features := make([]string, 0, len(b.OCIv1.OSFeatures))
+		for _, f := range b.OCIv1.OSFeatures {
+			if f != feature {
+				features = append(features, f)
+			}
+		}
+		b.OCIv1.OSFeatures = features
+	}
+	if util.StringInSlice(feature, b.Docker.OSFeatures) {
+		features := make([]string, 0, len(b.Docker.OSFeatures))
+		for _, f := range b.Docker.OSFeatures {
+			if f != feature {
+				features = append(features, f)
+			}
+		}
+		b.Docker.OSFeatures = features
+	}
+}
+
+// ClearOSFeatures clears the list of features of the OS which the container,
+// or a container built using an image built from this container, depends on
+// the OS supplying.
+func (b *Builder) ClearOSFeatures() {
+	b.OCIv1.OSFeatures = []string{}
+	b.Docker.OSFeatures = []string{}
 }
 
 // Architecture returns a name of the architecture on which the container, or a

--- a/define/build.go
+++ b/define/build.go
@@ -262,4 +262,12 @@ type BuildOptions struct {
 	UnsetEnvs []string
 	// Envs is a list of environment variables to set in the final image.
 	Envs []string
+	// OSFeatures specifies operating system features the image requires.
+	// It is typically only set when the OS is "windows".
+	OSFeatures []string
+	// OSVersion specifies the exact operating system version the image
+	// requires.  It is typically only set when the OS is "windows".  Any
+	// value set in a base image will be preserved, so this does not
+	// frequently need to be set.
+	OSVersion string
 }

--- a/define/build.go
+++ b/define/build.go
@@ -260,4 +260,6 @@ type BuildOptions struct {
 	AllPlatforms bool
 	// UnsetEnvs is a list of environments to not add to final image.
 	UnsetEnvs []string
+	// Envs is a list of environment variables to set in the final image.
+	Envs []string
 }

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -421,6 +421,24 @@ By default, Buildah manages _/etc/hosts_, adding the container's own IP address.
 
 Set the OS of the image to be built, and that of the base image to be pulled, if the build uses one, instead of using the current operating system of the host.
 
+**--os-feature** *feature*
+
+Set the name of a required operating system *feature* for the image which will
+be built.  By default, if the image is not based on *scratch*, the base image's
+required OS feature list is kept, if the base image specified any.  This option
+is typically only meaningful when the image's OS is Windows.
+
+If *feature* has a trailing `-`, then the *feature* is removed from the set of
+required features which will be listed in the image.
+
+**--os-version** *version*
+
+Set the exact required operating system *version* for the image which will be
+built.  By default, if the image is not based on *scratch*, the base image's
+required OS version is kept, if the base image specified one.  This option is
+typically only meaningful when the image's OS is Windows, and is typically set in
+Windows base images, so using this option is usually unnecessary.
+
 **--output**, **-o**=""
 
 Output destination (format: type=local,dest=path)
@@ -844,6 +862,12 @@ buildah build --env LANG=en_US.UTF-8 -t imageName .
 buildah build --env EDITOR -t imageName .
 
 buildah build --unsetenv LANG -t imageName .
+
+buildah build --os-version 10.0.19042.1645 -t imageName .
+
+buildah build --os-feature win32k -t imageName .
+
+buildah build --os-feature win32k- -t imageName .
 
 ### Building an multi-architecture image using the --manifest option (requires emulation software)
 

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -902,6 +902,7 @@ buildah build -o - . > out.tar
   Note: You can set an arbitrary Git repository via the git:// scheme.
 
 ### Building an image using a URL to a tarball'ed context
+
   Buildah will fetch the tarball archive, decompress it and use its contents as the build context.  The Containerfile or Dockerfile at the root of the archive and the rest of the archive will get used as the context of the build. If you pass an -f PATH/Containerfile option as well, the system will look for that file inside the contents of the tarball.
 
   buildah build -f dev/Containerfile https://10.10.10.1/buildah/context.tar.gz
@@ -909,6 +910,7 @@ buildah build -o - . > out.tar
   Note: supported compression formats are 'xz', 'bzip2', 'gzip' and 'identity' (no compression).
 
 ### Using Build Time Variables
+
 #### Replace the value set for the HTTP_PROXY environment variable within the Containerfile.
 
 buildah build --build-arg=HTTP_PROXY="http://127.0.0.1:8321"

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -38,9 +38,10 @@ Add a line to /etc/hosts. The format is hostname:ip. The **--add-host** option c
 
 Instead of building for a set of platforms specified using the **--platform** option, inspect the build's base images, and build for all of the platforms for which they are all available.  Stages that use *scratch* as a starting point can not be inspected, so at least one non-*scratch* stage must be present for detection to work usefully.
 
-**--annotation** *annotation*
+**--annotation** *annotation[=value]*
 
 Add an image *annotation* (e.g. annotation=*value*) to the image metadata. Can be used multiple times.
+If *annotation* is named, but neither `=` nor a `value` is provided, then the *annotation* is removed from the image.
 
 Note: this information is not present in Docker image formats, so it is discarded when writing images in Docker formats.
 
@@ -335,9 +336,10 @@ Run up to N concurrent stages in parallel.  If the number of jobs is greater tha
 stdin will be read from /dev/null.  If 0 is specified, then there is
 no limit on the number of jobs that run in parallel.
 
-**--label** *label*
+**--label** *label[=value]*
 
 Add an image *label* (e.g. label=*value*) to the image metadata. Can be used multiple times.
+If *label* is named, but neither `=` nor a `value` is provided, then the *label* is removed from the image.
 
 Users can set a special LABEL **io.containers.capabilities=CAP1,CAP2,CAP3** in
 a Containerfile that specifies the list of Linux capabilities required for the

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -241,6 +241,14 @@ Set custom DNS options
 
 Set custom DNS search domains
 
+**--env** *env[=value]*
+
+Add a value (e.g. env=*value*) to the built image.  Can be used multiple times.
+If neither `=` nor a `*value*` are specified, but *env* is set in the current
+environment, the value from the current environment will be added to the image.
+To remove an environment variable from the built image, use the `--unsetenv`
+option.
+
 **--file**, **-f** *Containerfile*
 
 Specifies a Containerfile which contains instructions for building the image,
@@ -828,6 +836,12 @@ buildah build --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc .
 buildah build -f Containerfile.in -t imageName .
 
 buildah build --network mynet .
+
+buildah build --env LANG=en_US.UTF-8 -t imageName .
+
+buildah build --env EDITOR -t imageName .
+
+buildah build --unsetenv LANG -t imageName .
 
 ### Building an multi-architecture image using the --manifest option (requires emulation software)
 

--- a/docs/buildah-config.1.md
+++ b/docs/buildah-config.1.md
@@ -162,6 +162,26 @@ Set the target *operating system* for any images which will be built using
 the specified container.  By default, if the container was based on an image,
 its OS is kept, otherwise the host's OS's name is recorded.
 
+**--os-feature** *feature*
+
+Set the name of a required operating system *feature* for any images which will
+be built using the specified container.  By default, if the container was based
+on an image, the base image's required OS feature list is kept, if it specified
+one.  This option is typically only meaningful when the image's OS is Windows.
+
+If *feature* has a trailing `-`, then the *feature* is removed from the set of
+required features which will be listed in the image.  If the *feature* is set
+to "-" then the entire features list is removed from the config.
+
+**--os-version** *version*
+
+Set the exact required operating system *version* for any images which will be
+built using the specified container.  By default, if the container was based on
+an image, the base image's required OS version is kept, if it specified one.
+This option is typically only meaningful when the image's OS is Windows, and is
+typically set in Windows base images, so using this option is usually
+unnecessary.
+
 **--port**, **-p** *port*
 
 Add a *port* to expose when running containers based on any images which
@@ -234,6 +254,12 @@ buildah config --port 1234 --port 8080 containerID
 buildah config --env 1234=5678 containerID
 
 buildah config --env 1234- containerID
+
+buildah config --os-version 10.0.19042.1645 containerID
+
+buildah config --os-feature win32k containerID
+
+buildah config --os-feature win32k- containerID
 
 ## SEE ALSO
 buildah(1)

--- a/docs/buildah-config.1.md
+++ b/docs/buildah-config.1.md
@@ -77,10 +77,12 @@ ignore the `cmd` value of the container image.  However if you use the array
 form, then the cmd will be appended onto the end of the entrypoint cmd and be
 executed together.
 
-**--env**, **-e** *env=value*
+**--env**, **-e** *env[=value]*
 
 Add a value (e.g. env=*value*) to the environment for containers based on any
 images which will be built using the specified container. Can be used multiple times.
+If *env* is named but neither `=` nor a `value` is specified, then the value
+will be taken from the current process environment.
 If *env* has a trailing `-`, then the *env* is removed from the config.
 If the *env* is set to "-" then all environment variables are removed from the config.
 
@@ -228,6 +230,8 @@ buildah config --volume /usr/myvol containerID
 buildah config --volume /usr/myvol- containerID
 
 buildah config --port 1234 --port 8080 containerID
+
+buildah config --env 1234=5678 containerID
 
 buildah config --env 1234- containerID
 

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -134,6 +134,7 @@ type Executor struct {
 	processLabel            string // Shares processLabel of first stage container with containers of other stages in same build
 	mountLabel              string // Shares mountLabel of first stage container with containers of other stages in same build
 	buildOutput             string // Specifies instructions for any custom build output
+	envs                    []string
 }
 
 type imageTypeAndHistoryAndDiffIDs struct {
@@ -276,8 +277,9 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		secrets:                        secrets,
 		sshsources:                     sshsources,
 		logPrefix:                      logPrefix,
-		unsetEnvs:                      options.UnsetEnvs,
+		unsetEnvs:                      append([]string{}, options.UnsetEnvs...),
 		buildOutput:                    options.BuildOutput,
+		envs:                           append([]string{}, options.Envs...),
 	}
 	if exec.err == nil {
 		exec.err = os.Stderr

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -134,6 +134,8 @@ type Executor struct {
 	processLabel            string // Shares processLabel of first stage container with containers of other stages in same build
 	mountLabel              string // Shares mountLabel of first stage container with containers of other stages in same build
 	buildOutput             string // Specifies instructions for any custom build output
+	osVersion               string
+	osFeatures              []string
 	envs                    []string
 }
 
@@ -279,6 +281,8 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		logPrefix:                      logPrefix,
 		unsetEnvs:                      append([]string{}, options.UnsetEnvs...),
 		buildOutput:                    options.BuildOutput,
+		osVersion:                      options.OSVersion,
+		osFeatures:                     append([]string{}, options.OSFeatures...),
 		envs:                           append([]string{}, options.Envs...),
 	}
 	if exec.err == nil {

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1485,6 +1485,17 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	if s.executor.os != "" {
 		s.builder.SetOS(s.executor.os)
 	}
+	if s.executor.osVersion != "" {
+		s.builder.SetOSVersion(s.executor.osVersion)
+	}
+	for _, osFeatureSpec := range s.executor.osFeatures {
+		switch {
+		case strings.HasSuffix(osFeatureSpec, "-"):
+			s.builder.UnsetOSFeature(strings.TrimSuffix(osFeatureSpec, "-"))
+		default:
+			s.builder.SetOSFeature(osFeatureSpec)
+		}
+	}
 	s.builder.SetUser(config.User)
 	s.builder.ClearPorts()
 	for p := range config.ExposedPorts {

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1545,23 +1545,23 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	for k, v := range config.Labels {
 		s.builder.SetLabel(k, v)
 	}
+	if s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolUndefined || s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolTrue {
+		s.builder.SetLabel(buildah.BuilderIdentityAnnotation, define.Version)
+	}
 	for _, labelSpec := range s.executor.labels {
 		label := strings.SplitN(labelSpec, "=", 2)
 		if len(label) > 1 {
 			s.builder.SetLabel(label[0], label[1])
 		} else {
-			s.builder.SetLabel(label[0], "")
+			s.builder.UnsetLabel(label[0])
 		}
-	}
-	if s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolUndefined || s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolTrue {
-		s.builder.SetLabel(buildah.BuilderIdentityAnnotation, define.Version)
 	}
 	for _, annotationSpec := range s.executor.annotations {
 		annotation := strings.SplitN(annotationSpec, "=", 2)
 		if len(annotation) > 1 {
 			s.builder.SetAnnotation(annotation[0], annotation[1])
 		} else {
-			s.builder.SetAnnotation(annotation[0], "")
+			s.builder.UnsetAnnotation(annotation[0])
 		}
 	}
 	if imageRef != nil {

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -93,6 +93,8 @@ type BudResults struct {
 	RusageLogFile       string
 	UnsetEnvs           []string
 	Envs                []string
+	OSFeatures          []string
+	OSVersion           string
 }
 
 // FromAndBugResults represents the results for common flags
@@ -220,6 +222,8 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.BoolVar(&flags.NoHosts, "no-hosts", false, "Do not create the new containers /etc/hosts file, use the one from the current image.")
 	fs.BoolVar(&flags.NoCache, "no-cache", false, "Do not use existing cached images for the container build. Build from the start with a new set of cached layers.")
 	fs.String("os", runtime.GOOS, "set the OS to the provided value instead of the current operating system of the host")
+	fs.StringArrayVar(&flags.OSFeatures, "os-feature", []string{}, "set required OS `feature` for the target image in addition to values from the base image")
+	fs.StringVar(&flags.OSVersion, "os-version", "", "set required OS `version` for the target image instead of the value from the base image")
 	fs.StringVar(&flags.Pull, "pull", "true", "pull the image from the registry if newer or not present in store, if false, only pull the image if not present, if always, pull the image even if the named image is present in store, if never, only use the image present in store if available")
 	fs.Lookup("pull").NoOptDefVal = "true" //allow `--pull ` to be set to `true` as expected.
 	fs.BoolVar(&flags.PullAlways, "pull-always", false, "pull the image even if the named image is present in store")
@@ -275,6 +279,8 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["logfile"] = commonComp.AutocompleteDefault
 	flagCompletion["manifest"] = commonComp.AutocompleteDefault
 	flagCompletion["os"] = commonComp.AutocompleteNone
+	flagCompletion["os-feature"] = commonComp.AutocompleteNone
+	flagCompletion["os-version"] = commonComp.AutocompleteNone
 	flagCompletion["pull"] = commonComp.AutocompleteDefault
 	flagCompletion["runtime-flag"] = commonComp.AutocompleteNone
 	flagCompletion["secret"] = commonComp.AutocompleteNone

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -176,7 +176,7 @@ func GetNameSpaceFlagsCompletions() commonComp.FlagCompletions {
 // GetLayerFlags returns the common flags for layers
 func GetLayerFlags(flags *LayerResults) pflag.FlagSet {
 	fs := pflag.FlagSet{}
-	fs.BoolVar(&flags.ForceRm, "force-rm", false, "Always remove intermediate containers after a build, even if the build is unsuccessful.")
+	fs.BoolVar(&flags.ForceRm, "force-rm", false, "always remove intermediate containers after a build, even if the build is unsuccessful.")
 	fs.BoolVar(&flags.Layers, "layers", UseLayers(), "cache intermediate layers during build. Use BUILDAH_LAYERS environment variable to override.")
 	return fs
 }
@@ -188,15 +188,15 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs := pflag.FlagSet{}
 	fs.BoolVar(&flags.AllPlatforms, "all-platforms", false, "attempt to build for all base image platforms")
 	fs.String("arch", runtime.GOARCH, "set the ARCH of the image to the provided value instead of the architecture of the host")
-	fs.StringArrayVar(&flags.Annotation, "annotation", []string{}, "Set metadata for an image (default [])")
+	fs.StringArrayVar(&flags.Annotation, "annotation", []string{}, "set metadata for an image (default [])")
 	fs.StringVar(&flags.Authfile, "authfile", "", "path of the authentication file.")
 	fs.StringArrayVar(&flags.BuildArg, "build-arg", []string{}, "`argument=value` to supply to the builder")
-	fs.StringVar(&flags.CacheFrom, "cache-from", "", "Images to utilise as potential cache sources. The build process does not currently support caching so this is a NOOP.")
+	fs.StringVar(&flags.CacheFrom, "cache-from", "", "images to utilise as potential cache sources. The build process does not currently support caching so this is a NOOP.")
 	fs.StringVar(&flags.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
-	fs.BoolVar(&flags.Compress, "compress", false, "This is legacy option, which has no effect on the image")
+	fs.BoolVar(&flags.Compress, "compress", false, "this is a legacy option, which has no effect on the image")
 	fs.StringVar(&flags.Creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	fs.BoolVarP(&flags.DisableCompression, "disable-compression", "D", true, "don't compress layers by default")
-	fs.BoolVar(&flags.DisableContentTrust, "disable-content-trust", false, "This is a Docker specific option and is a NOOP")
+	fs.BoolVar(&flags.DisableContentTrust, "disable-content-trust", false, "this is a Docker specific option and is a NOOP")
 	fs.StringArrayVar(&flags.Envs, "env", []string{}, "set environment variable for the image")
 	fs.StringVar(&flags.From, "from", "", "image name used to replace the value in the first FROM instruction in the Containerfile")
 	fs.StringVar(&flags.IgnoreFile, "ignorefile", "", "path to an alternate .dockerignore file")
@@ -204,7 +204,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.Format, "format", DefaultFormat(), "`format` of the built image's manifest and metadata. Use BUILDAH_FORMAT environment variable to override.")
 	fs.StringVar(&flags.Iidfile, "iidfile", "", "`file` to write the image ID to")
 	fs.IntVar(&flags.Jobs, "jobs", 1, "how many stages to run in parallel")
-	fs.StringArrayVar(&flags.Label, "label", []string{}, "Set metadata for an image (default [])")
+	fs.StringArrayVar(&flags.Label, "label", []string{}, "set metadata for an image (default [])")
 	fs.StringVar(&flags.Logfile, "logfile", "", "log to `file` instead of stdout/stderr")
 	fs.Int("loglevel", 0, "NO LONGER USED, flag ignored, and hidden")
 	if err := fs.MarkHidden("loglevel"); err != nil {
@@ -219,8 +219,8 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 		panic(fmt.Sprintf("error marking the rusage-logfile flag as hidden: %v", err))
 	}
 	fs.StringVar(&flags.Manifest, "manifest", "", "add the image to the specified manifest list. Creates manifest list if it does not exist")
-	fs.BoolVar(&flags.NoHosts, "no-hosts", false, "Do not create the new containers /etc/hosts file, use the one from the current image.")
-	fs.BoolVar(&flags.NoCache, "no-cache", false, "Do not use existing cached images for the container build. Build from the start with a new set of cached layers.")
+	fs.BoolVar(&flags.NoHosts, "no-hosts", false, "do not create new /etc/hosts files for RUN instructions, use the one from the base image.")
+	fs.BoolVar(&flags.NoCache, "no-cache", false, "do not use existing cached images for the container build. Build from the start with a new set of cached layers.")
 	fs.String("os", runtime.GOOS, "set the OS to the provided value instead of the current operating system of the host")
 	fs.StringArrayVar(&flags.OSFeatures, "os-feature", []string{}, "set required OS `feature` for the target image in addition to values from the base image")
 	fs.StringVar(&flags.OSVersion, "os-version", "", "set required OS `version` for the target image instead of the value from the base image")
@@ -236,7 +236,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	}
 	fs.BoolVarP(&flags.Quiet, "quiet", "q", false, "refrain from announcing build instructions and image read/write progress")
 	fs.BoolVar(&flags.IdentityLabel, "identity-label", true, "add default identity label (default true)")
-	fs.BoolVar(&flags.Rm, "rm", true, "Remove intermediate containers after a successful build")
+	fs.BoolVar(&flags.Rm, "rm", true, "remove intermediate containers after a successful build")
 	// "runtime" definition moved to avoid name collision in podman build.  Defined in cmd/buildah/build.go.
 	fs.StringSliceVar(&flags.RuntimeFlags, "runtime-flag", []string{}, "add global flags for the container runtime")
 	fs.StringArrayVar(&flags.Secrets, "secret", []string{}, "secret file to expose to the build")
@@ -254,7 +254,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.Int64Var(&flags.Timestamp, "timestamp", 0, "set created timestamp to the specified epoch seconds to allow for deterministic builds, defaults to current time")
 	fs.BoolVar(&flags.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	fs.String("variant", "", "override the `variant` of the specified image")
-	fs.StringSliceVar(&flags.UnsetEnvs, "unsetenv", nil, "Unset environment variable from final image")
+	fs.StringSliceVar(&flags.UnsetEnvs, "unsetenv", nil, "unset environment variable from final image")
 	return fs
 }
 
@@ -318,10 +318,10 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 	fs.StringVar(&flags.CPUSetCPUs, "cpuset-cpus", "", "CPUs in which to allow execution (0-3, 0,1)")
 	fs.StringVar(&flags.CPUSetMems, "cpuset-mems", "", "memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.")
 	fs.StringSliceVar(&flags.DecryptionKeys, "decryption-key", nil, "key needed to decrypt the image")
-	fs.StringArrayVar(&flags.Devices, "device", defaultContainerConfig.Containers.Devices, "Additional devices to be used within containers (default [])")
-	fs.StringSliceVar(&flags.DNSSearch, "dns-search", defaultContainerConfig.Containers.DNSSearches, "Set custom DNS search domains")
-	fs.StringSliceVar(&flags.DNSServers, "dns", defaultContainerConfig.Containers.DNSServers, "Set custom DNS servers or disable it completely by setting it to 'none', which prevents the automatic creation of `/etc/resolv.conf`.")
-	fs.StringSliceVar(&flags.DNSOptions, "dns-option", defaultContainerConfig.Containers.DNSOptions, "Set custom DNS options")
+	fs.StringArrayVar(&flags.Devices, "device", defaultContainerConfig.Containers.Devices, "additional devices to be used within containers (default [])")
+	fs.StringSliceVar(&flags.DNSSearch, "dns-search", defaultContainerConfig.Containers.DNSSearches, "set custom DNS search domains")
+	fs.StringSliceVar(&flags.DNSServers, "dns", defaultContainerConfig.Containers.DNSServers, "set custom DNS servers or disable it completely by setting it to 'none', which prevents the automatic creation of `/etc/resolv.conf`.")
+	fs.StringSliceVar(&flags.DNSOptions, "dns-option", defaultContainerConfig.Containers.DNSOptions, "set custom DNS options")
 	fs.BoolVar(&flags.HTTPProxy, "http-proxy", true, "pass through HTTP Proxy environment variables")
 	fs.StringVar(&flags.Isolation, "isolation", DefaultIsolation(), "`type` of process isolation to use. Use BUILDAH_ISOLATION environment variable to override.")
 	fs.StringVarP(&flags.Memory, "memory", "m", "", "memory limit (format: <number>[<unit>], where unit = b, k, m or g)")

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -92,6 +92,7 @@ type BudResults struct {
 	LogRusage           bool
 	RusageLogFile       string
 	UnsetEnvs           []string
+	Envs                []string
 }
 
 // FromAndBugResults represents the results for common flags
@@ -194,6 +195,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.Creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	fs.BoolVarP(&flags.DisableCompression, "disable-compression", "D", true, "don't compress layers by default")
 	fs.BoolVar(&flags.DisableContentTrust, "disable-content-trust", false, "This is a Docker specific option and is a NOOP")
+	fs.StringArrayVar(&flags.Envs, "env", []string{}, "set environment variable for the image")
 	fs.StringVar(&flags.From, "from", "", "image name used to replace the value in the first FROM instruction in the Containerfile")
 	fs.StringVar(&flags.IgnoreFile, "ignorefile", "", "path to an alternate .dockerignore file")
 	fs.StringSliceVarP(&flags.File, "file", "f", []string{}, "`pathname or URL` of a Dockerfile")
@@ -262,6 +264,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["cache-from"] = commonComp.AutocompleteNone
 	flagCompletion["cert-dir"] = commonComp.AutocompleteDefault
 	flagCompletion["creds"] = commonComp.AutocompleteNone
+	flagCompletion["env"] = commonComp.AutocompleteNone
 	flagCompletion["file"] = commonComp.AutocompleteDefault
 	flagCompletion["from"] = commonComp.AutocompleteDefault
 	flagCompletion["format"] = commonComp.AutocompleteNone

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2608,6 +2608,32 @@ EOM
   expect_output windows
 }
 
+@test "bud with custom os-version" {
+  run_buildah build $WITH_POLICY_JSON \
+    -f $BUDFILES/from-scratch/Containerfile \
+    -t os-version-test \
+    --os-version=1.0
+
+  run_buildah inspect --format "{{ .Docker.OSVersion }}" os-version-test
+  expect_output 1.0
+
+  run_buildah inspect --format "{{ .OCIv1.OSVersion }}" os-version-test
+  expect_output 1.0
+}
+
+@test "bud with custom os-features" {
+  run_buildah build $WITH_POLICY_JSON \
+    -f $BUDFILES/from-scratch/Containerfile \
+    -t os-features-test \
+    --os-feature removed --os-feature removed- --os-feature win32k
+
+  run_buildah inspect --format "{{ .Docker.OSFeatures }}" os-features-test
+  expect_output '[win32k]'
+
+  run_buildah inspect --format "{{ .OCIv1.OSFeatures }}" os-features-test
+  expect_output '[win32k]'
+}
+
 @test "bud with custom platform" {
   run_buildah build $WITH_POLICY_JSON \
     -f $BUDFILES/from-scratch/Containerfile \

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -716,14 +716,20 @@ _EOF
   run_buildah build --label "test=label" $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output "$want_output"
+
+  want_output='map["io.buildah.version":"'$buildah_version'"]'
+  run_buildah build --label "test=label" --label test $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
+  run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
+  expect_output "$want_output"
+
+  want_output='map[]'
+  run_buildah build --label io.buildah.version $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
+  run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
+  expect_output "$want_output"
 }
 
 @test "bud-from-scratch-override-version-label" {
-  run_buildah --version
-  local -a output_fields=($output)
-  buildah_version=${output_fields[2]}
-  want_output='map["io.buildah.version":"'$buildah_version'"]'
-
+  want_output='map["io.buildah.version":"oldversion"]'
   target=scratch-image
   run_buildah build --label "io.buildah.version=oldversion" $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
@@ -742,6 +748,9 @@ _EOF
   run_buildah build --annotation "test=annotation1,annotation2=z" $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   run_buildah inspect --format '{{index .ImageAnnotations "test"}}' ${target}
   expect_output "annotation1,annotation2=z"
+  run_buildah build --annotation "test=annotation1,annotation2=z" --annotation test $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
+  run_buildah inspect --format '{{index .ImageAnnotations "test"}}' ${target}
+  expect_output ""
 }
 
 @test "bud-from-scratch-layers" {

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -221,6 +221,8 @@ function check_matrix() {
    --healthcheck-timeout 7s \
    --healthcheck-retries 8 \
    --onbuild "RUN touch /foo" \
+   --os-version "1.0" \
+   --os-feature dynamic --os-feature - --os-feature removed --os-feature removed- --os-feature win32k \
   $cid
 
   run_buildah commit --format docker $WITH_POLICY_JSON $cid scratch-image-docker
@@ -230,6 +232,8 @@ function check_matrix() {
   check_matrix 'Architecture' 'amd64'
   check_matrix 'OS'           'linux'
   check_matrix 'Variant'      'abc'
+  check_matrix 'OSVersion'    '1.0'
+  check_matrix 'OSFeatures'   '[win32k]'
 
   run_buildah inspect --format '{{.ImageCreatedBy}}' $cid
   expect_output "COINCIDENCE"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Teach `buildah build` and `buildah config` about the OS version and features fields.  We don't tend to use them on Linux, but they're in the OCI and Docker config structures, so we need to be able to preserve and manipulate their values, much as we do for variant information.

Add a `--env` option to `buildah build` that functions similarly to the `buildah config --env` option, to complement `buildah build`'s `--unsetenv` option.

Document that `buildah config`'s `--env` function fetches the current value for a variable when the name is supplied, but no `=` or value follows it.

Allow the value of the `io.buildah.version` label to be manually specified on the `buildah build` command line if someone really wants to override the value that we would otherwise set by default.

Any `buildah.BuilderOptions.DefaultEnv` values have been ignored since the library was changed to read them from the server-side configuration, for the sake of podman remote builds, as part of #2131.  Update its godoc to note that and stop setting it.

Tweak the usage text for various CLI options to be more consistent about case.

#### How to verify it

New integration tests for `--os-version`, `--os-features`, and `--env`!
The same integration tests for `--unsetenv`!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The `buildah build` command now includes a `--env` option to complement its `--unsetenv` option.
The default value of the `io.buildah.version` label can now be overridden at the `buildah build` command line using the `--label` option.
The `buildah build` and `buildah config` commands now accept `--os-version` and `--os-feature` flags for setting the corresponding fields in an image's configuration. 
```

