### PR TITLE
run: allow re-using secret artifact from host in new `RUN` steps.

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -2688,10 +2688,6 @@ func getSecretMount(tokens []string, secrets map[string]define.Secret, mountlabe
 			return nil, "", err
 		}
 		ctrFileOnHost = filepath.Join(containerWorkingDir, "secrets", id)
-		_, err = os.Stat(ctrFileOnHost)
-		if !os.IsNotExist(err) {
-			return nil, "", err
-		}
 	default:
 		return nil, "", errors.New("invalid source secret type")
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3682,6 +3682,27 @@ _EOF
   run_buildah rm -a
 }
 
+@test "bud with containerfile secret and secret is accessed twice and build should be successful" {
+  _prefetch alpine
+  mytmpdir=${TEST_SCRATCH_DIR}/my-dir1
+  mkdir -p ${mytmpdir}
+  cat > $mytmpdir/mysecret << _EOF
+SOMESECRETDATA
+_EOF
+
+  cat > $mytmpdir/Dockerfile << _EOF
+FROM alpine
+
+RUN --mount=type=secret,id=mysecret,dst=/home/root/mysecret cat /home/root/mysecret
+
+RUN --mount=type=secret,id=mysecret,dst=/home/root/mysecret2 echo hello && cat /home/root/mysecret2
+_EOF
+
+  run_buildah build --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretimg -f ${mytmpdir}
+  expect_output --substring "hello"
+  expect_output --substring "SOMESECRETDATA"
+}
+
 @test "bud with containerfile secret accessed on second RUN" {
   _prefetch alpine
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir1


### PR DESCRIPTION
If a secret is used in a `RUN` step it is created on host but we had a
check which expects a secret to not exist on the host however same
secret can be remounted on another step so it can already exists on host
so remove the check since a secret can be mounted again from host in
another `RUN` step.

Closes: https://github.com/containers/buildah/issues/3993

