### PR TITLE
squash, layers: never use build cache when computing last step of last stage

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -969,14 +969,14 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// squash the contents of the base image.  Whichever is
 			// the case, we need to commit() to create a new image.
 			logCommit(s.output, -1)
-			if imgID, ref, err = s.commit(ctx, s.getCreatedBy(nil, ""), false, s.output); err != nil {
+			if imgID, ref, err = s.commit(ctx, s.getCreatedBy(nil, ""), false, s.output, s.executor.squash); err != nil {
 				return "", nil, errors.Wrapf(err, "error committing base container")
 			}
 		} else if len(s.executor.labels) > 0 || len(s.executor.annotations) > 0 {
 			// The image would be modified by the labels passed
 			// via the command line, so we need to commit.
 			logCommit(s.output, -1)
-			if imgID, ref, err = s.commit(ctx, s.getCreatedBy(stage.Node, ""), true, s.output); err != nil {
+			if imgID, ref, err = s.commit(ctx, s.getCreatedBy(stage.Node, ""), true, s.output, s.executor.squash); err != nil {
 				return "", nil, err
 			}
 		} else {
@@ -1107,7 +1107,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				// stage.
 				if lastStage || imageIsUsedLater {
 					logCommit(s.output, i)
-					imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), false, s.output)
+					imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), false, s.output, s.executor.squash)
 					if err != nil {
 						return "", nil, errors.Wrapf(err, "error committing container for step %+v", *step)
 					}
@@ -1141,7 +1141,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		// we need to call ib.Run() to correctly put the args together before
 		// determining if a cached layer with the same build args already exists
 		// and that is done in the if block below.
-		if checkForLayers && step.Command != "arg" {
+		if checkForLayers && step.Command != "arg" && !(s.executor.squash && lastInstruction && lastStage) {
 			cacheID, err = s.intermediateImageExists(ctx, node, addedContentSummary, s.stepRequiresLayer(step))
 			if err != nil {
 				return "", nil, errors.Wrap(err, "error checking if cached image exists from a previous build")
@@ -1194,10 +1194,6 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			}
 		}
 
-		// We want to save history for other layers during a squashed build.
-		// Toggle flag allows executor to treat other instruction and layers
-		// as regular builds and only perform squashing at last
-		squashToggle := false
 		// Note: If the build has squash, we must try to re-use as many layers as possible if cache is found.
 		// So only perform commit if its the lastInstruction of lastStage.
 		if cacheID != "" {
@@ -1214,30 +1210,27 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				}
 			}
 		} else {
-			if s.executor.squash {
-				// We want to save history for other layers during a squashed build.
-				// squashToggle flag allows executor to treat other instruction and layers
-				// as regular builds and only perform squashing at last
-				s.executor.squash = false
-				squashToggle = true
-			}
 			// We're not going to find any more cache hits, so we
 			// can stop looking for them.
 			checkForLayers = false
 			// Create a new image, maybe with a new layer, with the
 			// name for this stage if it's the last instruction.
 			logCommit(s.output, i)
-			imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), !s.stepRequiresLayer(step), commitName)
+			// While commiting we always set squash to false here
+			// because at this point we want to save history for
+			// layers even if its a squashed build so that they
+			// can be part of build-cache.
+			imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), !s.stepRequiresLayer(step), commitName, false)
 			if err != nil {
 				return "", nil, errors.Wrapf(err, "error committing container for step %+v", *step)
 			}
 		}
 
-		// Perform final squash for this build as we are one the,
-		// last instruction of last stage
-		if (s.executor.squash || squashToggle) && lastInstruction && lastStage {
-			s.executor.squash = true
-			imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), !s.stepRequiresLayer(step), commitName)
+		// Create a squashed version of this image
+		// if we're supposed to create one and this
+		// is the last instruction of the last stage.
+		if s.executor.squash && lastInstruction && lastStage {
+			imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), !s.stepRequiresLayer(step), commitName, true)
 			if err != nil {
 				return "", nil, errors.Wrapf(err, "error committing final squash step %+v", *step)
 			}
@@ -1573,7 +1566,7 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 // commit writes the container's contents to an image, using a passed-in tag as
 // the name if there is one, generating a unique ID-based one otherwise.
 // or commit via any custom exporter if specified.
-func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer bool, output string) (string, reference.Canonical, error) {
+func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer bool, output string, squash bool) (string, reference.Canonical, error) {
 	ib := s.stage.Builder
 	var buildOutputOption define.BuildOutputOption
 	if s.executor.buildOutput != "" {
@@ -1714,7 +1707,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		ReportWriter:          writer,
 		PreferredManifestType: s.executor.outputFormat,
 		SystemContext:         s.executor.systemContext,
-		Squash:                s.executor.squash,
+		Squash:                squash,
 		EmptyLayer:            emptyLayer,
 		BlobDirectory:         s.executor.blobDirectory,
 		SignBy:                s.executor.signBy,


### PR DESCRIPTION
When using `--squash` with `--layes` last step of a squashed build produces 
a layer which contains contents from other layers as well. So last step of last 
stage should be always computed and never fetched from build cache, while 
other steps and stages don't have this restriction.