### PR TITLE
[CI:DOCS] GHA: Fix dynamic script filename

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -58,7 +58,7 @@ jobs:
 
             - name: Get failed cron names and Build IDs
               id: cron
-              run: './_podman/.github/actions/${{ github.workflow }}/${{ github.job }}.sh'
+              run: './_podman/.github/actions/check_cirrus_cron/cron_failures.sh'
 
             - if: steps.cron.outputs.failures > 0
               shell: bash


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

When re-using this workflow from other repositories, the yaml filename
(with extension) or manually specified workflow name is used.  This may
not match the script filename from the podman repository.  Since the script
will never have a different filename, fix this by hard-coding it.

This resolves errors like:

```
Run
./_podman/.github/actions/.github/workflows/check_cirrus_cron.yml/cron_failures.sh
  ./_podman/.github/actions/.github/workflows/check_cirrus_cron.yml/cron_failures.sh
  shell: /usr/bin/bash -e {0}
  env:
    RCPTCSV: rh.container.bot@gmail.com,podman-monitor@lists.podman.io
    NAME_ID_FILEPATH: ./artifacts/name_id.txt
/home/runner/work/_temp/a4b017c4-7dac-473e-8b3d-a7373ed0156b.sh: line 1:
./_podman/.github/actions/.github/workflows/check_cirrus_cron.yml/cron_failures.sh:
No such file or directory
Error: Process completed with exit code 127.
```

i.e. `${{ github.workflow }}` resolved to `check_cirrus_cron.yml`
instead of the expected `check_cirrus_cron` by the workflow.

#### How to verify it

Impossible, the PR must be merged then the workflow in another repository (like netavark) must be manually triggered :disappointed: 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

[Example failing job.](https://github.com/containers/netavark/runs/7326130923?check_suite_focus=true)

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

