### PR TITLE
Minor error message fixes

### DIFF
--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -178,9 +178,9 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 	// no transport is specified.
 	if image != "" {
 		if dest, err = alltransports.ParseImageName(image); err != nil {
-			candidates, err := shortnames.ResolveLocally(systemContext, image)
-			if err != nil {
-				return err
+			candidates, err2 := shortnames.ResolveLocally(systemContext, image)
+			if err2 != nil {
+				return err2
 			}
 			if len(candidates) == 0 {
 				return fmt.Errorf("error parsing target image name %q", image)

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -341,7 +341,7 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 	if iopts.cidfile != "" {
 		filePath := iopts.cidfile
 		if err := ioutil.WriteFile(filePath, []byte(builder.ContainerID), 0644); err != nil {
-			return fmt.Errorf("filed to write Container ID File %q: %w", filePath, err)
+			return fmt.Errorf("failed to write container ID file %q: %w", filePath, err)
 		}
 	}
 	fmt.Printf("%s\n", builder.Container)

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -112,7 +112,7 @@ func pullCmd(c *cobra.Command, args []string, iopts pullOptions) error {
 
 	decConfig, err := util.DecryptConfig(iopts.decryptionKeys)
 	if err != nil {
-		return fmt.Errorf("unable to obtain decrypt config: %w", err)
+		return fmt.Errorf("unable to obtain decryption config: %w", err)
 	}
 
 	policy, ok := define.PolicyMap[iopts.pullPolicy]

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -416,6 +416,7 @@ func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logr
 	for i, d := range dockerfilecontents[1:] {
 		additionalNode, err := imagebuilder.ParseDockerfile(bytes.NewReader(d))
 		if err != nil {
+			dockerfiles := dockerfiles[1:]
 			return "", nil, fmt.Errorf("error parsing additional Dockerfile %s: %w", dockerfiles[i], err)
 		}
 		mainNode.Children = append(mainNode.Children, additionalNode.Children...)
@@ -682,6 +683,7 @@ func baseImages(dockerfilenames []string, dockerfilecontents [][]byte, from stri
 	for i, d := range dockerfilecontents[1:] {
 		additionalNode, err := imagebuilder.ParseDockerfile(bytes.NewReader(d))
 		if err != nil {
+			dockerfilenames := dockerfilenames[1:]
 			return nil, fmt.Errorf("error parsing additional Dockerfile %s: %w", dockerfilenames[i], err)
 		}
 		mainNode.Children = append(mainNode.Children, additionalNode.Children...)

--- a/run_common.go
+++ b/run_common.go
@@ -1147,7 +1147,7 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 
 		containerStartR.file, containerStartW.file, err = os.Pipe()
 		if err != nil {
-			return fmt.Errorf("error creating container create pipe: %w", err)
+			return fmt.Errorf("error creating container start pipe: %w", err)
 		}
 		defer containerStartR.Close()
 		defer containerStartW.Close()

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5009,3 +5009,11 @@ _EOF
   echo checking:
   ! grep 'not fully killed' ${TEST_SCRATCH_DIR}/log
 }
+
+@test "build-multiple-parse" {
+  _prefetch alpine
+  echo 'FROM alpine' | tee ${TEST_SCRATCH_DIR}/Dockerfile1
+  echo '# escape=|\nFROM alpine' | tee ${TEST_SCRATCH_DIR}/Dockerfile2
+  run_buildah 125 build -f ${TEST_SCRATCH_DIR}/Dockerfile1 -f ${TEST_SCRATCH_DIR}/Dockerfile2 ${TEST_SCRATCH_DIR}
+  assert "$output" =~ "error parsing additional Dockerfile ${TEST_SCRATCH_DIR}/Dockerfile2"
+}

--- a/tests/copy/copy.go
+++ b/tests/copy/copy.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -89,14 +90,14 @@ func main() {
 			}
 
 			if len(args) < 1 {
-				return fmt.Errorf("no source name provided: %w", err)
+				return errors.New("no source name provided")
 			}
 			src, err := alltransports.ParseImageName(args[0])
 			if err != nil {
 				return fmt.Errorf("error parsing source name: %w", err)
 			}
 			if len(args) < 1 {
-				return fmt.Errorf("no destination name provided: %w", err)
+				return errors.New("no destination name provided")
 			}
 			dest, err := alltransports.ParseImageName(args[1])
 			if err != nil {

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -322,8 +322,8 @@ function die() {
 # By default we do an exact-match comparison against $output, but there
 # are two different ways to invoke us, each with an optional description:
 #
-#      xpect               "EXPECT" [DESCRIPTION]
-#      xpect "RESULT" "OP" "EXPECT" [DESCRIPTION]
+#      assert               "EXPECT" [DESCRIPTION]
+#      assert "RESULT" "OP" "EXPECT" [DESCRIPTION]
 #
 # The first form (one or two arguments) does an exact-match comparison
 # of "$output" against "EXPECT". The second (three or four args) compares
@@ -332,8 +332,8 @@ function die() {
 #
 # Examples:
 #
-#   xpect "this is exactly what we expect"
-#   xpect "${lines[0]}" =~ "^abc"  "first line begins with abc"
+#   assert "this is exactly what we expect"
+#   assert "${lines[0]}" =~ "^abc"  "first line begins with abc"
 #
 function assert() {
     local actual_string="$output"

--- a/tests/testreport/testreport.go
+++ b/tests/testreport/testreport.go
@@ -187,7 +187,7 @@ func getProcessOOMScoreAdjust(r *types.TestReport) error {
 	}
 	fields := strings.Fields(string(score))
 	if len(fields) != 1 {
-		return fmt.Errorf("badly formatted line %q in %q: %w", string(score), node, err)
+		return fmt.Errorf("badly formatted line %q in %q: expected to find only one field", string(score), node)
 	}
 	oom, err := strconv.Atoi(fields[0])
 	if err != nil {
@@ -274,7 +274,7 @@ func getLinuxIDMappings(r *types.TestReport) error {
 			line := scanner.Text()
 			fields := strings.Fields(line)
 			if len(fields) != 3 {
-				return nil, fmt.Errorf("badly formatted line %q in %q: %w", line, node, err)
+				return nil, fmt.Errorf("badly formatted line %q in %q: expected to find exactly three fields", line, node)
 			}
 			cid, err := strconv.ParseUint(fields[0], 10, 32)
 			if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When multiple Dockerfiles are specified using `buildah build`'s `-f` flag, if an error is encountered when parsing one of the files after the first (main) file, the error message would mention the wrong file's name.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

New integration test!

#### Does this PR introduce a user-facing change?

```release-note
None
```