### PR TITLE
buildah source pull/push: show progress bar

### DIFF
--- a/cmd/buildah/source.go
+++ b/cmd/buildah/source.go
@@ -113,13 +113,15 @@ func init() {
 	sourcePullCommand.SetUsageTemplate(UsageTemplate())
 	sourceCommand.AddCommand(sourcePullCommand)
 	sourcePullFlags := sourcePullCommand.Flags()
-	sourcePullFlags.BoolVar(&sourcePullOptions.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	sourcePullFlags.StringVar(&sourcePullOptions.Credentials, "creds", "", "use `[username[:password]]` for accessing the registry")
+	sourcePullFlags.BoolVar(&sourcePullOptions.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
+	sourcePullFlags.BoolVarP(&sourcePullOptions.Quiet, "quiet", "q", false, "don't output pull progress information")
 
 	// buildah source push
 	sourcePushCommand.SetUsageTemplate(UsageTemplate())
 	sourceCommand.AddCommand(sourcePushCommand)
 	sourcePushFlags := sourcePushCommand.Flags()
-	sourcePushFlags.BoolVar(&sourcePushOptions.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	sourcePushFlags.StringVar(&sourcePushOptions.Credentials, "creds", "", "use `[username[:password]]` for accessing the registry")
+	sourcePushFlags.BoolVar(&sourcePushOptions.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
+	sourcePushFlags.BoolVarP(&sourcePushOptions.Quiet, "quiet", "q", false, "don't output push progress information")
 }

--- a/docs/buildah-source-pull.1.md
+++ b/docs/buildah-source-pull.1.md
@@ -21,6 +21,10 @@ The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
 
+**--quiet**, **-q**
+
+Suppress the progress output when pushing a source image.
+
 **--tls-verify** *bool-value*
 
 Require HTTPS and verification of certificates when talking to container

--- a/docs/buildah-source-push.1.md
+++ b/docs/buildah-source-push.1.md
@@ -20,6 +20,10 @@ The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
 
+**--quiet**, **-q**
+
+Suppress the progress output when pushing a source image.
+
 **--tls-verify** *bool-value*
 
 Require HTTPS and verification of certificates when talking to container

--- a/internal/source/pull.go
+++ b/internal/source/pull.go
@@ -20,6 +20,8 @@ type PullOptions struct {
 	TLSVerify bool
 	// [username[:password] to use when connecting to the registry.
 	Credentials string
+	// Quiet the progess bars when pushing.
+	Quiet bool
 }
 
 // Pull `imageInput` from a container registry to `sourcePath`.
@@ -64,6 +66,9 @@ func Pull(ctx context.Context, imageInput string, sourcePath string, options Pul
 
 	copyOpts := copy.Options{
 		SourceCtx: sysCtx,
+	}
+	if !options.Quiet {
+		copyOpts.ReportWriter = os.Stderr
 	}
 	if _, err := copy.Image(ctx, policyContext, ociDest.Reference(), srcRef, &copyOpts); err != nil {
 		return errors.Wrap(err, "error pulling source image")

--- a/internal/source/push.go
+++ b/internal/source/push.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"context"
+	"os"
 
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/image/v5/copy"
@@ -17,6 +18,8 @@ type PushOptions struct {
 	TLSVerify bool
 	// [username[:password] to use when connecting to the registry.
 	Credentials string
+	// Quiet the progess bars when pushing.
+	Quiet bool
 }
 
 // Push the source image at `sourcePath` to `imageInput` at a container
@@ -54,6 +57,9 @@ func Push(ctx context.Context, sourcePath string, imageInput string, options Pus
 
 	copyOpts := &copy.Options{
 		DestinationCtx: sysCtx,
+	}
+	if !options.Quiet {
+		copyOpts.ReportWriter = os.Stderr
 	}
 	if _, err := copy.Image(ctx, policyContext, destRef, ociSource.Reference(), copyOpts); err != nil {
 		return errors.Wrap(err, "error pushing source image")

--- a/tests/source.bats
+++ b/tests/source.bats
@@ -126,11 +126,26 @@ load helpers
 
   start_registry
 
+  # --quiet=true
+  run_buildah source push --quiet --tls-verify=false --creds testuser:testpassword $srcdir localhost:${REGISTRY_PORT}/source:test
+  expect_output ""
+  # --quiet=false (implicit)
   run_buildah source push --tls-verify=false --creds testuser:testpassword $srcdir localhost:${REGISTRY_PORT}/source:test
+  expect_output --substring "Copying blob"
+  expect_output --substring "Copying config"
 
   pulldir=${TEST_SCRATCH_DIR}/pulledsource
+  # --quiet=true
+  run_buildah source pull --quiet --tls-verify=false --creds testuser:testpassword localhost:${REGISTRY_PORT}/source:test $pulldir
+  expect_output ""
+  # --quiet=false (implicit)
+  rm -rf $pulldir
   run_buildah source pull --tls-verify=false --creds testuser:testpassword localhost:${REGISTRY_PORT}/source:test $pulldir
+  expect_output --substring "Copying blob"
+  expect_output --substring "Copying config"
 
   run diff -r $srcdir $pulldir
   [ "$status" -eq 0 ]
+
+  stop_registry
 }


### PR DESCRIPTION
Render the progress bar on stdout by default.  Add a --quiet/-q option
to re-silence if desired.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

@rhatdan PTAL