### PR TITLE
stage_executor, output: generate correct artifacts for `multi-stage` builds and `cached` builds with `--output`

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1017,7 +1017,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			}
 			// Generate build output if needed.
 			if canGenerateBuildOutput {
-				if err := s.generateBuildOutput(buildah.CommitOptions{}, buildOutputOption); err != nil {
+				if err := s.generateBuildOutput(buildOutputOption); err != nil {
 					return "", nil, err
 				}
 			}
@@ -1030,7 +1030,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			}
 			// Generate build output if needed.
 			if canGenerateBuildOutput {
-				if err := s.generateBuildOutput(buildah.CommitOptions{}, buildOutputOption); err != nil {
+				if err := s.generateBuildOutput(buildOutputOption); err != nil {
 					return "", nil, err
 				}
 			}
@@ -1048,7 +1048,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// but instead just re-tag image. For such use-cases if `-o` or `--output` was
 			// specified honor that and export the contents of the current build anyways.
 			if canGenerateBuildOutput {
-				if err := s.generateBuildOutput(buildah.CommitOptions{}, buildOutputOption); err != nil {
+				if err := s.generateBuildOutput(buildOutputOption); err != nil {
 					return "", nil, err
 				}
 			}
@@ -1179,7 +1179,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 					logImageID(imgID)
 					// Generate build output if needed.
 					if canGenerateBuildOutput {
-						if err := s.generateBuildOutput(buildah.CommitOptions{}, buildOutputOption); err != nil {
+						if err := s.generateBuildOutput(buildOutputOption); err != nil {
 							return "", nil, err
 						}
 					}
@@ -1354,7 +1354,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			}
 			// Generate build output if needed.
 			if canGenerateBuildOutput {
-				if err := s.generateBuildOutput(buildah.CommitOptions{}, buildOutputOption); err != nil {
+				if err := s.generateBuildOutput(buildOutputOption); err != nil {
 					return "", nil, err
 				}
 			}
@@ -1388,7 +1388,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				}
 				// Generate build output if needed.
 				if canGenerateBuildOutput {
-					if err := s.generateBuildOutput(buildah.CommitOptions{}, buildOutputOption); err != nil {
+					if err := s.generateBuildOutput(buildOutputOption); err != nil {
 						return "", nil, err
 					}
 				}
@@ -1403,7 +1403,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				// for us to perform `commit` anywhere in the code.
 				// Generate build output if needed.
 				if canGenerateBuildOutput {
-					if err := s.generateBuildOutput(buildah.CommitOptions{}, buildOutputOption); err != nil {
+					if err := s.generateBuildOutput(buildOutputOption); err != nil {
 						return "", nil, err
 					}
 				}
@@ -2005,7 +2005,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	return imgID, ref, nil
 }
 
-func (s *StageExecutor) generateBuildOutput(commitOpts buildah.CommitOptions, buildOutputOpts define.BuildOutputOption) error {
+func (s *StageExecutor) generateBuildOutput(buildOutputOpts define.BuildOutputOption) error {
 	extractRootfsOpts := buildah.ExtractRootfsOptions{}
 	if unshare.IsRootless() {
 		// In order to maintain as much parity as possible
@@ -2020,7 +2020,7 @@ func (s *StageExecutor) generateBuildOutput(commitOpts buildah.CommitOptions, bu
 		extractRootfsOpts.StripSetgidBit = true
 		extractRootfsOpts.StripXattrs = true
 	}
-	rc, errChan, err := s.builder.ExtractRootfs(commitOpts, extractRootfsOpts)
+	rc, errChan, err := s.builder.ExtractRootfs(buildah.CommitOptions{}, extractRootfsOpts)
 	if err != nil {
 		return fmt.Errorf("failed to extract rootfs from given container image: %w", err)
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1171,6 +1171,30 @@ _EOF
   expect_output --substring 'hello'
 }
 
+@test "build with custom build output for multi-stage and output rootfs to directory" {
+  _prefetch alpine
+  mytmpdir=${TEST_SCRATCH_DIR}/my-dir
+  mkdir -p $mytmpdir
+  cat > $mytmpdir/Containerfile << _EOF
+FROM alpine as builder
+RUN touch rogue
+
+FROM builder as intermediate
+RUN touch artifact
+
+FROM scratch as outputs
+COPY --from=intermediate artifact target
+_EOF
+  run_buildah build --output type=local,dest=$mytmpdir/rootfs $WITH_POLICY_JSON -t test-bud -f $mytmpdir/Containerfile .
+  ls $mytmpdir/rootfs
+  # exported rootfs must contain only 'target' from last/final stage and not contain file `rouge` from first stage
+  expect_output --substring 'target'
+  # must not contain rouge from first stage
+  assert "$output" =~ "rogue"
+  # must not contain artifact from second stage
+  assert "$output" =~ "artifact"
+}
+
 @test "build with custom build output and output rootfs to tar" {
   _prefetch alpine
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir


### PR DESCRIPTION
Following PR solves two problems with artifacts generated by `--output`

#### Refactor: decouple build output generation and commit.
A bit of code refactoring code. 

#### Generate correct artifact with `--output` for `multi-stage` builds

When processing multi-stage builds and `--output` is specified we tend to
generate `output` for every stage that is being built and getting
committed however we should not do that and we should only commit the
last or the target stage when performing a `mult-stage` builds so
following commit ensures that we only generate output from the `rootfs`
of the last/target stage.

See: https://github.com/containers/buildah/issues/4131

#### Generate artifacts with `--output` even if entire build is cached

In certain cases build are entierly cached and we will never perform
commit for last or final stage. In such cases where we don't get
opportunity to perform commit we must manually process `--output` if it
was specified. Following commit ensures that.

For example a scenario below must produce `output` even though
everything was cached.

Example
```Dockerfile
FROM alpine
RUN echo hello
RUN touch hello
```
```console
buildah build --layers -t test .
buildah build --layers -t test --output build .
```
See: https://github.com/containers/buildah/issues/4132



<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

Closes: https://github.com/containers/buildah/issues/4132
Closes: https://github.com/containers/buildah/issues/4131


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
--output: generates correct artifact for multi-stage builds
--output: generates artifacts even if build is cached
```

