### PR TITLE
[CI:DOCS] Cirrus: Ensure the build-push VM image is labeled

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,6 +76,7 @@ meta_task:
             ${FEDORA_CACHE_IMAGE_NAME}
             ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
             ${UBUNTU_CACHE_IMAGE_NAME}
+            build-push-${IMAGE_SUFFIX}
         BUILDID: "${CIRRUS_BUILD_ID}"
         REPOREF: "${CIRRUS_CHANGE_IN_REPO}"
         GCPJSON: ENCRYPTED[d3614d6f5cc0e66be89d4252b3365fd84f14eee0259d4eb47e25fc0bc2842c7937f5ee8c882b7e547b4c5ec4b6733b14]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Recently the container image build jobs have been failing with the
cirrus error:

```
Failed to start: INVALID_ARGUMENT: Operation with name
"operation-1657739085511-5e3b475527b8f-779ec7ef-41f9804e" failed with
status = HttpJsonStatusCode{statusCode=INVALID_ARGUMENT} and message =
BAD REQUEST
```

I was able to track this down to an obsolete
`build-push-c6193881921355776` image.  Fortunately I was able to
un-obsolete the VM image.  Update the time-stamping meta_task to include
this image to prevent this problem in the future.

#### How to verify it

[Examine the `main` output log of the `meta` task.](https://cirrus-ci.com/task/6279483954036736?logs=main#L7)  It should now mention a timestamp update for the build-push VM image.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

Not really a docs-update.  The only CI task needed to run to verify this is `meta`.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

