### PR TITLE
[release-1.23] Cirrus: Use the latest imgts container

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -66,7 +66,7 @@ meta_task:
     alias: meta
 
     container:
-        image: "quay.io/libpod/imgts:${IMAGE_SUFFIX}"  # see contrib/imgts
+        image: "quay.io/libpod/imgts:latest"
         cpu: 1
         memory: 1
 


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Contains important updates re: preserving release-branch CI VM images.
Ref: https://github.com/containers/automation_images/pull/157

#### How to verify it

The meta task will run and successfully mark all the CI VM images with the permanent=true label after the PR is merged.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```