### PR TITLE
buildah: set missing `XDG_RUNTIME_DIR` before setting default `runroot`

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -25,6 +25,9 @@ var (
 )
 
 func getStore(c *cobra.Command) (storage.Store, error) {
+	if err := setXDGRuntimeDir(); err != nil {
+		return nil, err
+	}
 	options, err := storage.DefaultStoreOptions(unshare.IsRootless(), unshare.GetRootlessUID())
 	if err != nil {
 		return nil, err
@@ -33,11 +36,6 @@ func getStore(c *cobra.Command) (storage.Store, error) {
 		options.GraphRoot = globalFlagResults.Root
 		options.RunRoot = globalFlagResults.RunRoot
 	}
-
-	if err := setXDGRuntimeDir(); err != nil {
-		return nil, err
-	}
-
 	if c.Flag("storage-driver").Changed {
 		options.GraphDriverName = globalFlagResults.StorageDriver
 		// If any options setup in config, these should be dropped if user overrode the driver


### PR DESCRIPTION
In sessions which are rootless and contains no valid login session
`XDG_RUNTIME_DIR` is not set for such use-case `getStore(` automatically
sets `XDG_RUNTIME_DIR` just move it before we set default `runroot` so we
end up populating correcting `runroot` for cases which are rootless and
no valid login is present.

Missing `XDG_RUNTIME_DIR` causes various parts of code to point at incorrect
runroot and thus causing missing checks of a layer is already mounted or not etc.

Closes: https://github.com/containers/buildah/issues/4093

Similar fixes were attempted before for `login`: https://github.com/containers/buildah/pull/2145
I think above PR is a similar generic fix for all commands.