### PR TITLE
build,cache: support remote cache sources ( via `--cache-to`, `--cache-from` ) and introduce `cacheKey/layerKey`

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	nettypes "github.com/containers/common/libnetwork/types"
+	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
 	encconfig "github.com/containers/ocicrypt/config"
 	"github.com/containers/storage/pkg/archive"
@@ -136,6 +137,12 @@ type BuildOptions struct {
 	RuntimeArgs []string
 	// TransientMounts is a list of mounts that won't be kept in the image.
 	TransientMounts []string
+	// CacheFrom specifies any remote repository which can be treated as
+	// potential cache source.
+	CacheFrom reference.Named
+	// CacheTo specifies any remote repository which can be treated as
+	// potential cache destination.
+	CacheTo reference.Named
 	// Compression specifies the type of compression which is applied to
 	// layer blobs.  The default is to not use compression, but
 	// archive.Gzip is recommended.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -96,7 +96,37 @@ The value of `[name]` is matched with the following priority order:
 
 **--cache-from**
 
-Images to utilise as potential cache sources. Buildah does not currently support --cache-from so this is a NOOP.
+Repository to utilize as a potential cache source. When specified, Buildah will try to look for
+cache images in the specified repository and will attempt to pull cache images instead of actually
+executing the build steps locally. Buildah will only attempt to pull previously cached images if they
+are considered as valid cache hits.
+
+Use the `--cache-to` option to populate a remote repository with cache content.
+
+Example
+
+```bash
+# populate a cache and also consult it
+buildah build -t test --layers --cache-to registry/myrepo/cache --cache-from registry/myrepo/cache .
+```
+
+Note: `--cache-from` option is ignored unless `--layers` is specified.
+
+**--cache-to**
+
+Set this flag to specify a remote repository that will be used to store cache images. Buildah will attempt to
+push newly built cache image to the remote repository.
+
+Note: Use the `--cache-from` option in order to use cache content in a remote repository.
+
+Example
+
+```bash
+# populate a cache and also consult it
+buildah build -t test --layers --cache-to registry/myrepo/cache --cache-from registry/myrepo/cache .
+```
+
+Note: `--cache-to` option is ignored unless `--layers` is specified.
 
 **--cap-add**=*CAP\_xxx*
 

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -58,6 +58,8 @@ var builtinAllowedBuildArgs = map[string]bool{
 // interface.  It coordinates the entire build by using one or more
 // StageExecutors to handle each stage of the build.
 type Executor struct {
+	cacheFrom                      reference.Named
+	cacheTo                        reference.Named
 	containerSuffix                string
 	logger                         *logrus.Logger
 	stages                         map[string]*StageExecutor
@@ -212,6 +214,8 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 	}
 
 	exec := Executor{
+		cacheFrom:                      options.CacheFrom,
+		cacheTo:                        options.CacheTo,
 		containerSuffix:                options.ContainerSuffix,
 		logger:                         logger,
 		stages:                         make(map[string]*StageExecutor),

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/pkg/util"
 	"github.com/containers/common/pkg/auth"
+	"github.com/containers/image/v5/docker/reference"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -233,10 +234,6 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		return options, nil, nil, errors.New("'rm' and 'force-rm' can only be set with either 'layers' or 'no-cache'")
 	}
 
-	if c.Flag("cache-from").Changed {
-		logrus.Debugf("build --cache-from not enabled, has no effect")
-	}
-
 	if c.Flag("compress").Changed {
 		logrus.Debugf("--compress option specified but is ignored")
 	}
@@ -290,6 +287,22 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 			iopts.Quiet = true
 		}
 	}
