### PR TITLE
.Docker.History .OCIv1.History and .History are the same thing

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -214,10 +214,6 @@ _EOF
 
   # Built image must not contain history for the layers which we have just built.
   run_buildah build $WITH_POLICY_JSON --omit-history -t source -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile1
-  run_buildah inspect --format "{{index .Docker.History}}" source
-  expect_output "[]"
-  run_buildah inspect --format "{{index .OCIv1.History}}" source
-  expect_output "[]"
   run_buildah inspect --format "{{index .History}}" source
   expect_output "[]"
 }
@@ -467,7 +463,7 @@ _EOF
   expect_output "map[8080/tcp:{}]"
   run_buildah inspect --format "{{.Docker.ContainerConfig.ExposedPorts}}" test2
   expect_output "map[8080/tcp:{}]"
-  run_buildah inspect --format "{{index .Docker.History 2}}" test1
+  run_buildah inspect --format "{{index .History 2}}" test1
   expect_output --substring "FROM docker.io/library/alpine:latest"
 
   run_buildah build $WITH_POLICY_JSON --layers -t test3 -f Dockerfile.2 ${TEST_SCRATCH_DIR}/use-layers
@@ -3002,14 +2998,6 @@ EOM
   _prefetch alpine
   run_buildah build $WITH_POLICY_JSON --layers -t multi-stage-args --build-arg SECRET=secretthings -f Dockerfile.arg $BUDFILES/multi-stage-builds
   run_buildah inspect --format '{{range .History}}{{println .CreatedBy}}{{end}}' multi-stage-args
