### PR TITLE
copier: work around freebsd bug for "mkdir /"

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -1558,7 +1558,9 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 					directoryModes[path] = defaultDirMode
 				}
 			} else {
-				if !os.IsExist(err) {
+				// FreeBSD can return EISDIR for "mkdir /":
+				// https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=59739.
+				if !os.IsExist(err) && !errors.Is(err, syscall.EISDIR) {
 					return errors.Wrapf(err, "copier: put: error checking directory %q", path)
 				}
 			}
@@ -1941,7 +1943,9 @@ func copierHandlerMkdir(req request, idMappings *idtools.IDMappings) (*response,
 				return errorResponse("copier: mkdir: error setting permissions on %q to 0%o: %v", path, dirMode)
 			}
 		} else {
-			if !os.IsExist(err) {
+			// FreeBSD can return EISDIR for "mkdir /":
+			// https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=59739.
+			if !os.IsExist(err) && !errors.Is(err, syscall.EISDIR) {
 				return errorResponse("copier: mkdir: error checking directory %q: %v", path, err)
 			}
 		}


### PR DESCRIPTION
On FreeBSD, os.Mkdir can return EISDIR if the target exists. The
implementation for os.MkdirAll first checks if the target exists so
avoids generating this error.

Signed-off-by: Doug Rabson <dfr@rabson.org>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind other

#### What this PR does / why we need it:

Needed for porting buildah to FreeBSD.

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->


```release-note
None
```

