### PR TITLE
build, userns: add support for `--userns=auto`

### DIFF
--- a/define/types.go
+++ b/define/types.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/chrootarchive"
 	"github.com/containers/storage/pkg/ioutils"
+	"github.com/containers/storage/types"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -87,6 +88,8 @@ type IDMappingOptions struct {
 	HostGIDMapping bool
 	UIDMap         []specs.LinuxIDMapping
 	GIDMap         []specs.LinuxIDMapping
+	AutoUserNs     bool
+	AutoUserNsOpts types.AutoUserNsOptions
 }
 
 // Secret is a secret source that can be used in a RUN

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -694,11 +694,25 @@ Unset environment variables from the final image.
 **--userns** *how*
 
 Sets the configuration for user namespaces when handling `RUN` instructions.
-The configured value can be "" (the empty string) or "private" to indicate
+The configured value can be "" (the empty string) , "private" or "auto" to indicate
 that a new user namespace should be created, it can be "host" to indicate that
 the user namespace in which `buildah` itself is being run should be reused, or
 it can be the path to an user namespace which is already in use by another
 process.
+
+auto: automatically create a unique user namespace.
+
+The --userns=auto flag, requires that the user name containers and a range of subordinate user ids that the build container is allowed to use be specified in the /etc/subuid and /etc/subgid files.
+
+Example: `containers:2147483647:2147483648`.
+
+Buildah allocates unique ranges of UIDs and GIDs from the containers subordinate user ids. The size of the ranges is based on the number of UIDs required in the image. The number of UIDs and GIDs can be overridden with the size option.
+
+Valid `auto` options:
+
+* gidmapping=CONTAINER_GID:HOST_GID:SIZE: to force a GID mapping to be present in the user namespace.
+* size=SIZE: to specify an explicit size for the automatic user namespace. e.g. --userns=auto:size=8192. If size is not specified, auto will estimate a size for the user namespace.
+* uidmapping=CONTAINER_UID:HOST_UID:SIZE: to force a UID mapping to be present in the user namespace.
 
 **--userns-gid-map-group** *group*
 

--- a/new.go
+++ b/new.go
@@ -76,15 +76,20 @@ func imageNamePrefix(imageName string) string {
 func newContainerIDMappingOptions(idmapOptions *define.IDMappingOptions) storage.IDMappingOptions {
 	var options storage.IDMappingOptions
 	if idmapOptions != nil {
-		options.HostUIDMapping = idmapOptions.HostUIDMapping
-		options.HostGIDMapping = idmapOptions.HostGIDMapping
-		uidmap, gidmap := convertRuntimeIDMaps(idmapOptions.UIDMap, idmapOptions.GIDMap)
-		if len(uidmap) > 0 && len(gidmap) > 0 {
-			options.UIDMap = uidmap
-			options.GIDMap = gidmap
+		if idmapOptions.AutoUserNs {
+			options.AutoUserNs = true
+			options.AutoUserNsOpts = idmapOptions.AutoUserNsOpts
 		} else {
-			options.HostUIDMapping = true
-			options.HostGIDMapping = true
+			options.HostUIDMapping = idmapOptions.HostUIDMapping
+			options.HostGIDMapping = idmapOptions.HostGIDMapping
+			uidmap, gidmap := convertRuntimeIDMaps(idmapOptions.UIDMap, idmapOptions.GIDMap)
+			if len(uidmap) > 0 && len(gidmap) > 0 {
+				options.UIDMap = uidmap
+				options.GIDMap = gidmap
+			} else {
+				options.HostUIDMapping = true
+				options.HostGIDMapping = true
+			}
 		}
 	}
 	return options


### PR DESCRIPTION
Buildah now supports `--userns=auto` which can automatically pick an empty range and create an user namespace for the container.

The `--userns=auto` flag, requires that the user name containers and a range of subordinate user ids that the build container is allowed to use be specified in the /etc/subuid and /etc/subgid files.

Example: `containers:2147483647:2147483648`.

Buildah allocates unique ranges of UIDs and GIDs from the containers subordinate user ids. The size of the ranges is based on the number of UIDs required in the image. The number of UIDs and GIDs can be overridden with the size option.

Valid auto options:

    * gidmapping=CONTAINER_GID:HOST_GID:SIZE: to force a GID mapping to be present in the user namespace.

    * size=SIZE: to specify an explicit size for the automatic user namespace. e.g. --userns=auto:size=8192. If size is not specified, auto will estimate a size for the user namespace.

    * uidmapping=CONTAINER_UID:HOST_UID:SIZE: to force a UID mapping to be present in the user namespace.

Closes: https://github.com/containers/buildah/issues/4060