-  run grep "secretthings" <<< "$output"
-  expect_output ""
-
-  run_buildah inspect --format '{{range .OCIv1.History}}{{println .CreatedBy}}{{end}}' multi-stage-args
-  run grep "secretthings" <<< "$output"
-  expect_output ""
-
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' multi-stage-args
   run grep "secretthings" <<< "$output"
   expect_output ""
 }

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -249,13 +249,9 @@ function check_matrix() {
   check_matrix 'Config.Volumes'      "map[/VOLUME:{}]"
   check_matrix 'Config.WorkingDir'   '/tmp'
 
-  run_buildah inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-docker
+  run_buildah inspect --type=image --format '{{(index .History 0).Comment}}' scratch-image-docker
   expect_output "PROBABLY-EMPTY"
-  run_buildah inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-docker
-  expect_output "PROBABLY-EMPTY"
-  run_buildah inspect --type=image --format '{{(index .Docker.History 0).Comment}}' scratch-image-oci
-  expect_output "PROBABLY-EMPTY"
-  run_buildah inspect --type=image --format '{{(index .OCIv1.History 0).Comment}}' scratch-image-oci
+  run_buildah inspect --type=image --format '{{(index .History 0).Comment}}' scratch-image-oci
   expect_output "PROBABLY-EMPTY"
 
   # The following aren't part of the Docker v2 spec, so they're discarded when we save to Docker format.

--- a/tests/history.bats
+++ b/tests/history.bats
@@ -10,11 +10,10 @@ function testconfighistory() {
   run_buildah from --name "$container" --format docker scratch
   run_buildah config $config --add-history "$container"
   run_buildah commit $WITH_POLICY_JSON "$container" "$image"
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image"
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' "$image"
+  run_buildah inspect --format '{{range .History}}{{println .CreatedBy}}{{end}}' "$image"
   expect_output --substring "$expected"
   if test "$3" != "not-oci" ; then
-      run_buildah inspect --format '{{range .OCIv1.History}}{{println .CreatedBy}}{{end}}' "$image"
+      run_buildah inspect --format '{{range .History}}{{println .CreatedBy}}{{end}}' "$image"
       expect_output --substring "$expected"
   fi
 }
@@ -35,8 +34,7 @@ function testconfighistory() {
   run_buildah from --name healthcheckctr --format docker scratch
   run_buildah config --healthcheck "CMD /foo" --healthcheck-timeout=10s --healthcheck-interval=20s --healthcheck-retries=7 --healthcheck-start-period=30s --add-history healthcheckctr
   run_buildah commit $WITH_POLICY_JSON healthcheckctr healthcheckimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' healthcheckimg
+  run_buildah inspect --format '{{range .History}}{{println .CreatedBy}}{{end}}' healthcheckimg
   expect_output --substring "HEALTHCHECK --interval=20s --retries=7 --start-period=30s --timeout=10s CMD /foo"
 }
 
@@ -48,8 +46,7 @@ function testconfighistory() {
   run_buildah from --name onbuildctr --format docker scratch
   run_buildah config --onbuild "CMD /foo" --add-history onbuildctr
   run_buildah commit $WITH_POLICY_JSON onbuildctr onbuildimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' onbuildimg
+  run_buildah inspect --format '{{range .History}}{{println .CreatedBy}}{{end}}' onbuildimg
   expect_output --substring "ONBUILD CMD /foo"
 }
 
@@ -57,7 +54,7 @@ function testconfighistory() {
   run_buildah from --name onbuildctr --format docker scratch
   run_buildah config --onbuild "CMD /foo" --add-history onbuildctr
   run_buildah commit --omit-history $WITH_POLICY_JSON onbuildctr onbuildimg
-  run_buildah inspect --format "{{index .Docker.History}}" onbuildimg
+  run_buildah inspect --format "{{index .History}}" onbuildimg
   expect_output "[]"
 }
 
@@ -91,8 +88,7 @@ function testconfighistory() {
   run_buildah add --add-history addctr ${TEST_SCRATCH_DIR}/randomfile
   digest="$output"
   run_buildah commit $WITH_POLICY_JSON addctr addimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' addimg
+  run_buildah inspect --format '{{range .History}}{{println .CreatedBy}}{{end}}' addimg
   expect_output --substring "ADD file:$digest"
 }
 
@@ -102,8 +98,7 @@ function testconfighistory() {
   run_buildah copy --add-history copyctr ${TEST_SCRATCH_DIR}/randomfile
   digest="$output"
   run_buildah commit $WITH_POLICY_JSON copyctr copyimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' copyimg
+  run_buildah inspect --format '{{range .History}}{{println .CreatedBy}}{{end}}' copyimg
   expect_output --substring "COPY file:$digest"
 }
 
@@ -112,8 +107,7 @@ function testconfighistory() {
   run_buildah from --name runctr --format docker $WITH_POLICY_JSON busybox
   run_buildah run --add-history runctr -- uname -a
   run_buildah commit $WITH_POLICY_JSON runctr runimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' runimg
+  run_buildah inspect --format '{{range .History}}{{println .CreatedBy}}{{end}}' runimg
   expect_output --substring "/bin/sh -c uname -a"
 }
 
@@ -128,7 +122,7 @@ EOF
 
   run_buildah build $WITH_POLICY_JSON -t test --build-arg HTTP_PROXY="helloworld" ${ctxdir}
   expect_output --substring 'helloworld'
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' test
+  run_buildah inspect --format '{{range .History}}{{println .CreatedBy}}{{end}}' test
   # history should not contain value for HTTP_PROXY since it was not in Containerfile
   assert "$output" !~ 'HTTP_PROXY=helloworld'
   assert "$output" !~ 'helloworld'
@@ -146,7 +140,7 @@ EOF
 
   run_buildah build $WITH_POLICY_JSON -t test --build-arg HTTP_PROXY="helloworld" ${ctxdir}
   expect_output --substring 'helloworld'
-  run_buildah inspect --format '{{range .Docker.History}}{{println .CreatedBy}}{{end}}' test
+  run_buildah inspect --format '{{range .History}}{{println .CreatedBy}}{{end}}' test
   # history should not contain value for HTTP_PROXY since it was not in Containerfile
   expect_output --substring 'HTTP_PROXY=helloworld'
 }


### PR DESCRIPTION
Since tests are treating these as different fields, and they podman
inspect does not support the failover, we can not use these tests
against podman.

Removing .Docker.History and .OCIv1.History fixes the issue, and I
believe does not change anything.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

