### PR TITLE
bump github.com/opencontainers/runtime-tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198
 	github.com/opencontainers/runc v1.1.3
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
-	github.com/opencontainers/runtime-tools v0.9.0
+	github.com/opencontainers/runtime-tools v0.9.1-0.20220714195903-17b3287fafb7
 	github.com/opencontainers/selinux v1.10.1
 	github.com/openshift/imagebuilder v1.2.4-0.20220711175835-4151e43600df
 	github.com/seccomp/libseccomp-golang v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,7 @@ github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngE
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
@@ -965,6 +966,7 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34fGzaAZGFW22KVZDfyrYW+QABMrWnJBnSs=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mount v0.2.0/go.mod h1:aAivFE2LB3W4bACsUXChRHQ0qKWsetY4Y9V7sxOougM=
@@ -1070,15 +1072,18 @@ github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-spec v1.0.2-0.20190207185410-29686dbc5559/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.0.3-0.20201121164853-7413a7f753e1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
-github.com/opencontainers/runtime-tools v0.9.0 h1:FYgwVsKRI/H9hU32MJ/4MLOzXWodKK5zsQavY8NPMkU=
 github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
+github.com/opencontainers/runtime-tools v0.9.1-0.20220714195903-17b3287fafb7 h1:Rf+QsQGxrYCia8mVyOPnoQZ+vJkZGL+ESWBDUM5s9cQ=
+github.com/opencontainers/runtime-tools v0.9.1-0.20220714195903-17b3287fafb7/go.mod h1:/tgP02fPXGHkU3/qKK1Y0Db4yqNyGm03vLq/mzHzcS4=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opencontainers/selinux v1.8.5/go.mod h1:HTvjPFoGMbpQsG886e3lQwnsRWtE4TC1OF3OUvG9FAo=
+github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opencontainers/selinux v1.10.1 h1:09LIPVRP3uuZGQvgR+SgMSNBd1Eb3vlRbGqQpoHsF8w=
 github.com/opencontainers/selinux v1.10.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
@@ -1276,6 +1281,7 @@ github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLY
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli v1.19.1/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=

--- a/vendor/github.com/opencontainers/runtime-tools/generate/config.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/config.go
@@ -123,6 +123,13 @@ func (g *Generator) initConfigLinuxResourcesPids() {
 	}
 }
 
