### PR TITLE
Switch to golang native error wrapping

### DIFF
--- a/add.go
+++ b/add.go
@@ -2,6 +2,7 @@ package buildah
 
 import (
 	"archive/tar"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -24,7 +25,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/opencontainers/runc/libcontainer/userns"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -105,7 +105,7 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 	if lastModified != "" {
 		d, err := time.Parse(time.RFC1123, lastModified)
 		if err != nil {
-			return errors.Wrapf(err, "error parsing last-modified time")
+			return fmt.Errorf("error parsing last-modified time: %w", err)
 		}
 		date = d
 	}
@@ -117,17 +117,17 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 		// we can figure out how much content there is.
 		f, err := ioutil.TempFile(mountpoint, "download")
 		if err != nil {
-			return errors.Wrapf(err, "error creating temporary file to hold %q", src)
+			return fmt.Errorf("error creating temporary file to hold %q: %w", src, err)
 		}
 		defer os.Remove(f.Name())
 		defer f.Close()
 		size, err = io.Copy(f, response.Body)
 		if err != nil {
-			return errors.Wrapf(err, "error writing %q to temporary file %q", src, f.Name())
+			return fmt.Errorf("error writing %q to temporary file %q: %w", src, f.Name(), err)
 		}
 		_, err = f.Seek(0, io.SeekStart)
 		if err != nil {
-			return errors.Wrapf(err, "error setting up to read %q from temporary file %q", src, f.Name())
+			return fmt.Errorf("error setting up to read %q from temporary file %q: %w", src, f.Name(), err)
 		}
 		responseBody = f
 	}
@@ -155,10 +155,14 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 	}
 	err = tw.WriteHeader(&hdr)
 	if err != nil {
-		return errors.Wrapf(err, "error writing header")
+		return fmt.Errorf("error writing header: %w", err)
 	}
-	_, err = io.Copy(tw, responseBody)
-	return errors.Wrapf(err, "error writing content from %q to tar stream", src)
+
+	if _, err := io.Copy(tw, responseBody); err != nil {
+		return fmt.Errorf("error writing content from %q to tar stream: %w", src, err)
+	}
+
+	return nil
 }
 
 // includeDirectoryAnyway returns true if "path" is a prefix for an exception
@@ -204,13 +208,13 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		contextDir = string(os.PathSeparator)
 		currentDir, err = os.Getwd()
 		if err != nil {
-			return errors.Wrapf(err, "error determining current working directory")
+			return fmt.Errorf("error determining current working directory: %w", err)
 		}
 	} else {
 		if !filepath.IsAbs(options.ContextDir) {
 			contextDir, err = filepath.Abs(options.ContextDir)
 			if err != nil {
-				return errors.Wrapf(err, "error converting context directory path %q to an absolute path", options.ContextDir)
+				return fmt.Errorf("error converting context directory path %q to an absolute path: %w", options.ContextDir, err)
 			}
 		}
 	}
@@ -238,7 +242,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		}
 		localSourceStats, err = copier.Stat(contextDir, contextDir, statOptions, localSources)
 		if err != nil {
-			return errors.Wrapf(err, "checking on sources under %q", contextDir)
+			return fmt.Errorf("checking on sources under %q: %w", contextDir, err)
 		}
 	}
 	numLocalSourceItems := 0
@@ -252,15 +256,15 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 				errorText = fmt.Sprintf("possible escaping context directory error: %s", errorText)
 			}
-			return errors.Errorf("checking on sources under %q: %v", contextDir, errorText)
+			return fmt.Errorf("checking on sources under %q: %v", contextDir, errorText)
 		}
 		if len(localSourceStat.Globbed) == 0 {
-			return errors.Wrapf(syscall.ENOENT, "checking source under %q: no glob matches", contextDir)
+			return fmt.Errorf("checking source under %q: no glob matches: %w", contextDir, syscall.ENOENT)
 		}
 		numLocalSourceItems += len(localSourceStat.Globbed)
 	}
 	if numLocalSourceItems+len(remoteSources) == 0 {
-		return errors.Wrapf(syscall.ENOENT, "no sources %v found", sources)
+		return fmt.Errorf("no sources %v found: %w", sources, syscall.ENOENT)
 	}
 
 	// Find out which user (and group) the destination should belong to.
@@ -269,14 +273,14 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	if options.Chown != "" {
 		userUID, userGID, err = b.userForCopy(mountPoint, options.Chown)
 		if err != nil {
-			return errors.Wrapf(err, "error looking up UID/GID for %q", options.Chown)
+			return fmt.Errorf("error looking up UID/GID for %q: %w", options.Chown, err)
 		}
 	}
 	var chmodDirsFiles *os.FileMode
 	if options.Chmod != "" {
 		p, err := strconv.ParseUint(options.Chmod, 8, 32)
 		if err != nil {
-			return errors.Wrapf(err, "error parsing chmod %q", options.Chmod)
+			return fmt.Errorf("error parsing chmod %q: %w", options.Chmod, err)
 		}
 		perm := os.FileMode(p)
 		chmodDirsFiles = &perm
@@ -328,7 +332,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	}
 	destStats, err := copier.Stat(mountPoint, filepath.Join(mountPoint, b.WorkDir()), statOptions, []string{extractDirectory})
 	if err != nil {
-		return errors.Wrapf(err, "error checking on destination %v", extractDirectory)
+		return fmt.Errorf("error checking on destination %v: %w", extractDirectory, err)
 	}
 	if (len(destStats) == 0 || len(destStats[0].Globbed) == 0) && !destMustBeDirectory && destCanBeFile {
 		// destination doesn't exist - extract to parent and rename the incoming file to the destination's name
@@ -344,7 +348,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 
 	if len(destStats) == 1 && len(destStats[0].Globbed) == 1 && destStats[0].Results[destStats[0].Globbed[0]].IsRegular {
 		if destMustBeDirectory {
-			return errors.Errorf("destination %v already exists but is not a directory", destination)
+			return fmt.Errorf("destination %v already exists but is not a directory", destination)
 		}
 		// destination exists - it's a file, we need to extract to parent and rename the incoming file to the destination's name
 		renameTarget = filepath.Base(extractDirectory)
@@ -353,7 +357,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 
 	pm, err := fileutils.NewPatternMatcher(options.Excludes)
 	if err != nil {
-		return errors.Wrapf(err, "error processing excludes list %v", options.Excludes)
+		return fmt.Errorf("error processing excludes list %v: %w", options.Excludes, err)
 	}
 
 	// Make sure that, if it's a symlink, we'll chroot to the target of the link;
@@ -361,7 +365,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	evalOptions := copier.EvalOptions{}
 	evaluated, err := copier.Eval(mountPoint, extractDirectory, evalOptions)
 	if err != nil {
-		return errors.Wrapf(err, "error checking on destination %v", extractDirectory)
+		return fmt.Errorf("error checking on destination %v: %w", extractDirectory, err)
 	}
 	extractDirectory = evaluated
 
@@ -379,7 +383,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		ChownNew: chownDirs,
 	}
 	if err := copier.Mkdir(mountPoint, extractDirectory, mkdirOptions); err != nil {
-		return errors.Wrapf(err, "error ensuring target directory exists")
+		return fmt.Errorf("error ensuring target directory exists: %w", err)
 	}
 
 	// Copy each source in turn.
@@ -423,10 +427,10 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			}()
 			wg.Wait()
 			if getErr != nil {
-				getErr = errors.Wrapf(getErr, "error reading %q", src)
+				getErr = fmt.Errorf("error reading %q: %w", src, getErr)
 			}
 			if putErr != nil {
-				putErr = errors.Wrapf(putErr, "error storing %q", src)
+				putErr = fmt.Errorf("error storing %q: %w", src, putErr)
 			}
 			multiErr = multierror.Append(getErr, putErr)
 			if multiErr != nil && multiErr.ErrorOrNil() != nil {
@@ -455,16 +459,16 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		for _, glob := range localSourceStat.Globbed {
 			rel, err := filepath.Rel(contextDir, glob)
 			if err != nil {
-				return errors.Wrapf(err, "error computing path of %q relative to %q", glob, contextDir)
+				return fmt.Errorf("error computing path of %q relative to %q: %w", glob, contextDir, err)
 			}
 			if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-				return errors.Errorf("possible escaping context directory error: %q is outside of %q", glob, contextDir)
+				return fmt.Errorf("possible escaping context directory error: %q is outside of %q", glob, contextDir)
 			}
 			// Check for dockerignore-style exclusion of this item.
 			if rel != "." {
 				excluded, err := pm.Matches(filepath.ToSlash(rel)) // nolint:staticcheck
 				if err != nil {
-					return errors.Wrapf(err, "error checking if %q(%q) is excluded", glob, rel)
+					return fmt.Errorf("error checking if %q(%q) is excluded: %w", glob, rel, err)
 				}
 				if excluded {
 					// non-directories that are excluded are excluded, no question, but
@@ -520,7 +524,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 				getErr = copier.Get(contextDir, contextDir, getOptions, []string{glob}, writer)
 				closeErr = writer.Close()
 				if renameTarget != "" && renamedItems > 1 {
-					renameErr = errors.Errorf("internal error: renamed %d items when we expected to only rename 1", renamedItems)
+					renameErr = fmt.Errorf("internal error: renamed %d items when we expected to only rename 1", renamedItems)
 				}
 				wg.Done()
 			}()
@@ -558,16 +562,16 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			}()
 			wg.Wait()
 			if getErr != nil {
-				getErr = errors.Wrapf(getErr, "error reading %q", src)
+				getErr = fmt.Errorf("error reading %q: %w", src, getErr)
 			}
 			if closeErr != nil {
-				closeErr = errors.Wrapf(closeErr, "error closing %q", src)
+				closeErr = fmt.Errorf("error closing %q: %w", src, closeErr)
 			}
 			if renameErr != nil {
-				renameErr = errors.Wrapf(renameErr, "error renaming %q", src)
+				renameErr = fmt.Errorf("error renaming %q: %w", src, renameErr)
 			}
 			if putErr != nil {
-				putErr = errors.Wrapf(putErr, "error storing %q", src)
+				putErr = fmt.Errorf("error storing %q: %w", src, putErr)
 			}
 			multiErr = multierror.Append(getErr, closeErr, renameErr, putErr)
 			if multiErr != nil && multiErr.ErrorOrNil() != nil {
@@ -582,7 +586,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			if options.IgnoreFile != "" {
 				excludesFile = " using " + options.IgnoreFile
 			}
-			return errors.Wrapf(syscall.ENOENT, "no items matching glob %q copied (%d filtered out%s)", localSourceStat.Glob, len(localSourceStat.Globbed), excludesFile)
+			return fmt.Errorf("no items matching glob %q copied (%d filtered out%s): %w", localSourceStat.Glob, len(localSourceStat.Globbed), excludesFile, syscall.ENOENT)
 		}
 	}
 	return nil