+	var cacheTo reference.Named
+	var cacheFrom reference.Named
+	cacheTo = nil
+	cacheFrom = nil
+	if c.Flag("cache-to").Changed {
+		cacheTo, err = parse.RepoNameToNamedReference(iopts.CacheTo)
+		if err != nil {
+			return options, nil, nil, fmt.Errorf("unable to parse value provided `%s` to --cache-to: %w", iopts.CacheTo, err)
+		}
+	}
+	if c.Flag("cache-from").Changed {
+		cacheFrom, err = parse.RepoNameToNamedReference(iopts.CacheFrom)
+		if err != nil {
+			return options, nil, nil, fmt.Errorf("unable to parse value provided `%s` to --cache-from: %w", iopts.CacheTo, err)
+		}
+	}
 	options = define.BuildOptions{
 		AddCapabilities:         iopts.CapAdd,
 		AdditionalBuildContexts: additionalBuildContext,
@@ -300,6 +313,8 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		Args:                    args,
 		BlobDirectory:           iopts.BlobCache,
 		BuildOutput:             iopts.BuildOutput,
+		CacheFrom:               cacheFrom,
+		CacheTo:                 cacheTo,
 		CNIConfigDir:            iopts.CNIConfigDir,
 		CNIPluginPath:           iopts.CNIPlugInPath,
 		CPPFlags:                iopts.CPPFlags,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -54,6 +54,7 @@ type BudResults struct {
 	BuildArg            []string
 	BuildContext        []string
 	CacheFrom           string
+	CacheTo             string
 	CertDir             string
 	Compress            bool
 	Creds               string
@@ -197,7 +198,8 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringArrayVar(&flags.OCIHooksDir, "hooks-dir", []string{}, "set the OCI hooks directory path (may be set multiple times)")
 	fs.StringArrayVar(&flags.BuildArg, "build-arg", []string{}, "`argument=value` to supply to the builder")
 	fs.StringArrayVar(&flags.BuildContext, "build-context", []string{}, "`argument=value` to supply additional build context to the builder")
-	fs.StringVar(&flags.CacheFrom, "cache-from", "", "images to utilise as potential cache sources. The build process does not currently support caching so this is a NOOP.")
+	fs.StringVar(&flags.CacheFrom, "cache-from", "", "remote repository to utilise as potential cache source.")
+	fs.StringVar(&flags.CacheTo, "cache-to", "", "remote repository to utilise as potential cache destination.")
 	fs.StringVar(&flags.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	fs.BoolVar(&flags.Compress, "compress", false, "this is a legacy option, which has no effect on the image")
 	fs.StringArrayVar(&flags.CPPFlags, "cpp-flag", []string{}, "set additional flag to pass to C preprocessor (cpp)")
@@ -276,6 +278,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["build-arg"] = commonComp.AutocompleteNone
 	flagCompletion["build-context"] = commonComp.AutocompleteNone
 	flagCompletion["cache-from"] = commonComp.AutocompleteNone
+	flagCompletion["cache-to"] = commonComp.AutocompleteNone
 	flagCompletion["cert-dir"] = commonComp.AutocompleteDefault
 	flagCompletion["cpp-flag"] = commonComp.AutocompleteNone
 	flagCompletion["creds"] = commonComp.AutocompleteNone

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -19,6 +19,7 @@ import (
 	internalParse "github.com/containers/buildah/internal/parse"
 	"github.com/containers/buildah/pkg/sshagent"
 	"github.com/containers/common/pkg/parse"
+	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/unshare"
@@ -47,6 +48,18 @@ const (
 	// Lifecycle of following directory will be inherited from how host machine treats temporary directory
 	BuildahCacheDir = "buildah-cache"
 )
+
+// RepoNameToNamedReference parse the raw string to Named reference
+func RepoNameToNamedReference(dest string) (reference.Named, error) {
+	named, err := reference.ParseNormalizedNamed(dest)
+	if err != nil {
+		return nil, fmt.Errorf("invalid repo %q: must contain registry and repository: %w", dest, err)
+	}
+	if !reference.IsNameOnly(named) {
+		return nil, fmt.Errorf("repository must contain neither a tag nor digest: %v", named)
+	}
+	return named, nil
+}
 
 // CommonBuildOptions parses the build options from the bud cli
 func CommonBuildOptions(c *cobra.Command) (*define.CommonBuildOptions, error) {


### PR DESCRIPTION
Following commit

* Initiates `cacheKey` or `layerKey` for intermediate images generated
  for layers. ( only used when working with remote sources )
* Allows end users to upload cached layers with `cacheKey` to remote
  sources using `--cache-to`. `--cache-to` is a optional flag to be used
with `buildah build` which publishes cached layers to remote sources.
* Allows end users to use cached layers from `remote` sources with
  `--cache-from`. `--cache-from` is a optional flag to be used with
`buildah build` and it pulls cached layers from remote sources in a step
by step manner only if is a valid cache hit.

Example
* Populate cache source or use cached layers if already present
```bash
buildah build -t test --layers --cache-to registry/myrepo/cache --cache-from registry/myrepo/cache .
```

Future Improvements:
* Also support pushing cache to other storage units rather than conventional container registry like **object storage ( AWS S3, Redis, Minio etc )**
* `cacheKey` or `layerKey` model is only being used when working with
  remote sources however local cache lookup can be also optimized if its
is altered to use `cacheKey` model instead of iterating through all the
images in local storage. As discussed here: https://github.com/containers/buildah/pull/3406

References:
* Feature is quite similar to `kaniko`'s `--cache-repo`: https://github.com/GoogleContainerTools/kaniko#--cache-repo

Closes: https://github.com/containers/buildah/issues/620

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build: adds supports for --cache-to i.e alllow pushing cache layers to remote source
build: adds support for --cache-from i.e allow using cache layers from remote sources
```

