### PR TITLE
[CI:DOCS] GHA: Allow re-use of Cirrus-Cron fail-mail workflow

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -17,6 +17,22 @@ on:
         - cron:  '59 23 * * 1-5'
     # Debug: Allow triggering job manually in github-actions WebUI
     workflow_dispatch: {}
+    # Allow re-use of this workflow by other repositories
+    # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+    workflow_call:
+      secrets:
+        # Debug-mode can reveal secrets, force it to be secrets-managed.
+        ACTIONS_STEP_DEBUG:
+          required: true
+        ACTION_MAIL_SERVER:
+          required: true
+        ACTION_MAIL_USERNAME:
+          required: true
+        ACTION_MAIL_PASSWORD:
+          required: true
+        ACTION_MAIL_SENDER:
+          required: true
+
 
 env:
     # Debug-mode can reveal secrets, only enable by a secret value.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind other

#### What this PR does / why we need it:

Github-actions has (finally) added a mechanism for re-using workflows
from other repositories.  Rather than duplicate the Cirrus-Cron failure
notification workflow everywhere, allow re-using it from here.  As per
the docs, it's required to declare all the incoming secret variable
names which are supplied by the caller.  Do that.

#### How to verify it

In all their wisdom, github has designed these workflow changes to be un-verifiable.  The PR must be merged, then we can see if it works or not :sob: 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

See the caller implementation here: https://github.com/containers/netavark/pull/325

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

