### PR TITLE
build: verify and consider `builtinargs` and `userargs` while processing `baseImage` name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/runtime-tools v0.9.0
 	github.com/opencontainers/selinux v1.10.1
-	github.com/openshift/imagebuilder v1.2.4-0.20220502172744-009dbc6cb805
+	github.com/openshift/imagebuilder v1.2.4-0.20220711175835-4151e43600df
 	github.com/seccomp/libseccomp-golang v0.10.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -796,8 +796,8 @@ github.com/opencontainers/selinux v1.8.5/go.mod h1:HTvjPFoGMbpQsG886e3lQwnsRWtE4
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opencontainers/selinux v1.10.1 h1:09LIPVRP3uuZGQvgR+SgMSNBd1Eb3vlRbGqQpoHsF8w=
 github.com/opencontainers/selinux v1.10.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/openshift/imagebuilder v1.2.4-0.20220502172744-009dbc6cb805 h1:bfLqBGqF04GAoqbMkSrd5VPk/t66OnP0bTTisMaF4ro=
-github.com/openshift/imagebuilder v1.2.4-0.20220502172744-009dbc6cb805/go.mod h1:TRYHe4CH9U6nkDjxjBNM5klrLbJBrRbpJE5SaRwUBsQ=
+github.com/openshift/imagebuilder v1.2.4-0.20220711175835-4151e43600df h1:vf6pdI10F2Tim5a9JKiVVl4/dpNz1OEhz4EnfLdLtiA=
+github.com/openshift/imagebuilder v1.2.4-0.20220711175835-4151e43600df/go.mod h1:TRYHe4CH9U6nkDjxjBNM5klrLbJBrRbpJE5SaRwUBsQ=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=

--- a/tests/bud/base-with-arg/Containerfile
+++ b/tests/bud/base-with-arg/Containerfile
@@ -1,0 +1,20 @@
+FROM --platform=$TARGETPLATFORM alpine AS build
+LABEL architecture=$TARGETARCH
+
+FROM build AS platform-amd64
+ENV BUILT_FOR=amd64
+
+FROM build AS platform-arm64
+ENV BUILT_FOR=arm64
+
+FROM build AS platform-386
+ENV BUILT_FOR=386
+
+FROM build AS platform-arm/v7
+ENV BUILT_FOR=arm/v7
+
+FROM build AS platform-arm/v6
+ENV BUILT_FOR=arm/v6
+
+FROM platform-${TARGETARCH} AS final
+RUN echo "This is built for ${BUILT_FOR}"

--- a/tests/bud/base-with-arg/Containerfile2
+++ b/tests/bud/base-with-arg/Containerfile2
@@ -1,0 +1,11 @@
+FROM alpine as build
+ARG CUSTOM_TARGET
+
+FROM build AS platform-first
+ENV BUILT_FOR=first
+
+FROM build AS platform-second
+ENV BUILT_FOR=second
+
+FROM platform-${CUSTOM_TARGET} AS final
+RUN echo "This is built for ${BUILT_FOR}"

--- a/tests/bud/base-with-arg/Containerfilebad
+++ b/tests/bud/base-with-arg/Containerfilebad
@@ -1,0 +1,11 @@
+FROM alpine as build
+
+FROM build AS platform-first
+ENV BUILT_FOR=first
+
+FROM build AS platform-second
+ENV BUILT_FOR=second
+
+# Should fail since we never declared CUSTOM_TARGET
+FROM platform-${CUSTOM_TARGET} AS final
+RUN echo "This is built for ${BUILT_FOR}"

--- a/vendor/github.com/openshift/imagebuilder/.travis.yml
+++ b/vendor/github.com/openshift/imagebuilder/.travis.yml
@@ -1,16 +1,23 @@
 language: go
 
-go:
-  - "1.16"
-  - "1.17"
+services:
+  - docker
 
-install:
+go:
+  - "1.17"
+  - "1.18"
+
+before_install:
+  - sudo apt-get update -q -y
+  - sudo apt-get install -q -y golang
+  - docker pull busybox
+  - docker pull centos:7
+  - chmod -R go-w ./dockerclient/testdata
 
 script:
   - make build
   - make test
+  - travis_wait 30 make test-conformance
 
 notifications:
   irc: "chat.freenode.net#openshift-dev"
-
-sudo: false

--- a/vendor/github.com/openshift/imagebuilder/Makefile
+++ b/vendor/github.com/openshift/imagebuilder/Makefile
@@ -3,9 +3,9 @@ build:
 .PHONY: build
 
 test:
-	go test $(go list ./... | grep -v /vendor/)
+	go test ./...
 .PHONY: test
 
 test-conformance:
-	go test -v -tags conformance -timeout 10m ./dockerclient
+	go test -v -tags conformance -timeout 30m ./dockerclient
 .PHONY: test-conformance

