### PR TITLE
Make util and copier build on FreeBSD

### DIFF
--- a/copier/mknod_int.go
+++ b/copier/mknod_int.go
@@ -1,0 +1,12 @@
+//go:build !windows && !freebsd
+// +build !windows,!freebsd
+
+package copier
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func mknod(path string, mode uint32, dev int) error {
+	return unix.Mknod(path, mode, dev)
+}

--- a/copier/mknod_uint64.go
+++ b/copier/mknod_uint64.go
@@ -1,0 +1,12 @@
+//go:build freebsd
+// +build freebsd
+
+package copier
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func mknod(path string, mode uint32, dev int) error {
+	return unix.Mknod(path, mode, uint64(dev))
+}

--- a/copier/syscall_unix.go
+++ b/copier/syscall_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package copier
@@ -43,10 +44,6 @@ func mkdev(major, minor uint32) uint64 {
 
 func mkfifo(path string, mode uint32) error {
 	return unix.Mkfifo(path, mode)
-}
-
-func mknod(path string, mode uint32, dev int) error {
-	return unix.Mknod(path, mode, dev)
 }
 
 func chmod(path string, mode os.FileMode) error {

--- a/util/util_uint64.go
+++ b/util/util_uint64.go
@@ -1,4 +1,5 @@
-// +build linux,!mips,!mipsle,!mips64,!mips64le
+//go:build (linux && !mips && !mipsle && !mips64 && !mips64le) || freebsd
+// +build linux,!mips,!mipsle,!mips64,!mips64le freebsd
 
 package util
 

--- a/util/util_unix.go
+++ b/util/util_unix.go
@@ -1,4 +1,5 @@
-// +build linux darwin
+//go:build linux || darwin || freebsd
+// +build linux darwin freebsd
 
 package util
 


### PR DESCRIPTION
The mknod syscall takes a uint64 value for dev on FreeBSD.

Signed-off-by: Doug Rabson <dfr@rabson.org>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind other

#### What this PR does / why we need it:

Needed for porting buildah to FreeBSD.