@@ -604,7 +608,7 @@ func (b *Builder) userForRun(mountPoint string, userspec string) (specs.User, st
 	if !strings.Contains(userspec, ":") {
 		groups, err2 := chrootuser.GetAdditionalGroupsForUser(mountPoint, uint64(u.UID))
 		if err2 != nil {
-			if errors.Cause(err2) != chrootuser.ErrNoSuchUser && err == nil {
+			if !errors.Is(err2, chrootuser.ErrNoSuchUser) && err == nil {
 				err = err2
 			}
 		} else {
@@ -634,7 +638,7 @@ func (b *Builder) userForCopy(mountPoint string, userspec string) (uint32, uint3
 
 	// If userspec did not specify any values for user or group, then fail
 	if user == "" && group == "" {
-		return 0, 0, errors.Errorf("can't find uid for user %s", userspec)
+		return 0, 0, fmt.Errorf("can't find uid for user %s", userspec)
 	}
 
 	// If userspec specifies values for user or group, check for numeric values

--- a/buildah.go
+++ b/buildah.go
@@ -19,7 +19,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/ioutils"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -408,10 +407,10 @@ func OpenBuilder(store storage.Store, container string) (*Builder, error) {
 	}
 	b := &Builder{}
 	if err = json.Unmarshal(buildstate, &b); err != nil {
-		return nil, errors.Wrapf(err, "error parsing %q, read from %q", string(buildstate), filepath.Join(cdir, stateFile))
+		return nil, fmt.Errorf("error parsing %q, read from %q: %w", string(buildstate), filepath.Join(cdir, stateFile), err)
 	}
 	if b.Type != containerType {
-		return nil, errors.Errorf("container %q is not a %s container (is a %q container)", container, define.Package, b.Type)
+		return nil, fmt.Errorf("container %q is not a %s container (is a %q container)", container, define.Package, b.Type)
 	}
 
 	netInt, err := getNetworkInterface(store, b.CNIConfigDir, b.CNIPluginPath)
@@ -520,7 +519,7 @@ func (b *Builder) Save() error {
 		return err
 	}
 	if err = ioutils.AtomicWriteFile(filepath.Join(cdir, stateFile), buildstate, 0600); err != nil {
-		return errors.Wrapf(err, "error saving builder state to %q", filepath.Join(cdir, stateFile))
+		return fmt.Errorf("error saving builder state to %q: %w", filepath.Join(cdir, stateFile), err)
 	}
 	return nil
 }

--- a/chroot/run_test.go
+++ b/chroot/run_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package chroot
@@ -107,7 +108,7 @@ func testMinimal(t *testing.T, modify func(g *generate.Generator, rootDir, bundl
 	}
 
 	var report types.TestReport
-	if json.Unmarshal(output.Bytes(), &report) != nil {
+	if err := json.Unmarshal(output.Bytes(), &report); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 

--- a/chroot/seccomp.go
+++ b/chroot/seccomp.go
@@ -4,11 +4,11 @@
 package chroot
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/containers/common/pkg/seccomp"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	libseccomp "github.com/seccomp/libseccomp-golang"
 	"github.com/sirupsen/logrus"
 )
@@ -111,11 +111,11 @@ func setSeccomp(spec *specs.Spec) error {
 
 	filter, err := libseccomp.NewFilter(mapAction(spec.Linux.Seccomp.DefaultAction, nil))
 	if err != nil {
-		return errors.Wrapf(err, "error creating seccomp filter with default action %q", spec.Linux.Seccomp.DefaultAction)
+		return fmt.Errorf("error creating seccomp filter with default action %q: %w", spec.Linux.Seccomp.DefaultAction, err)
 	}
 	for _, arch := range spec.Linux.Seccomp.Architectures {
 		if err = filter.AddArch(mapArch(arch)); err != nil {
-			return errors.Wrapf(err, "error adding architecture %q(%q) to seccomp filter", arch, mapArch(arch))
+			return fmt.Errorf("error adding architecture %q(%q) to seccomp filter: %w", arch, mapArch(arch), err)
 		}
 	}
 	for _, rule := range spec.Linux.Seccomp.Syscalls {
@@ -131,7 +131,7 @@ func setSeccomp(spec *specs.Spec) error {
 		for scnum := range scnames {
 			if len(rule.Args) == 0 {
 				if err = filter.AddRule(scnum, mapAction(rule.Action, rule.ErrnoRet)); err != nil {
-					return errors.Wrapf(err, "error adding a rule (%q:%q) to seccomp filter", scnames[scnum], rule.Action)
+					return fmt.Errorf("error adding a rule (%q:%q) to seccomp filter: %w", scnames[scnum], rule.Action, err)
 				}
 				continue
 			}
@@ -140,7 +140,7 @@ func setSeccomp(spec *specs.Spec) error {
 			for _, arg := range rule.Args {
 				condition, err := libseccomp.MakeCondition(arg.Index, mapOp(arg.Op), arg.Value, arg.ValueTwo)
 				if err != nil {
-					return errors.Wrapf(err, "error building a seccomp condition %d:%v:%d:%d", arg.Index, arg.Op, arg.Value, arg.ValueTwo)
+					return fmt.Errorf("error building a seccomp condition %d:%v:%d:%d: %w", arg.Index, arg.Op, arg.Value, arg.ValueTwo, err)
 				}
 				if arg.Op != specs.OpEqualTo {
 					opsAreAllEquality = false
@@ -156,22 +156,22 @@ func setSeccomp(spec *specs.Spec) error {
 				if len(rule.Args) > 1 && opsAreAllEquality && err.Error() == "two checks on same syscall argument" {
 					for i := range conditions {
 						if err = filter.AddRuleConditional(scnum, mapAction(rule.Action, rule.ErrnoRet), conditions[i:i+1]); err != nil {
-							return errors.Wrapf(err, "error adding a conditional rule (%q:%q[%d]) to seccomp filter", scnames[scnum], rule.Action, i)
+							return fmt.Errorf("error adding a conditional rule (%q:%q[%d]) to seccomp filter: %w", scnames[scnum], rule.Action, i, err)
 						}
 					}
 				} else {
-					return errors.Wrapf(err, "error adding a conditional rule (%q:%q) to seccomp filter", scnames[scnum], rule.Action)
+					return fmt.Errorf("error adding a conditional rule (%q:%q) to seccomp filter: %w", scnames[scnum], rule.Action, err)
 				}
 			}
 		}
 	}
 	if err = filter.SetNoNewPrivsBit(spec.Process.NoNewPrivileges); err != nil {
-		return errors.Wrapf(err, "error setting no-new-privileges bit to %v", spec.Process.NoNewPrivileges)
+		return fmt.Errorf("error setting no-new-privileges bit to %v: %w", spec.Process.NoNewPrivileges, err)
 	}
 	err = filter.Load()
 	filter.Release()
 	if err != nil {
-		return errors.Wrapf(err, "error activating seccomp filter")
+		return fmt.Errorf("error activating seccomp filter: %w", err)
 	}
 	return nil
 }
@@ -183,17 +183,17 @@ func setupSeccomp(spec *specs.Spec, seccompProfilePath string) error {
 	case "":
 		seccompConfig, err := seccomp.GetDefaultProfile(spec)
 		if err != nil {
-			return errors.Wrapf(err, "loading default seccomp profile failed")
+			return fmt.Errorf("loading default seccomp profile failed: %w", err)
 		}
 		spec.Linux.Seccomp = seccompConfig
 	default:
 		seccompProfile, err := ioutil.ReadFile(seccompProfilePath)
 		if err != nil {
-			return errors.Wrapf(err, "opening seccomp profile (%s) failed", seccompProfilePath)
+			return fmt.Errorf("opening seccomp profile (%s) failed: %w", seccompProfilePath, err)
 		}
 		seccompConfig, err := seccomp.LoadProfile(string(seccompProfile), spec)
 		if err != nil {
-			return errors.Wrapf(err, "loading seccomp profile (%s) failed", seccompProfilePath)
+			return fmt.Errorf("loading seccomp profile (%s) failed: %w", seccompProfilePath, err)
 		}
 		spec.Linux.Seccomp = seccompConfig
 	}

--- a/chroot/seccomp_unsupported.go
+++ b/chroot/seccomp_unsupported.go
@@ -1,10 +1,12 @@
+//go:build !linux || !seccomp
 // +build !linux !seccomp
 
 package chroot
 
 import (
+	"errors"
+
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 func setSeccomp(spec *specs.Spec) error {

--- a/chroot/selinux.go
+++ b/chroot/selinux.go
@@ -1,12 +1,14 @@
+//go:build linux
 // +build linux
 
 package chroot
 
 import (
+	"fmt"
+
 	"github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -15,7 +17,7 @@ func setSelinuxLabel(spec *specs.Spec) error {
 	logrus.Debugf("setting selinux label")
 	if spec.Process.SelinuxLabel != "" && selinux.GetEnabled() {
 		if err := label.SetProcessLabel(spec.Process.SelinuxLabel); err != nil {
-			return errors.Wrapf(err, "error setting process label to %q", spec.Process.SelinuxLabel)
+			return fmt.Errorf("error setting process label to %q: %w", spec.Process.SelinuxLabel, err)
 		}
 	}
 	return nil

--- a/chroot/selinux_unsupported.go
+++ b/chroot/selinux_unsupported.go
@@ -1,10 +1,12 @@
+//go:build !linux
 // +build !linux
 
 package chroot
 
 import (
+	"errors"
+
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 func setSelinuxLabel(spec *specs.Spec) error {

--- a/chroot/unsupported.go
+++ b/chroot/unsupported.go
@@ -1,15 +1,16 @@
+//go:build !linux
 // +build !linux
 
 package chroot
 
 import (
+	"errors"
 	"io"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 // RunUsingChroot is not supported.
 func RunUsingChroot(spec *specs.Spec, bundlePath string, stdin io.Reader, stdout, stderr io.Writer) (err error) {
-	return errors.Errorf("--isolation chroot is not supported on this platform")
+	return errors.New("--isolation chroot is not supported on this platform")
 }

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/buildah/docker"
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/mattn/go-shellwords"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -118,7 +117,7 @@ func updateCmd(builder *buildah.Builder, cmd string) error {
 	}
 	cmdSpec, err := shellwords.Parse(cmd)
 	if err != nil {
-		return errors.Errorf("error parsing --cmd %q: %v", cmd, err)
+		return fmt.Errorf("error parsing --cmd %q: %w", cmd, err)
 	}
 	builder.SetCmd(cmdSpec)
 	return nil
@@ -204,7 +203,7 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 		shell := iopts.shell
 		shellSpec, err := shellwords.Parse(shell)
 		if err != nil {
-			return errors.Errorf("error parsing --shell %q: %v", shell, err)
+			return fmt.Errorf("error parsing --shell %q: %w", shell, err)
 		}
 		builder.SetShell(shellSpec)
 		conditionallyAddHistory(builder, c, "/bin/sh -c #(nop) SHELL %s", shell)
@@ -252,7 +251,7 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 		default:
 			value := os.Getenv(env[0])
 			if value == "" {
-				return errors.Errorf("error setting env %q: no value given", env[0])
+				return fmt.Errorf("error setting env %q: no value given", env[0])
 			}
 			builder.SetEnv(env[0], value)
 		}
@@ -364,14 +363,14 @@ func updateHealthcheck(builder *buildah.Builder, c *cobra.Command, iopts configR
 		if c.Flag("healthcheck").Changed {
 			test, err := shellwords.Parse(iopts.healthcheck)
 			if err != nil {
-				return errors.Errorf("error parsing --healthcheck %q: %v", iopts.healthcheck, err)
+				return fmt.Errorf("error parsing --healthcheck %q: %w", iopts.healthcheck, err)
 			}
 			healthcheck.Test = test
 		}
 		if c.Flag("healthcheck-interval").Changed {
 			duration, err := time.ParseDuration(iopts.healthcheckInterval)
 			if err != nil {
-				return errors.Errorf("error parsing --healthcheck-interval %q: %v", iopts.healthcheckInterval, err)
+				return fmt.Errorf("error parsing --healthcheck-interval %q: %w", iopts.healthcheckInterval, err)
 			}
 			healthcheck.Interval = duration
 			args = args + "--interval=" + iopts.healthcheckInterval + " "
@@ -385,7 +384,7 @@ func updateHealthcheck(builder *buildah.Builder, c *cobra.Command, iopts configR
 		if c.Flag("healthcheck-start-period").Changed {
 			duration, err := time.ParseDuration(iopts.healthcheckStartPeriod)
 			if err != nil {
-				return errors.Errorf("error parsing --healthcheck-start-period %q: %v", iopts.healthcheckStartPeriod, err)
+				return fmt.Errorf("error parsing --healthcheck-start-period %q: %w", iopts.healthcheckStartPeriod, err)
 			}
 			healthcheck.StartPeriod = duration
 			args = args + "--start-period=" + iopts.healthcheckStartPeriod + " "
@@ -393,7 +392,7 @@ func updateHealthcheck(builder *buildah.Builder, c *cobra.Command, iopts configR
 		if c.Flag("healthcheck-timeout").Changed {
 			duration, err := time.ParseDuration(iopts.healthcheckTimeout)
 			if err != nil {
-				return errors.Errorf("error parsing --healthcheck-timeout %q: %v", iopts.healthcheckTimeout, err)
+				return fmt.Errorf("error parsing --healthcheck-timeout %q: %w", iopts.healthcheckTimeout, err)
 			}
 			healthcheck.Timeout = duration
 			args = args + "--timeout=" + iopts.healthcheckTimeout + " "
@@ -411,13 +410,13 @@ func updateHealthcheck(builder *buildah.Builder, c *cobra.Command, iopts configR
 
 func configCmd(c *cobra.Command, args []string, iopts configResults) error {
 	if len(args) == 0 {
-		return errors.Errorf("container ID must be specified")
+		return fmt.Errorf("container ID must be specified")
 	}
 	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
 		return err
 	}
 	if len(args) > 1 {
-		return errors.Errorf("too many arguments specified")
+		return fmt.Errorf("too many arguments specified")
 	}
 	name := args[0]
 
@@ -428,7 +427,7 @@ func configCmd(c *cobra.Command, args []string, iopts configResults) error {
 
 	builder, err := openBuilder(getContext(), store, name)
 	if err != nil {
-		return errors.Wrapf(err, "error reading build container %q", name)
+		return fmt.Errorf("error reading build container %q: %w", name, err)
 	}
 
 	if err := updateConfig(builder, c, iopts); err != nil {

--- a/cmd/buildah/dumpbolt.go
+++ b/cmd/buildah/dumpbolt.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	bolt "go.etcd.io/bbolt"
 )
@@ -25,7 +24,7 @@ var (
 func dumpBoltCmd(c *cobra.Command, args []string) error {
 	db, err := bolt.Open(args[0], 0600, &bolt.Options{ReadOnly: true})
 	if err != nil {
-		return errors.Wrapf(err, "error opening database %q", args[0])
+		return fmt.Errorf("error opening database %q: %w", args[0], err)
 	}
 	defer db.Close()
 

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/libimage"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -108,7 +108,7 @@ func init() {
 func imagesCmd(c *cobra.Command, args []string, iopts *imageResults) error {
 	if len(args) > 0 {
 		if iopts.all {
-			return errors.Errorf("when using the --all switch, you may not pass any images names or IDs")
+			return errors.New("when using the --all switch, you may not pass any images names or IDs")
 		}
 
 		if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
@@ -125,7 +125,7 @@ func imagesCmd(c *cobra.Command, args []string, iopts *imageResults) error {
 	}
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return errors.Wrapf(err, "error building system context")
+		return fmt.Errorf("error building system context: %w", err)
 	}
 	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
 	if err != nil {
@@ -148,7 +148,7 @@ func imagesCmd(c *cobra.Command, args []string, iopts *imageResults) error {
 	}
 
 	if iopts.quiet && iopts.format != "" {
-		return errors.Errorf("quiet and format are mutually exclusive")
+		return errors.New("quiet and format are mutually exclusive")
 	}
 
 	opts := imageOptions{

--- a/cmd/buildah/info.go
+++ b/cmd/buildah/info.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -53,7 +52,7 @@ func infoCmd(c *cobra.Command, iopts infoResults) error {
 
 	infoArr, err := buildah.Info(store)
 	if err != nil {
-		return errors.Wrapf(err, "error getting info")
+		return fmt.Errorf("error getting info: %w", err)
 	}
 
 	if iopts.debug {
@@ -68,13 +67,13 @@ func infoCmd(c *cobra.Command, iopts infoResults) error {
 	if iopts.format != "" {
 		format := iopts.format
 		if matched, err := regexp.MatchString("{{.*}}", format); err != nil {
-			return errors.Wrapf(err, "error validating format provided: %s", format)
+			return fmt.Errorf("error validating format provided: %s: %w", format, err)
 		} else if !matched {
-			return errors.Errorf("error invalid format provided: %s", format)
+			return fmt.Errorf("error invalid format provided: %s", format)
 		}
 		t, err := template.New("format").Parse(format)
 		if err != nil {
-			return errors.Wrapf(err, "Template parsing error")
+			return fmt.Errorf("Template parsing error: %w", err)
 		}
 		if err = t.Execute(os.Stdout, info); err != nil {
 			return err

--- a/cmd/buildah/login.go
+++ b/cmd/buildah/login.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/pkg/auth"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -47,10 +48,10 @@ func init() {
 
 func loginCmd(c *cobra.Command, args []string, iopts *loginReply) error {
 	if len(args) > 1 {
-		return errors.Errorf("too many arguments, login takes only 1 argument")
+		return errors.New("too many arguments, login takes only 1 argument")
 	}
 	if len(args) == 0 {
-		return errors.Errorf("please specify a registry to login to")
+		return errors.New("please specify a registry to login to")
 	}
 
 	if err := setXDGRuntimeDir(); err != nil {
@@ -59,7 +60,7 @@ func loginCmd(c *cobra.Command, args []string, iopts *loginReply) error {
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return errors.Wrapf(err, "error building system context")
+		return fmt.Errorf("error building system context: %w", err)
 	}
 	ctx := getContext()
 	iopts.loginOpts.GetLoginSet = c.Flag("get-login").Changed

--- a/cmd/buildah/logout.go
+++ b/cmd/buildah/logout.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/pkg/auth"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -36,10 +37,10 @@ func init() {
 
 func logoutCmd(c *cobra.Command, args []string, iopts *auth.LogoutOptions) error {
 	if len(args) > 1 {
-		return errors.Errorf("too many arguments, logout takes at most 1 argument")
+		return errors.New("too many arguments, logout takes at most 1 argument")
 	}
 	if len(args) == 0 && !iopts.All {
-		return errors.Errorf("registry must be given")
+		return errors.New("registry must be given")
 	}
 
 	if err := setXDGRuntimeDir(); err != nil {
@@ -48,7 +49,7 @@ func logoutCmd(c *cobra.Command, args []string, iopts *auth.LogoutOptions) error
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return errors.Wrapf(err, "error building system context")
+		return fmt.Errorf("error building system context: %w", err)
 	}
 	return auth.Logout(systemContext, iopts, args)
 }

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	buildahcli "github.com/containers/buildah/pkg/cli"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -77,7 +76,7 @@ func mountCmd(c *cobra.Command, args []string, opts mountOptions) error {
 		// Differently, allow the mount if we are already in a userns, as the mount point will still
 		// be accessible once "buildah mount" exits.
 		if os.Geteuid() != 0 && store.GraphDriverName() != "vfs" {
-			return errors.Errorf("cannot mount using driver %s in rootless mode. You need to run it in a `buildah unshare` session", store.GraphDriverName())
+			return fmt.Errorf("cannot mount using driver %s in rootless mode. You need to run it in a `buildah unshare` session", store.GraphDriverName())
 		}
 
 		for _, name := range args {
@@ -86,7 +85,7 @@ func mountCmd(c *cobra.Command, args []string, opts mountOptions) error {
 				if lastError != nil {
 					fmt.Fprintln(os.Stderr, lastError)
 				}
-				lastError = errors.Wrapf(err, "error reading build container %q", name)
+				lastError = fmt.Errorf("error reading build container %q: %w", name, err)
 				continue
 			}
 			mountPoint, err := builder.Mount(builder.MountLabel)
@@ -94,7 +93,7 @@ func mountCmd(c *cobra.Command, args []string, opts mountOptions) error {
 				if lastError != nil {
 					fmt.Fprintln(os.Stderr, lastError)
 				}
-				lastError = errors.Wrapf(err, "error mounting %q container %q", name, builder.Container)
+				lastError = fmt.Errorf("error mounting %q container %q: %w", name, builder.Container, err)
 				continue
 			}
 			if len(args) > 1 {
@@ -114,7 +113,7 @@ func mountCmd(c *cobra.Command, args []string, opts mountOptions) error {
 	} else {
 		builders, err := openBuilders(store)
 		if err != nil {
-			return errors.Wrapf(err, "error reading build containers")
+			return fmt.Errorf("error reading build containers: %w", err)
 		}
 
 		for _, builder := range builders {

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -11,7 +12,6 @@ import (
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/pkg/auth"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -81,13 +81,13 @@ func init() {
 
 func pullCmd(c *cobra.Command, args []string, iopts pullOptions) error {
 	if len(args) == 0 {
-		return errors.Errorf("an image name must be specified")
+		return errors.New("an image name must be specified")
 	}
 	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
 		return err
 	}
 	if len(args) > 1 {
-		return errors.Errorf("too many arguments specified")
+		return errors.New("too many arguments specified")
 	}
 	if err := auth.CheckAuthFile(iopts.authfile); err != nil {
 		return err
@@ -95,7 +95,7 @@ func pullCmd(c *cobra.Command, args []string, iopts pullOptions) error {
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return errors.Wrapf(err, "error building system context")
+		return fmt.Errorf("error building system context: %w", err)
 	}
 	platforms, err := parse.PlatformsFromOptions(c)
 	if err != nil {
@@ -112,7 +112,7 @@ func pullCmd(c *cobra.Command, args []string, iopts pullOptions) error {
 
 	decConfig, err := util.DecryptConfig(iopts.decryptionKeys)
 	if err != nil {
-		return errors.Wrapf(err, "unable to obtain decrypt config")
+		return fmt.Errorf("unable to obtain decrypt config: %w", err)
 	}
 
 	policy, ok := define.PolicyMap[iopts.pullPolicy]

--- a/cmd/buildah/rename.go
+++ b/cmd/buildah/rename.go
@@ -1,8 +1,9 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/containers/buildah"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -37,21 +38,21 @@ func renameCmd(c *cobra.Command, args []string) error {
 
 	builder, err = openBuilder(getContext(), store, name)
 	if err != nil {
-		return errors.Wrapf(err, "error reading build container %q", name)
+		return fmt.Errorf("error reading build container %q: %w", name, err)
 	}
 
 	oldName := builder.Container
 	if oldName == newName {
-		return errors.Errorf("renaming a container with the same name as its current name")
+		return fmt.Errorf("renaming a container with the same name as its current name")
 	}
 
 	if build, err := openBuilder(getContext(), store, newName); err == nil {
-		return errors.Errorf("The container name %q is already in use by container %q", newName, build.ContainerID)
+		return fmt.Errorf("The container name %q is already in use by container %q", newName, build.ContainerID)
 	}
 
 	err = store.SetNames(builder.ContainerID, []string{newName})
 	if err != nil {
-		return errors.Wrapf(err, "error renaming container %q to the name %q", oldName, newName)
+		return fmt.Errorf("error renaming container %q to the name %q: %w", oldName, newName, err)
 	}
 	builder.Container = newName
 	return builder.Save()

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/libimage"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -48,16 +48,16 @@ func init() {
 
 func rmiCmd(c *cobra.Command, args []string, iopts rmiOptions) error {
 	if len(args) == 0 && !iopts.all && !iopts.prune {
-		return errors.Errorf("image name or ID must be specified")
+		return errors.New("image name or ID must be specified")
 	}
 	if len(args) > 0 && iopts.all {
-		return errors.Errorf("when using the --all switch, you may not pass any images names or IDs")
+		return errors.New("when using the --all switch, you may not pass any images names or IDs")
 	}
 	if iopts.all && iopts.prune {
-		return errors.Errorf("when using the --all switch, you may not use --prune switch")
+		return errors.New("when using the --all switch, you may not use --prune switch")
 	}
 	if len(args) > 0 && iopts.prune {
-		return errors.Errorf("when using the --prune switch, you may not pass any images names or IDs")
+		return errors.New("when using the --prune switch, you may not pass any images names or IDs")
 	}
 
 	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -10,7 +12,6 @@ import (
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
 	"github.com/containers/storage/pkg/lockfile"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -88,7 +89,7 @@ func init() {
 
 func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 	if len(args) == 0 {
-		return errors.Errorf("container ID must be specified")
+		return errors.New("container ID must be specified")
 	}
 	name := args[0]
 	args = Tail(args)
@@ -97,7 +98,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 	}
 
 	if len(args) == 0 {
-		return errors.Errorf("command must be specified")
+		return errors.New("command must be specified")
 	}
 
 	store, err := getStore(c)
@@ -107,7 +108,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 
 	builder, err := openBuilder(getContext(), store, name)
 	if err != nil {
-		return errors.Wrapf(err, "error reading build container %q", name)
+		return fmt.Errorf("error reading build container %q: %w", name, err)
 	}
 
 	isolation, err := parse.IsolationOption(c.Flag("isolation").Value.String())
@@ -156,7 +157,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return errors.Wrapf(err, "error building system context")
+		return fmt.Errorf("error building system context: %w", err)
 	}
 	mounts, mountedImages, lockedTargets, err := internalParse.GetVolumes(systemContext, store, iopts.volumes, iopts.mounts, iopts.contextDir)
 	if err != nil {

--- a/cmd/buildah/tag.go
+++ b/cmd/buildah/tag.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/libimage"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +29,7 @@ func tagCmd(c *cobra.Command, args []string) error {
 	}
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return errors.Wrapf(err, "error building system context")
+		return fmt.Errorf("error building system context: %w", err)
 	}
 	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
 	if err != nil {

--- a/cmd/buildah/umount.go
+++ b/cmd/buildah/umount.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	buildahcli "github.com/containers/buildah/pkg/cli"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -36,10 +36,10 @@ func umountCmd(c *cobra.Command, args []string) error {
 	}
 	umountContainerErrStr := "error unmounting container"
 	if len(args) == 0 && !umountAll {
-		return errors.Errorf("at least one container ID must be specified")
+		return errors.New("at least one container ID must be specified")
 	}
 	if len(args) > 0 && umountAll {
-		return errors.Errorf("when using the --all switch, you may not pass any container IDs")
+		return errors.New("when using the --all switch, you may not pass any container IDs")
 	}
 	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
 		return err
@@ -58,7 +58,7 @@ func umountCmd(c *cobra.Command, args []string) error {
 				if lastError != nil {
 					fmt.Fprintln(os.Stderr, lastError)
 				}
-				lastError = errors.Wrapf(err, "%s %s", umountContainerErrStr, name)
+				lastError = fmt.Errorf("%s %s: %w", umountContainerErrStr, name, err)
 				continue
 			}
 			if builder.MountPoint == "" {
@@ -69,7 +69,7 @@ func umountCmd(c *cobra.Command, args []string) error {
 				if lastError != nil {
 					fmt.Fprintln(os.Stderr, lastError)
 				}
-				lastError = errors.Wrapf(err, "%s %q", umountContainerErrStr, builder.Container)
+				lastError = fmt.Errorf("%s %q: %w", umountContainerErrStr, builder.Container, err)
 				continue
 			}
 			fmt.Printf("%s\n", builder.ContainerID)
@@ -77,7 +77,7 @@ func umountCmd(c *cobra.Command, args []string) error {
 	} else {
 		builders, err := openBuilders(store)
 		if err != nil {
-			return errors.Wrapf(err, "error reading build Containers")
+			return fmt.Errorf("error reading build Containers: %w", err)
 		}
 		for _, builder := range builders {
 			if builder.MountPoint == "" {
@@ -88,7 +88,7 @@ func umountCmd(c *cobra.Command, args []string) error {
 				if lastError != nil {
 					fmt.Fprintln(os.Stderr, lastError)
 				}
-				lastError = errors.Wrapf(err, "%s %q", umountContainerErrStr, builder.Container)
+				lastError = fmt.Errorf("%s %q: %w", umountContainerErrStr, builder.Container, err)
 				continue
 			}
 			fmt.Printf("%s\n", builder.ContainerID)

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package main
@@ -10,7 +11,6 @@ import (
 
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/unshare"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -47,12 +47,12 @@ func unshareMount(c *cobra.Command, mounts []string) ([]string, func(), error) {
 		for _, mounted := range mountedContainers {
 			builder, err := openBuilder(getContext(), store, mounted)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, errors.Wrapf(err, "error loading information about build container %q", mounted))
+				fmt.Fprintln(os.Stderr, fmt.Errorf("error loading information about build container %q: %w", mounted, err))
 				continue
 			}
 			err = builder.Unmount()
 			if err != nil {
-				fmt.Fprintln(os.Stderr, errors.Wrapf(err, "error unmounting build container %q", mounted))
+				fmt.Fprintln(os.Stderr, fmt.Errorf("error unmounting build container %q: %w", mounted, err))
 				continue
 			}
 		}
@@ -72,12 +72,12 @@ func unshareMount(c *cobra.Command, mounts []string) ([]string, func(), error) {
 		builder, err := openBuilder(getContext(), store, container)
 		if err != nil {
 			unmount()
-			return nil, nil, errors.Wrapf(err, "error loading information about build container %q", container)
+			return nil, nil, fmt.Errorf("error loading information about build container %q: %w", container, err)
 		}
 		mountPoint, err := builder.Mount(builder.MountLabel)
 		if err != nil {
 			unmount()
-			return nil, nil, errors.Wrapf(err, "error mounting build container %q", container)
+			return nil, nil, fmt.Errorf("error mounting build container %q: %w", container, err)
 		}
 		logrus.Debugf("mounted container %q at %q", container, mountPoint)
 		mountedContainers = append(mountedContainers, container)

--- a/commit.go
+++ b/commit.go
@@ -3,6 +3,8 @@ package buildah
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -25,7 +27,6 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/stringid"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -145,7 +146,7 @@ func checkRegistrySourcesAllows(forWhat string, dest types.ImageReference) (inse
 			AllowedRegistries  []string `json:"allowedRegistries,omitempty"`
 		}
 		if err := json.Unmarshal([]byte(registrySources), &sources); err != nil {
-			return false, errors.Wrapf(err, "error parsing $BUILD_REGISTRY_SOURCES (%q) as JSON", registrySources)
+			return false, fmt.Errorf("error parsing $BUILD_REGISTRY_SOURCES (%q) as JSON: %w", registrySources, err)
 		}
 		blocked := false
 		if len(sources.BlockedRegistries) > 0 {
@@ -156,7 +157,7 @@ func checkRegistrySourcesAllows(forWhat string, dest types.ImageReference) (inse
 			}
 		}
 		if blocked {
-			return false, errors.Errorf("%s registry at %q denied by policy: it is in the blocked registries list", forWhat, reference.Domain(dref))
+			return false, fmt.Errorf("%s registry at %q denied by policy: it is in the blocked registries list", forWhat, reference.Domain(dref))
 		}
 		allowed := true
 		if len(sources.AllowedRegistries) > 0 {
@@ -168,7 +169,7 @@ func checkRegistrySourcesAllows(forWhat string, dest types.ImageReference) (inse
 			}
 		}
 		if !allowed {
-			return false, errors.Errorf("%s registry at %q denied by policy: not in allowed registries list", forWhat, reference.Domain(dref))
+			return false, fmt.Errorf("%s registry at %q denied by policy: not in allowed registries list", forWhat, reference.Domain(dref))
 		}
 		if len(sources.InsecureRegistries) > 0 {
 			return true, nil
@@ -204,7 +205,7 @@ func (b *Builder) addManifest(ctx context.Context, manifestName string, imageSpe
 
 	names, err := util.ExpandNames([]string{manifestName}, systemContext, b.store)
 	if err != nil {
-		return "", errors.Wrapf(err, "error encountered while expanding manifest list name %q", manifestName)
+		return "", fmt.Errorf("error encountered while expanding manifest list name %q: %w", manifestName, err)
 	}
 
 	ref, err := util.VerifyTagName(imageSpec)
@@ -247,7 +248,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 	// work twice.
 	if options.OmitTimestamp {
 		if options.HistoryTimestamp != nil {
-			return imgID, nil, "", errors.Errorf("OmitTimestamp ahd HistoryTimestamp can not be used together")
+			return imgID, nil, "", fmt.Errorf("OmitTimestamp ahd HistoryTimestamp can not be used together")
 		}
 		timestamp := time.Unix(0, 0).UTC()
 		options.HistoryTimestamp = &timestamp
@@ -257,7 +258,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 		nameToRemove = stringid.GenerateRandomID() + "-tmp"
 		dest2, err := is.Transport.ParseStoreReference(b.store, nameToRemove)
 		if err != nil {
-			return imgID, nil, "", errors.Wrapf(err, "error creating temporary destination reference for image")
+			return imgID, nil, "", fmt.Errorf("error creating temporary destination reference for image: %w", err)
 		}
 		dest = dest2
 	}
@@ -266,23 +267,23 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 
 	blocked, err := isReferenceBlocked(dest, systemContext)
 	if err != nil {
-		return "", nil, "", errors.Wrapf(err, "error checking if committing to registry for %q is blocked", transports.ImageName(dest))
+		return "", nil, "", fmt.Errorf("error checking if committing to registry for %q is blocked: %w", transports.ImageName(dest), err)
 	}
 	if blocked {
-		return "", nil, "", errors.Errorf("commit access to registry for %q is blocked by configuration", transports.ImageName(dest))
+		return "", nil, "", fmt.Errorf("commit access to registry for %q is blocked by configuration", transports.ImageName(dest))
 	}
 
 	// Load the system signing policy.
 	commitPolicy, err := signature.DefaultPolicy(systemContext)
 	if err != nil {
-		return "", nil, "", errors.Wrapf(err, "error obtaining default signature policy")
+		return "", nil, "", fmt.Errorf("error obtaining default signature policy: %w", err)
 	}
 	// Override the settings for local storage to make sure that we can always read the source "image".
 	commitPolicy.Transports[is.Transport.Name()] = storageAllowedPolicyScopes
 
 	policyContext, err := signature.NewPolicyContext(commitPolicy)
 	if err != nil {
-		return imgID, nil, "", errors.Wrapf(err, "error creating new signature policy context")
+		return imgID, nil, "", fmt.Errorf("error creating new signature policy context: %w", err)
 	}
 	defer func() {
 		if err2 := policyContext.Destroy(); err2 != nil {
@@ -297,7 +298,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 	}
 	if insecure {
 		if systemContext.DockerInsecureSkipTLSVerify == types.OptionalBoolFalse {
-			return imgID, nil, "", errors.Errorf("can't require tls verification on an insecured registry")
+			return imgID, nil, "", fmt.Errorf("can't require tls verification on an insecured registry")
 		}
 		systemContext.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
 		systemContext.OCIInsecureSkipTLSVerify = true
@@ -308,7 +309,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 	// Build an image reference from which we can copy the finished image.
 	src, err = b.makeContainerImageRef(options)
 	if err != nil {
-		return imgID, nil, "", errors.Wrapf(err, "error computing layer digests and building metadata for container %q", b.ContainerID)
+		return imgID, nil, "", fmt.Errorf("error computing layer digests and building metadata for container %q: %w", b.ContainerID, err)
 	}
 	// In case we're using caching, decide how to handle compression for a cache.
 	// If we're using blob caching, set it up for the source.
@@ -321,12 +322,12 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 		}
 		cache, err := blobcache.NewBlobCache(src, options.BlobDirectory, compress)
 		if err != nil {
-			return imgID, nil, "", errors.Wrapf(err, "error wrapping image reference %q in blob cache at %q", transports.ImageName(src), options.BlobDirectory)
+			return imgID, nil, "", fmt.Errorf("error wrapping image reference %q in blob cache at %q: %w", transports.ImageName(src), options.BlobDirectory, err)
 		}
 		maybeCachedSrc = cache
 		cache, err = blobcache.NewBlobCache(dest, options.BlobDirectory, compress)
 		if err != nil {
-			return imgID, nil, "", errors.Wrapf(err, "error wrapping image reference %q in blob cache at %q", transports.ImageName(dest), options.BlobDirectory)
+			return imgID, nil, "", fmt.Errorf("error wrapping image reference %q in blob cache at %q: %w", transports.ImageName(dest), options.BlobDirectory, err)
 		}
 		maybeCachedDest = cache
 	}
@@ -347,7 +348,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 
 	var manifestBytes []byte
 	if manifestBytes, err = retryCopyImage(ctx, policyContext, maybeCachedDest, maybeCachedSrc, dest, getCopyOptions(b.store, options.ReportWriter, nil, systemContext, "", false, options.SignBy, options.OciEncryptLayers, options.OciEncryptConfig, nil), options.MaxRetries, options.RetryDelay); err != nil {
-		return imgID, nil, "", errors.Wrapf(err, "error copying layers and metadata for container %q", b.ContainerID)
+		return imgID, nil, "", fmt.Errorf("error copying layers and metadata for container %q: %w", b.ContainerID, err)
 	}
 	// If we've got more names to attach, and we know how to do that for
 	// the transport that we're writing the new image to, add them now.
@@ -356,10 +357,10 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 		case is.Transport.Name():
 			img, err := is.Transport.GetStoreImage(b.store, dest)
 			if err != nil {
-				return imgID, nil, "", errors.Wrapf(err, "error locating just-written image %q", transports.ImageName(dest))
+				return imgID, nil, "", fmt.Errorf("error locating just-written image %q: %w", transports.ImageName(dest), err)
 			}
 			if err = util.AddImageNames(b.store, "", systemContext, img, options.AdditionalTags); err != nil {
-				return imgID, nil, "", errors.Wrapf(err, "error setting image names to %v", append(img.Names, options.AdditionalTags...))
+				return imgID, nil, "", fmt.Errorf("error setting image names to %v: %w", append(img.Names, options.AdditionalTags...), err)
 			}
 			logrus.Debugf("assigned names %v to image %q", img.Names, img.ID)
 		default:
@@ -368,8 +369,8 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 	}
 
 	img, err := is.Transport.GetStoreImage(b.store, dest)
-	if err != nil && errors.Cause(err) != storage.ErrImageUnknown {
-		return imgID, nil, "", errors.Wrapf(err, "error locating image %q in local storage", transports.ImageName(dest))
+	if err != nil && !errors.Is(err, storage.ErrImageUnknown) {
+		return imgID, nil, "", fmt.Errorf("error locating image %q in local storage: %w", transports.ImageName(dest), err)
 	}
 	if err == nil {
 		imgID = img.ID
@@ -381,12 +382,12 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 		}
 		if len(prunedNames) < len(img.Names) {
 			if err = b.store.SetNames(imgID, prunedNames); err != nil {
-				return imgID, nil, "", errors.Wrapf(err, "failed to prune temporary name from image %q", imgID)
+				return imgID, nil, "", fmt.Errorf("failed to prune temporary name from image %q: %w", imgID, err)
 			}
 			logrus.Debugf("reassigned names %v to image %q", prunedNames, img.ID)
 			dest2, err := is.Transport.ParseStoreReference(b.store, "@"+imgID)
 			if err != nil {
-				return imgID, nil, "", errors.Wrapf(err, "error creating unnamed destination reference for image")
+				return imgID, nil, "", fmt.Errorf("error creating unnamed destination reference for image: %w", err)
 			}
 			dest = dest2
 		}
@@ -399,7 +400,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 
 	manifestDigest, err := manifest.Digest(manifestBytes)
 	if err != nil {
-		return imgID, nil, "", errors.Wrapf(err, "error computing digest of manifest of new image %q", transports.ImageName(dest))
+		return imgID, nil, "", fmt.Errorf("error computing digest of manifest of new image %q: %w", transports.ImageName(dest), err)
 	}
 
 	var ref reference.Canonical

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package buildah
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -18,7 +19,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/stringid"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -28,7 +28,7 @@ import (
 func unmarshalConvertedConfig(ctx context.Context, dest interface{}, img types.Image, wantedManifestMIMEType string) error {
 	_, actualManifestMIMEType, err := img.Manifest(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "error getting manifest MIME type for %q", transports.ImageName(img.Reference()))
+		return fmt.Errorf("error getting manifest MIME type for %q: %w", transports.ImageName(img.Reference()), err)
 	}
 	if wantedManifestMIMEType != actualManifestMIMEType {
 		layerInfos := img.LayerInfos()
@@ -40,22 +40,22 @@ func unmarshalConvertedConfig(ctx context.Context, dest interface{}, img types.I
 			LayerInfos: layerInfos,
 		})
 		if err != nil {
-			return errors.Wrapf(err, "resetting recorded compression for %q", transports.ImageName(img.Reference()))
+			return fmt.Errorf("resetting recorded compression for %q: %w", transports.ImageName(img.Reference()), err)
 		}
 		secondUpdatedImg, err := updatedImg.UpdatedImage(ctx, types.ManifestUpdateOptions{
 			ManifestMIMEType: wantedManifestMIMEType,
 		})
 		if err != nil {
-			return errors.Wrapf(err, "error converting image %q from %q to %q", transports.ImageName(img.Reference()), actualManifestMIMEType, wantedManifestMIMEType)
+			return fmt.Errorf("error converting image %q from %q to %q: %w", transports.ImageName(img.Reference()), actualManifestMIMEType, wantedManifestMIMEType, err)
 		}
 		img = secondUpdatedImg
 	}
 	config, err := img.ConfigBlob(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "error reading %s config from %q", wantedManifestMIMEType, transports.ImageName(img.Reference()))
+		return fmt.Errorf("error reading %s config from %q: %w", wantedManifestMIMEType, transports.ImageName(img.Reference()), err)
 	}
 	if err := json.Unmarshal(config, dest); err != nil {
-		return errors.Wrapf(err, "error parsing %s configuration %q from %q", wantedManifestMIMEType, string(config), transports.ImageName(img.Reference()))
+		return fmt.Errorf("error parsing %s configuration %q from %q: %w", wantedManifestMIMEType, string(config), transports.ImageName(img.Reference()), err)
 	}
 	return nil
 }
@@ -64,11 +64,11 @@ func (b *Builder) initConfig(ctx context.Context, img types.Image, sys *types.Sy
 	if img != nil { // A pre-existing image, as opposed to a "FROM scratch" new one.
 		rawManifest, manifestMIMEType, err := img.Manifest(ctx)
 		if err != nil {
-			return errors.Wrapf(err, "error reading image manifest for %q", transports.ImageName(img.Reference()))
+			return fmt.Errorf("error reading image manifest for %q: %w", transports.ImageName(img.Reference()), err)
 		}
 		rawConfig, err := img.ConfigBlob(ctx)
 		if err != nil {
-			return errors.Wrapf(err, "error reading image configuration for %q", transports.ImageName(img.Reference()))
+			return fmt.Errorf("error reading image configuration for %q: %w", transports.ImageName(img.Reference()), err)
 		}
 		b.Manifest = rawManifest
 		b.Config = rawConfig
@@ -89,7 +89,7 @@ func (b *Builder) initConfig(ctx context.Context, img types.Image, sys *types.Sy
 			// Attempt to recover format-specific data from the manifest.
 			v1Manifest := ociv1.Manifest{}
 			if err := json.Unmarshal(b.Manifest, &v1Manifest); err != nil {
-				return errors.Wrapf(err, "error parsing OCI manifest %q", string(b.Manifest))
+				return fmt.Errorf("error parsing OCI manifest %q: %w", string(b.Manifest), err)
 			}
 			for k, v := range v1Manifest.Annotations {
 				// NOTE: do not override annotations that are

--- a/copier/copier.go
+++ b/copier/copier.go
@@ -4,7 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/json"
-	stderrors "errors"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -25,7 +25,6 @@ import (
 	"github.com/containers/storage/pkg/fileutils"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/reexec"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -454,17 +453,17 @@ func cleanerReldirectory(candidate string) string {
 // the two directories are on different volumes
 func convertToRelSubdirectory(root, directory string) (relative string, err error) {
 	if root == "" || !filepath.IsAbs(root) {
-		return "", errors.Errorf("expected root directory to be an absolute path, got %q", root)
+		return "", fmt.Errorf("expected root directory to be an absolute path, got %q", root)
 	}
 	if directory == "" || !filepath.IsAbs(directory) {
-		return "", errors.Errorf("expected directory to be an absolute path, got %q", root)
+		return "", fmt.Errorf("expected directory to be an absolute path, got %q", root)
 	}
 	if filepath.VolumeName(root) != filepath.VolumeName(directory) {
-		return "", errors.Errorf("%q and %q are on different volumes", root, directory)
+		return "", fmt.Errorf("%q and %q are on different volumes", root, directory)
 	}
 	rel, err := filepath.Rel(root, directory)
 	if err != nil {
-		return "", errors.Wrapf(err, "error computing path of %q relative to %q", directory, root)
+		return "", fmt.Errorf("error computing path of %q relative to %q: %w", directory, root, err)
 	}
 	return cleanerReldirectory(rel), nil
 }
@@ -472,7 +471,7 @@ func convertToRelSubdirectory(root, directory string) (relative string, err erro
 func currentVolumeRoot() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", errors.Wrapf(err, "error getting current working directory")
+		return "", fmt.Errorf("error getting current working directory: %w", err)
 	}
 	return filepath.VolumeName(cwd) + string(os.PathSeparator), nil
 }
@@ -480,7 +479,7 @@ func currentVolumeRoot() (string, error) {
 func isVolumeRoot(candidate string) (bool, error) {
 	abs, err := filepath.Abs(candidate)
 	if err != nil {
-		return false, errors.Wrapf(err, "error converting %q to an absolute path", candidate)
+		return false, fmt.Errorf("error converting %q to an absolute path: %w", candidate, err)
 	}
 	return abs == filepath.VolumeName(abs)+string(os.PathSeparator), nil
 }
@@ -494,7 +493,7 @@ func copier(bulkReader io.Reader, bulkWriter io.Writer, req request) (*response,
 		if req.Root == "" {
 			wd, err := os.Getwd()
 			if err != nil {
-				return nil, errors.Wrapf(err, "error getting current working directory")
+				return nil, fmt.Errorf("error getting current working directory: %w", err)
 			}
 			req.Directory = wd
 		} else {
@@ -504,19 +503,19 @@ func copier(bulkReader io.Reader, bulkWriter io.Writer, req request) (*response,
 	if req.Root == "" {
 		root, err := currentVolumeRoot()
 		if err != nil {
-			return nil, errors.Wrapf(err, "error determining root of current volume")
+			return nil, fmt.Errorf("error determining root of current volume: %w", err)
 		}
 		req.Root = root
 	}
 	if filepath.IsAbs(req.Directory) {
 		_, err := convertToRelSubdirectory(req.Root, req.Directory)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error rewriting %q to be relative to %q", req.Directory, req.Root)
+			return nil, fmt.Errorf("error rewriting %q to be relative to %q: %w", req.Directory, req.Root, err)
 		}
 	}
 	isAlreadyRoot, err := isVolumeRoot(req.Root)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error checking if %q is a root directory", req.Root)
+		return nil, fmt.Errorf("error checking if %q is a root directory: %w", req.Root, err)
 	}
 	if !isAlreadyRoot && canChroot {
 		return copierWithSubprocess(bulkReader, bulkWriter, req)
@@ -578,27 +577,27 @@ func copierWithSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req reques
 	cmd := reexec.Command(copierCommand)
 	stdinRead, stdinWrite, err := os.Pipe()
 	if err != nil {
-		return nil, errors.Wrapf(err, "pipe")
+		return nil, fmt.Errorf("pipe: %w", err)
 	}
 	defer closeIfNotNilYet(&stdinRead, "stdin pipe reader")
 	defer closeIfNotNilYet(&stdinWrite, "stdin pipe writer")
 	encoder := json.NewEncoder(stdinWrite)
 	stdoutRead, stdoutWrite, err := os.Pipe()
 	if err != nil {
-		return nil, errors.Wrapf(err, "pipe")
+		return nil, fmt.Errorf("pipe: %w", err)
 	}
 	defer closeIfNotNilYet(&stdoutRead, "stdout pipe reader")
 	defer closeIfNotNilYet(&stdoutWrite, "stdout pipe writer")
 	decoder := json.NewDecoder(stdoutRead)
 	bulkReaderRead, bulkReaderWrite, err := os.Pipe()
 	if err != nil {
-		return nil, errors.Wrapf(err, "pipe")
+		return nil, fmt.Errorf("pipe: %w", err)
 	}
 	defer closeIfNotNilYet(&bulkReaderRead, "child bulk content reader pipe, read end")
 	defer closeIfNotNilYet(&bulkReaderWrite, "child bulk content reader pipe, write end")
 	bulkWriterRead, bulkWriterWrite, err := os.Pipe()
 	if err != nil {
-		return nil, errors.Wrapf(err, "pipe")
+		return nil, fmt.Errorf("pipe: %w", err)
 	}
 	defer closeIfNotNilYet(&bulkWriterRead, "child bulk content writer pipe, read end")
 	defer closeIfNotNilYet(&bulkWriterWrite, "child bulk content writer pipe, write end")
@@ -611,7 +610,7 @@ func copierWithSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req reques
 	cmd.Stderr = &errorBuffer
 	cmd.ExtraFiles = []*os.File{bulkReaderRead, bulkWriterWrite}
 	if err = cmd.Start(); err != nil {
-		return nil, errors.Wrapf(err, "error starting subprocess")
+		return nil, fmt.Errorf("error starting subprocess: %w", err)
 	}
 	cmdToWaitFor := cmd
 	defer func() {
@@ -633,9 +632,9 @@ func copierWithSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req reques
 	bulkWriterWrite = nil
 	killAndReturn := func(err error, step string) (*response, error) { // nolint: unparam
 		if err2 := cmd.Process.Kill(); err2 != nil {
-			return nil, errors.Wrapf(err, "error killing subprocess: %v; %s", err2, step)
+			return nil, fmt.Errorf("error killing subprocess: %v; %s: %w", err2, step, err)
 		}
-		return nil, errors.Wrap(err, step)
+		return nil, fmt.Errorf("%v: %w", step, err)
 	}
 	if err = encoder.Encode(req); err != nil {
 		return killAndReturn(err, "error encoding request for copier subprocess")
@@ -691,10 +690,10 @@ func copierWithSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req reques
 		}
 	}
 	if readError != nil {
-		return nil, errors.Wrapf(readError, "error passing bulk input to subprocess")
+		return nil, fmt.Errorf("error passing bulk input to subprocess: %w", readError)
 	}
 	if writeError != nil {
-		return nil, errors.Wrapf(writeError, "error passing bulk output from subprocess")
+		return nil, fmt.Errorf("error passing bulk output from subprocess: %w", writeError)
 	}
 	return resp, nil
 }
@@ -846,7 +845,7 @@ func copierHandler(bulkReader io.Reader, bulkWriter io.Writer, req request) (*re
 	excludes := req.Excludes()
 	pm, err := fileutils.NewPatternMatcher(excludes)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error processing excludes list %v", excludes)
+		return nil, nil, fmt.Errorf("error processing excludes list %v: %w", excludes, err)
 	}
 
 	var idMappings *idtools.IDMappings
@@ -857,7 +856,7 @@ func copierHandler(bulkReader io.Reader, bulkWriter io.Writer, req request) (*re
 
 	switch req.Request {
 	default:
-		return nil, nil, errors.Errorf("not an implemented request type: %q", req.Request)
+		return nil, nil, fmt.Errorf("not an implemented request type: %q", req.Request)
 	case requestEval:
 		resp := copierHandlerEval(req)
 		return resp, nil, nil
@@ -884,7 +883,7 @@ func copierHandler(bulkReader io.Reader, bulkWriter io.Writer, req request) (*re
 func pathIsExcluded(root, path string, pm *fileutils.PatternMatcher) (string, bool, error) {
 	rel, err := convertToRelSubdirectory(root, path)
 	if err != nil {
-		return "", false, errors.Wrapf(err, "copier: error computing path of %q relative to root %q", path, root)
+		return "", false, fmt.Errorf("copier: error computing path of %q relative to root %q: %w", path, root, err)
 	}
 	if pm == nil {
 		return rel, false, nil
@@ -898,7 +897,7 @@ func pathIsExcluded(root, path string, pm *fileutils.PatternMatcher) (string, bo
 	// it expects Unix-style paths.
 	matches, err := pm.Matches(filepath.ToSlash(rel)) // nolint:staticcheck
 	if err != nil {
-		return rel, false, errors.Wrapf(err, "copier: error checking if %q is excluded", rel)
+		return rel, false, fmt.Errorf("copier: error checking if %q is excluded: %w", rel, err)
 	}
 	if matches {
 		return rel, true, nil
@@ -916,7 +915,7 @@ func pathIsExcluded(root, path string, pm *fileutils.PatternMatcher) (string, bo
 func resolvePath(root, path string, evaluateFinalComponent bool, pm *fileutils.PatternMatcher) (string, error) {
 	rel, err := convertToRelSubdirectory(root, path)
 	if err != nil {
-		return "", errors.Errorf("error making path %q relative to %q", path, root)
+		return "", fmt.Errorf("error making path %q relative to %q", path, root)
 	}
 	workingPath := root
 	followed := 0
@@ -953,7 +952,7 @@ func resolvePath(root, path string, evaluateFinalComponent bool, pm *fileutils.P
 				// resolve the remaining components
 				rel, err := convertToRelSubdirectory(root, filepath.Join(workingPath, target))
 				if err != nil {
-					return "", errors.Errorf("error making path %q relative to %q", filepath.Join(workingPath, target), root)
+					return "", fmt.Errorf("error making path %q relative to %q", filepath.Join(workingPath, target), root)
 				}
 				workingPath = root
 				components = append(strings.Split(filepath.Clean(string(os.PathSeparator)+rel), string(os.PathSeparator)), components[1:]...)
@@ -1101,11 +1100,10 @@ func copierHandlerStat(req request, pm *fileutils.PatternMatcher) *response {
 }
 
 func errorIsPermission(err error) bool {
-	err = errors.Cause(err)
 	if err == nil {
 		return false
 	}
-	return os.IsPermission(err) || strings.Contains(err.Error(), "permission denied")
+	return errors.Is(err, os.ErrPermission) || strings.Contains(err.Error(), "permission denied")
 }
 
 func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMatcher, idMappings *idtools.IDMappings) (*response, func() error, error) {
@@ -1154,7 +1152,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 			// if the named thing-to-read is a symlink, dereference it
 			info, err := os.Lstat(item)
 			if err != nil {
-				return errors.Wrapf(err, "copier: get: lstat %q", item)
+				return fmt.Errorf("copier: get: lstat %q: %w", item, err)
 			}
 			// chase links. if we hit a dead end, we should just fail
 			followedLinks := 0
@@ -1171,15 +1169,15 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 				}
 				item = path
 				if _, err = convertToRelSubdirectory(req.Root, item); err != nil {
-					return errors.Wrapf(err, "copier: get: computing path of %q(%q) relative to %q", queue[i], item, req.Root)
+					return fmt.Errorf("copier: get: computing path of %q(%q) relative to %q: %w", queue[i], item, req.Root, err)
 				}
 				if info, err = os.Lstat(item); err != nil {
-					return errors.Wrapf(err, "copier: get: lstat %q(%q)", queue[i], item)
+					return fmt.Errorf("copier: get: lstat %q(%q): %w", queue[i], item, err)
 				}
 				followedLinks++
 			}
 			if followedLinks >= maxFollowedLinks {
-				return errors.Wrapf(syscall.ELOOP, "copier: get: resolving symlink %q(%q)", queue[i], item)
+				return fmt.Errorf("copier: get: resolving symlink %q(%q): %w", queue[i], item, syscall.ELOOP)
 			}
 			// evaluate excludes relative to the root directory
 			if info.Mode().IsDir() {
@@ -1193,11 +1191,11 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 								return filepath.SkipDir
 							}
 							return nil
-						} else if os.IsNotExist(errors.Cause(err)) {
+						} else if errors.Is(err, os.ErrNotExist) {
 							logrus.Warningf("copier: file disappeared while reading: %q", path)
 							return nil
 						}
-						return errors.Wrapf(err, "copier: get: error reading %q", path)
+						return fmt.Errorf("copier: get: error reading %q: %w", path, err)
 					}
 					if d.Type() == os.ModeSocket {
 						logrus.Warningf("copier: skipping socket %q", d.Name())
@@ -1208,7 +1206,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 					// for the tar header
 					rel, relErr := convertToRelSubdirectory(item, path)
 					if relErr != nil {
-						return errors.Wrapf(relErr, "copier: get: error computing path of %q relative to top directory %q", path, item)
+						return fmt.Errorf("copier: get: error computing path of %q relative to top directory %q: %w", path, item, relErr)
 					}
 					// prefix the original item's name if we're keeping it
 					if relNamePrefix != "" {
@@ -1264,7 +1262,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 					if d.Type() == os.ModeSymlink {
 						target, err := os.Readlink(path)
 						if err != nil {
-							return errors.Wrapf(err, "copier: get: readlink(%q(%q))", rel, path)
+							return fmt.Errorf("copier: get: readlink(%q(%q)): %w", rel, path, err)
 						}
 						symlinkTarget = target
 					}
@@ -1284,7 +1282,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 					if err := copierHandlerGetOne(info, symlinkTarget, rel, path, options, tw, hardlinkChecker, idMappings); err != nil {
 						if req.GetOptions.IgnoreUnreadable && errorIsPermission(err) {
 							return ok
-						} else if os.IsNotExist(errors.Cause(err)) {
+						} else if errors.Is(err, os.ErrNotExist) {
 							logrus.Warningf("copier: file disappeared while reading: %q", path)
 							return nil
 						}
@@ -1294,7 +1292,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 				}
 				// walk the directory tree, checking/adding items individually
 				if err := filepath.WalkDir(item, walkfn); err != nil {
-					return errors.Wrapf(err, "copier: get: %q(%q)", queue[i], item)
+					return fmt.Errorf("copier: get: %q(%q): %w", queue[i], item, err)
 				}
 				itemsCopied++
 			} else {
@@ -1313,13 +1311,13 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 					if req.GetOptions.IgnoreUnreadable && errorIsPermission(err) {
 						continue
 					}
-					return errors.Wrapf(err, "copier: get: %q", queue[i])
+					return fmt.Errorf("copier: get: %q: %w", queue[i], err)
 				}
 				itemsCopied++
 			}
 		}
 		if itemsCopied == 0 {
-			return errors.Wrapf(syscall.ENOENT, "copier: get: copied no items")
+			return fmt.Errorf("copier: get: copied no items: %w", syscall.ENOENT)
 		}
 		return nil
 	}
@@ -1359,7 +1357,7 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 	// build the header using the name provided
 	hdr, err := tar.FileInfoHeader(srcfi, symlinkTarget)
 	if err != nil {
-		return errors.Wrapf(err, "error generating tar header for %s (%s)", contentPath, symlinkTarget)
+		return fmt.Errorf("error generating tar header for %s (%s): %w", contentPath, symlinkTarget, err)
 	}
 	if name != "" {
 		hdr.Name = filepath.ToSlash(name)
@@ -1381,7 +1379,7 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 	if !options.StripXattrs {
 		xattrs, err = Lgetxattrs(contentPath)
 		if err != nil {
-			return errors.Wrapf(err, "error getting extended attributes for %q", contentPath)
+			return fmt.Errorf("error getting extended attributes for %q: %w", contentPath, err)
 		}
 	}
 	hdr.Xattrs = xattrs // nolint:staticcheck
@@ -1393,12 +1391,12 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 		if options.ExpandArchives && isArchivePath(contentPath) {
 			f, err := os.Open(contentPath)
 			if err != nil {
-				return errors.Wrapf(err, "error opening file for reading archive contents")
+				return fmt.Errorf("error opening file for reading archive contents: %w", err)
 			}
 			defer f.Close()
 			rc, _, err := compression.AutoDecompress(f)
 			if err != nil {
-				return errors.Wrapf(err, "error decompressing %s", contentPath)
+				return fmt.Errorf("error decompressing %s: %w", contentPath, err)
 			}
 			defer rc.Close()
 			tr := tar.NewReader(rc)
@@ -1408,22 +1406,22 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 					hdr.Name = handleRename(options.Rename, hdr.Name)
 				}
 				if err = tw.WriteHeader(hdr); err != nil {
-					return errors.Wrapf(err, "error writing tar header from %q to pipe", contentPath)
+					return fmt.Errorf("error writing tar header from %q to pipe: %w", contentPath, err)
 				}
 				if hdr.Size != 0 {
 					n, err := io.Copy(tw, tr)
 					if err != nil {
-						return errors.Wrapf(err, "error extracting content from archive %s: %s", contentPath, hdr.Name)
+						return fmt.Errorf("error extracting content from archive %s: %s: %w", contentPath, hdr.Name, err)
 					}
 					if n != hdr.Size {
-						return errors.Errorf("error extracting contents of archive %s: incorrect length for %q", contentPath, hdr.Name)
+						return fmt.Errorf("error extracting contents of archive %s: incorrect length for %q", contentPath, hdr.Name)
 					}
 					tw.Flush()
 				}
 				hdr, err = tr.Next()
 			}
 			if err != io.EOF {
-				return errors.Wrapf(err, "error extracting contents of archive %s", contentPath)
+				return fmt.Errorf("error extracting contents of archive %s: %w", contentPath, err)
 			}
 			return nil
 		}
@@ -1445,7 +1443,7 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 		hostPair := idtools.IDPair{UID: hdr.Uid, GID: hdr.Gid}
 		hdr.Uid, hdr.Gid, err = idMappings.ToContainer(hostPair)
 		if err != nil {
-			return errors.Wrapf(err, "error mapping host filesystem owners %#v to container filesystem owners", hostPair)
+			return fmt.Errorf("error mapping host filesystem owners %#v to container filesystem owners: %w", hostPair, err)
 		}
 	}
 	// force ownership and/or permissions, if requested
@@ -1469,29 +1467,29 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 		// open the file first so that we don't write a header for it if we can't actually read it
 		f, err = os.Open(contentPath)
 		if err != nil {
-			return errors.Wrapf(err, "error opening file for adding its contents to archive")
+			return fmt.Errorf("error opening file for adding its contents to archive: %w", err)
 		}
 		defer f.Close()
 	} else if hdr.Typeflag == tar.TypeDir {
 		// open the directory file first to make sure we can access it.
 		f, err = os.Open(contentPath)
 		if err != nil {
-			return errors.Wrapf(err, "error opening directory for adding its contents to archive")
+			return fmt.Errorf("error opening directory for adding its contents to archive: %w", err)
 		}
 		defer f.Close()
 	}
 	// output the header
 	if err = tw.WriteHeader(hdr); err != nil {
-		return errors.Wrapf(err, "error writing header for %s (%s)", contentPath, hdr.Name)
+		return fmt.Errorf("error writing header for %s (%s): %w", contentPath, hdr.Name, err)
 	}
 	if hdr.Typeflag == tar.TypeReg {
 		// output the content
 		n, err := io.Copy(tw, f)
 		if err != nil {
-			return errors.Wrapf(err, "error copying %s", contentPath)
+			return fmt.Errorf("error copying %s: %w", contentPath, err)
 		}
 		if n != hdr.Size {
-			return errors.Errorf("error copying %s: incorrect size (expected %d bytes, read %d bytes)", contentPath, n, hdr.Size)
+			return fmt.Errorf("error copying %s: incorrect size (expected %d bytes, read %d bytes)", contentPath, n, hdr.Size)
 		}
 		tw.Flush()
 	}
@@ -1542,7 +1540,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 	ensureDirectoryUnderRoot := func(directory string) error {
 		rel, err := convertToRelSubdirectory(req.Root, directory)
 		if err != nil {
-			return errors.Wrapf(err, "%q is not a subdirectory of %q", directory, req.Root)
+			return fmt.Errorf("%q is not a subdirectory of %q: %w", directory, req.Root, err)
 		}
 		subdir := ""
 		for _, component := range strings.Split(rel, string(os.PathSeparator)) {
@@ -1550,7 +1548,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			path := filepath.Join(req.Root, subdir)
 			if err := os.Mkdir(path, 0700); err == nil {
 				if err = lchown(path, defaultDirUID, defaultDirGID); err != nil {
-					return errors.Wrapf(err, "copier: put: error setting owner of %q to %d:%d", path, defaultDirUID, defaultDirGID)
+					return fmt.Errorf("copier: put: error setting owner of %q to %d:%d: %w", path, defaultDirUID, defaultDirGID, err)
 				}
 				// make a conditional note to set this directory's permissions
 				// later, but not if we already had an explictly-provided mode
@@ -1561,7 +1559,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				// FreeBSD can return EISDIR for "mkdir /":
 				// https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=59739.
 				if !os.IsExist(err) && !errors.Is(err, syscall.EISDIR) {
-					return errors.Wrapf(err, "copier: put: error checking directory %q", path)
+					return fmt.Errorf("copier: put: error checking directory %q: %w", path, err)
 				}
 			}
 		}
@@ -1570,14 +1568,14 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 	makeDirectoryWriteable := func(directory string) error {
 		st, err := os.Lstat(directory)
 		if err != nil {
-			return errors.Wrapf(err, "copier: put: error reading permissions of directory %q", directory)
+			return fmt.Errorf("copier: put: error reading permissions of directory %q: %w", directory, err)
 		}
 		mode := st.Mode() & os.ModePerm
 		if _, ok := directoryModes[directory]; !ok {
 			directoryModes[directory] = mode
 		}
 		if err = os.Chmod(directory, 0o700); err != nil {
-			return errors.Wrapf(err, "copier: put: error making directory %q writable", directory)
+			return fmt.Errorf("copier: put: error making directory %q writable: %w", directory, err)
 		}
 		return nil
 	}
@@ -1586,7 +1584,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 		if err != nil && os.IsExist(err) {
 			if req.PutOptions.NoOverwriteDirNonDir {
 				if st, err2 := os.Lstat(path); err2 == nil && st.IsDir() {
-					return 0, errors.Wrapf(err, "copier: put: error creating file at %q", path)
+					return 0, fmt.Errorf("copier: put: error creating file at %q: %w", path, err)
 				}
 			}
 			if err = os.RemoveAll(path); err != nil {
@@ -1597,7 +1595,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 					err = os.RemoveAll(path)
 				}
 				if err != nil {
-					return 0, errors.Wrapf(err, "copier: put: error removing item to be overwritten %q", path)
+					return 0, fmt.Errorf("copier: put: error removing item to be overwritten %q: %w", path, err)
 				}
 			}
 			f, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|os.O_EXCL, 0600)
@@ -1609,12 +1607,12 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			f, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|os.O_EXCL, 0600)
 		}
 		if err != nil {
-			return 0, errors.Wrapf(err, "copier: put: error opening file %q for writing", path)
+			return 0, fmt.Errorf("copier: put: error opening file %q for writing: %w", path, err)
 		}
 		defer f.Close()
 		n, err := io.Copy(f, tr)
 		if err != nil {
-			return n, errors.Wrapf(err, "copier: put: error writing file %q", path)
+			return n, fmt.Errorf("copier: put: error writing file %q: %w", path, err)
 		}
 		return n, nil
 	}
@@ -1673,7 +1671,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				containerPair := idtools.IDPair{UID: hdr.Uid, GID: hdr.Gid}
 				hostPair, err := idMappings.ToHost(containerPair)
 				if err != nil {
-					return errors.Wrapf(err, "error mapping container filesystem owner 0,0 to host filesystem owners")
+					return fmt.Errorf("error mapping container filesystem owner 0,0 to host filesystem owners: %w", err)
 				}
 				hdr.Uid, hdr.Gid = hostPair.UID, hostPair.GID
 			}
@@ -1718,14 +1716,14 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			switch hdr.Typeflag {
 			// no type flag for sockets
 			default:
-				return errors.Errorf("unrecognized Typeflag %c", hdr.Typeflag)
+				return fmt.Errorf("unrecognized Typeflag %c", hdr.Typeflag)
 			case tar.TypeReg, tar.TypeRegA:
 				var written int64
 				written, err = createFile(path, tr)
 				// only check the length if there wasn't an error, which we'll
 				// check along with errors for other types of entries
 				if err == nil && written != hdr.Size {
-					return errors.Errorf("copier: put: error creating regular file %q: incorrect length (%d != %d)", path, written, hdr.Size)
+					return fmt.Errorf("copier: put: error creating regular file %q: incorrect length (%d != %d)", path, written, hdr.Size)
 				}
 			case tar.TypeLink:
 				var linkTarget string
@@ -1738,7 +1736,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 					hdr.Linkname = handleRename(req.PutOptions.Rename, hdr.Linkname)
 				}
 				if linkTarget, err = resolvePath(targetDirectory, filepath.Join(req.Root, filepath.FromSlash(hdr.Linkname)), true, nil); err != nil {
-					return errors.Errorf("error resolving hardlink target path %q under root %q", hdr.Linkname, req.Root)
+					return fmt.Errorf("error resolving hardlink target path %q under root %q", hdr.Linkname, req.Root)
 				}
 				if err = os.Link(linkTarget, path); err != nil && os.IsExist(err) {
 					if req.PutOptions.NoOverwriteDirNonDir {
@@ -1843,11 +1841,11 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			}
 			// check for errors
 			if err != nil {
-				return errors.Wrapf(err, "copier: put: error creating %q", path)
+				return fmt.Errorf("copier: put: error creating %q: %w", path, err)
 			}
 			// set ownership
 			if err = lchown(path, hdr.Uid, hdr.Gid); err != nil {
-				return errors.Wrapf(err, "copier: put: error setting ownership of %q to %d:%d", path, hdr.Uid, hdr.Gid)
+				return fmt.Errorf("copier: put: error setting ownership of %q to %d:%d: %w", path, hdr.Uid, hdr.Gid, err)
 			}
 			// set permissions, except for symlinks, since we don't
 			// have an lchmod, and directories, which we'll fix up
@@ -1856,7 +1854,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			// write to, but which we'll need to create content in
 			if hdr.Typeflag != tar.TypeSymlink && hdr.Typeflag != tar.TypeDir {
 				if err = os.Chmod(path, mode); err != nil {
-					return errors.Wrapf(err, "copier: put: error setting permissions on %q to 0%o", path, mode)
+					return fmt.Errorf("copier: put: error setting permissions on %q to 0%o: %w", path, mode, err)
 				}
 			}
 			// set other bits that might have been reset by chown()
@@ -1871,14 +1869,14 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 					mode |= syscall.S_ISVTX
 				}
 				if err = syscall.Chmod(path, uint32(mode)); err != nil {
-					return errors.Wrapf(err, "error setting additional permissions on %q to 0%o", path, mode)
+					return fmt.Errorf("error setting additional permissions on %q to 0%o: %w", path, mode, err)
 				}
 			}
 			// set xattrs, including some that might have been reset by chown()
 			if !req.PutOptions.StripXattrs {
 				if err = Lsetxattrs(path, hdr.Xattrs); err != nil { // nolint:staticcheck
 					if !req.PutOptions.IgnoreXattrErrors {
-						return errors.Wrapf(err, "copier: put: error setting extended attributes on %q", path)
+						return fmt.Errorf("copier: put: error setting extended attributes on %q: %w", path, err)
 					}
 				}
 			}
@@ -1887,13 +1885,13 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				hdr.AccessTime = hdr.ModTime
 			}
 			if err = lutimes(hdr.Typeflag == tar.TypeSymlink, path, hdr.AccessTime, hdr.ModTime); err != nil {
-				return errors.Wrapf(err, "error setting access and modify timestamps on %q to %s and %s", path, hdr.AccessTime, hdr.ModTime)
+				return fmt.Errorf("error setting access and modify timestamps on %q to %s and %s: %w", path, hdr.AccessTime, hdr.ModTime, err)
 			}
 		nextHeader:
 			hdr, err = tr.Next()
 		}
 		if err != io.EOF {
-			return errors.Wrapf(err, "error reading tar stream: expected EOF")
+			return fmt.Errorf("error reading tar stream: expected EOF: %w", err)
 		}
 		return nil
 	}
@@ -1971,16 +1969,4 @@ func copierHandlerRemove(req request) *response {
 		return errorResponse("copier: remove %q: %v", req.Directory, err)
 	}
 	return &response{Error: "", Remove: removeResponse{}}
-}
-
-func unwrapError(err error) error {
-	e := errors.Cause(err)
-	for e != nil {
-		err = e
-		e = stderrors.Unwrap(err)
-		if e == err {
-			break
-		}
-	}
-	return err
 }

--- a/copier/copier_linux_test.go
+++ b/copier/copier_linux_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/reexec"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/syndtr/gocapability/capability"
@@ -41,7 +41,7 @@ func getWrapped(root string, directory string, getOptions GetOptions, globs []st
 	}
 	encoded, err := json.Marshal(&options)
 	if err != nil {
-		return errors.Wrapf(err, "error marshalling options")
+		return fmt.Errorf("error marshalling options: %w", err)
 	}
 	cmd := reexec.Command("get")
 	cmd.Env = append(cmd.Env, "OPTIONS="+string(encoded))

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containers/buildah/util"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/sirupsen/logrus"
@@ -554,7 +555,7 @@ func testPut(t *testing.T) {
 				defer os.RemoveAll(tmp)
 				err = Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, NoOverwriteDirNonDir: !overwrite}, bytes.NewReader(archive))
 				if overwrite {
-					if unwrapError(err) != syscall.EPERM {
+					if util.Cause(err) != syscall.EPERM {
 						assert.Nilf(t, err, "expected to overwrite directory with type %c: %v", typeFlag, err)
 					}
 				} else {
@@ -582,7 +583,7 @@ func testPut(t *testing.T) {
 				defer os.RemoveAll(tmp)
 				err = Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, NoOverwriteNonDirDir: !overwrite}, bytes.NewReader(archive))
 				if overwrite {
-					if unwrapError(err) != syscall.EPERM {
+					if util.Cause(err) != syscall.EPERM {
 						assert.Nilf(t, err, "expected to overwrite file with type %c: %v", typeFlag, err)
 					}
 				} else {
@@ -658,7 +659,7 @@ func isExpectedError(err error, inSubdir bool, name string, expectedErrors []exp
 		if expectedError.name != name {
 			continue
 		}
-		if !strings.Contains(unwrapError(err).Error(), unwrapError(expectedError.err).Error()) {
+		if !strings.Contains(util.Cause(err).Error(), util.Cause(expectedError.err).Error()) {
 			// not expecting this specific error
 			continue
 		}

--- a/copier/syscall_unix.go
+++ b/copier/syscall_unix.go
@@ -4,11 +4,11 @@
 package copier
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -17,13 +17,13 @@ var canChroot = os.Getuid() == 0
 func chroot(root string) (bool, error) {
 	if canChroot {
 		if err := os.Chdir(root); err != nil {
-			return false, errors.Wrapf(err, "error changing to intended-new-root directory %q", root)
+			return false, fmt.Errorf("error changing to intended-new-root directory %q: %w", root, err)
 		}
 		if err := unix.Chroot(root); err != nil {
-			return false, errors.Wrapf(err, "error chrooting to directory %q", root)
+			return false, fmt.Errorf("error chrooting to directory %q: %w", root, err)
 		}
 		if err := os.Chdir(string(os.PathSeparator)); err != nil {
-			return false, errors.Wrapf(err, "error changing to just-became-root directory %q", root)
+			return false, fmt.Errorf("error changing to just-became-root directory %q: %w", root, err)
 		}
 		return true, nil
 	}

--- a/copier/xattrs_test.go
+++ b/copier/xattrs_test.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/containers/buildah/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +39,7 @@ func TestXattrs(t *testing.T) {
 			defer os.Remove(f.Name())
 
 			err = Lsetxattrs(f.Name(), map[string]string{attribute: value})
-			if unwrapError(err) == syscall.ENOTSUP {
+			if util.Cause(err) == syscall.ENOTSUP {
 				t.Skipf("extended attributes not supported on %q, skipping", tmp)
 			}
 			if !assert.Nil(t, err, "error setting attribute on file: %v", err) {

--- a/delete.go
+++ b/delete.go
@@ -1,14 +1,12 @@
 package buildah
 
-import (
-	"github.com/pkg/errors"
-)
+import "fmt"
 
 // Delete removes the working container.  The buildah.Builder object should not
 // be used after this method is called.
 func (b *Builder) Delete() error {
 	if err := b.store.DeleteContainer(b.ContainerID); err != nil {
-		return errors.Wrapf(err, "error deleting build container %q", b.ContainerID)
+		return fmt.Errorf("error deleting build container %q: %w", b.ContainerID, err)
 	}
 	b.MountPoint = ""
 	b.Container = ""

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/opencontainers/runtime-tools v0.9.0
 	github.com/opencontainers/selinux v1.10.1
 	github.com/openshift/imagebuilder v1.2.4-0.20220502172744-009dbc6cb805
-	github.com/pkg/errors v0.9.1
 	github.com/seccomp/libseccomp-golang v0.10.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.5.0
@@ -87,6 +86,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/proglottis/gpgme v0.1.2 // indirect
 	github.com/prometheus/client_golang v1.11.1 // indirect

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -3,6 +3,7 @@ package imagebuildah
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -33,7 +34,6 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/openshift/imagebuilder"
 	"github.com/openshift/imagebuilder/dockerfile/parser"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 )
@@ -68,10 +68,10 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 	}
 
 	if len(paths) == 0 {
-		return "", nil, errors.Errorf("error building: no dockerfiles specified")
+		return "", nil, errors.New("error building: no dockerfiles specified")
 	}
 	if len(options.Platforms) > 1 && options.IIDFile != "" {
-		return "", nil, errors.Errorf("building multiple images, but iidfile %q can only be used to store one image ID", options.IIDFile)
+		return "", nil, fmt.Errorf("building multiple images, but iidfile %q can only be used to store one image ID", options.IIDFile)
 	}
 
 	logger := logrus.New()
@@ -94,7 +94,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 			continue
 		}
 		if _, err := util.VerifyTagName(tag); err != nil {
-			return "", nil, errors.Wrapf(err, "tag %s", tag)
+			return "", nil, fmt.Errorf("tag %s: %w", tag, err)
 		}
 	}
 
@@ -109,7 +109,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 			}
 			if resp.ContentLength == 0 {
 				resp.Body.Close()
-				return "", nil, errors.Errorf("no contents in %q", dfile)
+				return "", nil, fmt.Errorf("no contents in %q", dfile)
 			}
 			data = resp.Body
 		} else {
@@ -147,11 +147,11 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 			dinfo, err = contents.Stat()
 			if err != nil {
 				contents.Close()
-				return "", nil, errors.Wrapf(err, "error reading info about %q", dfile)
+				return "", nil, fmt.Errorf("error reading info about %q: %w", dfile, err)
 			}
 			if dinfo.Mode().IsRegular() && dinfo.Size() == 0 {
 				contents.Close()
-				return "", nil, errors.Errorf("no contents in %q", dfile)
+				return "", nil, fmt.Errorf("no contents in %q", dfile)
 			}
 			data = contents
 		}
@@ -258,7 +258,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 				logFile := platformOptions.LogFile + "_" + platformOptions.OS + "_" + platformOptions.Architecture
 				f, err := os.OpenFile(logFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 				if err != nil {
-					return errors.Wrapf(err, "opening logfile: %q", logFile)
+					return fmt.Errorf("opening logfile: %q: %w", logFile, err)
 				}
 				defer f.Close()
 				loggerPerPlatform = logrus.New()
@@ -302,7 +302,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 		// partially-populated state at any point if we're creating it
 		// fresh.
 		list, err := rt.LookupManifestList(manifestList)
-		if err != nil && errors.Cause(err) == storage.ErrImageUnknown {
+		if err != nil && errors.Is(err, storage.ErrImageUnknown) {
 			list, err = rt.CreateManifestList(manifestList)
 		}
 		if err != nil {
@@ -363,7 +363,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logrus.Logger, logPrefix string, options define.BuildOptions, dockerfiles []string, dockerfilecontents [][]byte) (string, reference.Canonical, error) {
 	mainNode, err := imagebuilder.ParseDockerfile(bytes.NewReader(dockerfilecontents[0]))
 	if err != nil {
-		return "", nil, errors.Wrapf(err, "error parsing main Dockerfile: %s", dockerfiles[0])
+		return "", nil, fmt.Errorf("error parsing main Dockerfile: %s: %w", dockerfiles[0], err)
 	}
 
 	warnOnUnsetBuildArgs(logger, mainNode, options.Args)
@@ -405,7 +405,7 @@ func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logr
 	for i, d := range dockerfilecontents[1:] {
 		additionalNode, err := imagebuilder.ParseDockerfile(bytes.NewReader(d))
 		if err != nil {
-			return "", nil, errors.Wrapf(err, "error parsing additional Dockerfile %s", dockerfiles[i])
+			return "", nil, fmt.Errorf("error parsing additional Dockerfile %s: %w", dockerfiles[i], err)
 		}
 		mainNode.Children = append(mainNode.Children, additionalNode.Children...)
 	}
@@ -431,7 +431,7 @@ func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logr
 				labelLine = fmt.Sprintf("LABEL %q=%q\n", key, value)
 				additionalNode, err := imagebuilder.ParseDockerfile(strings.NewReader(labelLine))
 				if err != nil {
-					return "", nil, errors.Wrapf(err, "error while adding additional LABEL steps")
+					return "", nil, fmt.Errorf("error while adding additional LABEL steps: %w", err)
 				}
 				mainNode.Children = append(mainNode.Children, additionalNode.Children...)
 			}
@@ -440,22 +440,22 @@ func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logr
 
 	exec, err := newExecutor(logger, logPrefix, store, options, mainNode)
 	if err != nil {
-		return "", nil, errors.Wrapf(err, "error creating build executor")
+		return "", nil, fmt.Errorf("error creating build executor: %w", err)
 	}
 	b := imagebuilder.NewBuilder(options.Args)
 	defaultContainerConfig, err := config.Default()
 	if err != nil {
-		return "", nil, errors.Wrapf(err, "failed to get container config")
+		return "", nil, fmt.Errorf("failed to get container config: %w", err)
 	}
 	b.Env = append(defaultContainerConfig.GetDefaultEnv(), b.Env...)
 	stages, err := imagebuilder.NewStages(mainNode, b)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "error reading multiple stages")
+		return "", nil, fmt.Errorf("error reading multiple stages: %w", err)
 	}
 	if options.Target != "" {
 		stagesTargeted, ok := stages.ThroughTarget(options.Target)
 		if !ok {
-			return "", nil, errors.Errorf("The target %q was not found in the provided Dockerfile", options.Target)
+			return "", nil, fmt.Errorf("The target %q was not found in the provided Dockerfile", options.Target)
 		}
 		stages = stagesTargeted
 	}
@@ -506,7 +506,7 @@ func preprocessContainerfileContents(logger *logrus.Logger, containerfile string
 	if flags, ok := os.LookupEnv("BUILDAH_CPPFLAGS"); ok {
 		args, err := shellwords.Parse(flags)
 		if err != nil {
-			return nil, errors.Errorf("error parsing BUILDAH_CPPFLAGS %q: %v", flags, err)
+			return nil, fmt.Errorf("error parsing BUILDAH_CPPFLAGS %q: %v", flags, err)
 		}
 		cppArgs = append(cppArgs, args...)
 	}
@@ -517,14 +517,14 @@ func preprocessContainerfileContents(logger *logrus.Logger, containerfile string
 	cmd.Stderr = &stderrBuffer
 
 	if err = cmd.Start(); err != nil {
-		return nil, errors.Wrapf(err, "preprocessing %s", containerfile)
+		return nil, fmt.Errorf("preprocessing %s: %w", containerfile, err)
 	}
 	if err = cmd.Wait(); err != nil {
 		if stderrBuffer.Len() != 0 {
 			logger.Warnf("Ignoring %s\n", stderrBuffer.String())
 		}
 		if stdoutBuffer.Len() == 0 {
-			return nil, errors.Wrapf(err, "error preprocessing %s: preprocessor produced no output", containerfile)
+			return nil, fmt.Errorf("error preprocessing %s: preprocessor produced no output: %w", containerfile, err)
 		}
 	}
 	return &stdoutBuffer, nil
@@ -536,18 +536,18 @@ func preprocessContainerfileContents(logger *logrus.Logger, containerfile string
 func platformsForBaseImages(ctx context.Context, logger *logrus.Logger, dockerfilepaths []string, dockerfiles [][]byte, from string, args map[string]string, additionalBuildContext map[string]*define.AdditionalBuildContext, systemContext *types.SystemContext) ([]struct{ OS, Arch, Variant string }, error) {
 	baseImages, err := baseImages(dockerfilepaths, dockerfiles, from, args, additionalBuildContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "determining list of base images")
+		return nil, fmt.Errorf("determining list of base images: %w", err)
 	}
 	logrus.Debugf("unresolved base images: %v", baseImages)
 	if len(baseImages) == 0 {
-		return nil, errors.Wrapf(err, "build uses no non-scratch base images")
+		return nil, fmt.Errorf("build uses no non-scratch base images: %w", err)
 	}
 	targetPlatforms := make(map[string]struct{})
 	var platformList []struct{ OS, Arch, Variant string }
 	for baseImageIndex, baseImage := range baseImages {
 		resolved, err := shortnames.Resolve(systemContext, baseImage)
 		if err != nil {
-			return nil, errors.Wrapf(err, "resolving image name %q", baseImage)
+			return nil, fmt.Errorf("resolving image name %q: %w", baseImage, err)
 		}
 		var manifestBytes []byte
 		var manifestType string
@@ -582,27 +582,27 @@ func platformsForBaseImages(ctx context.Context, logger *logrus.Logger, dockerfi
 		}
 		if len(manifestBytes) == 0 {
 			if len(resolved.PullCandidates) > 0 {
-				return nil, errors.Errorf("base image name %q didn't resolve to a manifest list", baseImage)
+				return nil, fmt.Errorf("base image name %q didn't resolve to a manifest list", baseImage)
 			}
-			return nil, errors.Errorf("base image name %q didn't resolve to anything", baseImage)
+			return nil, fmt.Errorf("base image name %q didn't resolve to anything", baseImage)
 		}
 		if manifestType != v1.MediaTypeImageIndex {
 			list, err := manifest.ListFromBlob(manifestBytes, manifestType)
 			if err != nil {
-				return nil, errors.Wrapf(err, "parsing manifest list from base image %q", baseImage)
+				return nil, fmt.Errorf("parsing manifest list from base image %q: %w", baseImage, err)
 			}
 			list, err = list.ConvertToMIMEType(v1.MediaTypeImageIndex)
 			if err != nil {
-				return nil, errors.Wrapf(err, "converting manifest list from base image %q to v2s2 list", baseImage)
+				return nil, fmt.Errorf("converting manifest list from base image %q to v2s2 list: %w", baseImage, err)
 			}
 			manifestBytes, err = list.Serialize()
 			if err != nil {
-				return nil, errors.Wrapf(err, "encoding converted v2s2 manifest list for base image %q", baseImage)
+				return nil, fmt.Errorf("encoding converted v2s2 manifest list for base image %q: %w", baseImage, err)
 			}
 		}
 		index, err := manifest.OCI1IndexFromManifest(manifestBytes)
 		if err != nil {
-			return nil, errors.Wrapf(err, "decoding manifest list for base image %q", baseImage)
+			return nil, fmt.Errorf("decoding manifest list for base image %q: %w", baseImage, err)
 		}
 		if baseImageIndex == 0 {
 			// populate the list with the first image's normalized platforms
@@ -641,7 +641,7 @@ func platformsForBaseImages(ctx context.Context, logger *logrus.Logger, dockerfi
 			for platform := range targetPlatforms {
 				platform, err := platforms.Parse(platform)
 				if err != nil {
-					return nil, errors.Wrapf(err, "parsing platform double/triple %q", platform)
+					return nil, fmt.Errorf("parsing platform double/triple %q: %w", platform, err)
 				}
 				platformList = append(platformList, struct{ OS, Arch, Variant string }{
 					OS:      platform.OS,
@@ -665,13 +665,13 @@ func platformsForBaseImages(ctx context.Context, logger *logrus.Logger, dockerfi
 func baseImages(dockerfilenames []string, dockerfilecontents [][]byte, from string, args map[string]string, additionalBuildContext map[string]*define.AdditionalBuildContext) ([]string, error) {
 	mainNode, err := imagebuilder.ParseDockerfile(bytes.NewReader(dockerfilecontents[0]))
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing main Dockerfile: %s", dockerfilenames[0])
+		return nil, fmt.Errorf("error parsing main Dockerfile: %s: %w", dockerfilenames[0], err)
 	}
 
 	for i, d := range dockerfilecontents[1:] {
 		additionalNode, err := imagebuilder.ParseDockerfile(bytes.NewReader(d))
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing additional Dockerfile %s", dockerfilenames[i])
+			return nil, fmt.Errorf("error parsing additional Dockerfile %s: %w", dockerfilenames[i], err)
 		}
 		mainNode.Children = append(mainNode.Children, additionalNode.Children...)
 	}
@@ -679,12 +679,12 @@ func baseImages(dockerfilenames []string, dockerfilecontents [][]byte, from stri
 	b := imagebuilder.NewBuilder(args)
 	defaultContainerConfig, err := config.Default()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get container config")
+		return nil, fmt.Errorf("failed to get container config: %w", err)
 	}
 	b.Env = defaultContainerConfig.GetDefaultEnv()
 	stages, err := imagebuilder.NewStages(mainNode, b)
 	if err != nil {
-		return nil, errors.Wrap(err, "error reading multiple stages")
+		return nil, fmt.Errorf("error reading multiple stages: %w", err)
 	}
 	var baseImages []string
 	nicknames := make(map[string]bool)

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -36,7 +36,6 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/openshift/imagebuilder"
 	"github.com/openshift/imagebuilder/dockerfile/parser"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -90,10 +89,10 @@ func (s *StageExecutor) Preserve(path string) error {
 		// except ensure that it exists.
 		createdDirPerms := os.FileMode(0755)
 		if err := copier.Mkdir(s.mountPoint, filepath.Join(s.mountPoint, path), copier.MkdirOptions{ChmodNew: &createdDirPerms}); err != nil {
-			return errors.Wrapf(err, "error ensuring volume path exists")
+			return fmt.Errorf("error ensuring volume path exists: %w", err)
 		}
 		if err := s.volumeCacheInvalidate(path); err != nil {
-			return errors.Wrapf(err, "error ensuring volume path %q is preserved", filepath.Join(s.mountPoint, path))
+			return fmt.Errorf("error ensuring volume path %q is preserved: %w", filepath.Join(s.mountPoint, path), err)
 		}
 		return nil
 	}
@@ -101,7 +100,7 @@ func (s *StageExecutor) Preserve(path string) error {
 	s.preserved++
 	cacheDir, err := s.executor.store.ContainerDirectory(s.builder.ContainerID)
 	if err != nil {
-		return errors.Errorf("unable to locate temporary directory for container")
+		return fmt.Errorf("unable to locate temporary directory for container")
 	}
 	cacheFile := filepath.Join(cacheDir, fmt.Sprintf("volume%d.tar", s.preserved))
 	// Save info about the top level of the location that we'll be archiving.
@@ -112,22 +111,22 @@ func (s *StageExecutor) Preserve(path string) error {
 	if evaluated, err := copier.Eval(s.mountPoint, filepath.Join(s.mountPoint, path), copier.EvalOptions{}); err == nil {
 		symLink, err := filepath.Rel(s.mountPoint, evaluated)
 		if err != nil {
-			return errors.Wrapf(err, "making evaluated path %q relative to %q", evaluated, s.mountPoint)
+			return fmt.Errorf("making evaluated path %q relative to %q: %w", evaluated, s.mountPoint, err)
 		}
 		if strings.HasPrefix(symLink, ".."+string(os.PathSeparator)) {
-			return errors.Errorf("evaluated path %q was not below %q", evaluated, s.mountPoint)
+			return fmt.Errorf("evaluated path %q was not below %q", evaluated, s.mountPoint)
 		}
 		archivedPath = evaluated
 		path = string(os.PathSeparator) + symLink
 	} else {
-		return errors.Wrapf(err, "error evaluating path %q", path)
+		return fmt.Errorf("error evaluating path %q: %w", path, err)
 	}
 
 	st, err := os.Stat(archivedPath)
 	if os.IsNotExist(err) {
 		createdDirPerms := os.FileMode(0755)
 		if err = copier.Mkdir(s.mountPoint, archivedPath, copier.MkdirOptions{ChmodNew: &createdDirPerms}); err != nil {
-			return errors.Wrapf(err, "error ensuring volume path exists")
+			return fmt.Errorf("error ensuring volume path exists: %w", err)
 		}
 		st, err = os.Stat(archivedPath)
 	}
@@ -139,7 +138,7 @@ func (s *StageExecutor) Preserve(path string) error {
 	if !s.volumes.Add(path) {
 		// This path is not a subdirectory of a volume path that we're
 		// already preserving, so adding it to the list should work.
-		return errors.Errorf("error adding %q to the volume cache", path)
+		return fmt.Errorf("error adding %q to the volume cache", path)
 	}
 	s.volumeCache[path] = cacheFile
 	// Now prune cache files for volumes that are now supplanted by this one.
@@ -204,14 +203,14 @@ func (s *StageExecutor) volumeCacheSaveVFS() (mounts []specs.Mount, err error) {
 	for cachedPath, cacheFile := range s.volumeCache {
 		archivedPath, err := copier.Eval(s.mountPoint, filepath.Join(s.mountPoint, cachedPath), copier.EvalOptions{})
 		if err != nil {
-			return nil, errors.Wrapf(err, "error evaluating volume path")
+			return nil, fmt.Errorf("error evaluating volume path: %w", err)
 		}
 		relativePath, err := filepath.Rel(s.mountPoint, archivedPath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error converting %q into a path relative to %q", archivedPath, s.mountPoint)
+			return nil, fmt.Errorf("error converting %q into a path relative to %q: %w", archivedPath, s.mountPoint, err)
 		}
 		if strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) {
-			return nil, errors.Errorf("error converting %q into a path relative to %q", archivedPath, s.mountPoint)
+			return nil, fmt.Errorf("error converting %q into a path relative to %q", archivedPath, s.mountPoint)
 		}
 		_, err = os.Stat(cacheFile)
 		if err == nil {
@@ -223,7 +222,7 @@ func (s *StageExecutor) volumeCacheSaveVFS() (mounts []specs.Mount, err error) {
 		}
 		createdDirPerms := os.FileMode(0755)
 		if err := copier.Mkdir(s.mountPoint, archivedPath, copier.MkdirOptions{ChmodNew: &createdDirPerms}); err != nil {
-			return nil, errors.Wrapf(err, "error ensuring volume path exists")
+			return nil, fmt.Errorf("error ensuring volume path exists: %w", err)
 		}
 		logrus.Debugf("caching contents of volume %q in %q", archivedPath, cacheFile)
 		cache, err := os.Create(cacheFile)
@@ -233,12 +232,12 @@ func (s *StageExecutor) volumeCacheSaveVFS() (mounts []specs.Mount, err error) {
 		defer cache.Close()
 		rc, err := chrootarchive.Tar(archivedPath, nil, s.mountPoint)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error archiving %q", archivedPath)
+			return nil, fmt.Errorf("error archiving %q: %w", archivedPath, err)
 		}
 		defer rc.Close()
 		_, err = io.Copy(cache, rc)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error archiving %q to %q", archivedPath, cacheFile)
+			return nil, fmt.Errorf("error archiving %q to %q: %w", archivedPath, cacheFile, err)
 		}
 		mount := specs.Mount{
 			Source:      archivedPath,
@@ -256,7 +255,7 @@ func (s *StageExecutor) volumeCacheRestoreVFS() (err error) {
 	for cachedPath, cacheFile := range s.volumeCache {
 		archivedPath, err := copier.Eval(s.mountPoint, filepath.Join(s.mountPoint, cachedPath), copier.EvalOptions{})
 		if err != nil {
-			return errors.Wrapf(err, "error evaluating volume path")
+			return fmt.Errorf("error evaluating volume path: %w", err)
 		}
 		logrus.Debugf("restoring contents of volume %q from %q", archivedPath, cacheFile)
 		cache, err := os.Open(cacheFile)
@@ -273,7 +272,7 @@ func (s *StageExecutor) volumeCacheRestoreVFS() (err error) {
 		}
 		err = chrootarchive.Untar(cache, archivedPath, nil)
 		if err != nil {
-			return errors.Wrapf(err, "error extracting archive at %q", archivedPath)
+			return fmt.Errorf("error extracting archive at %q: %w", archivedPath, err)
 		}
 		if st, ok := s.volumeCacheInfo[cachedPath]; ok {
 			if err := os.Chmod(archivedPath, st.Mode()); err != nil {
@@ -302,7 +301,7 @@ func (s *StageExecutor) volumeCacheSaveOverlay() (mounts []specs.Mount, err erro
 	for cachedPath := range s.volumeCache {
 		err = copier.Mkdir(s.mountPoint, filepath.Join(s.mountPoint, cachedPath), copier.MkdirOptions{})
 		if err != nil {
-			return nil, errors.Wrapf(err, "ensuring volume exists")
+			return nil, fmt.Errorf("ensuring volume exists: %w", err)
 		}
 		volumePath := filepath.Join(s.mountPoint, cachedPath)
 		mount := specs.Mount{
@@ -367,7 +366,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 			// value.  Otherwise just return the value found.
 			from, fromErr := imagebuilder.ProcessWord(copy.From, s.stage.Builder.Arguments())
 			if fromErr != nil {
-				return errors.Wrapf(fromErr, "unable to resolve argument %q", copy.From)
+				return fmt.Errorf("unable to resolve argument %q: %w", copy.From, fromErr)
 			}
 			var additionalBuildContext *define.AdditionalBuildContext
 			if foundContext, ok := s.executor.additionalBuildContexts[from]; ok {
@@ -399,7 +398,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 							// temp and point context to that.
 							path, subdir, err := define.TempDirForURL(internalUtil.GetTempDir(), internal.BuildahExternalArtifactsDir, additionalBuildContext.Value)
 							if err != nil {
-								return errors.Wrapf(err, "unable to download context from external source %q", additionalBuildContext.Value)
+								return fmt.Errorf("unable to download context from external source %q: %w", additionalBuildContext.Value, err)
 							}
 							// point context dir to the extracted path
 							contextDir = filepath.Join(path, subdir)
@@ -424,7 +423,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 					contextDir = builder.MountPoint
 					idMappingOptions = &builder.IDMappingOptions
 				} else {
-					return errors.Errorf("the stage %q has not been built", copy.From)
+					return fmt.Errorf("the stage %q has not been built", copy.From)
 				}
 			} else if additionalBuildContext.IsImage {
 				// Image was selected as additionalContext so only process image.
@@ -449,7 +448,7 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 					sources = append(sources, src)
 				} else {
 					// returns an error to be compatible with docker
-					return errors.Errorf("source can't be a URL for COPY")
+					return fmt.Errorf("source can't be a URL for COPY")
 				}
 			} else {
 				sources = append(sources, filepath.Join(contextDir, src))
@@ -483,7 +482,7 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 		if strings.Contains(flag, "from") {
 			arr := strings.SplitN(flag, ",", 2)
 			if len(arr) < 2 {
-				return nil, errors.Errorf("Invalid --mount command: %s", flag)
+				return nil, fmt.Errorf("Invalid --mount command: %s", flag)
 			}
 			tokens := strings.Split(arr[1], ",")
 			for _, val := range tokens {
@@ -491,14 +490,14 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 				switch kv[0] {
 				case "from":
 					if len(kv) == 1 {
-						return nil, errors.Errorf("unable to resolve argument for `from=`: bad argument")
+						return nil, fmt.Errorf("unable to resolve argument for `from=`: bad argument")
 					}
 					if kv[1] == "" {
-						return nil, errors.Errorf("unable to resolve argument for `from=`: from points to an empty value")
+						return nil, fmt.Errorf("unable to resolve argument for `from=`: from points to an empty value")
 					}
 					from, fromErr := imagebuilder.ProcessWord(kv[1], s.stage.Builder.Arguments())
 					if fromErr != nil {
-						return nil, errors.Wrapf(fromErr, "unable to resolve argument %q", kv[1])
+						return nil, fmt.Errorf("unable to resolve argument %q: %w", kv[1], fromErr)
 					}
 					// If additional buildContext contains this
 					// give priority to that and break if additional
@@ -507,7 +506,7 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 						if additionalBuildContext.IsImage {
 							mountPoint, err := s.getImageRootfs(s.ctx, additionalBuildContext.Value)
 							if err != nil {
-								return nil, errors.Errorf("%s from=%s: image found with that name", flag, from)
+								return nil, fmt.Errorf("%s from=%s: image found with that name", flag, from)
 							}
 							// The `from` in stageMountPoints should point
 							// to `mountPoint` replaced from additional
@@ -535,7 +534,7 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 									// temp and point context to that.
 									path, subdir, err := define.TempDirForURL(internalUtil.GetTempDir(), internal.BuildahExternalArtifactsDir, additionalBuildContext.Value)
 									if err != nil {
-										return nil, errors.Wrapf(err, "unable to download context from external source %q", additionalBuildContext.Value)
+										return nil, fmt.Errorf("unable to download context from external source %q: %w", additionalBuildContext.Value, err)
 									}
 									// point context dir to the extracted path
 									mountPoint = filepath.Join(path, subdir)
@@ -561,7 +560,7 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 					} else {
 						mountPoint, err := s.getImageRootfs(s.ctx, from)
 						if err != nil {
-							return nil, errors.Errorf("%s from=%s: no stage or image found with that name", flag, from)
+							return nil, fmt.Errorf("%s from=%s: no stage or image found with that name", flag, from)
 						}
 						stageMountPoints[from] = internal.StageMountDetails{IsStage: false, MountPoint: mountPoint}
 						break
@@ -584,13 +583,13 @@ func (s *StageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 		return err
 	}
 	if s.builder == nil {
-		return errors.Errorf("no build container available")
+		return fmt.Errorf("no build container available")
 	}
 	stdin := s.executor.in
 	if stdin == nil {
 		devNull, err := os.Open(os.DevNull)
 		if err != nil {
-			return errors.Errorf("error opening %q for reading: %v", os.DevNull, err)
+			return fmt.Errorf("error opening %q for reading: %v", os.DevNull, err)
 		}
 		defer devNull.Close()
 		stdin = devNull
@@ -668,7 +667,7 @@ func (s *StageExecutor) UnrecognizedInstruction(step *imagebuilder.Step) error {
 		s.executor.logger.Errorf("+(UNHANDLED LOGLEVEL) %#v", step)
 	}
 
-	return errors.Errorf(err)
+	return fmt.Errorf(err)
 }
 
 // prepare creates a working container based on the specified image, or if one
@@ -683,7 +682,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		base, err := ib.From(node)
 		if err != nil {
 			logrus.Debugf("prepare(node.Children=%#v)", node.Children)
-			return nil, errors.Wrapf(err, "error determining starting point for build")
+			return nil, fmt.Errorf("error determining starting point for build: %w", err)
 		}
 		from = base
 	}
@@ -709,7 +708,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 	if stage.Builder.Platform != "" {
 		os, arch, variant, err := parse.Platform(stage.Builder.Platform)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to parse platform %q", stage.Builder.Platform)
+			return nil, fmt.Errorf("unable to parse platform %q: %w", stage.Builder.Platform, err)
 		}
 		if arch != "" || variant != "" {
 			builderSystemContext.ArchitectureChoice = arch
@@ -752,7 +751,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 
 	builder, err = buildah.NewBuilder(ctx, s.executor.store, builderOptions)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error creating build container")
+		return nil, fmt.Errorf("error creating build container: %w", err)
 	}
 
 	// If executor's ProcessLabel and MountLabel is empty means this is the first stage
@@ -814,7 +813,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 			if err2 := builder.Delete(); err2 != nil {
 				logrus.Debugf("error deleting container which we failed to update: %v", err2)
 			}
-			return nil, errors.Wrapf(err, "error updating build context")
+			return nil, fmt.Errorf("error updating build context: %w", err)
 		}
 	}
 	mountPoint, err := builder.Mount(builder.MountLabel)
@@ -822,7 +821,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		if err2 := builder.Delete(); err2 != nil {
 			logrus.Debugf("error deleting container which we failed to mount: %v", err2)
 		}
-		return nil, errors.Wrapf(err, "error mounting new container")
+		return nil, fmt.Errorf("error mounting new container: %w", err)
 	}
 	if rebase {
 		// Make this our "current" working container.
@@ -969,7 +968,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// the case, we need to commit() to create a new image.
 			logCommit(s.output, -1)
 			if imgID, ref, err = s.commit(ctx, s.getCreatedBy(nil, ""), false, s.output, s.executor.squash); err != nil {
-				return "", nil, errors.Wrapf(err, "error committing base container")
+				return "", nil, fmt.Errorf("error committing base container: %w", err)
 			}
 		} else if len(s.executor.labels) > 0 || len(s.executor.annotations) > 0 {
 			// The image would be modified by the labels passed
@@ -997,7 +996,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		// Resolve any arguments in this instruction.
 		step := ib.Step()
 		if err := step.Resolve(node); err != nil {
-			return "", nil, errors.Wrapf(err, "error resolving step %+v", *node)
+			return "", nil, fmt.Errorf("error resolving step %+v: %w", *node, err)
 		}
 		logrus.Debugf("Parsed Step: %+v", *step)
 		if !s.executor.quiet {
@@ -1010,21 +1009,21 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			command := strings.ToUpper(step.Command)
 			// chmod, chown and from flags should have an '=' sign, '--chmod=', '--chown=' or '--from='
 			if command == "COPY" && (flag == "--chmod" || flag == "--chown" || flag == "--from") {
-				return "", nil, errors.Errorf("COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image|stage> flags")
+				return "", nil, fmt.Errorf("COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image|stage> flags")
 			}
 			if command == "ADD" && (flag == "--chmod" || flag == "--chown") {
-				return "", nil, errors.Errorf("ADD only supports the --chmod=<permissions> and the --chown=<uid:gid> flags")
+				return "", nil, fmt.Errorf("ADD only supports the --chmod=<permissions> and the --chown=<uid:gid> flags")
 			}
 			if strings.Contains(flag, "--from") && command == "COPY" {
 				arr := strings.Split(flag, "=")
 				if len(arr) != 2 {
-					return "", nil, errors.Errorf("%s: invalid --from flag, should be --from=<name|stage>", command)
+					return "", nil, fmt.Errorf("%s: invalid --from flag, should be --from=<name|stage>", command)
 				}
 				// If arr[1] has an argument within it, resolve it to its
 				// value.  Otherwise just return the value found.
 				from, fromErr := imagebuilder.ProcessWord(arr[1], s.stage.Builder.Arguments())
 				if fromErr != nil {
-					return "", nil, errors.Wrapf(fromErr, "unable to resolve argument %q", arr[1])
+					return "", nil, fmt.Errorf("unable to resolve argument %q: %w", arr[1], fromErr)
 				}
 
 				// Before looking into additional context
@@ -1047,7 +1046,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 						// replace with image set in build context
 						from = additionalBuildContext.Value
 						if _, err := s.getImageRootfs(ctx, from); err != nil {
-							return "", nil, errors.Errorf("%s --from=%s: no stage or image found with that name", command, from)
+							return "", nil, fmt.Errorf("%s --from=%s: no stage or image found with that name", command, from)
 						}
 						break
 					}
@@ -1062,7 +1061,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				if otherStage, ok := s.executor.stages[from]; ok && otherStage.index < s.index {
 					break
 				} else if _, err = s.getImageRootfs(ctx, from); err != nil {
-					return "", nil, errors.Errorf("%s --from=%s: no stage or image found with that name", command, from)
+					return "", nil, fmt.Errorf("%s --from=%s: no stage or image found with that name", command, from)
 				}
 				break
 			}
@@ -1082,8 +1081,8 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		if !s.executor.layers {
 			err := ib.Run(step, s, noRunsRemaining)
 			if err != nil {
-				logrus.Debugf("%v", errors.Wrapf(err, "error building at step %+v", *step))
-				return "", nil, errors.Wrapf(err, "error building at STEP \"%s\"", step.Message)
+				logrus.Debugf("Error building at step %+v: %v", *step, err)
+				return "", nil, fmt.Errorf("error building at STEP \"%s\": %w", step.Message, err)
 			}
 			// In case we added content, retrieve its digest.
 			addedContentType, addedContentDigest := s.builder.ContentDigester.Digest()
@@ -1116,7 +1115,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 					logCommit(s.output, i)
 					imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), false, s.output, s.executor.squash)
 					if err != nil {
-						return "", nil, errors.Wrapf(err, "error committing container for step %+v", *step)
+						return "", nil, fmt.Errorf("error committing container for step %+v: %w", *step, err)
 					}
 					logImageID(imgID)
 				} else {
@@ -1151,7 +1150,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		if checkForLayers && step.Command != "arg" && !(s.executor.squash && lastInstruction && lastStage) {
 			cacheID, err = s.intermediateImageExists(ctx, node, addedContentSummary, s.stepRequiresLayer(step))
 			if err != nil {
-				return "", nil, errors.Wrap(err, "error checking if cached image exists from a previous build")
+				return "", nil, fmt.Errorf("error checking if cached image exists from a previous build: %w", err)
 			}
 		}
 
@@ -1162,8 +1161,8 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		if cacheID == "" {
 			// Process the instruction directly.
 			if err = ib.Run(step, s, noRunsRemaining); err != nil {
-				logrus.Debugf("%v", errors.Wrapf(err, "error building at step %+v", *step))
-				return "", nil, errors.Wrapf(err, "error building at STEP \"%s\"", step.Message)
+				logrus.Debugf("Error building at step %+v: %v", *step, err)
+				return "", nil, fmt.Errorf("error building at STEP \"%s\": %w", step.Message, err)
 			}
 
 			// In case we added content, retrieve its digest.
@@ -1182,7 +1181,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			if checkForLayers {
 				cacheID, err = s.intermediateImageExists(ctx, node, addedContentSummary, s.stepRequiresLayer(step))
 				if err != nil {
-					return "", nil, errors.Wrap(err, "error checking if cached image exists from a previous build")
+					return "", nil, fmt.Errorf("error checking if cached image exists from a previous build: %w", err)
 				}
 			}
 		} else {
@@ -1195,8 +1194,8 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			if !s.stepRequiresLayer(step) {
 				err := ib.Run(step, s, noRunsRemaining)
 				if err != nil {
-					logrus.Debugf("%v", errors.Wrapf(err, "error building at step %+v", *step))
-					return "", nil, errors.Wrapf(err, "error building at STEP \"%s\"", step.Message)
+					logrus.Debugf("Error building at step %+v: %v", *step, err)
+					return "", nil, fmt.Errorf("error building at STEP \"%s\": %w", step.Message, err)
 				}
 			}
 		}
@@ -1229,7 +1228,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// can be part of build-cache.
 			imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), !s.stepRequiresLayer(step), commitName, false)
 			if err != nil {
-				return "", nil, errors.Wrapf(err, "error committing container for step %+v", *step)
+				return "", nil, fmt.Errorf("error committing container for step %+v: %w", *step, err)
 			}
 		}
 
@@ -1239,7 +1238,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		if s.executor.squash && lastInstruction && lastStage {
 			imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), !s.stepRequiresLayer(step), commitName, true)
 			if err != nil {
-				return "", nil, errors.Wrapf(err, "error committing final squash step %+v", *step)
+				return "", nil, fmt.Errorf("error committing final squash step %+v: %w", *step, err)
 			}
 		}
 
@@ -1268,7 +1267,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// ID that we really should not be pulling anymore (see
 			// containers/podman/issues/10307).
 			if _, err := s.prepare(ctx, imgID, false, true, define.PullNever); err != nil {
-				return "", nil, errors.Wrap(err, "error preparing container for next step")
+				return "", nil, fmt.Errorf("error preparing container for next step: %w", err)
 			}
 		}
 	}
@@ -1472,7 +1471,7 @@ func (s *StageExecutor) tagExistingImage(ctx context.Context, cacheID, output st
 			if err == nil {
 				err = destroyErr
 			} else {
-				err = errors.Wrap(err, destroyErr.Error())
+				err = fmt.Errorf("%v: %w", destroyErr.Error(), err)
 			}
 		}
 	}()
@@ -1480,27 +1479,27 @@ func (s *StageExecutor) tagExistingImage(ctx context.Context, cacheID, output st
 	// Look up the source image, expecting it to be in local storage
 	src, err := is.Transport.ParseStoreReference(s.executor.store, cacheID)
 	if err != nil {
-		return "", nil, errors.Wrapf(err, "error getting source imageReference for %q", cacheID)
+		return "", nil, fmt.Errorf("error getting source imageReference for %q: %w", cacheID, err)
 	}
 	options := cp.Options{
 		RemoveSignatures: true, // more like "ignore signatures", since they don't get removed when src and dest are the same image
 	}
 	manifestBytes, err := cp.Image(ctx, policyContext, dest, src, &options)
 	if err != nil {
-		return "", nil, errors.Wrapf(err, "error copying image %q", cacheID)
+		return "", nil, fmt.Errorf("error copying image %q: %w", cacheID, err)
 	}
 	manifestDigest, err := manifest.Digest(manifestBytes)
 	if err != nil {
-		return "", nil, errors.Wrapf(err, "error computing digest of manifest for image %q", cacheID)
+		return "", nil, fmt.Errorf("error computing digest of manifest for image %q: %w", cacheID, err)
 	}
 	img, err := is.Transport.GetStoreImage(s.executor.store, dest)
 	if err != nil {
-		return "", nil, errors.Wrapf(err, "error locating new copy of image %q (i.e., %q)", cacheID, transports.ImageName(dest))
+		return "", nil, fmt.Errorf("error locating new copy of image %q (i.e., %q): %w", cacheID, transports.ImageName(dest), err)
 	}
 	var ref reference.Canonical
 	if dref := dest.DockerReference(); dref != nil {
 		if ref, err = reference.WithDigest(dref, manifestDigest); err != nil {
-			return "", nil, errors.Wrapf(err, "error computing canonical reference for new image %q (i.e., %q)", cacheID, transports.ImageName(dest))
+			return "", nil, fmt.Errorf("error computing canonical reference for new image %q (i.e., %q): %w", cacheID, transports.ImageName(dest), err)
 		}
 	}
 	return img.ID, ref, nil
@@ -1512,14 +1511,14 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 	// Get the list of images available in the image store
 	images, err := s.executor.store.Images()
 	if err != nil {
-		return "", errors.Wrap(err, "error getting image list from store")
+		return "", fmt.Errorf("error getting image list from store: %w", err)
 	}
 	var baseHistory []v1.History
 	var baseDiffIDs []digest.Digest
 	if s.builder.FromImageID != "" {
 		_, baseHistory, baseDiffIDs, err = s.executor.getImageTypeAndHistoryAndDiffIDs(ctx, s.builder.FromImageID)
 		if err != nil {
-			return "", errors.Wrapf(err, "error getting history of base image %q", s.builder.FromImageID)
+			return "", fmt.Errorf("error getting history of base image %q: %w", s.builder.FromImageID, err)
 		}
 	}
 	for _, image := range images {
@@ -1528,7 +1527,7 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 		if image.TopLayer != "" {
 			imageTopLayer, err = s.executor.store.Layer(image.TopLayer)
 			if err != nil {
-				return "", errors.Wrapf(err, "error getting top layer info")
+				return "", fmt.Errorf("error getting top layer info: %w", err)
 			}
 			// Figure out which layer from this image we should
 			// compare our container's base layer to.
@@ -1581,7 +1580,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		logrus.Debugf("Generating custom build output with options %q", s.executor.buildOutput)
 		buildOutputOption, err = parse.GetBuildOutput(s.executor.buildOutput)
 		if err != nil {
-			return "", nil, errors.Wrapf(err, "failed to parse build output")
+			return "", nil, fmt.Errorf("failed to parse build output: %w", err)
 		}
 	}
 	var imageRef types.ImageReference
@@ -1742,12 +1741,12 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		}
 		rc, errChan, err := s.builder.ExtractRootfs(options, extractRootfsOpts)
 		if err != nil {
-			return "", nil, errors.Wrapf(err, "failed to extract rootfs from given container image")
+			return "", nil, fmt.Errorf("failed to extract rootfs from given container image: %w", err)
 		}
 		defer rc.Close()
 		err = internalUtil.ExportFromReader(rc, buildOutputOption)
 		if err != nil {
-			return "", nil, errors.Wrapf(err, "failed to export build output")
+			return "", nil, fmt.Errorf("failed to export build output: %w", err)
 		}
 		if errChan != nil {
 			err = <-errChan
@@ -1765,7 +1764,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	if imageRef != nil {
 		if dref := imageRef.DockerReference(); dref != nil {
 			if ref, err = reference.WithDigest(dref, manifestDigest); err != nil {
-				return "", nil, errors.Wrapf(err, "error computing canonical reference for new image %q", imgID)
+				return "", nil, fmt.Errorf("error computing canonical reference for new image %q: %w", imgID, err)
 			}
 		}
 	}

--- a/import.go
+++ b/import.go
@@ -2,6 +2,8 @@ package buildah
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/docker"
@@ -13,12 +15,11 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 )
 
 func importBuilderDataFromImage(ctx context.Context, store storage.Store, systemContext *types.SystemContext, imageID, containerName, containerID string) (*Builder, error) {
 	if imageID == "" {
-		return nil, errors.Errorf("Internal error: imageID is empty in importBuilderDataFromImage")
+		return nil, errors.New("Internal error: imageID is empty in importBuilderDataFromImage")
 	}
 
 	storeopts, err := storage.DefaultStoreOptions(false, 0)
@@ -29,18 +30,18 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 
 	ref, err := is.Transport.ParseStoreReference(store, imageID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "no such image %q", imageID)
+		return nil, fmt.Errorf("no such image %q: %w", imageID, err)
 	}
 	src, err := ref.NewImageSource(ctx, systemContext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error instantiating image source")
+		return nil, fmt.Errorf("error instantiating image source: %w", err)
 	}
 	defer src.Close()
 
 	imageDigest := ""
 	manifestBytes, manifestType, err := src.GetManifest(ctx, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error loading image manifest for %q", transports.ImageName(ref))
+		return nil, fmt.Errorf("error loading image manifest for %q: %w", transports.ImageName(ref), err)
 	}
 	if manifestDigest, err := manifest.Digest(manifestBytes); err == nil {
 		imageDigest = manifestDigest.String()
@@ -50,18 +51,18 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 	if manifest.MIMETypeIsMultiImage(manifestType) {
 		list, err := manifest.ListFromBlob(manifestBytes, manifestType)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing image manifest for %q as list", transports.ImageName(ref))
+			return nil, fmt.Errorf("error parsing image manifest for %q as list: %w", transports.ImageName(ref), err)
 		}
 		instance, err := list.ChooseInstance(systemContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error finding an appropriate image in manifest list %q", transports.ImageName(ref))
+			return nil, fmt.Errorf("error finding an appropriate image in manifest list %q: %w", transports.ImageName(ref), err)
 		}
 		instanceDigest = &instance
 	}
 
 	image, err := image.FromUnparsedImage(ctx, systemContext, image.UnparsedInstance(src, instanceDigest))
 	if err != nil {
-		return nil, errors.Wrapf(err, "error instantiating image for %q instance %q", transports.ImageName(ref), instanceDigest)
+		return nil, fmt.Errorf("error instantiating image for %q instance %q: %w", transports.ImageName(ref), instanceDigest, err)
 	}
 
 	imageName := ""
@@ -72,7 +73,7 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 		if img.TopLayer != "" {
 			layer, err4 := store.Layer(img.TopLayer)
 			if err4 != nil {
-				return nil, errors.Wrapf(err4, "error reading information about image's top layer")
+				return nil, fmt.Errorf("error reading information about image's top layer: %w", err4)
 			}
 			uidmap, gidmap = convertStorageIDMaps(layer.UIDMap, layer.GIDMap)
 		}
@@ -109,7 +110,7 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 	}
 
 	if err := builder.initConfig(ctx, image, systemContext); err != nil {
-		return nil, errors.Wrapf(err, "error preparing image configuration")
+		return nil, fmt.Errorf("error preparing image configuration: %w", err)
 	}
 
 	return builder, nil
@@ -117,7 +118,7 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 
 func importBuilder(ctx context.Context, store storage.Store, options ImportOptions) (*Builder, error) {
 	if options.Container == "" {
-		return nil, errors.Errorf("container name must be specified")
+		return nil, errors.New("container name must be specified")
 	}
 
 	c, err := store.Container(options.Container)
@@ -146,7 +147,7 @@ func importBuilder(ctx context.Context, store storage.Store, options ImportOptio
 
 	err = builder.Save()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error saving builder state")
+		return nil, fmt.Errorf("error saving builder state: %w", err)
 	}
 
 	return builder, nil
@@ -154,19 +155,19 @@ func importBuilder(ctx context.Context, store storage.Store, options ImportOptio
 
 func importBuilderFromImage(ctx context.Context, store storage.Store, options ImportFromImageOptions) (*Builder, error) {
 	if options.Image == "" {
-		return nil, errors.Errorf("image name must be specified")
+		return nil, errors.New("image name must be specified")
 	}
 
 	systemContext := getSystemContext(store, options.SystemContext, options.SignaturePolicyPath)
 
 	_, img, err := util.FindImage(store, "", systemContext, options.Image)
 	if err != nil {
-		return nil, errors.Wrapf(err, "importing settings")
+		return nil, fmt.Errorf("importing settings: %w", err)
 	}
 
 	builder, err := importBuilderDataFromImage(ctx, store, systemContext, img.ID, "", "")
 	if err != nil {
-		return nil, errors.Wrapf(err, "error importing build settings from image %q", options.Image)
+		return nil, fmt.Errorf("error importing build settings from image %q: %w", options.Image, err)
 	}
 
 	builder.setupLogger()

--- a/info.go
+++ b/info.go
@@ -3,6 +3,7 @@ package buildah
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -17,7 +18,6 @@ import (
 	"github.com/containers/storage/pkg/system"
 	"github.com/containers/storage/pkg/unshare"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -189,7 +189,7 @@ func readUptime() (string, error) {
 	}
 	f := bytes.Fields(buf)
 	if len(f) < 1 {
-		return "", errors.Errorf("invalid uptime")
+		return "", errors.New("invalid uptime")
 	}
 	return string(f[0]), nil
 }

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"errors"
+
 	"github.com/containers/buildah/internal"
 	internalUtil "github.com/containers/buildah/internal/util"
 	"github.com/containers/common/pkg/parse"
@@ -16,7 +18,6 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/lockfile"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -76,22 +77,22 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
 			newMount.Options = append(newMount.Options, kv[0])
 		case "from":
 			if len(kv) == 1 {
-				return newMount, "", errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			fromImage = kv[1]
 		case "bind-propagation":
 			if len(kv) == 1 {
-				return newMount, "", errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			newMount.Options = append(newMount.Options, kv[1])
 		case "src", "source":
 			if len(kv) == 1 {
-				return newMount, "", errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			newMount.Source = kv[1]
 		case "target", "dst", "destination":
 			if len(kv) == 1 {
-				return newMount, "", errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, "", fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			if err := parse.ValidateVolumeCtrDir(kv[1]); err != nil {
 				return newMount, "", err
@@ -103,7 +104,7 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
 			// and can thus be safely ignored.
 			// See also the handling of the equivalent "delegated" and "cached" in ValidateVolumeOpts
 		default:
-			return newMount, "", errors.Wrapf(errBadMntOption, kv[0])
+			return newMount, "", fmt.Errorf("%v: %w", kv[0], errBadMntOption)
 		}
 	}
 
@@ -223,22 +224,22 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 			sharing = kv[1]
 		case "bind-propagation":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			newMount.Options = append(newMount.Options, kv[1])
 		case "id":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			id = kv[1]
 		case "from":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			fromStage = kv[1]
 		case "target", "dst", "destination":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			if err := parse.ValidateVolumeCtrDir(kv[1]); err != nil {
 				return newMount, lockedTargets, err
@@ -247,35 +248,35 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 			setDest = true
 		case "src", "source":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			newMount.Source = kv[1]
 		case "mode":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			mode, err = strconv.ParseUint(kv[1], 8, 32)
 			if err != nil {
-				return newMount, lockedTargets, errors.Wrapf(err, "Unable to parse cache mode")
+				return newMount, lockedTargets, fmt.Errorf("unable to parse cache mode: %w", err)
 			}
 		case "uid":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			uid, err = strconv.Atoi(kv[1])
 			if err != nil {
-				return newMount, lockedTargets, errors.Wrapf(err, "Unable to parse cache uid")
+				return newMount, lockedTargets, fmt.Errorf("unable to parse cache uid: %w", err)
 			}
 		case "gid":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			gid, err = strconv.Atoi(kv[1])
 			if err != nil {
-				return newMount, lockedTargets, errors.Wrapf(err, "Unable to parse cache gid")
+				return newMount, lockedTargets, fmt.Errorf("unable to parse cache gid: %w", err)
 			}
 		default:
-			return newMount, lockedTargets, errors.Wrapf(errBadMntOption, kv[0])
+			return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadMntOption)
 		}
 	}
 
@@ -313,7 +314,7 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		// create cache on host if not present
 		err = os.MkdirAll(cacheParent, os.FileMode(0755))
 		if err != nil {
-			return newMount, lockedTargets, errors.Wrapf(err, "Unable to create build cache directory")
+			return newMount, lockedTargets, fmt.Errorf("unable to create build cache directory: %w", err)
 		}
 
 		if id != "" {
@@ -328,7 +329,7 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		//buildkit parity: change uid and gid if specified otheriwise keep `0`
 		err = idtools.MkdirAllAndChownNew(newMount.Source, os.FileMode(mode), idPair)
 		if err != nil {
-			return newMount, lockedTargets, errors.Wrapf(err, "Unable to change uid,gid of cache directory")
+			return newMount, lockedTargets, fmt.Errorf("unable to change uid,gid of cache directory: %w", err)
 		}
 	}
 
@@ -337,7 +338,7 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		// lock parent cache
 		lockfile, err := lockfile.GetLockfile(filepath.Join(newMount.Source, BuildahCacheLockfile))
 		if err != nil {
-			return newMount, lockedTargets, errors.Wrapf(err, "Unable to acquire lock when sharing mode is locked")
+			return newMount, lockedTargets, fmt.Errorf("unable to acquire lock when sharing mode is locked: %w", err)
 		}
 		// Will be unlocked after the RUN step is executed.
 		lockfile.Lock()
@@ -347,7 +348,7 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		break
 	default:
 		// error out for unknown values
-		return newMount, lockedTargets, errors.Wrapf(err, "Unrecognized value %q for field `sharing`", sharing)
+		return newMount, lockedTargets, fmt.Errorf("unrecognized value %q for field `sharing`: %w", sharing, err)
 	}
 
 	// buildkit parity: default sharing should be shared
@@ -375,10 +376,10 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 // ValidateVolumeMountHostDir validates the host path of buildah --volume
 func ValidateVolumeMountHostDir(hostDir string) error {
 	if !filepath.IsAbs(hostDir) {
-		return errors.Errorf("invalid host path, must be an absolute path %q", hostDir)
+		return fmt.Errorf("invalid host path, must be an absolute path %q", hostDir)
 	}
 	if _, err := os.Stat(hostDir); err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	return nil
 }
@@ -421,7 +422,7 @@ func getVolumeMounts(volumes []string) (map[string]specs.Mount, error) {
 			return nil, err
 		}
 		if _, ok := finalVolumeMounts[volumeMount.Destination]; ok {
-			return nil, errors.Wrapf(errDuplicateDest, volumeMount.Destination)
+			return nil, fmt.Errorf("%v: %w", volumeMount.Destination, errDuplicateDest)
 		}
 		finalVolumeMounts[volumeMount.Destination] = volumeMount
 	}
@@ -433,7 +434,7 @@ func Volume(volume string) (specs.Mount, error) {
 	mount := specs.Mount{}
 	arr := SplitStringWithColonEscape(volume)
 	if len(arr) < 2 {
-		return mount, errors.Errorf("incorrect volume format %q, should be host-dir:ctr-dir[:option]", volume)
+		return mount, fmt.Errorf("incorrect volume format %q, should be host-dir:ctr-dir[:option]", volume)
 	}
 	if err := ValidateVolumeMountHostDir(arr[0]); err != nil {
 		return mount, err
@@ -468,7 +469,7 @@ func GetVolumes(ctx *types.SystemContext, store storage.Store, volumes []string,
 	}
 	for dest, mount := range volumeMounts {
 		if _, ok := unifiedMounts[dest]; ok {
-			return nil, mountedImages, lockedTargets, errors.Wrapf(errDuplicateDest, dest)
+			return nil, mountedImages, lockedTargets, fmt.Errorf("%v: %w", dest, errDuplicateDest)
 		}
 		unifiedMounts[dest] = mount
 	}
@@ -489,7 +490,7 @@ func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, c
 	mountedImages := make([]string, 0)
 	lockedTargets := make([]string, 0)
 
-	errInvalidSyntax := errors.Errorf("incorrect mount format: should be --mount type=<bind|tmpfs>,[src=<host-dir>,]target=<ctr-dir>[,options]")
+	errInvalidSyntax := errors.New("incorrect mount format: should be --mount type=<bind|tmpfs>,[src=<host-dir>,]target=<ctr-dir>[,options]")
 
 	// TODO(vrothberg): the manual parsing can be replaced with a regular expression
 	//                  to allow a more robust parsing of the mount format and to give
@@ -497,13 +498,13 @@ func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, c
 	for _, mount := range mounts {
 		arr := strings.SplitN(mount, ",", 2)
 		if len(arr) < 2 {
-			return nil, mountedImages, lockedTargets, errors.Wrapf(errInvalidSyntax, "%q", mount)
+			return nil, mountedImages, lockedTargets, fmt.Errorf("%q: %w", mount, errInvalidSyntax)
 		}
 		kv := strings.Split(arr[0], "=")
 		// TODO: type is not explicitly required in Docker.
 		// If not specified, it defaults to "volume".
 		if len(kv) != 2 || kv[0] != "type" {
-			return nil, mountedImages, lockedTargets, errors.Wrapf(errInvalidSyntax, "%q", mount)
+			return nil, mountedImages, lockedTargets, fmt.Errorf("%q: %w", mount, errInvalidSyntax)
 		}
 
 		tokens := strings.Split(arr[1], ",")
@@ -514,7 +515,7 @@ func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, c
 				return nil, mountedImages, lockedTargets, err
 			}
 			if _, ok := finalMounts[mount.Destination]; ok {
-				return nil, mountedImages, lockedTargets, errors.Wrapf(errDuplicateDest, mount.Destination)
+				return nil, mountedImages, lockedTargets, fmt.Errorf("%v: %w", mount.Destination, errDuplicateDest)
 			}
 			finalMounts[mount.Destination] = mount
 			mountedImages = append(mountedImages, image)
@@ -525,7 +526,7 @@ func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, c
 				return nil, mountedImages, lockedTargets, err
 			}
 			if _, ok := finalMounts[mount.Destination]; ok {
-				return nil, mountedImages, lockedTargets, errors.Wrapf(errDuplicateDest, mount.Destination)
+				return nil, mountedImages, lockedTargets, fmt.Errorf("%v: %w", mount.Destination, errDuplicateDest)
 			}
 			finalMounts[mount.Destination] = mount
 		case TypeTmpfs:
@@ -534,11 +535,11 @@ func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, c
 				return nil, mountedImages, lockedTargets, err
 			}
 			if _, ok := finalMounts[mount.Destination]; ok {
-				return nil, mountedImages, lockedTargets, errors.Wrapf(errDuplicateDest, mount.Destination)
+				return nil, mountedImages, lockedTargets, fmt.Errorf("%v: %w", mount.Destination, errDuplicateDest)
 			}
 			finalMounts[mount.Destination] = mount
 		default:
-			return nil, mountedImages, lockedTargets, errors.Errorf("invalid filesystem type %q", kv[1])
+			return nil, mountedImages, lockedTargets, fmt.Errorf("invalid filesystem type %q", kv[1])
 		}
 	}
 
@@ -567,19 +568,19 @@ func GetTmpfsMount(args []string) (specs.Mount, error) {
 			newMount.Options = append(newMount.Options, kv[0])
 		case "tmpfs-mode":
 			if len(kv) == 1 {
-				return newMount, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			newMount.Options = append(newMount.Options, fmt.Sprintf("mode=%s", kv[1]))
 		case "tmpfs-size":
 			if len(kv) == 1 {
-				return newMount, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			newMount.Options = append(newMount.Options, fmt.Sprintf("size=%s", kv[1]))
 		case "src", "source":
-			return newMount, errors.Errorf("source is not supported with tmpfs mounts")
+			return newMount, errors.New("source is not supported with tmpfs mounts")
 		case "target", "dst", "destination":
 			if len(kv) == 1 {
-				return newMount, errors.Wrapf(errBadOptionArg, kv[0])
+				return newMount, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			if err := parse.ValidateVolumeCtrDir(kv[1]); err != nil {
 				return newMount, err
@@ -587,7 +588,7 @@ func GetTmpfsMount(args []string) (specs.Mount, error) {
 			newMount.Destination = kv[1]
 			setDest = true
 		default:
-			return newMount, errors.Wrapf(errBadMntOption, kv[0])
+			return newMount, fmt.Errorf("%v: %w", kv[0], errBadMntOption)
 		}
 	}
 

--- a/internal/source/create.go
+++ b/internal/source/create.go
@@ -2,12 +2,12 @@ package source
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
 	spec "github.com/opencontainers/image-spec/specs-go"
 	specV1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // CreateOptions includes data to alter certain knobs when creating a source
@@ -33,7 +33,7 @@ func (o *CreateOptions) createdTime() *time.Time {
 // that `sourcePath` must not exist.
 func Create(ctx context.Context, sourcePath string, options CreateOptions) error {
 	if _, err := os.Stat(sourcePath); err == nil {
-		return errors.Errorf("error creating source image: %q already exists", sourcePath)
+		return fmt.Errorf("error creating source image: %q already exists", sourcePath)
 	}
 
 	ociDest, err := openOrCreateSourceImage(ctx, sourcePath)

--- a/internal/source/push.go
+++ b/internal/source/push.go
@@ -2,13 +2,13 @@ package source
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
 )
 
 // PushOptions includes data to alter certain knobs when pushing a source
@@ -48,11 +48,11 @@ func Push(ctx context.Context, sourcePath string, imageInput string, options Pus
 
 	policy, err := signature.DefaultPolicy(sysCtx)
 	if err != nil {
-		return errors.Wrapf(err, "error obtaining default signature policy")
+		return fmt.Errorf("error obtaining default signature policy: %w", err)
 	}
 	policyContext, err := signature.NewPolicyContext(policy)
 	if err != nil {
-		return errors.Wrapf(err, "error creating new signature policy context")
+		return fmt.Errorf("error creating new signature policy context: %w", err)
 	}
 
 	copyOpts := &copy.Options{
@@ -62,7 +62,7 @@ func Push(ctx context.Context, sourcePath string, imageInput string, options Pus
 		copyOpts.ReportWriter = os.Stderr
 	}
 	if _, err := copy.Image(ctx, policyContext, destRef, ociSource.Reference(), copyOpts); err != nil {
-		return errors.Wrap(err, "error pushing source image")
+		return fmt.Errorf("error pushing source image: %w", err)
 	}
 
 	return nil

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/opencontainers/go-digest"
 	specV1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // MediaTypeSourceImageConfig specifies the media type of a source-image config.
@@ -33,11 +33,11 @@ type ImageConfig struct {
 func writeManifest(ctx context.Context, manifest *specV1.Manifest, ociDest types.ImageDestination) (*digest.Digest, int64, error) {
 	rawData, err := json.Marshal(&manifest)
 	if err != nil {
-		return nil, -1, errors.Wrap(err, "error marshalling manifest")
+		return nil, -1, fmt.Errorf("error marshalling manifest: %w", err)
 	}
 
 	if err := ociDest.PutManifest(ctx, rawData, nil); err != nil {
-		return nil, -1, errors.Wrap(err, "error writing manifest")
+		return nil, -1, fmt.Errorf("error writing manifest: %w", err)
 	}
 
 	manifestDigest := digest.FromBytes(rawData)
@@ -52,12 +52,12 @@ func readManifestFromImageSource(ctx context.Context, src types.ImageSource) (*s
 		return nil, nil, -1, err
 	}
 	if mimeType != specV1.MediaTypeImageManifest {
-		return nil, nil, -1, errors.Errorf("image %q is of type %q (expected: %q)", strings.TrimPrefix(src.Reference().StringWithinTransport(), "//"), mimeType, specV1.MediaTypeImageManifest)
+		return nil, nil, -1, fmt.Errorf("image %q is of type %q (expected: %q)", strings.TrimPrefix(src.Reference().StringWithinTransport(), "//"), mimeType, specV1.MediaTypeImageManifest)
 	}
 
 	manifest := specV1.Manifest{}
 	if err := json.Unmarshal(rawData, &manifest); err != nil {
-		return nil, nil, -1, errors.Wrap(err, "error reading manifest")
+		return nil, nil, -1, fmt.Errorf("error reading manifest: %w", err)
 	}
 
 	manifestDigest := digest.FromBytes(rawData)
@@ -99,7 +99,7 @@ func openOrCreateSourceImage(ctx context.Context, sourcePath string) (types.Imag
 func addConfig(ctx context.Context, config *ImageConfig, ociDest types.ImageDestination) (*types.BlobInfo, error) {
 	rawData, err := json.Marshal(config)
 	if err != nil {
-		return nil, errors.Wrap(err, "error marshalling config")
+		return nil, fmt.Errorf("error marshalling config: %w", err)
 	}
 
 	info := types.BlobInfo{
@@ -107,7 +107,7 @@ func addConfig(ctx context.Context, config *ImageConfig, ociDest types.ImageDest
 	}
 	addedBlob, err := ociDest.PutBlob(ctx, bytes.NewReader(rawData), info, nil, true)
 	if err != nil {
-		return nil, errors.Wrap(err, "error adding config")
+		return nil, fmt.Errorf("error adding config: %w", err)
 	}
 
 	return &addedBlob, nil

--- a/new.go
+++ b/new.go
@@ -2,6 +2,7 @@ package buildah
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -19,7 +20,6 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/openshift/imagebuilder"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -190,12 +190,12 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 	if ref != nil {
 		srcSrc, err := ref.NewImageSource(ctx, systemContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error instantiating image for %q", transports.ImageName(ref))
+			return nil, fmt.Errorf("error instantiating image for %q: %w", transports.ImageName(ref), err)
 		}
 		defer srcSrc.Close()
 		manifestBytes, manifestType, err := srcSrc.GetManifest(ctx, nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error loading image manifest for %q", transports.ImageName(ref))
+			return nil, fmt.Errorf("error loading image manifest for %q: %w", transports.ImageName(ref), err)
 		}
 		if manifestDigest, err := manifest.Digest(manifestBytes); err == nil {
 			imageDigest = manifestDigest.String()
@@ -204,17 +204,17 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		if manifest.MIMETypeIsMultiImage(manifestType) {
 			list, err := manifest.ListFromBlob(manifestBytes, manifestType)
 			if err != nil {
-				return nil, errors.Wrapf(err, "error parsing image manifest for %q as list", transports.ImageName(ref))
+				return nil, fmt.Errorf("error parsing image manifest for %q as list: %w", transports.ImageName(ref), err)
 			}
 			instance, err := list.ChooseInstance(systemContext)
 			if err != nil {
-				return nil, errors.Wrapf(err, "error finding an appropriate image in manifest list %q", transports.ImageName(ref))
+				return nil, fmt.Errorf("error finding an appropriate image in manifest list %q: %w", transports.ImageName(ref), err)
 			}
 			instanceDigest = &instance
 		}
 		src, err = image.FromUnparsedImage(ctx, systemContext, image.UnparsedInstance(srcSrc, instanceDigest))
 		if err != nil {
-			return nil, errors.Wrapf(err, "error instantiating image for %q instance %q", transports.ImageName(ref), instanceDigest)
+			return nil, fmt.Errorf("error instantiating image for %q instance %q: %w", transports.ImageName(ref), instanceDigest, err)
 		}
 	}
 
@@ -234,7 +234,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 	if options.Container == "" {
 		containers, err := store.Containers()
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to check for container names")
+			return nil, fmt.Errorf("unable to check for container names: %w", err)
 		}
 		tmpName = findUnusedContainer(tmpName, containers)
 	}
@@ -262,8 +262,8 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 			name = tmpName
 			break
 		}
-		if errors.Cause(err) != storage.ErrDuplicateName || options.Container != "" {
-			return nil, errors.Wrapf(err, "error creating container")
+		if !errors.Is(err, storage.ErrDuplicateName) || options.Container != "" {
+			return nil, fmt.Errorf("error creating container: %w", err)
 		}
 		tmpName = fmt.Sprintf("%s-%d", name, rand.Int()%conflict)
 		conflict = conflict * 10
@@ -333,16 +333,16 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 	if options.Mount {
 		_, err = builder.Mount(container.MountLabel())
 		if err != nil {
-			return nil, errors.Wrapf(err, "error mounting build container %q", builder.ContainerID)
+			return nil, fmt.Errorf("error mounting build container %q: %w", builder.ContainerID, err)
 		}
 	}
 
 	if err := builder.initConfig(ctx, src, systemContext); err != nil {
-		return nil, errors.Wrapf(err, "error preparing image configuration")
+		return nil, fmt.Errorf("error preparing image configuration: %w", err)
 	}
 	err = builder.Save()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error saving builder state for container %q", builder.ContainerID)
+		return nil, fmt.Errorf("error saving builder state for container %q: %w", builder.ContainerID, err)
 	}
 
 	return builder, nil

--- a/pkg/chrootuser/user.go
+++ b/pkg/chrootuser/user.go
@@ -1,11 +1,11 @@
 package chrootuser
 
 import (
+	"errors"
+	"fmt"
 	"os/user"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 var (
@@ -76,9 +76,9 @@ func GetUser(rootdir, userspec string) (uint32, uint32, string, error) {
 		return uint32(uid64), uint32(gid64), homedir, nil
 	}
 
-	err = errors.Wrapf(uerr, "error determining run uid")
+	err = fmt.Errorf("error determining run uid: %w", uerr)
 	if uerr == nil {
-		err = errors.Wrapf(gerr, "error determining run gid")
+		err = fmt.Errorf("error determining run gid: %w", gerr)
 	}
 
 	return 0, 0, homedir, err
@@ -94,7 +94,7 @@ func GetGroup(rootdir, groupspec string) (uint32, error) {
 		gid64, gerr = lookupGroupInContainer(rootdir, groupspec)
 	}
 	if gerr != nil {
-		return 0, errors.Wrapf(gerr, "error looking up group for gid %q", groupspec)
+		return 0, fmt.Errorf("error looking up group for gid %q: %w", groupspec, gerr)
 	}
 	return uint32(gid64), nil
 }
@@ -103,7 +103,7 @@ func GetGroup(rootdir, groupspec string) (uint32, error) {
 func GetAdditionalGroupsForUser(rootdir string, userid uint64) ([]uint32, error) {
 	gids, err := lookupAdditionalGroupsForUIDInContainer(rootdir, userid)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up supplemental groups for uid %d", userid)
+		return nil, fmt.Errorf("error looking up supplemental groups for uid %d: %w", userid, err)
 	}
 	return gids, nil
 }

--- a/pkg/chrootuser/user_basic.go
+++ b/pkg/chrootuser/user_basic.go
@@ -1,9 +1,10 @@
+//go:build !linux
 // +build !linux
 
 package chrootuser
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 func lookupUserInContainer(rootdir, username string) (uint64, uint64, error) {

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
 
@@ -314,7 +313,7 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 	fs := pflag.FlagSet{}
 	defaultContainerConfig, err := config.Default()
 	if err != nil {
-		return fs, errors.Wrapf(err, "failed to get container config")
+		return fs, fmt.Errorf("failed to get container config: %w", err)
 	}
 
 	fs.StringSliceVar(&flags.AddHost, "add-host", []string{}, "add a custom host-to-IP mapping (`host:ip`) (default [])")
@@ -443,7 +442,7 @@ func DefaultHistory() bool {
 func VerifyFlagsArgsOrder(args []string) error {
 	for _, arg := range args {
 		if strings.HasPrefix(arg, "-") {
-			return errors.Errorf("No options (%s) can be specified after the image or container name", arg)
+			return fmt.Errorf("no options (%s) can be specified after the image or container name", arg)
 		}
 	}
 	return nil

--- a/pkg/formats/formats.go
+++ b/pkg/formats/formats.go
@@ -11,7 +11,6 @@ import (
 	"text/template"
 
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
 	"golang.org/x/term"
 )
 
@@ -98,7 +97,7 @@ func (t StdoutTemplateArray) Out() error {
 		t.Template = strings.Replace(strings.TrimSpace(t.Template[5:]), " ", "\t", -1)
 		headerTmpl, err := template.New("header").Funcs(headerFunctions).Parse(t.Template)
 		if err != nil {
-			return errors.Wrapf(err, parsingErrorStr)
+			return fmt.Errorf("%v: %w", parsingErrorStr, err)
 		}
 		err = headerTmpl.Execute(w, t.Fields)
 		if err != nil {
@@ -109,12 +108,12 @@ func (t StdoutTemplateArray) Out() error {
 	t.Template = strings.Replace(t.Template, " ", "\t", -1)
 	tmpl, err := template.New("image").Funcs(basicFunctions).Parse(t.Template)
 	if err != nil {
-		return errors.Wrapf(err, parsingErrorStr)
+		return fmt.Errorf("%v: %w", parsingErrorStr, err)
 	}
 	for _, raw := range t.Output {
 		basicTmpl := tmpl.Funcs(basicFunctions)
 		if err := basicTmpl.Execute(w, raw); err != nil {
-			return errors.Wrapf(err, parsingErrorStr)
+			return fmt.Errorf("%v: %w", parsingErrorStr, err)
 		}
 		fmt.Fprintln(w, "")
 	}
@@ -136,7 +135,7 @@ func (j JSONStruct) Out() error {
 func (t StdoutTemplate) Out() error {
 	tmpl, err := template.New("image").Parse(t.Template)
 	if err != nil {
-		return errors.Wrapf(err, "template parsing error")
+		return fmt.Errorf("template parsing error: %w", err)
 	}
 	err = tmpl.Execute(os.Stdout, t.Output)
 	if err != nil {

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -5,6 +5,7 @@ package parse
 // would be useful to projects vendoring buildah
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -25,7 +26,6 @@ import (
 	units "github.com/docker/go-units"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/openshift/imagebuilder"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -66,7 +66,7 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 	if memVal != "" {
 		memoryLimit, err = units.RAMInBytes(memVal)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid value for memory")
+			return nil, fmt.Errorf("invalid value for memory: %w", err)
 		}
 	}
 
@@ -77,7 +77,7 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 		} else {
 			memorySwap, err = units.RAMInBytes(memSwapValue)
 			if err != nil {
-				return nil, errors.Wrapf(err, "invalid value for memory-swap")
+				return nil, fmt.Errorf("invalid value for memory-swap: %w", err)
 			}
 		}
 	}
@@ -87,11 +87,11 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 	addHost, _ := flags.GetStringSlice("add-host")
 	if len(addHost) > 0 {
 		if noHosts {
-			return nil, errors.Errorf("--no-hosts and --add-host conflict, can not be used together")
+			return nil, errors.New("--no-hosts and --add-host conflict, can not be used together")
 		}
 		for _, host := range addHost {
 			if err := validateExtraHost(host); err != nil {
-				return nil, errors.Wrapf(err, "invalid value for add-host")
+				return nil, fmt.Errorf("invalid value for add-host: %w", err)
 			}
 		}
 	}
@@ -106,7 +106,7 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 			}
 		}
 		if noDNS && len(dnsServers) > 1 {
-			return nil, errors.Errorf("invalid --dns, --dns=none may not be used with any other --dns options")
+			return nil, errors.New("invalid --dns, --dns=none may not be used with any other --dns options")
 		}
 	}
 
@@ -114,7 +114,7 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 	if flags.Changed("dns-search") {
 		dnsSearch, _ = flags.GetStringSlice("dns-search")
 		if noDNS && len(dnsSearch) > 0 {
-			return nil, errors.Errorf("invalid --dns-search, --dns-search may not be used with --dns=none")
+			return nil, errors.New("invalid --dns-search, --dns-search may not be used with --dns=none")
 		}
 	}
 
@@ -122,12 +122,12 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 	if flags.Changed("dns-option") {
 		dnsOptions, _ = flags.GetStringSlice("dns-option")
 		if noDNS && len(dnsOptions) > 0 {
-			return nil, errors.Errorf("invalid --dns-option, --dns-option may not be used with --dns=none")
+			return nil, errors.New("invalid --dns-option, --dns-option may not be used with --dns=none")
 		}
 	}
 
 	if _, err := units.FromHumanSize(findFlagFunc("shm-size").Value.String()); err != nil {
-		return nil, errors.Wrapf(err, "invalid --shm-size")
+		return nil, fmt.Errorf("invalid --shm-size: %w", err)
 	}
 	volumes, _ := flags.GetStringArray("volume")
 	if err := Volumes(volumes); err != nil {
@@ -198,7 +198,7 @@ func GetAdditionalBuildContext(value string) (define.AdditionalBuildContext, err
 	} else {
 		path, err := filepath.Abs(value)
 		if err != nil {
-			return define.AdditionalBuildContext{}, errors.Wrapf(err, "unable to convert additional build-context %q path to absolute", value)
+			return define.AdditionalBuildContext{}, fmt.Errorf("unable to convert additional build-context %q path to absolute: %w", value, err)
 		}
 		ret.Value = path
 	}
@@ -208,11 +208,11 @@ func GetAdditionalBuildContext(value string) (define.AdditionalBuildContext, err
 func parseSecurityOpts(securityOpts []string, commonOpts *define.CommonBuildOptions) error {
 	for _, opt := range securityOpts {
 		if opt == "no-new-privileges" {
-			return errors.Errorf("no-new-privileges is not supported")
+			return errors.New("no-new-privileges is not supported")
 		}
 		con := strings.SplitN(opt, "=", 2)
 		if len(con) != 2 {
-			return errors.Errorf("invalid --security-opt name=value pair: %q", opt)
+			return fmt.Errorf("invalid --security-opt name=value pair: %q", opt)
 		}
 
 		switch con[0] {
@@ -223,7 +223,7 @@ func parseSecurityOpts(securityOpts []string, commonOpts *define.CommonBuildOpti
 		case "seccomp":
 			commonOpts.SeccompProfilePath = con[1]
 		default:
-			return errors.Errorf("invalid --security-opt 2: %q", opt)
+			return fmt.Errorf("invalid --security-opt 2: %q", opt)
 		}
 
 	}
@@ -233,11 +233,11 @@ func parseSecurityOpts(securityOpts []string, commonOpts *define.CommonBuildOpti
 			commonOpts.SeccompProfilePath = SeccompOverridePath
 		} else {
 			if !os.IsNotExist(err) {
-				return errors.WithStack(err)
+				return err
 			}
 			if _, err := os.Stat(SeccompDefaultPath); err != nil {
 				if !os.IsNotExist(err) {
-					return errors.WithStack(err)
+					return err
 				}
 			} else {
 				commonOpts.SeccompProfilePath = SeccompDefaultPath
@@ -292,10 +292,10 @@ func validateExtraHost(val string) error {
 	// allow for IPv6 addresses in extra hosts by only splitting on first ":"
 	arr := strings.SplitN(val, ":", 2)
 	if len(arr) != 2 || len(arr[0]) == 0 {
-		return errors.Errorf("bad format for add-host: %q", val)
+		return fmt.Errorf("bad format for add-host: %q", val)
 	}
 	if _, err := validateIPAddress(arr[1]); err != nil {
-		return errors.Errorf("invalid IP address in add-host: %q", arr[1])
+		return fmt.Errorf("invalid IP address in add-host: %q", arr[1])
 	}
 	return nil
 }
@@ -307,7 +307,7 @@ func validateIPAddress(val string) (string, error) {
 	if ip != nil {
 		return ip.String(), nil
 	}
-	return "", errors.Errorf("%s is not an ip address", val)
+	return "", fmt.Errorf("%s is not an ip address", val)
 }
 
 // SystemContextFromOptions returns a SystemContext populated with values
@@ -396,7 +396,7 @@ func SystemContextFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name strin
 			return nil, err
 		}
 		if len(specs) == 0 || specs[0] == "" {
-			return nil, errors.Errorf("unable to parse --platform value %v", specs)
+			return nil, fmt.Errorf("unable to parse --platform value %v", specs)
 		}
 		platform := specs[0]
 		os, arch, variant, err := Platform(platform)
@@ -404,7 +404,7 @@ func SystemContextFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name strin
 			return nil, err
 		}
 		if ctx.OSChoice != "" || ctx.ArchitectureChoice != "" || ctx.VariantChoice != "" {
-			return nil, errors.Errorf("invalid --platform may not be used with --os, --arch, or --variant")
+			return nil, errors.New("invalid --platform may not be used with --os, --arch, or --variant")
 		}
 		ctx.OSChoice = os
 		ctx.ArchitectureChoice = arch
@@ -431,7 +431,7 @@ func PlatformFromOptions(c *cobra.Command) (os, arch string, err error) {
 		return "", "", err
 	}
 	if len(platforms) < 1 {
-		return "", "", errors.Errorf("invalid platform syntax for --platform (use OS/ARCH[/VARIANT])")
+		return "", "", errors.New("invalid platform syntax for --platform (use OS/ARCH[/VARIANT])")
 	}
 	return platforms[0].OS, platforms[0].Arch, nil
 }
@@ -461,14 +461,14 @@ func PlatformsFromOptions(c *cobra.Command) (platforms []struct{ OS, Arch, Varia
 		platforms = nil
 		platformSpecs, err := c.Flags().GetStringSlice("platform")
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to parse platform")
+			return nil, fmt.Errorf("unable to parse platform: %w", err)
 		}
 		if os != "" || arch != "" || variant != "" {
-			return nil, errors.Errorf("invalid --platform may not be used with --os, --arch, or --variant")
+			return nil, fmt.Errorf("invalid --platform may not be used with --os, --arch, or --variant")
 		}
 		for _, pf := range platformSpecs {
 			if os, arch, variant, err = Platform(pf); err != nil {
-				return nil, errors.Wrapf(err, "unable to parse platform %q", pf)
+				return nil, fmt.Errorf("unable to parse platform %q: %w", pf, err)
 			}
 			platforms = append(platforms, struct{ OS, Arch, Variant string }{os, arch, variant})
 		}
@@ -500,7 +500,7 @@ func Platform(platform string) (os, arch, variant string, err error) {
 			return Platform(DefaultPlatform())
 		}
 	}
-	return "", "", "", errors.Errorf("invalid platform syntax for %q (use OS/ARCH[/VARIANT][,...])", platform)
+	return "", "", "", fmt.Errorf("invalid platform syntax for %q (use OS/ARCH[/VARIANT][,...])", platform)
 }
 
 func parseCreds(creds string) (string, string) {
@@ -529,7 +529,7 @@ func AuthConfig(creds string) (*types.DockerAuthConfig, error) {
 		fmt.Print("Password: ")
 		termPassword, err := term.ReadPassword(0)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not read password from terminal")
+			return nil, fmt.Errorf("could not read password from terminal: %w", err)
 		}
 		password = string(termPassword)
 	}
@@ -570,7 +570,7 @@ func GetBuildOutput(buildOutput string) (define.BuildOutputOption, error) {
 		switch arr[0] {
 		case "type":
 			if typeSelected {
-				return define.BuildOutputOption{}, fmt.Errorf("Duplicate %q not supported", arr[0])
+				return define.BuildOutputOption{}, fmt.Errorf("duplicate %q not supported", arr[0])
 			}
 			typeSelected = true
 			if arr[1] == "local" {
@@ -582,12 +582,12 @@ func GetBuildOutput(buildOutput string) (define.BuildOutputOption, error) {
 			}
 		case "dest":
 			if pathSelected {
-				return define.BuildOutputOption{}, fmt.Errorf("Duplicate %q not supported", arr[0])
+				return define.BuildOutputOption{}, fmt.Errorf("duplicate %q not supported", arr[0])
 			}
 			pathSelected = true
 			path = arr[1]
 		default:
-			return define.BuildOutputOption{}, fmt.Errorf("Unrecognized key %q in build output option: %q", arr[0], buildOutput)
+			return define.BuildOutputOption{}, fmt.Errorf("unrecognized key %q in build output option: %q", arr[0], buildOutput)
 		}
 	}
 
@@ -617,7 +617,7 @@ func IDMappingOptions(c *cobra.Command, isolation define.Isolation) (usernsOptio
 func GetAutoOptions(base string) (*storageTypes.AutoUserNsOptions, error) {
 	parts := strings.SplitN(base, ":", 2)
 	if parts[0] != "auto" {
-		return nil, fmt.Errorf("wrong user namespace mode")
+		return nil, errors.New("wrong user namespace mode")
 	}
 	options := storageTypes.AutoUserNsOptions{}
 	if len(parts) == 1 {
@@ -756,7 +756,7 @@ func IDMappingOptionsFromFlagSet(flags *pflag.FlagSet, persistentFlags *pflag.Fl
 			default:
 				how = strings.TrimPrefix(how, "ns:")
 				if _, err := os.Stat(how); err != nil {
-					return nil, nil, errors.Wrapf(err, "checking %s namespace", string(specs.UserNamespace))
+					return nil, nil, fmt.Errorf("checking %s namespace: %w", string(specs.UserNamespace), err)
 				}
 				logrus.Debugf("setting %q namespace to %q", string(specs.UserNamespace), how)
 				usernsOption.Path = how
@@ -768,7 +768,7 @@ func IDMappingOptionsFromFlagSet(flags *pflag.FlagSet, persistentFlags *pflag.Fl
 	// If the user requested that we use the host namespace, but also that
 	// we use mappings, that's not going to work.
 	if (len(uidmap) != 0 || len(gidmap) != 0) && usernsOption.Host {
-		return nil, nil, errors.Errorf("can not specify ID mappings while using host's user namespace")
+		return nil, nil, fmt.Errorf("can not specify ID mappings while using host's user namespace")
 	}
 	return usernsOptions, &define.IDMappingOptions{
 		HostUIDMapping: usernsOption.Host,
@@ -784,20 +784,20 @@ func parseIDMap(spec []string) (m [][3]uint32, err error) {
 	for _, s := range spec {
 		args := strings.FieldsFunc(s, func(r rune) bool { return !unicode.IsDigit(r) })
 		if len(args)%3 != 0 {
-			return nil, errors.Errorf("mapping %q is not in the form containerid:hostid:size[,...]", s)
+			return nil, fmt.Errorf("mapping %q is not in the form containerid:hostid:size[,...]", s)
 		}
 		for len(args) >= 3 {
 			cid, err := strconv.ParseUint(args[0], 10, 32)
 			if err != nil {
-				return nil, errors.Wrapf(err, "error parsing container ID %q from mapping %q as a number", args[0], s)
+				return nil, fmt.Errorf("error parsing container ID %q from mapping %q as a number: %w", args[0], s, err)
 			}
 			hostid, err := strconv.ParseUint(args[1], 10, 32)
 			if err != nil {
-				return nil, errors.Wrapf(err, "error parsing host ID %q from mapping %q as a number", args[1], s)
+				return nil, fmt.Errorf("error parsing host ID %q from mapping %q as a number: %w", args[1], s, err)
 			}
 			size, err := strconv.ParseUint(args[2], 10, 32)
 			if err != nil {
-				return nil, errors.Wrapf(err, "error parsing %q from mapping %q as a number", args[2], s)
+				return nil, fmt.Errorf("error parsing %q from mapping %q as a number: %w", args[2], s, err)
 			}
 			m = append(m, [3]uint32{uint32(cid), uint32(hostid), uint32(size)})
 			args = args[3:]
@@ -851,7 +851,7 @@ func NamespaceOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name st
 				// if not a path we assume it is a comma separated network list, see setupNamespaces() in run_linux.go
 				if filepath.IsAbs(how) || what != string(specs.NetworkNamespace) {
 					if _, err := os.Stat(how); err != nil {
-						return nil, define.NetworkDefault, errors.Wrapf(err, "checking %s namespace", what)
+						return nil, define.NetworkDefault, fmt.Errorf("checking %s namespace: %w", what, err)
 					}
 				}
 				policy = define.NetworkEnabled
@@ -877,7 +877,7 @@ func defaultIsolation() (define.Isolation, error) {
 		case "chroot":
 			return define.IsolationChroot, nil
 		default:
-			return 0, errors.Errorf("unrecognized $BUILDAH_ISOLATION value %q", isolation)
+			return 0, fmt.Errorf("unrecognized $BUILDAH_ISOLATION value %q", isolation)
 		}
 	}
 	if unshare.IsRootless() {
@@ -897,7 +897,7 @@ func IsolationOption(isolation string) (define.Isolation, error) {
 		case "chroot":
 			return define.IsolationChroot, nil
 		default:
-			return 0, errors.Errorf("unrecognized isolation type %q", isolation)
+			return 0, fmt.Errorf("unrecognized isolation type %q", isolation)
 		}
 	}
 	return defaultIsolation()
@@ -917,7 +917,7 @@ func Device(device string) (string, string, string, error) {
 	switch len(arr) {
 	case 3:
 		if !isValidDeviceMode(arr[2]) {
-			return "", "", "", errors.Errorf("invalid device mode: %s", arr[2])
+			return "", "", "", fmt.Errorf("invalid device mode: %s", arr[2])
 		}
 		permissions = arr[2]
 		fallthrough
@@ -926,7 +926,7 @@ func Device(device string) (string, string, string, error) {
 			permissions = arr[1]
 		} else {
 			if len(arr[1]) == 0 || arr[1][0] != '/' {
-				return "", "", "", errors.Errorf("invalid device mode: %s", arr[1])
+				return "", "", "", fmt.Errorf("invalid device mode: %s", arr[1])
 			}
 			dst = arr[1]
 		}
@@ -938,7 +938,7 @@ func Device(device string) (string, string, string, error) {
 		}
 		fallthrough
 	default:
-		return "", "", "", errors.Errorf("invalid device specification: %s", device)
+		return "", "", "", fmt.Errorf("invalid device specification: %s", device)
 	}
 
 	if dst == "" {
@@ -976,7 +976,7 @@ func GetTempDir() string {
 
 // Secrets parses the --secret flag
 func Secrets(secrets []string) (map[string]define.Secret, error) {
-	invalidSyntax := errors.Errorf("incorrect secret flag format: should be --secret id=foo,src=bar[,env=ENV,type=file|env]")
+	invalidSyntax := fmt.Errorf("incorrect secret flag format: should be --secret id=foo,src=bar[,env=ENV,type=file|env]")
 	parsed := make(map[string]define.Secret)
 	for _, secret := range secrets {
 		tokens := strings.Split(secret, ",")
@@ -1015,11 +1015,11 @@ func Secrets(secrets []string) (map[string]define.Secret, error) {
 		if typ == "file" {
 			fullPath, err := filepath.Abs(src)
 			if err != nil {
-				return nil, errors.Wrap(err, "could not parse secrets")
+				return nil, fmt.Errorf("could not parse secrets: %w", err)
 			}
 			_, err = os.Stat(fullPath)
 			if err != nil {
-				return nil, errors.Wrap(err, "could not parse secrets")
+				return nil, fmt.Errorf("could not parse secrets: %w", err)
 			}
 			src = fullPath
 		}

--- a/pkg/parse/parse_unix.go
+++ b/pkg/parse/parse_unix.go
@@ -1,14 +1,15 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package parse
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/containers/buildah/define"
 	"github.com/opencontainers/runc/libcontainer/devices"
-	"github.com/pkg/errors"
 )
 
 func DeviceFromPath(device string) (define.ContainerDevices, error) {
@@ -19,13 +20,13 @@ func DeviceFromPath(device string) (define.ContainerDevices, error) {
 	}
 	srcInfo, err := os.Stat(src)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting info of source device %s", src)
+		return nil, fmt.Errorf("error getting info of source device %s: %w", src, err)
 	}
 
 	if !srcInfo.IsDir() {
 		dev, err := devices.DeviceFromPath(src, permissions)
 		if err != nil {
-			return nil, errors.Wrapf(err, "%s is not a valid device", src)
+			return nil, fmt.Errorf("%s is not a valid device: %w", src, err)
 		}
 		dev.Path = dst
 		device := define.BuildahDevice{Device: *dev, Source: src, Destination: dst}
@@ -36,7 +37,7 @@ func DeviceFromPath(device string) (define.ContainerDevices, error) {
 	// If source device is a directory
 	srcDevices, err := devices.GetDevices(src)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting source devices from directory %s", src)
+		return nil, fmt.Errorf("error getting source devices from directory %s: %w", src, err)
 	}
 	for _, d := range srcDevices {
 		d.Path = filepath.Join(dst, filepath.Base(d.Path))

--- a/pkg/parse/parse_unsupported.go
+++ b/pkg/parse/parse_unsupported.go
@@ -1,10 +1,12 @@
+//go:build !linux && !darwin
 // +build !linux,!darwin
 
 package parse
 
 import (
+	"errors"
+
 	"github.com/containers/buildah/define"
-	"github.com/pkg/errors"
 )
 
 func getDefaultProcessLimits() []string {
@@ -12,5 +14,5 @@ func getDefaultProcessLimits() []string {
 }
 
 func DeviceFromPath(device string) (define.ContainerDevices, error) {
-	return nil, errors.Errorf("devices not supported")
+	return nil, errors.New("devices not supported")
 }

--- a/pkg/rusage/rusage_unix.go
+++ b/pkg/rusage/rusage_unix.go
@@ -1,12 +1,12 @@
+//go:build !windows
 // +build !windows
 
 package rusage
 
 import (
+	"fmt"
 	"syscall"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 func mkduration(tv syscall.Timeval) time.Duration {
@@ -17,7 +17,7 @@ func get() (Rusage, error) {
 	var rusage syscall.Rusage
 	err := syscall.Getrusage(syscall.RUSAGE_CHILDREN, &rusage)
 	if err != nil {
-		return Rusage{}, errors.Wrapf(err, "error getting resource usage")
+		return Rusage{}, fmt.Errorf("error getting resource usage: %w", err)
 	}
 	r := Rusage{
 		Date:     time.Now(),

--- a/pkg/rusage/rusage_unsupported.go
+++ b/pkg/rusage/rusage_unsupported.go
@@ -1,15 +1,15 @@
+//go:build windows
 // +build windows
 
 package rusage
 
 import (
+	"fmt"
 	"syscall"
-
-	"github.com/pkg/errors"
 )
 
 func get() (Rusage, error) {
-	return Rusage{}, errors.Wrapf(syscall.ENOTSUP, "error getting resource usage")
+	return Rusage{}, fmt.Errorf("error getting resource usage: %w", syscall.ENOTSUP)
 }
 
 // Supported returns true if resource usage counters are supported on this OS.

--- a/pkg/sshagent/sshagent.go
+++ b/pkg/sshagent/sshagent.go
@@ -1,6 +1,8 @@
 package sshagent
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -10,7 +12,6 @@ import (
 	"time"
 
 	"github.com/opencontainers/selinux/go-selinux"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
@@ -40,7 +41,7 @@ func newAgentServerKeyring(keys []interface{}) (*AgentServer, error) {
 	a := agent.NewKeyring()
 	for _, k := range keys {
 		if err := a.Add(agent.AddedKey{PrivateKey: k}); err != nil {
-			return nil, errors.Wrap(err, "failed to create ssh agent")
+			return nil, fmt.Errorf("failed to create ssh agent: %w", err)
 		}
 	}
 	return &AgentServer{
@@ -216,7 +217,7 @@ func NewSource(paths []string) (*Source, error) {
 
 		k, err := ssh.ParseRawPrivateKey(dt)
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot parse ssh key")
+			return nil, fmt.Errorf("cannot parse ssh key: %w", err)
 		}
 		keys = append(keys, k)
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,12 +1,11 @@
 package util
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Mirrors path to a tmpfile if path points to a
@@ -44,7 +43,7 @@ func DiscoverContainerfile(path string) (foundCtrFile string, err error) {
 	// Test for existence of the file
 	target, err := os.Stat(path)
 	if err != nil {
-		return "", errors.Wrap(err, "discovering Containerfile")
+		return "", fmt.Errorf("discovering Containerfile: %w", err)
 	}
 
 	switch mode := target.Mode(); {
@@ -61,7 +60,7 @@ func DiscoverContainerfile(path string) (foundCtrFile string, err error) {
 			// Test for existence of the Dockerfile file
 			file, err = os.Stat(ctrfile)
 			if err != nil {
-				return "", errors.Wrap(err, "cannot find Containerfile or Dockerfile in context directory")
+				return "", fmt.Errorf("cannot find Containerfile or Dockerfile in context directory: %w", err)
 			}
 		}
 
@@ -69,7 +68,7 @@ func DiscoverContainerfile(path string) (foundCtrFile string, err error) {
 		if mode := file.Mode(); mode.IsRegular() {
 			foundCtrFile = ctrfile
 		} else {
-			return "", errors.Errorf("assumed Containerfile %q is not a file", ctrfile)
+			return "", fmt.Errorf("assumed Containerfile %q is not a file", ctrfile)
 		}
 
 	case mode.IsRegular():

--- a/pull.go
+++ b/pull.go
@@ -2,6 +2,7 @@ package buildah
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/containers/image/v5/types"
 	encconfig "github.com/containers/ocicrypt/config"
 	"github.com/containers/storage"
-	"github.com/pkg/errors"
 )
 
 // PullOptions can be used to alter how an image is copied in from somewhere.
@@ -69,7 +69,6 @@ func Pull(ctx context.Context, imageName string, options PullOptions) (imageID s
 		libimageOptions.MaxRetries = &retries
 	}
 
-
 	pullPolicy, err := config.ParsePullPolicy(options.PullPolicy.String())
 	if err != nil {
 		return "", err
@@ -94,7 +93,7 @@ func Pull(ctx context.Context, imageName string, options PullOptions) (imageID s
 	}
 
 	if len(pulledImages) == 0 {
-		return "", errors.Errorf("internal error pulling %s: no image pulled and no error", imageName)
+		return "", fmt.Errorf("internal error pulling %s: no image pulled and no error", imageName)
 	}
 
 	return pulledImages[0].ID(), nil

--- a/push.go
+++ b/push.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,7 +32,7 @@ func cacheLookupReferenceFunc(directory string, compress types.LayerCompression)
 		}
 		ref, err := blobcache.NewBlobCache(ref, directory, compress)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error using blobcache %q", directory)
+			return nil, fmt.Errorf("error using blobcache %q: %w", directory, err)
 		}
 		return ref, nil
 	}
@@ -136,7 +135,7 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 
 	manifestDigest, err := manifest.Digest(manifestBytes)
 	if err != nil {
-		return nil, "", errors.Wrapf(err, "error computing digest of manifest of new image %q", transports.ImageName(dest))
+		return nil, "", fmt.Errorf("error computing digest of manifest of new image %q: %w", transports.ImageName(dest), err)
 	}
 
 	var ref reference.Canonical

--- a/run_linux.go
+++ b/run_linux.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -30,8 +31,6 @@ import (
 	"github.com/containers/buildah/internal"
 	internalParse "github.com/containers/buildah/internal/parse"
 	internalUtil "github.com/containers/buildah/internal/util"
-	"github.com/containers/common/pkg/hooks"
-	hooksExec "github.com/containers/common/pkg/hooks/exec"
 	"github.com/containers/buildah/pkg/overlay"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/pkg/sshagent"
@@ -43,6 +42,8 @@ import (
 	"github.com/containers/common/pkg/capabilities"
 	"github.com/containers/common/pkg/chown"
 	"github.com/containers/common/pkg/config"
+	"github.com/containers/common/pkg/hooks"
+	hooksExec "github.com/containers/common/pkg/hooks/exec"
 	"github.com/containers/common/pkg/subscriptions"
 	imagetypes "github.com/containers/image/v5/types"
 	"github.com/containers/storage"
@@ -59,7 +60,6 @@ import (
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/selinux/go-selinux/label"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 	"golang.org/x/term"
@@ -97,7 +97,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 
 	gp, err := generate.New("linux")
 	if err != nil {
-		return errors.Wrapf(err, "error generating new 'linux' runtime spec")
+		return fmt.Errorf("error generating new 'linux' runtime spec: %w", err)
 	}
 	g := &gp
 
@@ -116,7 +116,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	b.configureEnvironment(g, options, []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"})
 
 	if b.CommonBuildOpts == nil {
-		return errors.Errorf("Invalid format on container you must recreate the container")
+		return fmt.Errorf("invalid format on container you must recreate the container")
 	}
 
 	if err := addCommonOptsToSpec(b.CommonBuildOpts, g); err != nil {
@@ -131,7 +131,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	setupSelinux(g, b.ProcessLabel, b.MountLabel)
 	mountPoint, err := b.Mount(b.MountLabel)
 	if err != nil {
-		return errors.Wrapf(err, "error mounting container %q", b.ContainerID)
+		return fmt.Errorf("error mounting container %q: %w", b.ContainerID, err)
 	}
 	defer func() {
 		if err := b.Unmount(); err != nil {
@@ -323,7 +323,7 @@ rootless=%d
 	// Setup OCI hooks
 	_, err = b.setupOCIHooks(spec, (len(options.Mounts) > 0 || len(volumes) > 0))
 	if err != nil {
-		return errors.Wrap(err, "unable to setup OCI hooks")
+		return fmt.Errorf("unable to setup OCI hooks: %w", err)
 	}
 
 	runMountInfo := runMountInfo{
@@ -336,7 +336,7 @@ rootless=%d
 
 	runArtifacts, err := b.setupMounts(mountPoint, spec, path, options.Mounts, bindFiles, volumes, b.CommonBuildOpts.Volumes, options.RunMounts, runMountInfo)
 	if err != nil {
-		return errors.Wrapf(err, "error resolving mountpoints for container %q", b.ContainerID)
+		return fmt.Errorf("error resolving mountpoints for container %q: %w", b.ContainerID, err)
 	}
 	if runArtifacts.SSHAuthSock != "" {
 		sshenv := "SSH_AUTH_SOCK=" + runArtifacts.SSHAuthSock
@@ -376,7 +376,7 @@ rootless=%d
 		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, configureNetworks, moreCreateArgs, spec,
 			mountPoint, path, define.Package+"-"+filepath.Base(path), b.Container, hostFile)
 	default:
-		err = errors.Errorf("don't know how to run this command")
+		err = errors.New("don't know how to run this command")
 	}
 	return err
 }
@@ -462,7 +462,7 @@ func addCommonOptsToSpec(commonOpts *define.CommonBuildOptions, g *generate.Gene
 
 	defaultContainerConfig, err := config.Default()
 	if err != nil {
-		return errors.Wrapf(err, "failed to get container config")
+		return fmt.Errorf("failed to get container config: %w", err)
 	}
 	// Other process resource limits
 	if err := addRlimits(commonOpts.Ulimit, g, defaultContainerConfig.Containers.DefaultUlimits); err != nil {
@@ -504,11 +504,11 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, builtin
 			ChmodNew: &createDirPerms,
 		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "ensuring volume path %q", filepath.Join(mountPoint, volume))
+			return nil, fmt.Errorf("ensuring volume path %q: %w", filepath.Join(mountPoint, volume), err)
 		}
 		srcPath, err := copier.Eval(mountPoint, filepath.Join(mountPoint, volume), copier.EvalOptions{})
 		if err != nil {
-			return nil, errors.Wrapf(err, "evaluating path %q", srcPath)
+			return nil, fmt.Errorf("evaluating path %q: %w", srcPath, err)
 		}
 		stat, err := os.Stat(srcPath)
 		if err != nil && !os.IsNotExist(err) {
@@ -524,8 +524,8 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, builtin
 				return nil, err
 			}
 			logrus.Debugf("populating directory %q for volume %q using contents of %q", volumePath, volume, srcPath)
-			if err = extractWithTar(mountPoint, srcPath, volumePath); err != nil && !os.IsNotExist(errors.Cause(err)) {
-				return nil, errors.Wrapf(err, "error populating directory %q for volume %q using contents of %q", volumePath, volume, srcPath)
+			if err = extractWithTar(mountPoint, srcPath, volumePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("error populating directory %q for volume %q using contents of %q: %w", volumePath, volume, srcPath, err)
 			}
 		}
 		// Add the bind mount.
@@ -563,7 +563,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 	// After this point we need to know the per-container persistent storage directory.
 	cdir, err := b.store.ContainerDirectory(b.ContainerID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error determining work directory for container %q", b.ContainerID)
+		return nil, fmt.Errorf("error determining work directory for container %q: %w", b.ContainerID, err)
 	}
 
 	// Figure out which UID and GID to tell the subscriptions package to use
@@ -650,7 +650,7 @@ func cleanableDestinationListFromMounts(mounts []spec.Mount) []string {
 func (b *Builder) addResolvConf(rdir string, chownOpts *idtools.IDPair, dnsServers, dnsSearch, dnsOptions []string, namespaces []specs.LinuxNamespace) (string, error) {
 	defaultConfig, err := config.Default()
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get config")
+		return "", fmt.Errorf("failed to get config: %w", err)
 	}
 
 	nameservers := make([]string, 0, len(defaultConfig.Containers.DNSServers)+len(dnsServers))
@@ -688,7 +688,7 @@ func (b *Builder) addResolvConf(rdir string, chownOpts *idtools.IDPair, dnsServe
 		Searches:        searches,
 		Options:         options,
 	}); err != nil {
-		return "", errors.Wrapf(err, "error building resolv.conf for container %s", b.ContainerID)
+		return "", fmt.Errorf("error building resolv.conf for container %s: %w", b.ContainerID, err)
 	}
 
 	uid := 0
@@ -755,7 +755,7 @@ func (b *Builder) generateHostname(rdir, hostname string, chownOpts *idtools.IDP
 
 	cfile := filepath.Join(rdir, filepath.Base(hostnamePath))
 	if err = ioutils.AtomicWriteFile(cfile, hostnameBuffer.Bytes(), 0644); err != nil {
-		return "", errors.Wrapf(err, "error writing /etc/hostname into the container")
+		return "", fmt.Errorf("error writing /etc/hostname into the container: %w", err)
 	}
 
 	uid := 0
@@ -819,10 +819,10 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 	// Write the runtime configuration.
 	specbytes, err := json.Marshal(spec)
 	if err != nil {
-		return 1, errors.Wrapf(err, "error encoding configuration %#v as json", spec)
+		return 1, fmt.Errorf("error encoding configuration %#v as json: %w", spec, err)
 	}
 	if err = ioutils.AtomicWriteFile(filepath.Join(bundlePath, "config.json"), specbytes, 0600); err != nil {
-		return 1, errors.Wrapf(err, "error storing runtime configuration")
+		return 1, fmt.Errorf("error storing runtime configuration: %w", err)
 	}
 
 	logrus.Debugf("config = %v", string(specbytes))
@@ -851,7 +851,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 	copyPipes := false
 	finishCopy := make([]int, 2)
 	if err = unix.Pipe(finishCopy); err != nil {
-		return 1, errors.Wrapf(err, "error creating pipe for notifying to stop stdio")
+		return 1, fmt.Errorf("error creating pipe for notifying to stop stdio: %w", err)
 	}
 	finishedCopy := make(chan struct{}, 1)
 	var pargs []string
@@ -863,7 +863,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 			socketPath := filepath.Join(bundlePath, "console.sock")
 			consoleListener, err = net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
 			if err != nil {
-				return 1, errors.Wrapf(err, "error creating socket %q to receive terminal descriptor", consoleListener.Addr())
+				return 1, fmt.Errorf("error creating socket %q to receive terminal descriptor: %w", consoleListener.Addr(), err)
 			}
 			// Add console socket arguments.
 			moreCreateArgs = append(moreCreateArgs, "--console-socket", socketPath)
@@ -940,13 +940,13 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 	logrus.Debugf("Running %q", create.Args)
 	err = create.Run()
 	if err != nil {
-		return 1, errors.Wrapf(err, "error from %s creating container for %v: %s", runtime, pargs, runCollectOutput(options.Logger, errorFds, closeBeforeReadingErrorFds))
+		return 1, fmt.Errorf("error from %s creating container for %v: %s: %w", runtime, pargs, runCollectOutput(options.Logger, errorFds, closeBeforeReadingErrorFds), err)
 	}
 	defer func() {
 		err2 := del.Run()
 		if err2 != nil {
 			if err == nil {
-				err = errors.Wrapf(err2, "error deleting container")
+				err = fmt.Errorf("error deleting container: %w", err2)
 			} else {
 				options.Logger.Infof("error from %s deleting container: %v", runtime, err2)
 			}
@@ -960,7 +960,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 	}
 	pid, err := strconv.Atoi(strings.TrimSpace(string(pidValue)))
 	if err != nil {
-		return 1, errors.Wrapf(err, "error parsing pid %s as a number", string(pidValue))
+		return 1, fmt.Errorf("error parsing pid %s as a number: %w", string(pidValue), err)
 	}
 	var stopped uint32
 	var reaping sync.WaitGroup
@@ -984,7 +984,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 		logrus.Debug("waiting for parent start message")
 		b := make([]byte, 1)
 		if _, err := containerStartR.Read(b); err != nil {
-			return 1, errors.Wrap(err, "did not get container start message from parent")
+			return 1, fmt.Errorf("did not get container start message from parent: %w", err)
 		}
 		containerStartR.Close()
 	}
@@ -1006,7 +1006,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 	logrus.Debugf("Running %q", start.Args)
 	err = start.Run()
 	if err != nil {
-		return 1, errors.Wrapf(err, "error from %s starting container", runtime)
+		return 1, fmt.Errorf("error from %s starting container: %w", runtime, err)
 	}
 	defer func() {
 		if atomic.LoadUint32(&stopped) == 0 {
@@ -1040,17 +1040,17 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 				// container exited
 				break
 			}
-			return 1, errors.Wrapf(err, "error reading container state from %s (got output: %q)", runtime, string(stateOutput))
+			return 1, fmt.Errorf("error reading container state from %s (got output: %q): %w", runtime, string(stateOutput), err)
 		}
 		if err = json.Unmarshal(stateOutput, &state); err != nil {
-			return 1, errors.Wrapf(err, "error parsing container state %q from %s", string(stateOutput), runtime)
+			return 1, fmt.Errorf("error parsing container state %q from %s: %w", string(stateOutput), runtime, err)
 		}
 		switch state.Status {
 		case "running":
 		case "stopped":
 			atomic.StoreUint32(&stopped, 1)
 		default:
-			return 1, errors.Errorf("container status unexpectedly changed to %q", state.Status)
+			return 1, fmt.Errorf("container status unexpectedly changed to %q", state.Status)
 		}
 		if atomic.LoadUint32(&stopped) != 0 {
 			break
@@ -1132,19 +1132,19 @@ func setupRootlessNetwork(pid int) (teardown func(), err error) {
 
 	rootlessSlirpSyncR, rootlessSlirpSyncW, err := os.Pipe()
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot create slirp4netns sync pipe")
+		return nil, fmt.Errorf("cannot create slirp4netns sync pipe: %w", err)
 	}
 	defer rootlessSlirpSyncR.Close()
 
 	// Be sure there are no fds inherited to slirp4netns except the sync pipe
 	files, err := ioutil.ReadDir("/proc/self/fd")
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot list open fds")
+		return nil, fmt.Errorf("cannot list open fds: %w", err)
 	}
 	for _, f := range files {
 		fd, err := strconv.Atoi(f.Name())
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot parse fd")
+			return nil, fmt.Errorf("cannot parse fd: %w", err)
 		}
 		if fd == int(rootlessSlirpSyncW.Fd()) {
 			continue
@@ -1160,13 +1160,13 @@ func setupRootlessNetwork(pid int) (teardown func(), err error) {
 	err = cmd.Start()
 	rootlessSlirpSyncW.Close()
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot start slirp4netns")
+		return nil, fmt.Errorf("cannot start slirp4netns: %w", err)
 	}
 
 	b := make([]byte, 1)
 	for {
 		if err := rootlessSlirpSyncR.SetDeadline(time.Now().Add(1 * time.Second)); err != nil {
-			return nil, errors.Wrapf(err, "error setting slirp4netns pipe timeout")
+			return nil, fmt.Errorf("error setting slirp4netns pipe timeout: %w", err)
 		}
 		if _, err := rootlessSlirpSyncR.Read(b); err == nil {
 			break
@@ -1176,7 +1176,7 @@ func setupRootlessNetwork(pid int) (teardown func(), err error) {
 				var status syscall.WaitStatus
 				_, err := syscall.Wait4(cmd.Process.Pid, &status, syscall.WNOHANG, nil)
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed to read slirp4netns process status")
+					return nil, fmt.Errorf("failed to read slirp4netns process status: %w", err)
 				}
 				if status.Exited() || status.Signaled() {
 					return nil, errors.New("slirp4netns failed")
@@ -1184,7 +1184,7 @@ func setupRootlessNetwork(pid int) (teardown func(), err error) {
 
 				continue
 			}
-			return nil, errors.Wrapf(err, "failed to read from slirp4netns sync pipe")
+			return nil, fmt.Errorf("failed to read from slirp4netns sync pipe: %w", err)
 		}
 	}
 
@@ -1212,7 +1212,7 @@ func (b *Builder) runConfigureNetwork(pid int, isolation define.Isolation, optio
 	netns := fmt.Sprintf("/proc/%d/ns/net", pid)
 	netFD, err := unix.Open(netns, unix.O_RDONLY, 0)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error opening network namespace")
+		return nil, nil, fmt.Errorf("error opening network namespace: %w", err)
 	}
 	mynetns := fmt.Sprintf("/proc/%d/fd/%d", unix.Getpid(), netFD)
 
@@ -1481,7 +1481,7 @@ func runAcceptTerminal(logger *logrus.Logger, consoleListener *net.UnixListener,
 	defer consoleListener.Close()
 	c, err := consoleListener.AcceptUnix()
 	if err != nil {
-		return -1, errors.Wrapf(err, "error accepting socket descriptor connection")
+		return -1, fmt.Errorf("error accepting socket descriptor connection: %w", err)
 	}
 	defer c.Close()
 	// Expect a control message over our new connection.
@@ -1489,18 +1489,18 @@ func runAcceptTerminal(logger *logrus.Logger, consoleListener *net.UnixListener,
 	oob := make([]byte, 8192)
 	n, oobn, _, _, err := c.ReadMsgUnix(b, oob)
 	if err != nil {
-		return -1, errors.Wrapf(err, "error reading socket descriptor")
+		return -1, fmt.Errorf("error reading socket descriptor: %w", err)
 	}
 	if n > 0 {
 		logrus.Debugf("socket descriptor is for %q", string(b[:n]))
 	}
 	if oobn > len(oob) {
-		return -1, errors.Errorf("too much out-of-bounds data (%d bytes)", oobn)
+		return -1, fmt.Errorf("too much out-of-bounds data (%d bytes)", oobn)
 	}
 	// Parse the control message.
 	scm, err := unix.ParseSocketControlMessage(oob[:oobn])
 	if err != nil {
-		return -1, errors.Wrapf(err, "error parsing out-of-bound data as a socket control message")
+		return -1, fmt.Errorf("error parsing out-of-bound data as a socket control message: %w", err)
 	}
 	logrus.Debugf("control messages: %v", scm)
 	// Expect to get a descriptor.
@@ -1508,7 +1508,7 @@ func runAcceptTerminal(logger *logrus.Logger, consoleListener *net.UnixListener,
 	for i := range scm {
 		fds, err := unix.ParseUnixRights(&scm[i])
 		if err != nil {
-			return -1, errors.Wrapf(err, "error parsing unix rights control message: %v", &scm[i])
+			return -1, fmt.Errorf("error parsing unix rights control message: %v: %w", &scm[i], err)
 		}
 		logrus.Debugf("fds: %v", fds)
 		if len(fds) == 0 {
@@ -1518,7 +1518,7 @@ func runAcceptTerminal(logger *logrus.Logger, consoleListener *net.UnixListener,
 		break
 	}
 	if terminalFD == -1 {
-		return -1, errors.Errorf("unable to read terminal descriptor")
+		return -1, fmt.Errorf("unable to read terminal descriptor")
 	}
 	// Set the pseudoterminal's size to the configured size, or our own.
 	winsize := &unix.Winsize{}
@@ -1553,17 +1553,17 @@ func runMakeStdioPipe(uid, gid int) ([][]int, error) {
 	for i := range stdioPipe {
 		stdioPipe[i] = make([]int, 2)
 		if err := unix.Pipe(stdioPipe[i]); err != nil {
-			return nil, errors.Wrapf(err, "error creating pipe for container FD %d", i)
+			return nil, fmt.Errorf("error creating pipe for container FD %d: %w", i, err)
 		}
 	}
 	if err := unix.Fchown(stdioPipe[unix.Stdin][0], uid, gid); err != nil {
-		return nil, errors.Wrapf(err, "error setting owner of stdin pipe descriptor")
+		return nil, fmt.Errorf("error setting owner of stdin pipe descriptor: %w", err)
 	}
 	if err := unix.Fchown(stdioPipe[unix.Stdout][1], uid, gid); err != nil {
-		return nil, errors.Wrapf(err, "error setting owner of stdout pipe descriptor")
+		return nil, fmt.Errorf("error setting owner of stdout pipe descriptor: %w", err)
 	}
 	if err := unix.Fchown(stdioPipe[unix.Stderr][1], uid, gid); err != nil {
-		return nil, errors.Wrapf(err, "error setting owner of stderr pipe descriptor")
+		return nil, fmt.Errorf("error setting owner of stderr pipe descriptor: %w", err)
 	}
 	return stdioPipe, nil
 }
@@ -1659,20 +1659,20 @@ func setupNamespaces(logger *logrus.Logger, g *generate.Generator, namespaceOpti
 		}
 		if namespaceOption.Host {
 			if err := g.RemoveLinuxNamespace(namespaceOption.Name); err != nil {
-				return false, nil, false, errors.Wrapf(err, "error removing %q namespace for run", namespaceOption.Name)
+				return false, nil, false, fmt.Errorf("error removing %q namespace for run: %w", namespaceOption.Name, err)
 			}
 		} else if err := g.AddOrReplaceLinuxNamespace(namespaceOption.Name, namespaceOption.Path); err != nil {
 			if namespaceOption.Path == "" {
-				return false, nil, false, errors.Wrapf(err, "error adding new %q namespace for run", namespaceOption.Name)
+				return false, nil, false, fmt.Errorf("error adding new %q namespace for run: %w", namespaceOption.Name, err)
 			}
-			return false, nil, false, errors.Wrapf(err, "error adding %q namespace %q for run", namespaceOption.Name, namespaceOption.Path)
+			return false, nil, false, fmt.Errorf("error adding %q namespace %q for run: %w", namespaceOption.Name, namespaceOption.Path, err)
 		}
 	}
 
 	// If we've got mappings, we're going to have to create a user namespace.
 	if len(idmapOptions.UIDMap) > 0 || len(idmapOptions.GIDMap) > 0 || configureUserns {
 		if err := g.AddOrReplaceLinuxNamespace(string(specs.UserNamespace), ""); err != nil {
-			return false, nil, false, errors.Wrapf(err, "error adding new %q namespace for run", string(specs.UserNamespace))
+			return false, nil, false, fmt.Errorf("error adding new %q namespace for run: %w", string(specs.UserNamespace), err)
 		}
 		hostUidmap, hostGidmap, err := unshare.GetHostIDMappings("")
 		if err != nil {
@@ -1696,17 +1696,17 @@ func setupNamespaces(logger *logrus.Logger, g *generate.Generator, namespaceOpti
 		}
 		if !specifiedNetwork {
 			if err := g.AddOrReplaceLinuxNamespace(string(specs.NetworkNamespace), ""); err != nil {
-				return false, nil, false, errors.Wrapf(err, "error adding new %q namespace for run", string(specs.NetworkNamespace))
+				return false, nil, false, fmt.Errorf("error adding new %q namespace for run: %w", string(specs.NetworkNamespace), err)
 			}
 			configureNetwork = (policy != define.NetworkDisabled)
 		}
 	} else {
 		if err := g.RemoveLinuxNamespace(string(specs.UserNamespace)); err != nil {
-			return false, nil, false, errors.Wrapf(err, "error removing %q namespace for run", string(specs.UserNamespace))
+			return false, nil, false, fmt.Errorf("error removing %q namespace for run: %w", string(specs.UserNamespace), err)
 		}
 		if !specifiedNetwork {
 			if err := g.RemoveLinuxNamespace(string(specs.NetworkNamespace)); err != nil {
-				return false, nil, false, errors.Wrapf(err, "error removing %q namespace for run", string(specs.NetworkNamespace))
+				return false, nil, false, fmt.Errorf("error removing %q namespace for run: %w", string(specs.NetworkNamespace), err)
 			}
 		}
 	}
@@ -1810,7 +1810,7 @@ func addRlimits(ulimit []string, g *generate.Generator, defaultUlimits []string)
 	ulimit = append(defaultUlimits, ulimit...)
 	for _, u := range ulimit {
 		if ul, err = units.ParseUlimit(u); err != nil {
-			return errors.Wrapf(err, "ulimit option %q requires name=SOFT:HARD, failed to be parsed", u)
+			return fmt.Errorf("ulimit option %q requires name=SOFT:HARD, failed to be parsed: %w", u, err)
 		}
 
 		g.AddProcessRlimits("RLIMIT_"+strings.ToUpper(ul.Name), uint64(ul.Hard), uint64(ul.Soft))
@@ -1833,10 +1833,10 @@ func (b *Builder) runSetupVolumeMounts(mountLabel string, volumeMounts []string,
 	// Make sure the overlay directory is clean before running
 	containerDir, err := b.store.ContainerDirectory(b.ContainerID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up container directory for %s", b.ContainerID)
+		return nil, fmt.Errorf("error looking up container directory for %s: %w", b.ContainerID, err)
 	}
 	if err := overlay.CleanupContent(containerDir); err != nil {
-		return nil, errors.Wrapf(err, "error cleaning up overlay content for %s", b.ContainerID)
+		return nil, fmt.Errorf("error cleaning up overlay content for %s: %w", b.ContainerID, err)
 	}
 
 	parseMount := func(mountType, host, container string, options []string) (specs.Mount, error) {
@@ -1903,7 +1903,7 @@ func (b *Builder) runSetupVolumeMounts(mountLabel string, volumeMounts []string,
 
 			contentDir, err := overlay.TempDir(containerDir, idMaps.rootUID, idMaps.rootGID)
 			if err != nil {
-				return specs.Mount{}, errors.Wrapf(err, "failed to create TempDir in the %s directory", containerDir)
+				return specs.Mount{}, fmt.Errorf("failed to create TempDir in the %s directory: %w", containerDir, err)
 			}
 
 			overlayOpts := overlay.Options{
@@ -2003,16 +2003,16 @@ func setupReadOnlyPaths(g *generate.Generator) {
 func setupCapAdd(g *generate.Generator, caps ...string) error {
 	for _, cap := range caps {
 		if err := g.AddProcessCapabilityBounding(cap); err != nil {
-			return errors.Wrapf(err, "error adding %q to the bounding capability set", cap)
+			return fmt.Errorf("error adding %q to the bounding capability set: %w", cap, err)
 		}
 		if err := g.AddProcessCapabilityEffective(cap); err != nil {
-			return errors.Wrapf(err, "error adding %q to the effective capability set", cap)
+			return fmt.Errorf("error adding %q to the effective capability set: %w", cap, err)
 		}
 		if err := g.AddProcessCapabilityPermitted(cap); err != nil {
-			return errors.Wrapf(err, "error adding %q to the permitted capability set", cap)
+			return fmt.Errorf("error adding %q to the permitted capability set: %w", cap, err)
 		}
 		if err := g.AddProcessCapabilityAmbient(cap); err != nil {
-			return errors.Wrapf(err, "error adding %q to the ambient capability set", cap)
+			return fmt.Errorf("error adding %q to the ambient capability set: %w", cap, err)
 		}
 	}
 	return nil
@@ -2021,16 +2021,16 @@ func setupCapAdd(g *generate.Generator, caps ...string) error {
 func setupCapDrop(g *generate.Generator, caps ...string) error {
 	for _, cap := range caps {
 		if err := g.DropProcessCapabilityBounding(cap); err != nil {
-			return errors.Wrapf(err, "error removing %q from the bounding capability set", cap)
+			return fmt.Errorf("error removing %q from the bounding capability set: %w", cap, err)
 		}
 		if err := g.DropProcessCapabilityEffective(cap); err != nil {
-			return errors.Wrapf(err, "error removing %q from the effective capability set", cap)
+			return fmt.Errorf("error removing %q from the effective capability set: %w", cap, err)
 		}
 		if err := g.DropProcessCapabilityPermitted(cap); err != nil {
-			return errors.Wrapf(err, "error removing %q from the permitted capability set", cap)
+			return fmt.Errorf("error removing %q from the permitted capability set: %w", cap, err)
 		}
 		if err := g.DropProcessCapabilityAmbient(cap); err != nil {
-			return errors.Wrapf(err, "error removing %q from the ambient capability set", cap)
+			return fmt.Errorf("error removing %q from the ambient capability set: %w", cap, err)
 		}
 	}
 	return nil
@@ -2302,7 +2302,7 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 		Isolation:        isolation,
 	})
 	if conferr != nil {
-		return errors.Wrapf(conferr, "error encoding configuration for %q", runUsingRuntimeCommand)
+		return fmt.Errorf("error encoding configuration for %q: %w", runUsingRuntimeCommand, conferr)
 	}
 	cmd := reexec.Command(runUsingRuntimeCommand)
 	setPdeathsig(cmd)
@@ -2322,13 +2322,13 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 	cmd.Env = util.MergeEnv(os.Environ(), []string{fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel())})
 	preader, pwriter, err := os.Pipe()
 	if err != nil {
-		return errors.Wrapf(err, "error creating configuration pipe")
+		return fmt.Errorf("error creating configuration pipe: %w", err)
 	}
 	confwg.Add(1)
 	go func() {
 		_, conferr = io.Copy(pwriter, bytes.NewReader(config))
 		if conferr != nil {
-			conferr = errors.Wrapf(conferr, "error while copying configuration down pipe to child process")
+			conferr = fmt.Errorf("error while copying configuration down pipe to child process: %w", conferr)
 		}
 		confwg.Done()
 	}()
@@ -2339,14 +2339,14 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 	if configureNetwork {
 		containerCreateR.file, containerCreateW.file, err = os.Pipe()
 		if err != nil {
-			return errors.Wrapf(err, "error creating container create pipe")
+			return fmt.Errorf("error creating container create pipe: %w", err)
 		}
 		defer containerCreateR.Close()
 		defer containerCreateW.Close()
 
 		containerStartR.file, containerStartW.file, err = os.Pipe()
 		if err != nil {
-			return errors.Wrapf(err, "error creating container create pipe")
+			return fmt.Errorf("error creating container create pipe: %w", err)
 		}
 		defer containerStartR.Close()
 		defer containerStartW.Close()
@@ -2357,7 +2357,7 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 	defer preader.Close()
 	defer pwriter.Close()
 	if err := cmd.Start(); err != nil {
-		return errors.Wrapf(err, "error while starting runtime")
+		return fmt.Errorf("error while starting runtime: %w", err)
 	}
 
 	interrupted := make(chan os.Signal, 100)
@@ -2387,7 +2387,7 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 			}
 			pid, err := strconv.Atoi(strings.TrimSpace(string(pidValue)))
 			if err != nil {
-				return errors.Wrapf(err, "error parsing pid %s as a number", string(pidValue))
+				return fmt.Errorf("error parsing pid %s as a number: %w", string(pidValue), err)
 			}
 
 			teardown, netstatus, err := b.runConfigureNetwork(pid, isolation, options, configureNetworks, containerName)
@@ -2423,7 +2423,7 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 	}
 
 	if err := cmd.Wait(); err != nil {
-		return errors.Wrapf(err, "error while running runtime")
+		return fmt.Errorf("error while running runtime: %w", err)
 	}
 	confwg.Wait()
 	signal.Stop(interrupted)
@@ -2478,7 +2478,7 @@ func checkAndOverrideIsolationOptions(isolation define.Isolation, options *RunOp
 		pidns := options.NamespaceOptions.Find(string(specs.PIDNamespace))
 		userns := options.NamespaceOptions.Find(string(specs.UserNamespace))
 		if (pidns != nil && pidns.Host) && (userns != nil && !userns.Host) {
-			return errors.Errorf("not allowed to mix host PID namespace with container user namespace")
+			return fmt.Errorf("not allowed to mix host PID namespace with container user namespace")
 		}
 	}
 	return nil
@@ -2489,7 +2489,7 @@ func checkAndOverrideIsolationOptions(isolation define.Isolation, options *RunOp
 func DefaultNamespaceOptions() (define.NamespaceOptions, error) {
 	cfg, err := config.Default()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get container config")
+		return nil, fmt.Errorf("failed to get container config: %w", err)
 	}
 	options := define.NamespaceOptions{
 		{Name: string(specs.CgroupNamespace), Host: cfg.CgroupNS() == "host"},
@@ -2604,7 +2604,7 @@ func (b *Builder) runSetupRunMounts(mounts []string, sources runMountInfo, idMap
 			mountTargets = append(mountTargets, mount.Destination)
 			lockedTargets = lockedPaths
 		default:
-			return nil, nil, errors.Errorf("invalid mount type %q", kv[1])
+			return nil, nil, fmt.Errorf("invalid mount type %q", kv[1])
 		}
 	}
 	artifacts := &runMountArtifacts{
@@ -2719,7 +2719,7 @@ func (b *Builder) getSecretMount(tokens []string, secrets map[string]define.Secr
 	secr, ok := secrets[id]
 	if !ok {
 		if required {
-			return nil, "", errors.Errorf("secret required but no secret with id %s found", id)
+			return nil, "", fmt.Errorf("secret required but no secret with id %s found", id)
 		}
 		return nil, "", nil
 	}
@@ -2839,7 +2839,7 @@ func (b *Builder) getSSHMount(tokens []string, count int, sshsources map[string]
 	sshsource, ok := sshsources[id]
 	if !ok {
 		if required {
-			return nil, nil, errors.Errorf("ssh required but no ssh with id %s found", id)
+			return nil, nil, fmt.Errorf("ssh required but no ssh with id %s found", id)
 		}
 		return nil, nil, nil
 	}
@@ -2913,7 +2913,7 @@ func (b *Builder) cleanupRunMounts(context *imagetypes.SystemContext, mountpoint
 				// if image is being used by something else
 				_ = i.Unmount(false)
 			}
-			if errors.Cause(err) == storagetypes.ErrImageUnknown {
+			if errors.Is(err, storagetypes.ErrImageUnknown) {
 				// Ignore only if ErrImageUnknown
 				// Reason: Image is already unmounted do nothing
 				continue

--- a/run_test.go
+++ b/run_test.go
@@ -1,11 +1,12 @@
 package buildah
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/pkg/errors"
 )
 
 func TestAddRlimits(t *testing.T) {
@@ -26,11 +27,11 @@ func TestAddRlimits(t *testing.T) {
 			ulimit: []string{"bla"},
 			test: func(e error, g *generate.Generator) error {
 				if e == nil {
-					return errors.Errorf("expected to receive an error but got nil")
+					return errors.New("expected to receive an error but got nil")
 				}
 				errMsg := "invalid ulimit argument"
 				if !strings.Contains(e.Error(), errMsg) {
-					return errors.Errorf("expected error message to include %#v in %#v", errMsg, e.Error())
+					return fmt.Errorf("expected error message to include %#v in %#v", errMsg, e.Error())
 				}
 				return nil
 			},
@@ -40,11 +41,11 @@ func TestAddRlimits(t *testing.T) {
 			ulimit: []string{"bla=hard"},
 			test: func(e error, g *generate.Generator) error {
 				if e == nil {
-					return errors.Errorf("expected to receive an error but got nil")
+					return errors.New("expected to receive an error but got nil")
 				}
 				errMsg := "invalid ulimit type"
 				if !strings.Contains(e.Error(), errMsg) {
-					return errors.Errorf("expected error message to include %#v in %#v", errMsg, e.Error())
+					return fmt.Errorf("expected error message to include %#v in %#v", errMsg, e.Error())
 				}
 				return nil
 			},
@@ -60,15 +61,15 @@ func TestAddRlimits(t *testing.T) {
 				for _, rlimit := range rlimits {
 					if rlimit.Type == "RLIMIT_FSIZE" {
 						if rlimit.Hard != 4096 {
-							return errors.Errorf("expected spec to have %#v hard limit set to %v but got %v", rlimit.Type, 4096, rlimit.Hard)
+							return fmt.Errorf("expected spec to have %#v hard limit set to %v but got %v", rlimit.Type, 4096, rlimit.Hard)
 						}
 						if rlimit.Soft != 1024 {
-							return errors.Errorf("expected spec to have %#v hard limit set to %v but got %v", rlimit.Type, 1024, rlimit.Soft)
+							return fmt.Errorf("expected spec to have %#v hard limit set to %v but got %v", rlimit.Type, 1024, rlimit.Soft)
 						}
 						return nil
 					}
 				}
-				return errors.Errorf("expected spec to have RLIMIT_FSIZE")
+				return errors.New("expected spec to have RLIMIT_FSIZE")
 			},
 		},
 	}

--- a/run_unix.go
+++ b/run_unix.go
@@ -1,13 +1,15 @@
+//go:build darwin
 // +build darwin
 
 package buildah
 
 import (
+	"errors"
+
 	"github.com/containers/buildah/define"
 	nettypes "github.com/containers/common/libnetwork/types"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/containers/storage"
-	"github.com/pkg/errors"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // ContainerDevices is an alias for a slice of github.com/opencontainers/runc/libcontainer/configs.Device structures.

--- a/run_unsupported.go
+++ b/run_unsupported.go
@@ -1,11 +1,13 @@
+//go:build !linux && !darwin
 // +build !linux,!darwin
 
 package buildah
 
 import (
+	"errors"
+
 	nettypes "github.com/containers/common/libnetwork/types"
 	"github.com/containers/storage"
-	"github.com/pkg/errors"
 )
 
 func setChildProcess() error {

--- a/seccomp.go
+++ b/seccomp.go
@@ -1,13 +1,14 @@
+//go:build seccomp && linux
 // +build seccomp,linux
 
 package buildah
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/containers/common/pkg/seccomp"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 func setupSeccomp(spec *specs.Spec, seccompProfilePath string) error {
@@ -17,17 +18,17 @@ func setupSeccomp(spec *specs.Spec, seccompProfilePath string) error {
 	case "":
 		seccompConfig, err := seccomp.GetDefaultProfile(spec)
 		if err != nil {
-			return errors.Wrapf(err, "loading default seccomp profile failed")
+			return fmt.Errorf("loading default seccomp profile failed: %w", err)
 		}
 		spec.Linux.Seccomp = seccompConfig
 	default:
 		seccompProfile, err := ioutil.ReadFile(seccompProfilePath)
 		if err != nil {
-			return errors.Wrapf(err, "opening seccomp profile (%s) failed", seccompProfilePath)
+			return fmt.Errorf("opening seccomp profile (%s) failed: %w", seccompProfilePath, err)
 		}
 		seccompConfig, err := seccomp.LoadProfile(string(seccompProfile), spec)
 		if err != nil {
-			return errors.Wrapf(err, "loading seccomp profile (%s) failed", seccompProfilePath)
+			return fmt.Errorf("loading seccomp profile (%s) failed: %w", seccompProfilePath, err)
 		}
 		spec.Linux.Seccomp = seccompConfig
 	}

--- a/selinux.go
+++ b/selinux.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/opencontainers/runtime-tools/generate"
 	selinux "github.com/opencontainers/selinux/go-selinux"
-	"github.com/pkg/errors"
 )
 
 func selinuxGetEnabled() bool {
@@ -30,12 +29,12 @@ func runLabelStdioPipes(stdioPipe [][]int, processLabel, mountLabel string) erro
 	}
 	pipeContext, err := selinux.ComputeCreateContext(processLabel, mountLabel, "fifo_file")
 	if err != nil {
-		return errors.Wrapf(err, "computing file creation context for pipes")
+		return fmt.Errorf("computing file creation context for pipes: %w", err)
 	}
 	for i := range stdioPipe {
 		pipeFdName := fmt.Sprintf("/proc/self/fd/%d", stdioPipe[i][0])
 		if err := selinux.SetFileLabel(pipeFdName, pipeContext); err != nil && !os.IsNotExist(err) {
-			return errors.Wrapf(err, "setting file label on %q", pipeFdName)
+			return fmt.Errorf("setting file label on %q: %w", pipeFdName, err)
 		}
 	}
 	return nil

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -40,7 +41,6 @@ import (
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/openshift/imagebuilder"
 	"github.com/openshift/imagebuilder/dockerclient"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1548,33 +1548,33 @@ var internalTestCases = []testCase{
 			content := []byte("test content")
 
 			if err := os.Mkdir(filepath.Join(contextDir, "archive"), 0755); err != nil {
-				return errors.Wrapf(err, "error creating subdirectory of temporary context directory")
+				return fmt.Errorf("error creating subdirectory of temporary context directory: %w", err)
 			}
 			filename := filepath.Join(contextDir, "archive", "should-be-owned-by-root")
 			if err = ioutil.WriteFile(filename, content, 0640); err != nil {
-				return errors.Wrapf(err, "error creating file owned by root in temporary context directory")
+				return fmt.Errorf("error creating file owned by root in temporary context directory: %w", err)
 			}
 			if err = os.Chown(filename, 0, 0); err != nil {
-				return errors.Wrapf(err, "error setting ownership on file owned by root in temporary context directory")
+				return fmt.Errorf("error setting ownership on file owned by root in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on file owned by root file in temporary context directory")
+				return fmt.Errorf("error setting date on file owned by root file in temporary context directory: %w", err)
 			}
 			filename = filepath.Join(contextDir, "archive", "should-be-owned-by-99")
 			if err = ioutil.WriteFile(filename, content, 0640); err != nil {
-				return errors.Wrapf(err, "error creating file owned by 99 in temporary context directory")
+				return fmt.Errorf("error creating file owned by 99 in temporary context directory: %w", err)
 			}
 			if err = os.Chown(filename, 99, 99); err != nil {
-				return errors.Wrapf(err, "error setting ownership on file owned by 99 in temporary context directory")
+				return fmt.Errorf("error setting ownership on file owned by 99 in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on file owned by 99 in temporary context directory")
+				return fmt.Errorf("error setting date on file owned by 99 in temporary context directory: %w", err)
 			}
 
 			filename = filepath.Join(contextDir, "archive.tar")
 			f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				return errors.Wrapf(err, "error creating archive file")
+				return fmt.Errorf("error creating archive file: %w", err)
 			}
 			defer f.Close()
 			tw := tar.NewWriter(f)
@@ -1589,14 +1589,14 @@ var internalTestCases = []testCase{
 				Gid:      0,
 			})
 			if err != nil {
-				return errors.Wrapf(err, "error writing archive file header")
+				return fmt.Errorf("error writing archive file header: %w", err)
 			}
 			n, err := tw.Write(content)
 			if err != nil {
-				return errors.Wrapf(err, "error writing archive file contents")
+				return fmt.Errorf("error writing archive file contents: %w", err)
 			}
 			if n != len(content) {
-				return errors.Errorf("short write writing archive file contents")
+				return errors.New("short write writing archive file contents")
 			}
 			err = tw.WriteHeader(&tar.Header{
 				Name:     "archive/should-be-owned-by-99",
@@ -1608,14 +1608,14 @@ var internalTestCases = []testCase{
 				Gid:      99,
 			})
 			if err != nil {
-				return errors.Wrapf(err, "error writing archive file header")
+				return fmt.Errorf("error writing archive file header: %w", err)
 			}
 			n, err = tw.Write(content)
 			if err != nil {
-				return errors.Wrapf(err, "error writing archive file contents")
+				return fmt.Errorf("error writing archive file contents: %w", err)
 			}
 			if n != len(content) {
-				return errors.Errorf("short write writing archive file contents")
+				return errors.New("short write writing archive file contents")
 			}
 			return nil
 		},
@@ -1634,27 +1634,27 @@ var internalTestCases = []testCase{
 			content := []byte("test content")
 
 			if err := os.Mkdir(filepath.Join(contextDir, "subdir"), 0755); err != nil {
-				return errors.Wrapf(err, "error creating subdirectory of temporary context directory")
+				return fmt.Errorf("error creating subdirectory of temporary context directory: %w", err)
 			}
 			filename := filepath.Join(contextDir, "subdir", "would-be-owned-by-root")
 			if err = ioutil.WriteFile(filename, content, 0640); err != nil {
-				return errors.Wrapf(err, "error creating file owned by root in temporary context directory")
+				return fmt.Errorf("error creating file owned by root in temporary context directory: %w", err)
 			}
 			if err = os.Chown(filename, 0, 0); err != nil {
-				return errors.Wrapf(err, "error setting ownership on file owned by root in temporary context directory")
+				return fmt.Errorf("error setting ownership on file owned by root in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on file owned by root file in temporary context directory")
+				return fmt.Errorf("error setting date on file owned by root file in temporary context directory: %w", err)
 			}
 			filename = filepath.Join(contextDir, "subdir", "would-be-owned-by-99")
 			if err = ioutil.WriteFile(filename, content, 0640); err != nil {
-				return errors.Wrapf(err, "error creating file owned by 99 in temporary context directory")
+				return fmt.Errorf("error creating file owned by 99 in temporary context directory: %w", err)
 			}
 			if err = os.Chown(filename, 99, 99); err != nil {
-				return errors.Wrapf(err, "error setting ownership on file owned by 99 in temporary context directory")
+				return fmt.Errorf("error setting ownership on file owned by 99 in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on file owned by 99 in temporary context directory")
+				return fmt.Errorf("error setting date on file owned by 99 in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -1673,27 +1673,27 @@ var internalTestCases = []testCase{
 			content := []byte("test content")
 
 			if err := os.Mkdir(filepath.Join(contextDir, "subdir"), 0755); err != nil {
-				return errors.Wrapf(err, "error creating subdirectory of temporary context directory")
+				return fmt.Errorf("error creating subdirectory of temporary context directory: %w", err)
 			}
 			filename := filepath.Join(contextDir, "subdir", "would-be-owned-by-root")
 			if err = ioutil.WriteFile(filename, content, 0640); err != nil {
-				return errors.Wrapf(err, "error creating file owned by root in temporary context directory")
+				return fmt.Errorf("error creating file owned by root in temporary context directory: %w", err)
 			}
 			if err = os.Chown(filename, 0, 0); err != nil {
-				return errors.Wrapf(err, "error setting ownership on file owned by root in temporary context directory")
+				return fmt.Errorf("error setting ownership on file owned by root in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on file owned by root file in temporary context directory")
+				return fmt.Errorf("error setting date on file owned by root file in temporary context directory: %w", err)
 			}
 			filename = filepath.Join(contextDir, "subdir", "would-be-owned-by-99")
 			if err = ioutil.WriteFile(filename, content, 0640); err != nil {
-				return errors.Wrapf(err, "error creating file owned by 99 in temporary context directory")
+				return fmt.Errorf("error creating file owned by 99 in temporary context directory: %w", err)
 			}
 			if err = os.Chown(filename, 99, 99); err != nil {
-				return errors.Wrapf(err, "error setting ownership on file owned by 99 in temporary context directory")
+				return fmt.Errorf("error setting ownership on file owned by 99 in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on file owned by 99 in temporary context directory")
+				return fmt.Errorf("error setting date on file owned by 99 in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -1734,43 +1734,43 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			filename := filepath.Join(contextDir, "should-be-setuid-file")
 			if err = ioutil.WriteFile(filename, []byte("test content"), 0644); err != nil {
-				return errors.Wrapf(err, "error creating setuid test file in temporary context directory")
+				return fmt.Errorf("error creating setuid test file in temporary context directory: %w", err)
 			}
 			if err = syscall.Chmod(filename, syscall.S_ISUID|0755); err != nil {
-				return errors.Wrapf(err, "error setting setuid bit on test file in temporary context directory")
+				return fmt.Errorf("error setting setuid bit on test file in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on setuid test file in temporary context directory")
+				return fmt.Errorf("error setting date on setuid test file in temporary context directory: %w", err)
 			}
 			filename = filepath.Join(contextDir, "should-be-setgid-file")
 			if err = ioutil.WriteFile(filename, []byte("test content"), 0644); err != nil {
-				return errors.Wrapf(err, "error creating setgid test file in temporary context directory")
+				return fmt.Errorf("error creating setgid test file in temporary context directory: %w", err)
 			}
 			if err = syscall.Chmod(filename, syscall.S_ISGID|0755); err != nil {
-				return errors.Wrapf(err, "error setting setgid bit on test file in temporary context directory")
+				return fmt.Errorf("error setting setgid bit on test file in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on setgid test file in temporary context directory")
+				return fmt.Errorf("error setting date on setgid test file in temporary context directory: %w", err)
 			}
 			filename = filepath.Join(contextDir, "should-be-sticky-file")
 			if err = ioutil.WriteFile(filename, []byte("test content"), 0644); err != nil {
-				return errors.Wrapf(err, "error creating sticky test file in temporary context directory")
+				return fmt.Errorf("error creating sticky test file in temporary context directory: %w", err)
 			}
 			if err = syscall.Chmod(filename, syscall.S_ISVTX|0755); err != nil {
-				return errors.Wrapf(err, "error setting permissions on sticky test file in temporary context directory")
+				return fmt.Errorf("error setting permissions on sticky test file in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on sticky test file in temporary context directory")
+				return fmt.Errorf("error setting date on sticky test file in temporary context directory: %w", err)
 			}
 			filename = filepath.Join(contextDir, "should-not-be-setuid-setgid-sticky-file")
 			if err = ioutil.WriteFile(filename, []byte("test content"), 0644); err != nil {
-				return errors.Wrapf(err, "error creating non-suid non-sgid non-sticky test file in temporary context directory")
+				return fmt.Errorf("error creating non-suid non-sgid non-sticky test file in temporary context directory: %w", err)
 			}
 			if err = syscall.Chmod(filename, 0640); err != nil {
-				return errors.Wrapf(err, "error setting permissions on plain test file in temporary context directory")
+				return fmt.Errorf("error setting permissions on plain test file in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on plain test file in temporary context directory")
+				return fmt.Errorf("error setting date on plain test file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -1795,16 +1795,16 @@ var internalTestCases = []testCase{
 
 			filename := filepath.Join(contextDir, "xattrs-file")
 			if err = ioutil.WriteFile(filename, []byte("test content"), 0644); err != nil {
-				return errors.Wrapf(err, "error creating test file with xattrs in temporary context directory")
+				return fmt.Errorf("error creating test file with xattrs in temporary context directory: %w", err)
 			}
 			if err = copier.Lsetxattrs(filename, map[string]string{"user.a": "test"}); err != nil {
-				return errors.Wrapf(err, "error setting xattrs on test file in temporary context directory")
+				return fmt.Errorf("error setting xattrs on test file in temporary context directory: %w", err)
 			}
 			if err = syscall.Chmod(filename, 0640); err != nil {
-				return errors.Wrapf(err, "error setting permissions on test file in temporary context directory")
+				return fmt.Errorf("error setting permissions on test file in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on test file in temporary context directory")
+				return fmt.Errorf("error setting date on test file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -1822,7 +1822,7 @@ var internalTestCases = []testCase{
 			filename := filepath.Join(contextDir, "archive.tar")
 			f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				return errors.Wrapf(err, "error creating new archive file in temporary context directory")
+				return fmt.Errorf("error creating new archive file in temporary context directory: %w", err)
 			}
 			defer f.Close()
 			tw := tar.NewWriter(f)
@@ -1837,10 +1837,10 @@ var internalTestCases = []testCase{
 				ModTime:  testDate,
 			}
 			if err = tw.WriteHeader(&hdr); err != nil {
-				return errors.Wrapf(err, "error writing tar archive header")
+				return fmt.Errorf("error writing tar archive header: %w", err)
 			}
 			if _, err = io.Copy(tw, bytes.NewReader([]byte("whatever"))); err != nil {
-				return errors.Wrapf(err, "error writing tar archive content")
+				return fmt.Errorf("error writing tar archive content: %w", err)
 			}
 			hdr = tar.Header{
 				Name:     "setgid-file",
@@ -1852,10 +1852,10 @@ var internalTestCases = []testCase{
 				ModTime:  testDate,
 			}
 			if err = tw.WriteHeader(&hdr); err != nil {
-				return errors.Wrapf(err, "error writing tar archive header")
+				return fmt.Errorf("error writing tar archive header: %w", err)
 			}
 			if _, err = io.Copy(tw, bytes.NewReader([]byte("whatever"))); err != nil {
-				return errors.Wrapf(err, "error writing tar archive content")
+				return fmt.Errorf("error writing tar archive content: %w", err)
 			}
 			hdr = tar.Header{
 				Name:     "sticky-file",
@@ -1867,10 +1867,10 @@ var internalTestCases = []testCase{
 				ModTime:  testDate,
 			}
 			if err = tw.WriteHeader(&hdr); err != nil {
-				return errors.Wrapf(err, "error writing tar archive header")
+				return fmt.Errorf("error writing tar archive header: %w", err)
 			}
 			if _, err = io.Copy(tw, bytes.NewReader([]byte("whatever"))); err != nil {
-				return errors.Wrapf(err, "error writing tar archive content")
+				return fmt.Errorf("error writing tar archive content: %w", err)
 			}
 			return nil
 		},
@@ -1894,7 +1894,7 @@ var internalTestCases = []testCase{
 			filename := filepath.Join(contextDir, "archive.tar")
 			f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				return errors.Wrapf(err, "error creating new archive file in temporary context directory")
+				return fmt.Errorf("error creating new archive file in temporary context directory: %w", err)
 			}
 			defer f.Close()
 			tw := tar.NewWriter(f)
@@ -1910,10 +1910,10 @@ var internalTestCases = []testCase{
 				Xattrs:   map[string]string{"user.a": "test"},
 			}
 			if err = tw.WriteHeader(&hdr); err != nil {
-				return errors.Wrapf(err, "error writing tar archive header")
+				return fmt.Errorf("error writing tar archive header: %w", err)
 			}
 			if _, err = io.Copy(tw, bytes.NewReader([]byte("whatever"))); err != nil {
-				return errors.Wrapf(err, "error writing tar archive content")
+				return fmt.Errorf("error writing tar archive content: %w", err)
 			}
 			return nil
 		},
@@ -1954,16 +1954,16 @@ var internalTestCases = []testCase{
 
 			filename := filepath.Join(contextDir, "xattrs-file")
 			if err = ioutil.WriteFile(filename, []byte("test content"), 0644); err != nil {
-				return errors.Wrapf(err, "error creating test file with xattrs in temporary context directory")
+				return fmt.Errorf("error creating test file with xattrs in temporary context directory: %w", err)
 			}
 			if err = copier.Lsetxattrs(filename, map[string]string{"user.a": "test"}); err != nil {
-				return errors.Wrapf(err, "error setting xattrs on test file in temporary context directory")
+				return fmt.Errorf("error setting xattrs on test file in temporary context directory: %w", err)
 			}
 			if err = syscall.Chmod(filename, 0640); err != nil {
-				return errors.Wrapf(err, "error setting permissions on test file in temporary context directory")
+				return fmt.Errorf("error setting permissions on test file in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on test file in temporary context directory")
+				return fmt.Errorf("error setting date on test file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2121,10 +2121,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/*-a", "!**/*-c"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0600); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2141,10 +2141,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/*-a", "!**/*-c"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0644); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2161,10 +2161,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/*-a", "!**/*-c"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0600); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2181,10 +2181,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"!**/*-c"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0640); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2201,10 +2201,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("!**/*-c\n")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0100); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2221,10 +2221,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("subdir-c")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0200); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2241,10 +2241,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("subdir-c")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0400); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2261,10 +2261,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-c")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0200); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2281,10 +2281,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-c")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0400); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2301,10 +2301,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("subdir-*")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0000); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2321,10 +2321,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("subdir-*")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0660); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2341,10 +2341,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-*")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0000); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2361,10 +2361,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-*")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0660); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2381,10 +2381,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-f")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0666); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2401,10 +2401,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-f")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0640); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2421,10 +2421,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-b")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0705); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2441,10 +2441,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-b")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0750); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2461,10 +2461,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/subdir-e", "!**/subdir-f"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0750); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2481,10 +2481,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/subdir-e", "!**/subdir-f"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0750); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2501,10 +2501,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/subdir-f", "!**/subdir-g"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0750); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2521,10 +2521,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/subdir-f", "!**/subdir-g"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0750); err != nil {
-				return errors.Wrapf(err, "error writing .dockerignore file")
+				return fmt.Errorf("error writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return errors.Wrapf(err, "error setting date on .dockerignore file in temporary context directory")
+				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},

--- a/tests/copy/copy.go
+++ b/tests/copy/copy.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/unshare"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -89,31 +89,31 @@ func main() {
 			}
 
 			if len(args) < 1 {
-				return errors.Wrapf(err, "no source name provided")
+				return fmt.Errorf("no source name provided: %w", err)
 			}
 			src, err := alltransports.ParseImageName(args[0])
 			if err != nil {
-				return errors.Wrapf(err, "error parsing source name")
+				return fmt.Errorf("error parsing source name: %w", err)
 			}
 			if len(args) < 1 {
-				return errors.Wrapf(err, "no destination name provided")
+				return fmt.Errorf("no destination name provided: %w", err)
 			}
 			dest, err := alltransports.ParseImageName(args[1])
 			if err != nil {
-				return errors.Wrapf(err, "error parsing destination name")
+				return fmt.Errorf("error parsing destination name: %w", err)
 			}
 
 			policy, err := signature.DefaultPolicy(&systemContext)
 			if err != nil {
-				return errors.Wrapf(err, "error reading signature policy")
+				return fmt.Errorf("error reading signature policy: %w", err)
 			}
 			policyContext, err := signature.NewPolicyContext(policy)
 			if err != nil {
-				return errors.Wrapf(err, "error creating new signature policy context")
+				return fmt.Errorf("error creating new signature policy context: %w", err)
 			}
 			defer func() {
 				if err := policyContext.Destroy(); err != nil {
-					logrus.Error(errors.Wrapf(err, "error destroying signature policy context"))
+					logrus.Error(fmt.Errorf("error destroying signature policy context: %w", err))
 				}
 			}()
 

--- a/tests/e2e/buildah_suite_test.go
+++ b/tests/e2e/buildah_suite_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -205,11 +204,11 @@ func (p *BuildAhTest) CreateArtifact(image string) error {
 	}
 	policy, err := signature.DefaultPolicy(&systemContext)
 	if err != nil {
-		return errors.Errorf("error loading signature policy: %v", err)
+		return fmt.Errorf("error loading signature policy: %w", err)
 	}
 	policyContext, err := signature.NewPolicyContext(policy)
 	if err != nil {
-		return errors.Errorf("error loading signature policy: %v", err)
+		return fmt.Errorf("error loading signature policy: %w", err)
 	}
 	defer func() {
 		_ = policyContext.Destroy()
@@ -218,14 +217,14 @@ func (p *BuildAhTest) CreateArtifact(image string) error {
 
 	importRef, err := docker.ParseReference("//" + image)
 	if err != nil {
-		return errors.Errorf("error parsing image name %v: %v", image, err)
+		return fmt.Errorf("error parsing image name %v: %w", image, err)
 	}
 
 	imageDir := strings.Replace(image, "/", "_", -1)
 	exportDir := filepath.Join(p.ArtifactPath, imageDir)
 	exportRef, err := directory.NewReference(exportDir)
 	if err != nil {
-		return errors.Errorf("error creating image reference for %v: %v", exportDir, err)
+		return fmt.Errorf("error creating image reference for %v: %w", exportDir, err)
 	}
 
 	_, err = copy.Image(context.Background(), policyContext, exportRef, importRef, options)
@@ -245,7 +244,7 @@ func (p *BuildAhTest) RestoreArtifact(image string) error {
 
 	options := &copy.Options{}
 	if err != nil {
-		return errors.Errorf("error opening storage: %v", err)
+		return fmt.Errorf("error opening storage: %w", err)
 	}
 	defer func() {
 		_, _ = store.Shutdown(false)
@@ -254,32 +253,32 @@ func (p *BuildAhTest) RestoreArtifact(image string) error {
 	storage.Transport.SetStore(store)
 	ref, err := storage.Transport.ParseStoreReference(store, image)
 	if err != nil {
-		return errors.Errorf("error parsing image name: %v", err)
+		return fmt.Errorf("error parsing image name: %w", err)
 	}
 
 	imageDir := strings.Replace(image, "/", "_", -1)
 	importDir := filepath.Join(p.ArtifactPath, imageDir)
 	importRef, err := directory.NewReference(importDir)
 	if err != nil {
-		return errors.Errorf("error creating image reference for %v: %v", image, err)
+		return fmt.Errorf("error creating image reference for %v: %w", image, err)
 	}
 	systemContext := types.SystemContext{
 		SignaturePolicyPath: p.SignaturePath,
 	}
 	policy, err := signature.DefaultPolicy(&systemContext)
 	if err != nil {
-		return errors.Errorf("error loading signature policy: %v", err)
+		return fmt.Errorf("error loading signature policy: %w", err)
 	}
 	policyContext, err := signature.NewPolicyContext(policy)
 	if err != nil {
-		return errors.Errorf("error loading signature policy: %v", err)
+		return fmt.Errorf("error loading signature policy: %w", err)
 	}
 	defer func() {
 		_ = policyContext.Destroy()
 	}()
 	_, err = copy.Image(context.Background(), policyContext, ref, importRef, options)
 	if err != nil {
-		return errors.Errorf("error importing %s: %v", importDir, err)
+		return fmt.Errorf("error importing %s: %w", importDir, err)
 	}
 	return nil
 }

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -468,7 +468,7 @@ function expect_line_count() {
 function check_options_flag_err() {
     flag="$1"
     [ "$status" -eq 125 ]
-    [[ $output = *"No options ($flag) can be specified after"* ]]
+    [[ $output = *"no options ($flag) can be specified after"* ]]
 }
 
 #################

--- a/unmount.go
+++ b/unmount.go
@@ -1,19 +1,17 @@
 package buildah
 
-import (
-	"github.com/pkg/errors"
-)
+import "fmt"
 
 // Unmount unmounts a build container.
 func (b *Builder) Unmount() error {
 	_, err := b.store.Unmount(b.ContainerID, false)
 	if err != nil {
-		return errors.Wrapf(err, "error unmounting build container %q", b.ContainerID)
+		return fmt.Errorf("error unmounting build container %q: %w", b.ContainerID, err)
 	}
 	b.MountPoint = ""
 	err = b.Save()
 	if err != nil {
-		return errors.Wrapf(err, "error saving updated state for build container %q", b.ContainerID)
+		return fmt.Errorf("error saving updated state for build container %q: %w", b.ContainerID, err)
 	}
 	return nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -24,7 +25,6 @@ import (
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -118,18 +118,18 @@ func ExpandNames(names []string, systemContext *types.SystemContext, store stora
 		var name reference.Named
 		nameList, _, err := resolveName(n, systemContext, store)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing name %q", n)
+			return nil, fmt.Errorf("error parsing name %q: %w", n, err)
 		}
 		if len(nameList) == 0 {
 			named, err := reference.ParseNormalizedNamed(n)
 			if err != nil {
-				return nil, errors.Wrapf(err, "error parsing name %q", n)
+				return nil, fmt.Errorf("error parsing name %q: %w", n, err)
 			}
 			name = named
 		} else {
 			named, err := reference.ParseNormalizedNamed(nameList[0])
 			if err != nil {
-				return nil, errors.Wrapf(err, "error parsing name %q", nameList[0])
+				return nil, fmt.Errorf("error parsing name %q: %w", nameList[0], err)
 			}
 			name = named
 		}
@@ -169,7 +169,7 @@ func ResolveNameToReferences(
 ) (refs []types.ImageReference, err error) {
 	names, transport, err := resolveName(image, systemContext, store)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing name %q", image)
+		return nil, fmt.Errorf("error parsing name %q: %w", image, err)
 	}
 
 	if transport != DefaultTransport {
@@ -185,7 +185,7 @@ func ResolveNameToReferences(
 		refs = append(refs, ref)
 	}
 	if len(refs) == 0 {
-		return nil, errors.Errorf("error locating images with names %v", names)
+		return nil, fmt.Errorf("error locating images with names %v", names)
 	}
 	return refs, nil
 }
@@ -206,7 +206,7 @@ func AddImageNames(store storage.Store, firstRegistry string, systemContext *typ
 
 	for _, tag := range addNames {
 		if err := localImage.Tag(tag); err != nil {
-			return errors.Wrapf(err, "error tagging image %s", image.ID)
+			return fmt.Errorf("error tagging image %s: %w", image.ID, err)
 		}
 	}
 
@@ -217,7 +217,7 @@ func AddImageNames(store storage.Store, firstRegistry string, systemContext *typ
 // error message that reflects the reason of the failure.
 // In case err type is not a familiar one the error "defaultError" is returned.
 func GetFailureCause(err, defaultError error) error {
-	switch nErr := errors.Cause(err).(type) {
+	switch nErr := err.(type) {
 	case errcode.Errors:
 		return err
 	case errcode.Error, *url.Error:
@@ -263,7 +263,7 @@ func GetContainerIDs(uidmap, gidmap []specs.LinuxIDMapping, uid, gid uint32) (ui
 		}
 	}
 	if !uidMapped {
-		return 0, 0, errors.Errorf("container uses ID mappings (%#v), but doesn't map UID %d", uidmap, uid)
+		return 0, 0, fmt.Errorf("container uses ID mappings (%#v), but doesn't map UID %d", uidmap, uid)
 	}
 	gidMapped := true
 	for _, m := range gidmap {
@@ -275,7 +275,7 @@ func GetContainerIDs(uidmap, gidmap []specs.LinuxIDMapping, uid, gid uint32) (ui
 		}
 	}
 	if !gidMapped {
-		return 0, 0, errors.Errorf("container uses ID mappings (%#v), but doesn't map GID %d", gidmap, gid)
+		return 0, 0, fmt.Errorf("container uses ID mappings (%#v), but doesn't map GID %d", gidmap, gid)
 	}
 	return uid, gid, nil
 }
@@ -293,7 +293,7 @@ func GetHostIDs(uidmap, gidmap []specs.LinuxIDMapping, uid, gid uint32) (uint32,
 		}
 	}
 	if !uidMapped {
-		return 0, 0, errors.Errorf("container uses ID mappings (%#v), but doesn't map UID %d", uidmap, uid)
+		return 0, 0, fmt.Errorf("container uses ID mappings (%#v), but doesn't map UID %d", uidmap, uid)
 	}
 	gidMapped := true
 	for _, m := range gidmap {
@@ -305,7 +305,7 @@ func GetHostIDs(uidmap, gidmap []specs.LinuxIDMapping, uid, gid uint32) (uint32,
 		}
 	}
 	if !gidMapped {
-		return 0, 0, errors.Errorf("container uses ID mappings (%#v), but doesn't map GID %d", gidmap, gid)
+		return 0, 0, fmt.Errorf("container uses ID mappings (%#v), but doesn't map GID %d", gidmap, gid)
 	}
 	return uid, gid, nil
 }
@@ -459,4 +459,23 @@ func VerifyTagName(imageSpec string) (types.ImageReference, error) {
 		}
 	}
 	return ref, nil
+}
+
+// Cause returns the most underlying error for the provided one. There is a
+// maximum error depth of 100 to avoid endless loops. An additional error log
+// message will be created if this maximum has reached.
+func Cause(err error) (cause error) {
+	cause = err
+
+	const maxDepth = 100
+	for i := 0; i <= maxDepth; i++ {
+		res := errors.Unwrap(cause)
+		if res == nil {
+			return cause
+		}
+		cause = res
+	}
+
+	logrus.Errorf("Max error depth of %d reached, cannot unwrap until root cause: %v", maxDepth, err)
+	return cause
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,12 +1,15 @@
 package util
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"strconv"
 	"testing"
 
 	"github.com/containers/common/pkg/config"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMergeEnv(t *testing.T) {
@@ -134,4 +137,48 @@ func TestMountsSort(t *testing.T) {
 		}
 	}
 
+}
+
+func TestCause(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		err         func() error
+		expectedErr error
+	}{
+		{
+			name:        "nil error",
+			err:         func() error { return nil },
+			expectedErr: nil,
+		},
+		{
+			name:        "equal errors",
+			err:         func() error { return errors.New("foo") },
+			expectedErr: errors.New("foo"),
+		},
+		{
+			name:        "wrapped error",
+			err:         func() error { return fmt.Errorf("baz: %w", fmt.Errorf("bar: %w", errors.New("foo"))) },
+			expectedErr: errors.New("foo"),
+		},
+		{
+			name: "max depth reached",
+			err: func() error {
+				err := errors.New("error")
+				for i := 0; i <= 101; i++ {
+					err = fmt.Errorf("%d: %w", i, err)
+				}
+				return err
+			},
+			expectedErr: fmt.Errorf("0: %w", errors.New("error")),
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := Cause(tc.err())
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
 }


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now use the golang error wrapping format specifier `%w` instead of the deprecated github.com/pkg/errors package.


#### How to verify it
None
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

