### PR TITLE
imagebuildah: honor build output even if build container is not `commited`

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1148,6 +1148,26 @@ _EOF
   ls $mytmpdir/rootfs/hello
 }
 
+@test "build with custom build output and output rootfs to tar with no additional step" {
+  _prefetch alpine
+  mytmpdir=${TEST_SCRATCH_DIR}/my-dir
+  mkdir -p $mytmpdir
+  # We only want content of alpine nothing else
+  # so just `FROM alpine` should work.
+  cat > $mytmpdir/Containerfile << _EOF
+FROM alpine
+_EOF
+  run_buildah build --output type=tar,dest=$mytmpdir/rootfs.tar $WITH_POLICY_JSON -t test-bud -f $mytmpdir/Containerfile .
+  # explode tar
+  mkdir $mytmpdir/rootfs
+  tar -C $mytmpdir/rootfs -xvf $mytmpdir/rootfs.tar
+  run ls $mytmpdir/rootfs
+  # exported rootfs must contain `var`,`bin` directory which exists in alpine
+  # so output of `ls $mytmpdir/rootfs` must contain following strings
+  expect_output --substring 'var'
+  expect_output --substring 'bin'
+}
+
 @test "build with custom build output must fail for bad input" {
   _prefetch alpine
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir


### PR DESCRIPTION
For cases like where Containerfile only contains `FROM alpine` or `FROM
<imagename>` buildah will just perform name tagging and will not
actually commit contents of build container since there is actually no
changes made in the build process. However previously we only used to
export build output when we were actually commiting contents so `-o` or
`--output` was ignored for such edge-cases following commit ensures that
we honor `-o` or `--output` in all scenarios.

Example: Should be functional now
```Dockerfile
FROM alpine
```
```console
buildah build -t test -o type=tar,dest=out.tar .
```

Closes: https://github.com/containers/buildah/issues/4094

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix: users can generate build output of image even when contents of build container is not commited
```

