### PR TITLE
Use errors.Is() instead of os.Is{Not,}Exist

### DIFF
--- a/bind/mount.go
+++ b/bind/mount.go
@@ -150,7 +150,7 @@ func SetupIntermediateMountNamespace(spec *specs.Spec, bundlePath string) (unmou
 		// Check if the source is a directory or something else.
 		info, err := os.Stat(spec.Mounts[i].Source)
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, os.ErrNotExist) {
 				logrus.Warnf("couldn't find %q on host to bind mount into container", spec.Mounts[i].Source)
 				continue
 			}
@@ -269,7 +269,7 @@ func UnmountMountpoints(mountpoint string, mountpointsToRemove []string) error {
 		mount := getMountByID(id)
 		// check if this mountpoint is mounted
 		if err := unix.Lstat(mount.Mountpoint, &st); err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, os.ErrNotExist) {
 				logrus.Debugf("mountpoint %q is not present(?), skipping", mount.Mountpoint)
 				continue
 			}

--- a/buildah.go
+++ b/buildah.go
@@ -3,6 +3,7 @@ package buildah
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -445,7 +446,7 @@ func OpenBuilderByPath(store storage.Store, path string) (*Builder, error) {
 		}
 		buildstate, err := ioutil.ReadFile(filepath.Join(cdir, stateFile))
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, os.ErrNotExist) {
 				logrus.Debugf("error reading %q: %v, ignoring container %q", filepath.Join(cdir, stateFile), err, container.ID)
 				continue
 			}
