### PR TITLE
[CI:DOCS] demo: use `buildah unshare` for `rootless` invocations

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -25,7 +25,15 @@ This demo builds a container image from scratch. The container is going to injec
 
 Please make sure you have installed Buildah and Podman. Also this demo uses Quay.io to push the image to that registry when it is completed. If you are not logged in then it will fail at that step and finish. If you wish to login to Quay.io before running the demo, then it will push to your repository successfully.
 
-    $ sudo buildah login quay.io
+```bash
+# Rootful session
+$ sudo buildah login quay.io
+#
+#  or
+#
+# Rootless session
+$ buildah login quay.io
+```
 
 There are several variables you will want to set that are listed at the top of the script. The name for the container image, your quay.io username, your name, and the Fedora release number:
 

--- a/demos/buildah-scratch-demo.sh
+++ b/demos/buildah-scratch-demo.sh
@@ -7,6 +7,22 @@
 #   buildah login quay.io
 # Set some of the variables below
 
+#################
+#  is_rootless  #  Check if we run as normal user
+#################
+function is_rootless() {
+    [ "$(id -u)" -ne 0 ]
+}
+
+## Steps in this demo use pkg-managers like dnf and yum which
+## must be invoked as root. Similarly `buildah mount` only work
+## as root. The `buildah unshare` command switches your user
+## session to root within the user namespace.
+if is_rootless; then
+  buildah unshare $0
+  exit
+fi
+
 demoimg=myshdemo
 quayuser=ipbabble
 myname=WilliamHenry

--- a/demos/buildah_multi_stage.sh
+++ b/demos/buildah_multi_stage.sh
@@ -5,6 +5,22 @@
 # Assumptions install buildah and podman
 # Set some of the variables below
 
+
+#################
+#  is_rootless  #  Check if we run as normal user
+#################
+function is_rootless() {
+    [ "$(id -u)" -ne 0 ]
+}
+
+## The `buildah mount` only work as root so use
+## `buildah unshare` command which switches your
+## user session to root within the user namespace.
+if is_rootless; then
+  buildah unshare $0
+  exit
+fi
+
 demoimg=mymultidemo
 quayuser=myquayuser
 myname=MyName


### PR DESCRIPTION
Use `buildah unshare` to invoke `buildah mount` when demos are invoked
from rootless environments

* buildah_mult_stage: only unshare on needed steps
* buildah-scratch-demo: unshare entire script since it uses pkg managers
  commands which don't work well in rootless session without unshare.
  
  Closes: https://github.com/containers/buildah/issues/3912
