### PR TITLE
test helpers: default to being rootless-aware

### DIFF
--- a/tests/copy/copy.go
+++ b/tests/copy/copy.go
@@ -38,6 +38,11 @@ func main() {
 
 	unshare.MaybeReexecUsingUserNamespace(false)
 
+	storeOptions, err := storage.DefaultStoreOptionsAutoDetectUID()
+	if err != nil {
+		storeOptions = storage.StoreOptions{}
+	}
+
 	rootCmd := &cobra.Command{
 		Use:  "copy [flags] source destination",
 		Long: "copies an image",

--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/unshare"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -25,11 +26,16 @@ func main() {
 	if buildah.InitReexec() {
 		return
 	}
+	unshare.MaybeReexecUsingUserNamespace(false)
+
+	storeOptions, err := storage.DefaultStoreOptionsAutoDetectUID()
+	if err != nil {
+		storeOptions = storage.StoreOptions{}
+	}
 
 	expectedManifestType := ""
 	expectedConfigType := ""
 
-	storeOptions, _ := storage.DefaultStoreOptions(false, 0)
 	debug := flag.Bool("debug", false, "turn on debug logging")
 	root := flag.String("root", storeOptions.GraphRoot, "storage root directory")
 	runroot := flag.String("runroot", storeOptions.RunRoot, "storage runtime directory")


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Make `tests/copy/copy.go` and `tests/imgtype/imgtype.go` aware of rootless defaults, and have them re-exec themselves in user namespaces if they're run in such an environment.  This will make it easier to use `imgtype` to read manifest lists from registries in tests.

#### How to verify it

Current tests should not be impacted.
`imgtype -show-manifest -expected-manifest-type '*' ...` should now have no trouble reading manifest lists from remote registries. 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```