### PR TITLE
buildah: deep copy `options.Args` before performing concurrent `build/stage`

### DIFF
--- a/new.go
+++ b/new.go
@@ -317,7 +317,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		Capabilities:     copyStringSlice(options.Capabilities),
 		CommonBuildOpts:  options.CommonBuildOpts,
 		TopLayer:         topLayer,
-		Args:             options.Args,
+		Args:             copyStringStringMap(options.Args),
 		Format:           options.Format,
 		TempVolumes:      map[string]bool{},
 		Devices:          options.Devices,


### PR DESCRIPTION
Prevent fatal concurrent read/write over options.Args by concurrent
multi-arch builds and concurrent stages

[NO TESTS NEEDED]
[NO NEW TESTS NEEDED]

Fixes: report https://github.com/containers/buildah/pull/3899#issuecomment-1116293655