### PR TITLE
Replace $BUILDAH_BINARY with buildah() function

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -885,8 +885,8 @@ _EOF
 FROM alpine
 RUN echo 'hello'> hello
 _EOF
-  # Using BUILDAH_BINARY since run_buildah adds unwanted chars to tar created by pipe.
-  ${BUILDAH_BINARY} build $WITH_POLICY_JSON -o - -t test-bud -f $mytmpdir/Containerfile . > $mytmpdir/rootfs.tar
+  # Using buildah() defined in helpers.bash since run_buildah adds unwanted chars to tar created by pipe.
+  buildah build $WITH_POLICY_JSON -o - -t test-bud -f $mytmpdir/Containerfile . > $mytmpdir/rootfs.tar
   # explode tar
   mkdir $mytmpdir/rootfs
   tar -C $mytmpdir/rootfs -xvf $mytmpdir/rootfs.tar


### PR DESCRIPTION
Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind failing-test 

#### What this PR does / why we need it:
buildah() defined in helpers.bash is available instead of `$BUILDAH_BINARY`. This function calls `$BUILDAH_BINARY` with common options for tests.

I sometimes hit the Docker pull limit error locally at this test because `--registries-conf` is not passed.

#### How to verify it
Run the fixed test. Then, run `buildah images`.

With this fix, no images are displayed. Without this fix, `localhost/test-bud` and `docker.io/library/alpine` are displayed because `--root` flag is not used in the test.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

