### PR TITLE
Minor test tweak for podman-remote compatibility

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5015,5 +5015,5 @@ _EOF
   echo 'FROM alpine' | tee ${TEST_SCRATCH_DIR}/Dockerfile1
   echo '# escape=|\nFROM alpine' | tee ${TEST_SCRATCH_DIR}/Dockerfile2
   run_buildah 125 build -f ${TEST_SCRATCH_DIR}/Dockerfile1 -f ${TEST_SCRATCH_DIR}/Dockerfile2 ${TEST_SCRATCH_DIR}
-  assert "$output" =~ "error parsing additional Dockerfile ${TEST_SCRATCH_DIR}/Dockerfile2"
+  assert "$output" =~ "error parsing additional Dockerfile .*Dockerfile2: invalid ESCAPE"
 }


### PR DESCRIPTION
The new #4136 added a new test (multiple-parse). Make a small
change to it so it passes under podman-remote.

(Reason: the test was checking for a full Dockerfile2 path.
podman-remote only displays basenames).

Signed-off-by: Ed Santiago <santiago@redhat.com>
