### PR TITLE
Make `buildah build --label foo` create an empty "foo" label again

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -41,7 +41,7 @@ Instead of building for a set of platforms specified using the **--platform** op
 **--annotation** *annotation[=value]*
 
 Add an image *annotation* (e.g. annotation=*value*) to the image metadata. Can be used multiple times.
-If *annotation* is named, but neither `=` nor a `value` is provided, then the *annotation* is removed from the image.
+If *annotation* is named, but neither `=` nor a `value` is provided, then the *annotation* is set to an empty value.
 
 Note: this information is not present in Docker image formats, so it is discarded when writing images in Docker formats.
 
@@ -339,7 +339,7 @@ no limit on the number of jobs that run in parallel.
 **--label** *label[=value]*
 
 Add an image *label* (e.g. label=*value*) to the image metadata. Can be used multiple times.
-If *label* is named, but neither `=` nor a `value` is provided, then the *label* is removed from the image.
+If *label* is named, but neither `=` nor a `value` is provided, then the *label* is set to an empty value.
 
 Users can set a special LABEL **io.containers.capabilities=CAP1,CAP2,CAP3** in
 a Containerfile that specifies the list of Linux capabilities required for the

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1564,7 +1564,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		if len(label) > 1 {
 			s.builder.SetLabel(label[0], label[1])
 		} else {
-			s.builder.UnsetLabel(label[0])
+			s.builder.SetLabel(label[0], "")
 		}
 	}
 	for _, annotationSpec := range s.executor.annotations {
@@ -1572,7 +1572,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		if len(annotation) > 1 {
 			s.builder.SetAnnotation(annotation[0], annotation[1])
 		} else {
-			s.builder.UnsetAnnotation(annotation[0])
+			s.builder.SetAnnotation(annotation[0], "")
 		}
 	}
 	if imageRef != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -717,13 +717,8 @@ _EOF
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output "$want_output"
 
-  want_output='map["io.buildah.version":"'$buildah_version'"]'
-  run_buildah build --label "test=label" --label test $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
-  run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
-  expect_output "$want_output"
-
-  want_output='map[]'
-  run_buildah build --label io.buildah.version $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
+  want_output='map["io.buildah.version":"'$buildah_version'" "test":""]'
+  run_buildah build --label test $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
   expect_output "$want_output"
 }
@@ -748,9 +743,6 @@ _EOF
   run_buildah build --annotation "test=annotation1,annotation2=z" $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
   run_buildah inspect --format '{{index .ImageAnnotations "test"}}' ${target}
   expect_output "annotation1,annotation2=z"
-  run_buildah build --annotation "test=annotation1,annotation2=z" --annotation test $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
-  run_buildah inspect --format '{{index .ImageAnnotations "test"}}' ${target}
-  expect_output ""
 }
 
 @test "bud-from-scratch-layers" {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Restore podman's CLI compatibility with `docker build` by making its `--label` and `--annotate` options set empty labels and annotations when they're given a name but no `=` or value.

#### How to verify it

Updated integration test!

#### Which issue(s) this PR fixes:

Test failures in https://github.com/containers/podman/pull/14118, h/t @flouthoc.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```