### PR TITLE
GHA: Remove required reserved-name use

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -21,9 +21,6 @@ on:
     # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
     workflow_call:
       secrets:
-        # Debug-mode can reveal secrets, force it to be secrets-managed.
-        ACTIONS_STEP_DEBUG:
-          required: true
         ACTION_MAIL_SERVER:
           required: true
         ACTION_MAIL_USERNAME:
@@ -35,9 +32,6 @@ on:
 
 
 env:
-    # Debug-mode can reveal secrets, only enable by a secret value.
-    # Ref: https://help.github.com/en/actions/configuring-and-managing-workflows/managing-a-workflow-run#enabling-step-debug-logging
-    ACTIONS_STEP_DEBUG: '${{ secrets.ACTIONS_STEP_DEBUG }}'
     # CSV listing of e-mail addresses for delivery failure or error notices
     RCPTCSV: rh.container.bot@gmail.com,podman-monitor@lists.podman.io
     # Filename for table of cron-name to build-id data


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

Unfortunately github-actions now blacklists `ACTIONS_STEP_DEBUG` from
the list of secrets.  Resulting in the error:

```
Invalid workflow file: .github/workflows/check_cirrus_cron.yml#L25
secret name `ACTIONS_STEP_DEBUG` within `workflow_call` can not be used
since it would collide with system reserved name
```

This is unfortunate since overriding this with a "secret" blocks it's
use by users seeking to modify workflows to assist in circumventing
security protections.  Fix the workflow failures by removing references
to this variable name.  The benefits of reliable operation of this
specific monitoring workflow likely outweigh any security gains of
blocking debug-mode.

#### How to verify it

Manual review and post-merge followup.  Functionality cannot be determined in a PR, it must be merged then reviewed :disappointed: 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Address ongoing workflow failures such as: https://github.com/containers/buildah/actions/runs/2648436112

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

