### PR TITLE
buildkit, multistage: skip computing stages which dont contribute to target by checking against `dependencyTree`

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -378,12 +378,11 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 				// exists and if stage short_name matches any
 				// additionalContext replace stage with additional
 				// build context.
-				if _, err := strconv.Atoi(from); err == nil {
-					if stage, ok := s.executor.stages[from]; ok {
-						if foundContext, ok := s.executor.additionalBuildContexts[stage.name]; ok {
-							additionalBuildContext = foundContext
-						}
-					}
+				if index, err := strconv.Atoi(from); err == nil {
+					from = s.stages[index].Name
+				}
+				if foundContext, ok := s.executor.additionalBuildContexts[from]; ok {
+					additionalBuildContext = foundContext
 				}
 			}
 			if additionalBuildContext != nil {
@@ -1026,6 +1025,14 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				from, fromErr := imagebuilder.ProcessWord(arr[1], s.stage.Builder.Arguments())
 				if fromErr != nil {
 					return "", nil, errors.Wrapf(fromErr, "unable to resolve argument %q", arr[1])
+				}
+
+				// Before looking into additional context
+				// also account if the index is given instead
+				// of name so convert index in --from=<index>
+				// to name.
+				if index, err := strconv.Atoi(from); err == nil {
+					from = s.stages[index].Name
 				}
 				// If additional buildContext contains this
 				// give priority to that and break if additional

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2297,8 +2297,8 @@ _EOF
   _prefetch alpine ubuntu
   target=target
   run_buildah build $WITH_POLICY_JSON -t ${target} --target mytarget $BUDFILES/target
-  expect_output --substring "\[1/2] STEP 1/2: FROM ubuntu:latest"
-  expect_output --substring "\[2/2] STEP 1/2: FROM alpine:latest AS mytarget"
+  expect_output --substring "\[1/2] STEP 1/3: FROM ubuntu:latest"
+  expect_output --substring "\[2/2] STEP 1/3: FROM alpine:latest AS mytarget"
   run_buildah from --quiet ${target}
   cid=$output
   run_buildah mount ${cid}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -222,6 +222,141 @@ _EOF
   expect_output "[]"
 }
 
