### PR TITLE
Add FreeBSD support for 'buildah info'

### DIFF
--- a/info.go
+++ b/info.go
@@ -3,16 +3,14 @@ package buildah
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/containerd/containerd/platforms"
+	putil "github.com/containers/buildah/pkg/util"
 	"github.com/containers/buildah/util"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/system"
@@ -83,21 +81,15 @@ func hostInfo() map[string]interface{} {
 		"version":      hostDistributionInfo["Version"],
 	}
 
-	kv, err := readKernelVersion()
+	kv, err := putil.ReadKernelVersion()
 	if err != nil {
 		logrus.Error(err, "error reading kernel version")
 	}
 	info["kernel"] = kv
 
-	up, err := readUptime()
+	upDuration, err := putil.ReadUptime()
 	if err != nil {
 		logrus.Error(err, "error reading up time")
-	}
-	// Convert uptime in seconds to a human-readable format
-	upSeconds := up + "s"
-	upDuration, err := time.ParseDuration(upSeconds)
-	if err != nil {
-		logrus.Error(err, "error parsing system uptime")
 	}
 
 	hoursFound := false
@@ -168,30 +160,6 @@ func storeInfo(store storage.Store) (map[string]interface{}, error) {
 	}
 
 	return info, nil
-}
-
-func readKernelVersion() (string, error) {
-	buf, err := ioutil.ReadFile("/proc/version")
-	if err != nil {
-		return "", err
-	}
-	f := bytes.Fields(buf)
-	if len(f) < 2 {
-		return string(bytes.TrimSpace(buf)), nil
-	}
-	return string(f[2]), nil
-}
-
-func readUptime() (string, error) {
-	buf, err := ioutil.ReadFile("/proc/uptime")
-	if err != nil {
-		return "", err
-	}
-	f := bytes.Fields(buf)
-	if len(f) < 1 {
-		return "", errors.New("invalid uptime")
-	}
-	return string(f[0]), nil
 }
 
 // getHostDistributionInfo returns a map containing the host's distribution and version

--- a/pkg/util/uptime_darwin.go
+++ b/pkg/util/uptime_darwin.go
@@ -1,0 +1,10 @@
+package util
+
+import (
+	"errors"
+	"time"
+)
+
+func ReadUptime() (time.Duration, error) {
+	return 0, errors.New("readUptime not supported on darwin")
+}

--- a/pkg/util/uptime_freebsd.go
+++ b/pkg/util/uptime_freebsd.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// For some reason, unix.ClockGettime isn't implemented by x/sys/unix on FreeBSD
+func clockGettime(clockid int32, time *unix.Timespec) (err error) {
+	_, _, e1 := unix.Syscall(unix.SYS_CLOCK_GETTIME, uintptr(clockid), uintptr(unsafe.Pointer(time)), 0)
+	if e1 != 0 {
+		return e1
+	}
+	return nil
+}
+
+func ReadUptime() (time.Duration, error) {
+	var uptime unix.Timespec
+	if err := clockGettime(unix.CLOCK_UPTIME, &uptime); err != nil {
+		return 0, err
+	}
+	return time.Duration(unix.TimespecToNsec(uptime)), nil
+}

--- a/pkg/util/uptime_linux.go
+++ b/pkg/util/uptime_linux.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"time"
+)
+
+func ReadUptime() (time.Duration, error) {
+	buf, err := ioutil.ReadFile("/proc/uptime")
+	if err != nil {
+		return 0, err
+	}
+	f := bytes.Fields(buf)
+	if len(f) < 1 {
+		return 0, errors.New("invalid uptime")
+	}
+
+	// Convert uptime in seconds to a human-readable format
+	up := string(f[0])
+	upSeconds := up + "s"
+	upDuration, err := time.ParseDuration(upSeconds)
+	if err != nil {
+		return 0, err
+	}
+	return upDuration, nil
+}

--- a/pkg/util/uptime_windows.go
+++ b/pkg/util/uptime_windows.go
@@ -1,0 +1,10 @@
+package util
+
+import (
+	"errors"
+	"time"
+)
+
+func ReadUptime() (time.Duration, error) {
+	return 0, errors.New("readUptime not supported on windows")
+}

--- a/pkg/util/version_unix.go
+++ b/pkg/util/version_unix.go
@@ -1,0 +1,19 @@
+//go:build linux || freebsd || darwin
+// +build linux freebsd darwin
+
+package util
+
+import (
+	"bytes"
+
+	"golang.org/x/sys/unix"
+)
+
+func ReadKernelVersion() (string, error) {
+	var uname unix.Utsname
+	if err := unix.Uname(&uname); err != nil {
+		return "", err
+	}
+	n := bytes.IndexByte(uname.Release[:], 0)
+	return string(uname.Release[:n]), nil
+}

--- a/pkg/util/version_windows.go
+++ b/pkg/util/version_windows.go
@@ -1,0 +1,10 @@
+package util
+
+import (
+	"errors"
+)
+
+func ReadKernelVersion() (string, error) {
+	return "", errors.New("readKernelVersion not supported on windows")
+
+}


### PR DESCRIPTION
On non-windows platforms, we can use the uname syscall to get kernel
version information. For uptime, we can use clock_gettime(CLOCK_UPTIME)
on FreeBSD but I don't have a solution for darwin or windows.

Note: the existing code which unconditionally reads from /proc builds
on all platforms but only works on linux since using /proc in this way
is a linux feature.

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The info sub-command is used by buildah tests so fixing it is a precursor to getting some of those tests working on FreeBSD

#### Does this PR introduce a user-facing change?

None
