### PR TITLE
[CI:BUILD] WIP Cleanup Image Dockerfiles

### DIFF
--- a/contrib/buildahimage/centos7/Dockerfile
+++ b/contrib/buildahimage/centos7/Dockerfile
@@ -8,19 +8,32 @@ FROM centos:7
 
 # Remove directories used by yum that are just taking
 # up space.
-RUN useradd build; yum -y update; rpm --restore shadow-utils 2>/dev/null; yum -y install cpp buildah fuse-overlayfs xz; rm -rf /var/cache /var/log/dnf* /var/log/yum.*;
+RUN useradd build && \
+    yum -y update && \
+    yum -y reinstall shadow-utils && \
+    yum -y install buildah fuse-overlayfs xz && \
+    rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
-ADD https://raw.githubusercontent.com/containers/buildah/main/contrib/buildahimage/stable/containers.conf /etc/containers/
+ARG _REPO_URL=
+ADD $_REPO_URL/storage.conf /etc/containers/storage.conf
+ADD $_REPO_URL/containers.conf /etc/containers/
 
 # Adjust storage.conf to enable Fuse storage.
-RUN chmod 644 /etc/containers/containers.conf; sed -i -e '/size = ""/amount_program = "/usr/bin/fuse-overlayfs"' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
-RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock; touch /var/lib/shared/vfs-images/images.lock; touch /var/lib/shared/vfs-layers/layers.lock
+RUN chmod 644 /etc/containers/containers.conf && \
+    sed -i -e '/size = ""/amount_program = "/usr/bin/fuse-overlayfs"' && \
+           -e '/additionalimage.*/a "/var/lib/shared",' && \
+           -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
+           /usr/share/containers/storage.conf \
+           > /etc/containers/storage.conf
 
-# Define uid/gid ranges for our user https://github.com/containers/buildah/issues/3053
-RUN echo -e "build:1:999\nbuild:1001:64535" > /etc/subuid; \
- echo -e "build:1:999\nbuild:1001:64535"  > /etc/subgid; \
- mkdir -p /home/build/.local/share/containers; \
- chown -R build:build /home/build
+RUN mkdir -p /var/lib/shared/overlay-images \
+             /var/lib/shared/overlay-layers \
+             /var/lib/shared/vfs-images \
+             /var/lib/shared/vfs-layers && \
+    touch /var/lib/shared/overlay-images/images.lock && \
+    touch /var/lib/shared/overlay-layers/layers.lock && \
+    touch /var/lib/shared/vfs-images/images.lock && \
+    touch /var/lib/shared/vfs-layers/layers.lock
 
 # Set an environment variable to default to chroot isolation for RUN
 # instructions and "buildah run".


### PR DESCRIPTION
Cleans up the Dockerfiles for the buildah images that land on quay.

A number of readability changes, and an adjustment to sed to
handle storage.conf.

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

