### PR TITLE
buildah: add support for renaming a device in rootless setups using `--device`

### DIFF
--- a/define/types_unix.go
+++ b/define/types_unix.go
@@ -6,4 +6,13 @@ import (
 	"github.com/opencontainers/runc/libcontainer/devices"
 )
 
-type ContainerDevices = []devices.Device
+// BuildahDevice is a wrapper around devices.Device
+// with additional support for renaming a device
+// using bind-mount in rootless environments.
+type BuildahDevice struct {
+	devices.Device
+	Source      string
+	Destination string
+}
+
+type ContainerDevices = []BuildahDevice

--- a/run_linux.go
+++ b/run_linux.go
@@ -144,18 +144,56 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		g.SetProcessArgs(nil)
 	}
 
-	for _, d := range b.Devices {
-		sDev := spec.LinuxDevice{
-			Type:     string(d.Type),
-			Path:     d.Path,
-			Major:    d.Major,
-			Minor:    d.Minor,
-			FileMode: &d.FileMode,
-			UID:      &d.Uid,
-			GID:      &d.Gid,
+	// Mount devices if any and if session is rootless attempt a bind-mount
+	// just like podman.
+	if unshare.IsRootless() {
+		// We are going to create bind mounts for devices
+		// but we need to make sure that we don't override
+		// anything which is already in OCI spec.
+		mounts := make(map[string]interface{})
+		for _, m := range g.Mounts() {
+			mounts[m.Destination] = true
 		}
-		g.AddDevice(sDev)
-		g.AddLinuxResourcesDevice(true, string(d.Type), &d.Major, &d.Minor, string(d.Permissions))
+		newMounts := []spec.Mount{}
+		for _, d := range b.Devices {
+			// Default permission is read-only.
+			perm := "ro"
+			// Get permission configured for this device but only process `write`
+			// permission in rootless since `mknod` is not supported anyways.
+			if strings.Contains(string(d.Rule.Permissions), "w") {
+				perm = "rw"
+			}
+			devMnt := spec.Mount{
+				Destination: d.Destination,
+				Type:        parse.TypeBind,
+				Source:      d.Source,
+				Options:     []string{"slave", "nosuid", "noexec", perm, "rbind"},
+			}
+			// Podman parity: podman skips these two devices hence we do the same.
+			if d.Path == "/dev/ptmx" || strings.HasPrefix(d.Path, "/dev/tty") {
+				continue
+			}
+			// Device is already in OCI spec do not re-mount.
+			if _, found := mounts[d.Path]; found {
+				continue
+			}
+			newMounts = append(newMounts, devMnt)
+		}
+		g.Config.Mounts = append(newMounts, g.Config.Mounts...)
+	} else {
+		for _, d := range b.Devices {
+			sDev := spec.LinuxDevice{
+				Type:     string(d.Type),
+				Path:     d.Path,
+				Major:    d.Major,
+				Minor:    d.Minor,
+				FileMode: &d.FileMode,
+				UID:      &d.Uid,
+				GID:      &d.Gid,
+			}
+			g.AddDevice(sDev)
+			g.AddLinuxResourcesDevice(true, string(d.Type), &d.Major, &d.Minor, string(d.Permissions))
+		}
 	}
 
 	setupMaskedPaths(g)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2585,6 +2585,19 @@ _EOF
   run_buildah build $WITH_POLICY_JSON --squash $BUDFILES/layers-squash/Dockerfile.hardlinks
 }
 
+# Following test must pass for both rootless and rootfull
+@test "rootless: support --device and renaming device using bind-mount" {
+  skip_if_in_container # unable to perform mount of /dev/null for test in CI container setup
+  mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+
+  cat > ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile << _EOF
+FROM alpine
+RUN ls /test/dev
+_EOF
+  run_buildah build $WITH_POLICY_JSON --device /dev/null:/test/dev/null  -t test -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile
+  expect_output --substring "null"
+}
+
 @test "bud with additional directory of devices" {
   skip_if_rootless_environment
   skip_if_chroot


### PR DESCRIPTION
Buildah now supports renaming devices while performing a build using
`--device <some-name>:<new-name>`. Implementation is similar to `podman`
where we prefer using `bind-mount` for devices instead of `mknod` in
`rootless` setups.

Usage
```console
buildah build -t test --device /dev/null:/test/dev/null .
```

Closes: https://github.com/containers/buildah/issues/4002