### PR TITLE
Add subid support with BuildRequires and BUILDTAG

### DIFF
--- a/buildah.spec.rpkg
+++ b/buildah.spec.rpkg
@@ -52,6 +52,7 @@ BuildRequires: gpgme-devel
 BuildRequires: libassuan-devel
 BuildRequires: make
 BuildRequires: ostree-devel
+BuildRequires: shadow-utils-subid-devel
 %if 0%{?fedora} && ! 0%{?rhel}
 BuildRequires: btrfs-progs-devel
 %endif
@@ -123,7 +124,7 @@ mv vendor src
 export CNI_VERSION=`grep '^# github.com/containernetworking/cni ' src/modules.txt | sed 's,.* ,,'`
 export LDFLAGS="-X main.buildInfo=`date +%s` -X main.cniVersion=${CNI_VERSION}"
 
-export BUILDTAGS='seccomp selinux'
+export BUILDTAGS='seccomp libsubid selinux'
 %if 0%{?rhel}
 export BUILDTAGS='$BUILDTAGS exclude_graphdriver_btrfs btrfs_noversion'
 %endif


### PR DESCRIPTION

#### What type of PR is this?


 /kind feature


#### What this PR does / why we need it:

enable the use of libsubid to generalize newIDMapping (i.e. use either /etc/sub{g,u}id files OR the centralized FreeIPA ones if available

#### How to verify it

Build a container with multiple UID's using UID/GID configured both from files (/etc/sub{u,g}id) and FreeIPA (subid: sss in /etc/nsswitch.conf). Both should work. Currently the FreeIPA based mechanism fails

#### Which issue(s) this PR fixes:


None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change? No


```release-note
This change introduces support to make use of the recently fixed subid library check for Fedora and EL-family builds.
```