+func (g *Generator) initConfigLinuxResourcesUnified() {
+	g.initConfigLinuxResources()
+	if g.Config.Linux.Resources.Unified == nil {
+		g.Config.Linux.Resources.Unified = map[string]string{}
+	}
+}
+
 func (g *Generator) initConfigSolaris() {
 	g.initConfig()
 	if g.Config.Solaris == nil {
@@ -183,26 +190,5 @@ func (g *Generator) initConfigVM() {
 	g.initConfig()
 	if g.Config.VM == nil {
 		g.Config.VM = &rspec.VM{}
-	}
-}
-
-func (g *Generator) initConfigVMHypervisor() {
-	g.initConfigVM()
-	if &g.Config.VM.Hypervisor == nil {
-		g.Config.VM.Hypervisor = rspec.VMHypervisor{}
-	}
-}
-
-func (g *Generator) initConfigVMKernel() {
-	g.initConfigVM()
-	if &g.Config.VM.Kernel == nil {
-		g.Config.VM.Kernel = rspec.VMKernel{}
-	}
-}
-
-func (g *Generator) initConfigVMImage() {
-	g.initConfigVM()
-	if &g.Config.VM.Image == nil {
-		g.Config.VM.Image = rspec.VMImage{}
 	}
 }

--- a/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/consts.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/consts.go
@@ -4,9 +4,4 @@ const (
 	seccompOverwrite = "overwrite"
 	seccompAppend    = "append"
 	nothing          = "nothing"
-	kill             = "kill"
-	trap             = "trap"
-	trace            = "trace"
-	allow            = "allow"
-	errno            = "errno"
 )

--- a/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default.go
@@ -303,6 +303,7 @@ func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
 				"stat64",
 				"statfs",
 				"statfs64",
+				"statx",
 				"symlink",
 				"symlinkat",
 				"sync",
@@ -566,6 +567,20 @@ func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
 			},
 		}...)
 		/* Flags parameter of the clone syscall is the 2nd on s390 */
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
+			{
+				Names:  []string{"clone"},
+				Action: rspec.ActAllow,
+				Args: []rspec.LinuxSeccompArg{
+					{
+						Index:    1,
+						Value:    2080505856,
+						ValueTwo: 0,
+						Op:       rspec.OpMaskedEqual,
+					},
+				},
+			},
+		}...)
 	}
 
 	return &rspec.LinuxSeccomp{

--- a/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default_linux.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package seccomp

--- a/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default_unsupported.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package seccomp

--- a/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/syscall_compare.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/syscall_compare.go
@@ -92,22 +92,6 @@ func identical(config1, config2 *rspec.LinuxSyscall) bool {
 	return reflect.DeepEqual(config1, config2)
 }
 
-func identicalExceptAction(config1, config2 *rspec.LinuxSyscall) bool {
-	samename := sameName(config1, config2)
-	sameAction := sameAction(config1, config2)
-	sameArgs := sameArgs(config1, config2)
-
-	return samename && !sameAction && sameArgs
-}
-
-func identicalExceptArgs(config1, config2 *rspec.LinuxSyscall) bool {
-	samename := sameName(config1, config2)
-	sameAction := sameAction(config1, config2)
-	sameArgs := sameArgs(config1, config2)
-
-	return samename && sameAction && !sameArgs
-}
-
 func sameName(config1, config2 *rspec.LinuxSyscall) bool {
 	return reflect.DeepEqual(config1.Names, config2.Names)
 }

--- a/vendor/github.com/opencontainers/runtime-tools/validate/validate.go
+++ b/vendor/github.com/opencontainers/runtime-tools/validate/validate.go
@@ -131,9 +131,8 @@ func JSONSchemaURL(version string) (url string, err error) {
 	if err != nil {
 		return "", specerror.NewError(specerror.SpecVersionInSemVer, err, rspec.Version)
 	}
-	configRenamedToConfigSchemaVersion, err := semver.Parse("1.0.0-rc2") // config.json became config-schema.json in 1.0.0-rc2
-	if ver.Compare(configRenamedToConfigSchemaVersion) == -1 {
-		return "", fmt.Errorf("unsupported configuration version (older than %s)", configRenamedToConfigSchemaVersion)
+	if ver.LT(semver.Version{Major: 1, Minor: 0, Patch: 2}) {
+		return "", errors.New("unsupported configuration version (older than 1.0.2)")
 	}
 	return fmt.Sprintf(configSchemaTemplate, version), nil
 }
@@ -144,7 +143,7 @@ func JSONSchemaURL(version string) (url string, err error) {
 func (v *Validator) CheckJSONSchema() (errs error) {
 	logrus.Debugf("check JSON schema")
 
-	url, err := JSONSchemaURL(v.spec.Version)
+	url, err := JSONSchemaURL(strings.TrimSuffix(v.spec.Version, "-dev"))
 	if err != nil {
 		errs = multierror.Append(errs, err)
 		return errs

--- a/vendor/github.com/opencontainers/runtime-tools/validate/validate_linux.go
+++ b/vendor/github.com/opencontainers/runtime-tools/validate/validate_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package validate

--- a/vendor/github.com/opencontainers/runtime-tools/validate/validate_unsupported.go
+++ b/vendor/github.com/opencontainers/runtime-tools/validate/validate_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package validate

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -496,8 +496,8 @@ github.com/opencontainers/runc/libcontainer/utils
 # github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
-# github.com/opencontainers/runtime-tools v0.9.0
-## explicit
+# github.com/opencontainers/runtime-tools v0.9.1-0.20220714195903-17b3287fafb7
+## explicit; go 1.16
 github.com/opencontainers/runtime-tools/error
 github.com/opencontainers/runtime-tools/filepath
 github.com/opencontainers/runtime-tools/generate


### PR DESCRIPTION
This picks up the changes that add FreeBSD support to
runtime-tools/generate:

    go get github.com/opencontainers/runtime-tools@17b3287fafb78aee959deac9c234b7a123a242a7

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

This pulls in FreeBSD support for github.com/opencontainers/runtime-tools

#### How to verify it

Build and run buildah on FreeBSD

#### Special notes for your reviewer:

Not sure this is the right way to do this but it seems faster than waiting for a new release tag in runtime-tools.

#### Does this PR introduce a user-facing change?

None
