### PR TITLE
Add --cpp-flag flag to buildah build

### DIFF
--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -351,6 +351,7 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 		Compression:             compression,
 		ConfigureNetwork:        networkPolicy,
 		ContextDirectory:        contextDir,
+		CPPFlags:                iopts.CPPFlags,
 		DefaultMountsFilePath:   globalFlagResults.DefaultMountsFile,
 		Devices:                 iopts.Devices,
 		DropCapabilities:        iopts.CapDrop,

--- a/define/build.go
+++ b/define/build.go
@@ -187,6 +187,8 @@ type BuildOptions struct {
 	DropCapabilities []string
 	// CommonBuildOpts is *required*.
 	CommonBuildOpts *CommonBuildOptions
+	// CPPFlags are additional arguments to pass to the C Preprocessor (cpp).
+	CPPFlags []string
 	// DefaultMountsFilePath is the file path holding the mounts to be mounted in "host-path:container-path" format
 	DefaultMountsFilePath string
 	// IIDFile tells the builder to write the image ID to the specified file

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -114,6 +114,13 @@ This option is added to be aligned with other containers CLIs.
 Buildah doesn't send a copy of the context directory to a daemon or a remote server.
 Thus, compressing the data before sending it is irrelevant to Buildah.
 
+**--cpp-flag**=""
+
+Set additional flags to pass to the C Preprocessor cpp(1).
+Containerfiles ending with a ".in" suffix will be preprocessed via cpp(1). This option can be used to pass additional flags to cpp.
+Note: You can also set default CPPFLAGS by setting the BUILDAH\_CPPFLAGS
+environment variable (e.g., `export BUILDAH_CPPFLAGS="-DDEBUG"`).
+
 **--cpu-period**=*0*
 
 Set the CPU period for the Completely Fair Scheduler (CFS), which is a
@@ -853,7 +860,7 @@ buildah build --no-cache --rm=false -t imageName .
 
 buildah build --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc .
 
-buildah build -f Containerfile.in -t imageName .
+buildah build -f Containerfile.in --cpp-flag="-DDEBUG" -t imageName .
 
 buildah build --network mynet .
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -57,6 +57,7 @@ type BudResults struct {
 	CertDir             string
 	Compress            bool
 	Creds               string
+	CPPFlags            []string
 	DisableCompression  bool
 	DisableContentTrust bool
 	IgnoreFile          string
@@ -194,6 +195,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.CacheFrom, "cache-from", "", "images to utilise as potential cache sources. The build process does not currently support caching so this is a NOOP.")
 	fs.StringVar(&flags.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	fs.BoolVar(&flags.Compress, "compress", false, "this is a legacy option, which has no effect on the image")
+	fs.StringArrayVar(&flags.CPPFlags, "cpp-flag", []string{}, "set additional flag to pass to C preprocessor (cpp)")
 	fs.StringVar(&flags.Creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	fs.BoolVarP(&flags.DisableCompression, "disable-compression", "D", true, "don't compress layers by default")
 	fs.BoolVar(&flags.DisableContentTrust, "disable-content-trust", false, "this is a Docker specific option and is a NOOP")
@@ -261,17 +263,18 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 // GetBudFlagsCompletions returns the FlagCompletions for the common build flags
 func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion := commonComp.FlagCompletions{}
-	flagCompletion["arch"] = commonComp.AutocompleteNone
 	flagCompletion["annotation"] = commonComp.AutocompleteNone
+	flagCompletion["arch"] = commonComp.AutocompleteNone
 	flagCompletion["authfile"] = commonComp.AutocompleteDefault
 	flagCompletion["build-arg"] = commonComp.AutocompleteNone
 	flagCompletion["cache-from"] = commonComp.AutocompleteNone
 	flagCompletion["cert-dir"] = commonComp.AutocompleteDefault
+	flagCompletion["cpp-flag"] = commonComp.AutocompleteNone
 	flagCompletion["creds"] = commonComp.AutocompleteNone
 	flagCompletion["env"] = commonComp.AutocompleteNone
 	flagCompletion["file"] = commonComp.AutocompleteDefault
-	flagCompletion["from"] = commonComp.AutocompleteDefault
 	flagCompletion["format"] = commonComp.AutocompleteNone
+	flagCompletion["from"] = commonComp.AutocompleteDefault
 	flagCompletion["ignorefile"] = commonComp.AutocompleteDefault
 	flagCompletion["iidfile"] = commonComp.AutocompleteDefault
 	flagCompletion["jobs"] = commonComp.AutocompleteNone
@@ -281,18 +284,18 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["os"] = commonComp.AutocompleteNone
 	flagCompletion["os-feature"] = commonComp.AutocompleteNone
 	flagCompletion["os-version"] = commonComp.AutocompleteNone
+	flagCompletion["output"] = commonComp.AutocompleteNone
 	flagCompletion["pull"] = commonComp.AutocompleteDefault
 	flagCompletion["runtime-flag"] = commonComp.AutocompleteNone
 	flagCompletion["secret"] = commonComp.AutocompleteNone
-	flagCompletion["ssh"] = commonComp.AutocompleteNone
 	flagCompletion["sign-by"] = commonComp.AutocompleteNone
 	flagCompletion["signature-policy"] = commonComp.AutocompleteNone
+	flagCompletion["ssh"] = commonComp.AutocompleteNone
 	flagCompletion["tag"] = commonComp.AutocompleteNone
 	flagCompletion["target"] = commonComp.AutocompleteNone
 	flagCompletion["timestamp"] = commonComp.AutocompleteNone
-	flagCompletion["variant"] = commonComp.AutocompleteNone
 	flagCompletion["unsetenv"] = commonComp.AutocompleteNone
-	flagCompletion["output"] = commonComp.AutocompleteNone
+	flagCompletion["variant"] = commonComp.AutocompleteNone
 	return flagCompletion
 }
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2388,6 +2388,18 @@ _EOF
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
   expect_output --substring "success"
+  expect_output --substring "debug=no"
+  run_buildah build $WITH_POLICY_JSON -t ${target} --cpp-flag "-DDEBUG" -f $BUDFILES/containerfile/Containerfile.in $BUDFILES/containerfile
+  [ "${status}" -eq 0 ]
+  expect_output --substring "FROM alpine"
+  expect_output --substring "success"
+  expect_output --substring "debug=yes"
+
+  BUILDAH_CPPFLAGS="-DDEBUG" run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/containerfile/Containerfile.in $BUDFILES/containerfile
+  [ "${status}" -eq 0 ]
+  expect_output --substring "FROM alpine"
+  expect_output --substring "success"
+  expect_output --substring "debug=yes"
 }
 
 @test "bud with Dockerfile" {

--- a/tests/bud/containerfile/Containerfile.in
+++ b/tests/bud/containerfile/Containerfile.in
@@ -1,2 +1,7 @@
 # include "Containerfile"
 RUN echo "success"
+#if DEBUG
+RUN echo "debug=yes"
+# else
+RUN echo "debug=no"
+#endif


### PR DESCRIPTION
Allow users to pass in CPP flags to the C Preprocessor.

Fixes: https://github.com/containers/buildah/issues/3816

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