+# Test skipping images with FROM
+@test "build-test skipping unwanted stages with FROM" {
+  mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+
+  cat > ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile << _EOF
+FROM alpine
+RUN echo "unwanted stage"
+
+FROM alpine as one
+RUN echo "needed stage"
+
+FROM alpine
+RUN echo "another unwanted stage"
+
+FROM one
+RUN echo "target stage"
+_EOF
+
+  run_buildah build $WITH_POLICY_JSON -t source -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile
+  expect_output --substring "needed stage"
+  expect_output --substring "target stage"
+  assert "$output" !~ "unwanted stage"
+}
+
+# Test skipping images with FROM but stage name also conflicts with additional build context
+# so selected stage should be still skipped since it is not being actually used by additional build
+# context is being used.
+@test "build-test skipping unwanted stages with FROM and conflict with additional build context" {
+  mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+  # add file on original context
+  echo something > ${TEST_SCRATCH_DIR}/bud/platform/somefile
+
+  cat > ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile << _EOF
+FROM alpine
+RUN echo "unwanted stage"
+
+FROM alpine as one
+RUN echo "unwanted stage"
+RUN echo "from stage unwanted stage"
+
+FROM alpine
+RUN echo "another unwanted stage"
+
+FROM alpine
+COPY --from=one somefile .
+RUN cat somefile
+_EOF
+
+  run_buildah build $WITH_POLICY_JSON --build-context one=${TEST_SCRATCH_DIR}/bud/platform -t source -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile
+  expect_output --substring "something"
+  assert "$output" !~ "unwanted stage"
+}
+
+# Test skipping unwanted stage with COPY from stage name
+@test "build-test skipping unwanted stages with COPY from stage name" {
+  mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+
+  echo something > ${TEST_SCRATCH_DIR}/bud/platform/somefile
+  cat > ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile << _EOF
+FROM alpine
+RUN echo "unwanted stage"
+
+FROM alpine as one
+RUN echo "needed stage"
+COPY somefile file
+
+FROM alpine
+COPY --from=one file .
+RUN cat file
+RUN echo "target stage"
+_EOF
+
+  run_buildah build $WITH_POLICY_JSON -t source -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile ${TEST_SCRATCH_DIR}/bud/platform
+  expect_output --substring "needed stage"
+  expect_output --substring "something"
+  expect_output --substring "target stage"
+  assert "$output" !~ "unwanted stage"
+}
+
+# Test skipping unwanted stage with COPY from stage index
+@test "build-test skipping unwanted stages with COPY from stage index" {
+  mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+
+  echo something > ${TEST_SCRATCH_DIR}/bud/platform/somefile
+  cat > ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile << _EOF
+FROM alpine
+RUN echo "unwanted stage"
+
+FROM alpine
+RUN echo "needed stage"
+COPY somefile file
+
+FROM alpine
+RUN echo "another unwanted stage"
+
+FROM alpine
+COPY --from=1 file .
+RUN cat file
+RUN echo "target stage"
+_EOF
+
+  run_buildah build $WITH_POLICY_JSON -t source -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile ${TEST_SCRATCH_DIR}/bud/platform
+  expect_output --substring "needed stage"
+  expect_output --substring "something"
+  expect_output --substring "target stage"
+  assert "$output" !~ "unwanted stage"
+}
+
+# Test skipping unwanted stage with --mount from another stage
+@test "build-test skipping unwanted stages with --mount from stagename" {
+  mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+
+  echo something > ${TEST_SCRATCH_DIR}/bud/platform/somefile
+  cat > ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile << _EOF
+FROM alpine
+RUN echo "unwanted stage"
+
+FROM alpine as one
+RUN echo "needed stage"
+COPY somefile file
+
+FROM alpine
+RUN echo "another unwanted stage"
+
+FROM alpine
+RUN --mount=type=bind,from=one,target=/test cat /test/file
+RUN echo "target stage"
+_EOF
+
+  run_buildah build $WITH_POLICY_JSON -t source -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile ${TEST_SCRATCH_DIR}/bud/platform
+  expect_output --substring "needed stage"
+  expect_output --substring "something"
+  expect_output --substring "target stage"
+  assert "$output" !~ "unwanted stage"
+}
 
 # Test pinning image using additional build context
 @test "build-with-additional-build-context and COPY, test pinning image" {

--- a/tests/bud/from-as/Dockerfile.skip
+++ b/tests/bud/from-as/Dockerfile.skip
@@ -2,13 +2,18 @@ FROM alpine AS base
 RUN touch /1
 ENV LOCAL=/1
 RUN find $LOCAL
+RUN touch hello
 
 FROM base
 RUN find $LOCAL
 RUN touch /2
 ENV LOCAL2=/2
 RUN find $LOCAL2
+# so we don't end up skipping stage: 0
+COPY --from=0 hello .
 
 FROM base
 RUN find $LOCAL
 RUN ls /
+# so we don't end up skipping stage: 1
+COPY --from=1 hello .

--- a/tests/bud/target/Dockerfile
+++ b/tests/bud/target/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:latest
 RUN touch /1
+RUN touch hello
 
-FROM alpine:latest AS mytarget 
+FROM alpine:latest AS mytarget
 RUN touch /2
+# Just add a copy so we don't skip stage:0
+COPY --from=0 hello .
 
 FROM busybox:latest AS mytarget2 
 RUN touch /3
+# Just add a copy so we don't skip stage:1
+COPY --from=1 hello .


### PR DESCRIPTION
While performing mult-stage builds buildah does not needs to compute
and run each and every stage it can skip stages which are not used by
`target` stage.

Following commit adds `dependencyTree/dependencyMap` to executor which
calculates and populates the dependencyTree for all the stages and marks
if a particular stage is used by `Target/Final` stage directly or
indirectly and unmarked stages can be skipped.

```Dockerfile
## buildah should skip this stage
FROM alpine
RUN echo "unwanted stage"

FROM alpine as one
RUN echo "wanted stage"

## buildah should skip this stage
FROM alpune
RUN echo "another unwanted stage"

FROM one
RUN echo "wanted stage"
```

Closes: https://github.com/containers/buildah/issues/2469