### PR TITLE
`ADD|COPY` option `--keep-ownership` 

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -21,6 +21,7 @@ type addCopyResults struct {
 	addHistory       bool
 	chmod            string
 	chown            string
+	keepOwnership    bool
 	quiet            bool
 	ignoreFile       string
 	contextdir       string
@@ -66,6 +67,7 @@ func applyFlagVars(flags *pflag.FlagSet, opts *addCopyResults) {
 	}
 	flags.StringVar(&opts.chown, "chown", "", "set the user and group ownership of the destination content")
 	flags.StringVar(&opts.chmod, "chmod", "", "set the access permissions of the destination content")
+	flags.BoolVar(&opts.keepOwnership, "keep-ownership", false, "preserve user and group ownership of source content (only for local files)")
 	flags.StringVar(&opts.creds, "creds", "", "use `[username[:password]]` for accessing registries when pulling images")
 	if err := flags.MarkHidden("creds"); err != nil {
 		panic(fmt.Sprintf("error marking creds as hidden: %v", err))
@@ -222,10 +224,11 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 	builder.ContentDigester.Restart()
 
 	options := buildah.AddAndCopyOptions{
-		Chmod:            iopts.chmod,
-		Chown:            iopts.chown,
-		ContextDir:       contextdir,
-		IDMappingOptions: idMappingOptions,
+		Chmod:             iopts.chmod,
+		Chown:             iopts.chown,
+		ContextDir:        contextdir,
+		IDMappingOptions:  idMappingOptions,
+		PreserveOwnership: iopts.keepOwnership,
 	}
 	if iopts.contextdir != "" {
 		var excludes []string

--- a/docs/buildah-add.1.md
+++ b/docs/buildah-add.1.md
@@ -48,6 +48,10 @@ can be used.
 
 Path to an alternative .containerignore (.dockerignore) file. Requires \-\-contextdir be specified.
 
+**--keep-ownership**
+
+Preserve user and group ownership of source content (only for local files).
+
 **--quiet**, **-q**
 
 Refrain from printing a digest of the added content.

--- a/docs/buildah-copy.1.md
+++ b/docs/buildah-copy.1.md
@@ -46,6 +46,10 @@ can be used.
 
 Path to an alternative .containerignore (.dockerignore) file. Requires \-\-contextdir be specified.
 
+**--keep-ownership**
+
+Preserve user and group ownership of source content (only for local files).
+
 **--quiet**, **-q**
 
 Refrain from printing a digest of the copied content.

--- a/go.mod
+++ b/go.mod
@@ -45,3 +45,5 @@ require (
 replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.4.2
 
 replace github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.2-0.20211123152302-43a7dee1ec31
+
+replace github.com/openshift/imagebuilder => github.com/Dexus-Forks/imagebuilder v1.2.4-0.20220518131701-b5c6586df000

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Dexus-Forks/imagebuilder v1.2.4-0.20220518131701-b5c6586df000 h1:FGZ4sW9yTcq1Qkin/3mk95PXQXclLImD14Ro8LZb/n8=
+github.com/Dexus-Forks/imagebuilder v1.2.4-0.20220518131701-b5c6586df000/go.mod h1:TRYHe4CH9U6nkDjxjBNM5klrLbJBrRbpJE5SaRwUBsQ=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
@@ -796,8 +798,6 @@ github.com/opencontainers/selinux v1.8.5/go.mod h1:HTvjPFoGMbpQsG886e3lQwnsRWtE4
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opencontainers/selinux v1.10.1 h1:09LIPVRP3uuZGQvgR+SgMSNBd1Eb3vlRbGqQpoHsF8w=
 github.com/opencontainers/selinux v1.10.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/openshift/imagebuilder v1.2.4-0.20220502172744-009dbc6cb805 h1:bfLqBGqF04GAoqbMkSrd5VPk/t66OnP0bTTisMaF4ro=
-github.com/openshift/imagebuilder v1.2.4-0.20220502172744-009dbc6cb805/go.mod h1:TRYHe4CH9U6nkDjxjBNM5klrLbJBrRbpJE5SaRwUBsQ=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -360,7 +360,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 		var copyExcludes []string
 		stripSetuid := false
 		stripSetgid := false
-		preserveOwnership := false
+		preserveOwnership := copy.PreserveOwnership
 		contextDir := s.executor.contextDir
 		if len(copy.From) > 0 {
 			// If from has an argument within it, resolve it to its
@@ -1011,10 +1011,10 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			command := strings.ToUpper(step.Command)
 			// chmod, chown and from flags should have an '=' sign, '--chmod=', '--chown=' or '--from='
 			if command == "COPY" && (flag == "--chmod" || flag == "--chown" || flag == "--from") {
-				return "", nil, errors.Errorf("COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image|stage> flags")
+				return "", nil, errors.Errorf("COPY only supports the --chmod, --chown, --from, and --keep-ownership flags")
 			}
 			if command == "ADD" && (flag == "--chmod" || flag == "--chown") {
-				return "", nil, errors.Errorf("ADD only supports the --chmod=<permissions> and the --chown=<uid:gid> flags")
+				return "", nil, errors.Errorf("ADD only supports the --chmod, --chown, and --keep-ownership flags")
 			}
 			if strings.Contains(flag, "--from") && command == "COPY" {
 				arr := strings.Split(flag, "=")

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -281,3 +281,19 @@ stuff/mystuff"
   cmp $ubuntu/etc/passwd ${croot}/tmp/passwd
   cmp $ubuntu/etc/passwd ${croot}/tmp/passwd2
 }
+
+@test "add with --keep-ownership" {
+  skip_if_rootless_environment
+  skip_if_rootless
+
+  _prefetch busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
+  cid=$output
+  mytmpdir=${TEST_SCRATCH_DIR}/keep-ownership
+  mkdir -p "${mytmpdir}"
+  touch "${mytmpdir}/file4.txt"
+  chown 321:888 "${mytmpdir}/file4.txt"
+  run_buildah add --keep-ownership $cid "${mytmpdir}/file4.txt" /newfile_321_888
+  run_buildah run $cid stat -c "%u:%g" /newfile_321_888
+  expect_output "321:888" "stat ug /newfile_321_888"
+}

--- a/tests/bud/copy-from-keep-ownership/Dockerfile
+++ b/tests/bud/copy-from-keep-ownership/Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox AS basis
+RUN echo hello > /newfile && chown 123:456 /newfile
+FROM basis
+COPY --keep-ownership --from=basis /newfile /newfile_123_456
+RUN stat -c "%u:%g" /newfile_123_456

--- a/tests/bud/copy-from-keep-ownership/Dockerfile2
+++ b/tests/bud/copy-from-keep-ownership/Dockerfile2
@@ -1,0 +1,3 @@
+FROM busybox
+COPY --keep-ownership file2.txt /newfile_321_999
+RUN stat -c "%u:%g" /newfile_321_999

--- a/tests/bud/copy-from-keep-ownership/Dockerfile3
+++ b/tests/bud/copy-from-keep-ownership/Dockerfile3
@@ -1,0 +1,3 @@
+FROM busybox
+ADD --keep-ownership file3.txt /newfile_321_998
+RUN stat -c "%u:%g" /newfile_321_998

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -494,3 +494,19 @@ stuff/mystuff"
   expect_line_count 1
   assert "$output" = "test_file" "only contents of copied directory"
 }
+
+@test "copy with --keep-ownership" {
+  skip_if_rootless_environment
+  skip_if_rootless
+
+  _prefetch busybox
+  run_buildah from --quiet $WITH_POLICY_JSON busybox
+  cid=$output
+  mytmpdir=${TEST_SCRATCH_DIR}/keep-ownership
+  mkdir -p "${mytmpdir}"
+  touch "${mytmpdir}/file5.txt"
+  chown 321:777 "${mytmpdir}/file5.txt"
+  run_buildah copy --keep-ownership $cid "${mytmpdir}/file5.txt" /newfile_321_777
+  run_buildah run $cid stat -c "%u:%g" /newfile_321_777
+  expect_output "321:777" "stat ug /newfile_321_777"
+}

--- a/vendor/github.com/openshift/imagebuilder/.travis.yml
+++ b/vendor/github.com/openshift/imagebuilder/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - "1.16"
   - "1.17"
+  - "1.18"
 
 install:
 

--- a/vendor/github.com/openshift/imagebuilder/builder.go
+++ b/vendor/github.com/openshift/imagebuilder/builder.go
@@ -31,6 +31,9 @@ type Copy struct {
 	// to the executor for handling.
 	Chown string
 	Chmod string
+	// If used `--keep-ownership` on ADD/COPY (only for local files) but without 
+	// Chown option. This value is passed to the executor for handling.
+	PreserveOwnership bool
 }
 
 // Run defines a run operation required in the container.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -442,7 +442,7 @@ github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift/imagebuilder v1.2.4-0.20220502172744-009dbc6cb805
+# github.com/openshift/imagebuilder v1.2.4-0.20220502172744-009dbc6cb805 => github.com/Dexus-Forks/imagebuilder v1.2.4-0.20220518131701-b5c6586df000
 ## explicit
 github.com/openshift/imagebuilder
 github.com/openshift/imagebuilder/dockerclient
@@ -699,3 +699,4 @@ gopkg.in/yaml.v3
 k8s.io/klog
 # github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.4.2
 # github.com/opencontainers/image-spec => github.com/opencontainers/image-spec v1.0.2-0.20211123152302-43a7dee1ec31
+# github.com/openshift/imagebuilder => github.com/Dexus-Forks/imagebuilder v1.2.4-0.20220518131701-b5c6586df000


### PR DESCRIPTION
This is the follow-up PR that includes the initial PR from #3767 and is now fulfilled with additional changes, PRs (openshift/imagebuilder/pull/227) and tests.

Please follow the initial conversations in #3767.

What are the the intention for the PR:

ADD or COPY 
- without `--chown` and `--keep-ownership` result in `root:root` for the files.
- with `--chown 123:456` result in `123:456` for the files.
- with `--keep-ownership` result in `UID:GID` for the files, same as the origin source.


Closes #3767 

⚠️ Notice:

`go.mod` needs to add a replace for `github.com/openshift/imagebuilder` as long openshift/imagebuilder/pull/227 is unmerged
```
go mod edit -replace github.com/openshift/imagebuilder=github.com/Dexus-Forks/imagebuilder
```
