### PR TITLE
Set user namespace defaults correctly for the library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ gopath:
 	test $(shell pwd) = $(shell cd ../../../../src/github.com/containers/buildah ; pwd)
 
 codespell:
-	codespell -S Makefile,build,buildah,buildah.spec,imgtype,copy,AUTHORS,bin,vendor,.git,go.sum,CHANGELOG.md,changelog.txt,seccomp.json,.cirrus.yml,"*.xz,*.gz,*.tar,*.tgz,*ico,*.png,*.1,*.5,*.orig,*.rej" -L uint,iff,od,ERRO -w
+	codespell -S Makefile,buildah.spec.rpkg,AUTHORS,bin,vendor,.git,go.mod,go.sum,CHANGELOG.md,changelog.txt,seccomp.json,.cirrus.yml,"*.xz,*.gz,*.tar,*.tgz,*ico,*.png,*.1,*.5,*.orig,*.rej" -L uint,iff,od,ERRO -w
 
 .PHONY: validate
 validate: install.tools

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endif
 #     Note: Uses the -N -l go compiler options to disable compiler optimizations
 #           and inlining. Using these build options allows you to subsequently
 #           use source debugging tools like delve.
-all: bin/buildah bin/imgtype bin/copy docs
+all: bin/buildah bin/imgtype bin/copy bin/tutorial docs
 
 # Update nix/nixpkgs.json its latest stable commit
 .PHONY: nixpkgs
@@ -91,6 +91,9 @@ bin/imgtype: $(SOURCES) tests/imgtype/imgtype.go
 
 bin/copy: $(SOURCES) tests/copy/copy.go
 	$(GO_BUILD) $(BUILDAH_LDFLAGS) -o $@ $(BUILDFLAGS) ./tests/copy/copy.go
+
+bin/tutorial: $(SOURCES) tests/tutorial/tutorial.go
+	$(GO_BUILD) $(BUILDAH_LDFLAGS) -o $@ $(BUILDFLAGS) ./tests/tutorial/tutorial.go
 
 .PHONY: clean
 clean:

--- a/run_common.go
+++ b/run_common.go
@@ -331,7 +331,7 @@ func DefaultNamespaceOptions() (define.NamespaceOptions, error) {
 		{Name: string(specs.MountNamespace), Host: false},
 		{Name: string(specs.NetworkNamespace), Host: cfg.NetNS() == "host"},
 		{Name: string(specs.PIDNamespace), Host: cfg.PidNS() == "host"},
-		{Name: string(specs.UserNamespace), Host: cfg.Containers.UserNS == "host"},
+		{Name: string(specs.UserNamespace), Host: cfg.Containers.UserNS == "" || cfg.Containers.UserNS == "host"},
 		{Name: string(specs.UTSNamespace), Host: cfg.UTSNS() == "host"},
 	}
 	return options, nil

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -6,6 +6,7 @@ TEST_SOURCES=${TEST_SOURCES:-$(dirname ${BASH_SOURCE})}
 BUILDAH_BINARY=${BUILDAH_BINARY:-$TEST_SOURCES/../bin/buildah}
 IMGTYPE_BINARY=${IMGTYPE_BINARY:-$TEST_SOURCES/../bin/imgtype}
 COPY_BINARY=${COPY_BINARY:-$TEST_SOURCES/../bin/copy}
+TUTORIAL_BINARY=${TUTORIAL_BINARY:-$TEST_SOURCES/../bin/tutorial}
 STORAGE_DRIVER=${STORAGE_DRIVER:-vfs}
 PATH=$(dirname ${BASH_SOURCE})/../bin:${PATH}
 OCI=$(${BUILDAH_BINARY} info --format '{{.host.OCIRuntime}}' || command -v runc || command -v crun)

--- a/tests/tutorial.bats
+++ b/tests/tutorial.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "tutorial-cgroups" {
+	# confidence check for the sake of packages that consume our library
+	skip_if_no_runtime
+	skip_if_cgroupsv1
+	skip_if_rootless_environment
+	skip_if_chroot
+
+	_prefetch quay.io/libpod/alpine
+	run ${TUTORIAL_BINARY}
+	buildoutput="$output"
+	# should'nt have the "root" scope in our cgroups
+	echo "build output:"
+	echo "${output}"
+	! grep -q init.scope <<< "$buildoutput"
+	run sed -e '0,/^CUT START/d' -e '/^CUT END/,//d' <<< "$buildoutput"
+	# should've found a /sys/fs/cgroup with stuff in it
+	echo "contents of /sys/fs/cgroup:"
+	echo "${output}"
+	echo "number of lines: ${#lines[@]}"
+	test "${#lines[@]}" -gt 2
+}

--- a/tests/tutorial.bats
+++ b/tests/tutorial.bats
@@ -12,7 +12,7 @@ load helpers
 	_prefetch quay.io/libpod/alpine
 	run ${TUTORIAL_BINARY}
 	buildoutput="$output"
-	# should'nt have the "root" scope in our cgroups
+	# shouldn't have the "root" scope in our cgroups
 	echo "build output:"
 	echo "${output}"
 	! grep -q init.scope <<< "$buildoutput"

--- a/tests/tutorial/tutorial.go
+++ b/tests/tutorial/tutorial.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/containers/buildah"
+	"github.com/containers/buildah/define"
+	"github.com/containers/buildah/imagebuildah"
+	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/unshare"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func main() {
+	if buildah.InitReexec() {
+		return
+	}
+	unshare.MaybeReexecUsingUserNamespace(false)
+
+	buildStoreOptions, err := storage.DefaultStoreOptions(unshare.IsRootless(), unshare.GetRootlessUID())
+	if err != nil {
+		panic(err)
+	}
+
+	buildStore, err := storage.GetStore(buildStoreOptions)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if _, err := buildStore.Shutdown(false); err != nil {
+			if !errors.Is(err, storage.ErrLayerUsedByContainer) {
+				fmt.Printf("failed to shutdown storage: %q", err)
+			}
+		}
+	}()
+
+	d, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(d)
+	dockerfile := filepath.Join(d, "Dockerfile")
+	f, err := os.Create(dockerfile)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Fprintf(f, "FROM quay.io/libpod/alpine\nRUN echo CUT START; find /sys/fs/cgroup -print | sort ; echo CUT END")
+	f.Close()
+
+	buildOptions := define.BuildOptions{
+		ContextDirectory: d,
+		NamespaceOptions: []define.NamespaceOption{
+			{Name: string(specs.NetworkNamespace), Host: true},
+		},
+	}
+
+	_, _, err = imagebuildah.BuildDockerfiles(context.TODO(), buildStore, buildOptions, dockerfile)
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Set the default for user namespaces correctly for callers that don't use our CLI, e.g. OpenShift or our own tutorials.  When we don't do that, commands invoked through RUN instructions can see weird things, in this case an empty /sys/fs/cgroup directory.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

This caused test failures in https://github.com/openshift/builder/pull/304 before it started explicitly specifying a user namespace setting to work around it, but it's not the only consumer that might be affected.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```