### PR TITLE
vendor/containers/image: use "io.ReadAll" instead of "os.ReadAll"

### DIFF
--- a/vendor/github.com/containers/image/v5/ostree/ostree_src.go
+++ b/vendor/github.com/containers/image/v5/ostree/ostree_src.go
@@ -368,7 +368,7 @@ func (s *ostreeImageSource) GetSignatures(ctx context.Context, instanceDigest *d
 		}
 		defer sigReader.Close()
 
-		sig, err := os.ReadAll(sigReader)
+		sig, err := io.ReadAll(sigReader)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes FTBFS with go 1.18.3

Offending commit: "Update vendor of containers/(common,storage,image)" eb5b6ee8

PR in upstream package: https://github.com/containers/image/pull/1600

#### How to verify it

Build with tag "containers_image_ostree".

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None.

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>