@@ -482,7 +483,7 @@ func OpenAllBuilders(store storage.Store) (builders []*Builder, err error) {
 		}
 		buildstate, err := ioutil.ReadFile(filepath.Join(cdir, stateFile))
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, os.ErrNotExist) {
 				logrus.Debugf("error reading %q: %v, ignoring container %q", filepath.Join(cdir, stateFile), err, container.ID)
 				continue
 			}

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bufio"
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -1508,7 +1509,7 @@ func testEval(t *testing.T) {
 	for _, vector := range vectors {
 		t.Run(fmt.Sprintf("id=%s", vector.id), func(t *testing.T) {
 			err = os.Symlink(vector.linkTarget, linkname)
-			if err != nil && os.IsExist(err) {
+			if err != nil && errors.Is(err, os.ErrExist) {
 				os.Remove(linkname)
 				err = os.Symlink(vector.linkTarget, linkname)
 			}

--- a/image.go
+++ b/image.go
@@ -747,7 +747,7 @@ func (i *containerImageSource) GetBlob(ctx context.Context, blob types.BlobInfo,
 				}
 				layerFile.Close()
 			}
-			if !os.IsNotExist(err) {
+			if !errors.Is(err, os.ErrNotExist) {
 				logrus.Debugf("error checking for layer %q in %q: %v", blob.Digest.String(), blobDir, err)
 			}
 		}

--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -250,7 +250,7 @@ func Unmount(contentDir string) error {
 	}
 
 	// Ignore EINVAL as the specified merge dir is not a mount point
-	if err := unix.Unmount(mergeDir, 0); err != nil && !os.IsNotExist(err) && err != unix.EINVAL {
+	if err := unix.Unmount(mergeDir, 0); err != nil && !errors.Is(err, os.ErrNotExist) && err != unix.EINVAL {
 		return fmt.Errorf("unmount overlay %s: %w", mergeDir, err)
 	}
 	return nil
@@ -259,7 +259,7 @@ func Unmount(contentDir string) error {
 func recreate(contentDir string) error {
 	st, err := system.Stat(contentDir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return fmt.Errorf("failed to stat overlay upper directory: %w", err)
@@ -293,7 +293,7 @@ func CleanupContent(containerDir string) (Err error) {
 
 	files, err := ioutil.ReadDir(contentDir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return fmt.Errorf("read directory: %w", err)
@@ -305,7 +305,7 @@ func CleanupContent(containerDir string) (Err error) {
 		}
 	}
 
-	if err := os.RemoveAll(contentDir); err != nil && !os.IsNotExist(err) {
+	if err := os.RemoveAll(contentDir); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to cleanup overlay directory: %w", err)
 	}
 	return nil

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -245,11 +245,11 @@ func parseSecurityOpts(securityOpts []string, commonOpts *define.CommonBuildOpti
 		if _, err := os.Stat(SeccompOverridePath); err == nil {
 			commonOpts.SeccompProfilePath = SeccompOverridePath
 		} else {
-			if !os.IsNotExist(err) {
+			if !errors.Is(err, os.ErrNotExist) {
 				return err
 			}
 			if _, err := os.Stat(SeccompDefaultPath); err != nil {
-				if !os.IsNotExist(err) {
+				if !errors.Is(err, os.ErrNotExist) {
 					return err
 				}
 			} else {
@@ -1072,11 +1072,11 @@ func ContainerIgnoreFile(contextDir, path string) ([]string, string, error) {
 	}
 	path = filepath.Join(contextDir, ".containerignore")
 	excludes, err := imagebuilder.ParseIgnore(path)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		path = filepath.Join(contextDir, ".dockerignore")
 		excludes, err = imagebuilder.ParseIgnore(path)
 	}
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return excludes, "", nil
 	}
 	return excludes, path, err

--- a/run_common.go
+++ b/run_common.go
@@ -1365,7 +1365,7 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, builtin
 		// the volume contents.  If we do need to create it, then we'll
 		// need to populate it, too, so make a note of that.
 		if _, err := os.Stat(volumePath); err != nil {
-			if !os.IsNotExist(err) {
+			if !errors.Is(err, os.ErrNotExist) {
 				return nil, err
 			}
 			logrus.Debugf("setting up built-in volume path at %q for %q", volumePath, volume)
@@ -1391,7 +1391,7 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, builtin
 			return nil, fmt.Errorf("evaluating path %q: %w", srcPath, err)
 		}
 		stat, err := os.Stat(srcPath)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}
 		// If we need to populate the mounted volume's contents with
@@ -1844,7 +1844,7 @@ func (b *Builder) cleanupRunMounts(context *imageTypes.SystemContext, mountpoint
 	var prevErr error
 	for _, path := range artifacts.TmpFiles {
 		err := os.Remove(path)
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, os.ErrNotExist) {
 			if prevErr != nil {
 				logrus.Error(prevErr)
 			}

--- a/run_linux.go
+++ b/run_linux.go
@@ -381,7 +381,7 @@ func (b *Builder) setupOCIHooks(config *spec.Spec, hasVolumes bool) (map[string]
 		for _, hDir := range []string{hooks.DefaultDir, hooks.OverrideDir} {
 			manager, err := hooks.New(context.Background(), []string{hDir}, []string{})
 			if err != nil {
-				if os.IsNotExist(err) {
+				if errors.Is(err, os.ErrNotExist) {
 					continue
 				}
 				return nil, err
@@ -690,7 +690,7 @@ func setupNamespaces(logger *logrus.Logger, g *generate.Generator, namespaceOpti
 			// by the kernel
 			p := filepath.Join("/proc/sys", strings.Replace(name, ".", "/", -1))
 			_, err := os.Stat(p)
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
 				return false, nil, false, err
 			}
 			if err == nil {

--- a/selinux.go
+++ b/selinux.go
@@ -4,6 +4,7 @@
 package buildah
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -33,7 +34,7 @@ func runLabelStdioPipes(stdioPipe [][]int, processLabel, mountLabel string) erro
 	}
 	for i := range stdioPipe {
 		pipeFdName := fmt.Sprintf("/proc/self/fd/%d", stdioPipe[i][0])
-		if err := selinux.SetFileLabel(pipeFdName, pipeContext); err != nil && !os.IsNotExist(err) {
+		if err := selinux.SetFileLabel(pipeFdName, pipeContext); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("setting file label on %q: %w", pipeFdName, err)
 		}
 	}

--- a/tests/e2e/buildah_suite_test.go
+++ b/tests/e2e/buildah_suite_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -69,7 +70,7 @@ var _ = BeforeSuite(func() {
 	integrationRoot = filepath.Join(cwd, "../../")
 	buildah := BuildahCreate("/tmp")
 	buildah.ArtifactPath = artifactDir
-	if _, err := os.Stat(artifactDir); os.IsNotExist(err) {
+	if _, err := os.Stat(artifactDir); errors.Is(err, os.ErrNotExist) {
 		if err = os.Mkdir(artifactDir, 0777); err != nil {
 			fmt.Printf("%q\n", err)
 			os.Exit(1)

--- a/tests/serve/serve.go
+++ b/tests/serve/serve.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"log"
 	"net"
@@ -16,7 +17,7 @@ func sendThatFile(basepath string) func(w http.ResponseWriter, r *http.Request) 
 		filename := filepath.Join(basepath, filepath.Clean(string([]rune{filepath.Separator})+r.URL.Path))
 		f, err := os.Open(filename)
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, os.ErrNotExist) {
 				http.NotFound(w, r)
 				return
 			}

--- a/util.go
+++ b/util.go
@@ -187,7 +187,7 @@ func IsContainer(id string, store storage.Store) (bool, error) {
 	// Assuming that if the stateFile exists, that this is a Buildah
 	// container.
 	if _, err = os.Stat(filepath.Join(cdir, stateFile)); err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
 		}
 		return false, err

--- a/util/util.go
+++ b/util/util.go
@@ -387,7 +387,7 @@ var (
 func fileExistsAndNotADir(path string) bool {
 	file, err := os.Stat(path)
 
-	if file == nil || err != nil || os.IsNotExist(err) {
+	if file == nil || err != nil || errors.Is(err, os.ErrNotExist) {
 		return false
 	}
 	return !file.IsDir()


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

If errors for which `os.IsExist()` or `os.IsNotExist()` would have returned `true` have been wrapped using `fmt.Errorf()`'s "%w" verb, `os.IsExist()` and `os.IsNotExist()`, not having been retrofitted to use `errors.Is()`, will return `false`.

Use `errors.Is()` to check if an error is an `os.ErrExist` or `os.ErrNotExist` error instead of calling `os.IsExist()` or `os.IsNotExist()`.

#### How to verify it

Eyeball it and make sure I didn't get inadvertently reverse anything.  This is currently a preventative change.  All of our tests should continue to pass.  [NO NEW TESTS NEEDED]

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```