### PR TITLE
[CI:BUILD] Install latest buildah instead of compiling

### DIFF
--- a/contrib/buildahimage/README.md
+++ b/contrib/buildahimage/README.md
@@ -32,7 +32,9 @@ The container images are:
   * `quay.io/buildah/upstream:latest` - This image is built daily using the latest
     code found in this GitHub repository.  Due to the image changing frequently,
     it's not guaranteed to be stable or even executable.  The image is built with
-    [the upstream Dockerfile](upstream/Dockerfile).
+    [the upstream Dockerfile](upstream/Dockerfile).  Note: The actual compilation
+    of upstream buildah [occurs continuously in
+    COPR](https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/).
 
 
 ## Sample Usage

--- a/contrib/buildahimage/upstream/Containerfile
+++ b/contrib/buildahimage/upstream/Containerfile
@@ -9,50 +9,37 @@
 # Buildah development environment in /root/buildah.
 #
 FROM registry.fedoraproject.org/fedora:latest
-ENV GOPATH=/root/buildah
 
-# Install the software required to build Buildah.
-# Then create a directory and clone from the Buildah
-# GitHub repository, make and install Buildah
-# to the container.
-# Finally remove the buildah directory and a few other packages
-# that are needed for building but not running Buildah
-RUN useradd build && \
-    dnf -y copr enable rhcontainerbot/podman-next && \
-    dnf -y update  && \
+# Don't include container-selinux and remove
+# directories used by dnf that are just taking
+# up space.  The latest buildah + deps. come from
+# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/
+RUN dnf -y update && \
     rpm --setcaps shadow-utils 2>/dev/null && \
-    dnf -y install --enablerepo=updates-testing \
-     make \
-     cpp \
-     golang \
-     bats \
-     btrfs-progs-devel \
-     buildah \
-     device-mapper-devel \
-     glib2-devel \
-     gpgme-devel \
-     libassuan-devel \
-     libseccomp-devel \
-     git \
-     bzip2 \
-     xz \
-     go-md2man \
-     runc \
-     fuse-overlayfs \
-     fuse3 \
-     containers-common --exclude container-selinux; \
-     dnf -y remove bats git golang go-md2man make; \
-     dnf -y clean all;
+    dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
+    dnf -y copr enable rhcontainerbot/podman-next && \
+    dnf -y install buildah fuse-overlayfs \
+        --exclude container-selinux \
+        --enablerepo=updates-testing && \
+    dnf clean all && \
+    rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
+# Define uid/gid ranges for our user https://github.com/containers/buildah/issues/3053
+RUN useradd build && \
+    echo -e "build:1:999\npodman:1001:64535" > /etc/subuid && \
+    echo -e "build:1:999\npodman:1001:64535" > /etc/subgid && \
+    mkdir -p /home/build/.local/share/containers && \
+    chown -R build:build /home/build
 
 ADD https://raw.githubusercontent.com/containers/buildah/main/contrib/buildahimage/stable/containers.conf /etc/containers/
 
 # Copy & modify the defaults to provide reference if runtime changes needed.
 # Changes here are required for running with fuse-overlay storage inside container.
 RUN sed -e 's|^#mount_program|mount_program|g' \
-           -e '/additionalimage.*/a "/var/lib/shared",' \
-           -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
-           /usr/share/containers/storage.conf \
-           > /etc/containers/storage.conf && \
+        -e '/additionalimage.*/a "/var/lib/shared",' \
+        -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
+        /usr/share/containers/storage.conf \
+        > /etc/containers/storage.conf && \
     chmod 644 /etc/containers/storage.conf
 
 RUN mkdir -p /var/lib/shared/overlay-images \
@@ -63,12 +50,6 @@ RUN mkdir -p /var/lib/shared/overlay-images \
     touch /var/lib/shared/overlay-layers/layers.lock && \
     touch /var/lib/shared/vfs-images/images.lock && \
     touch /var/lib/shared/vfs-layers/layers.lock
-
-# Define uid/gid ranges for our user https://github.com/containers/buildah/issues/3053
-RUN echo -e "build:1:999\nbuild:1001:64535" > /etc/subuid \
- && echo -e "build:1:999\nbuild:1001:64535" > /etc/subgid && \
- mkdir -p /home/build/.local/share/containers && \
- chown -R build:build /home/build
 
 VOLUME /var/lib/containers
 VOLUME /home/build/.local/share/containers


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

When building the multi-arch "upstream" flavor of buildah container
images, it's more optimal to use separate compilation and image
construction steps.  The image-build automation is time-limited,
and operating under a (slow) emulation environment.  So using a
continuously pre-built buildah RPM will also improve build
reliability.

ref: https://github.com/containers/buildah/pull/4062

#### How to verify it

The manually-triggered 'upstream' container image build will complete successfully.  No fatal errors will appear in the build log.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