--- a/vendor/github.com/openshift/imagebuilder/dispatchers.go
+++ b/vendor/github.com/openshift/imagebuilder/dispatchers.go
@@ -142,7 +142,13 @@ func add(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	var chmod string
 	last := len(args) - 1
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
-	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
+	filteredUserArgs := make(map[string]string)
+	for k, v := range b.Args {
+		if _, ok := b.AllowedArgs[k]; ok {
+			filteredUserArgs[k] = v
+		}
+	}
+	userArgs := mergeEnv(envMapAsSlice(filteredUserArgs), b.Env)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {
@@ -223,8 +229,20 @@ func from(b *Builder, args []string, attributes map[string]bool, flagArgs []stri
 	for n, v := range b.HeadingArgs {
 		argStrs = append(argStrs, n+"="+v)
 	}
+	defaultArgs := envMapAsSlice(builtinBuildArgs)
+	filteredUserArgs := make(map[string]string)
+	for k, v := range b.UserArgs {
+		for _, a := range b.GlobalAllowedArgs {
+			if a == k {
+				filteredUserArgs[k] = v
+			}
+		}
+	}
+	userArgs := mergeEnv(envMapAsSlice(filteredUserArgs), b.Env)
+	userArgs = mergeEnv(defaultArgs, userArgs)
+	nameArgs := mergeEnv(argStrs, userArgs)
 	var err error
-	if name, err = ProcessWord(name, argStrs); err != nil {
+	if name, err = ProcessWord(name, nameArgs); err != nil {
 		return err
 	}
 
@@ -234,9 +252,6 @@ func from(b *Builder, args []string, attributes map[string]bool, flagArgs []stri
 			return fmt.Errorf("Windows does not support FROM scratch")
 		}
 	}
-	defaultArgs := envMapAsSlice(builtinBuildArgs)
-	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
-	userArgs = mergeEnv(defaultArgs, userArgs)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {
@@ -323,7 +338,13 @@ func run(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	args = handleJSONArgs(args, attributes)
 
 	var mounts []string
-	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
+	filteredUserArgs := make(map[string]string)
+	for k, v := range b.Args {
+		if _, ok := b.AllowedArgs[k]; ok {
+			filteredUserArgs[k] = v
+		}
+	}
+	userArgs := mergeEnv(envMapAsSlice(filteredUserArgs), b.Env)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/archive.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/archive.go
@@ -185,7 +185,7 @@ func archiveFromDisk(directory string, src, dst string, allowDownload bool, excl
 		directory = filepath.Dir(directory)
 	}
 
-	options, err := archiveOptionsFor(directory, infos, dst, excludes, check)
+	options, err := archiveOptionsFor(directory, infos, dst, excludes, allowDownload, check)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -635,7 +635,7 @@ func (m *archiveMapper) Filter(h *tar.Header, r io.Reader) ([]byte, bool, bool, 
 	return nil, false, false, nil
 }
 
-func archiveOptionsFor(directory string, infos []CopyInfo, dst string, excludes []string, check DirectoryCheck) (*archive.TarOptions, error) {
+func archiveOptionsFor(directory string, infos []CopyInfo, dst string, excludes []string, allowDownload bool, check DirectoryCheck) (*archive.TarOptions, error) {
 	dst = trimLeadingPath(dst)
 	dstIsDir := strings.HasSuffix(dst, "/") || dst == "." || dst == "/" || strings.HasSuffix(dst, "/.")
 	dst = trimTrailingSlash(dst)
@@ -667,7 +667,7 @@ func archiveOptionsFor(directory string, infos []CopyInfo, dst string, excludes 
 			if directory != "" {
 				infoPath = filepath.Join(directory, infoPath)
 			}
-			if isArchivePath(infoPath) {
+			if allowDownload && isArchivePath(infoPath) {
 				dstIsDir = true
 				break
 			}

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/copyinfo.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/copyinfo.go
@@ -15,7 +15,7 @@ import (
 type CopyInfo struct {
 	os.FileInfo
 	Path       string
-	Decompress bool
+	Decompress bool // deprecated, is never set and is ignored
 	FromDir    bool
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -486,7 +486,7 @@ github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift/imagebuilder v1.2.4-0.20220502172744-009dbc6cb805
+# github.com/openshift/imagebuilder v1.2.4-0.20220711175835-4151e43600df
 ## explicit; go 1.16
 github.com/openshift/imagebuilder
 github.com/openshift/imagebuilder/dockerclient


### PR DESCRIPTION
We already consider builtinargs and userArgs while computing `--from=`
flags so use same logic for computing name of baseImage while evaluating
FROM statements.

Allows use cases like
```Dockerfile
FROM --platform=linux/amd64 alpine as platform-amd64
# do something

FROM --platform=linux/arm64 alpine as platform-arm64
# do something

FROM platform-${TARGETARCH}
```
or

also allows `FROM ${SOME_DEFAULT_OR_USER_ARG}` in general

Following PR 

* Bumps Imagebuilder so we buildah can use https://github.com/openshift/imagebuilder/pull/229
* Adds tests to verfiy this feature at buildah end.

Closes: https://github.com/containers/podman/issues/14375