### PR TITLE
manifest: `inspect` should contain `OCI` annotations.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/containerd/containerd v1.6.6
 	github.com/containernetworking/cni v1.1.2
-	github.com/containers/common v0.49.0
+	github.com/containers/common v0.49.1-0.20220729170140-87fab4b7019a
 	github.com/containers/image/v5 v5.22.0
 	github.com/containers/ocicrypt v1.1.5
 	github.com/containers/storage v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -346,8 +346,8 @@ github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRD
 github.com/containernetworking/plugins v1.0.1/go.mod h1:QHCfGpaTwYTbbH+nZXKVTxNBDZcxSOplJT5ico8/FLE=
 github.com/containernetworking/plugins v1.1.1 h1:+AGfFigZ5TiQH00vhR8qPeSatj53eNGz0C1d3wVYlHE=
 github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
-github.com/containers/common v0.49.0 h1:RvXl6DV+AIiWFAInr9kda8v0kNFYp8Gi6TdMDJxiN0s=
-github.com/containers/common v0.49.0/go.mod h1:veUB/Ny3z9uCvwQTsG1/hxI+9xOprONp3mH3jO4mYqg=
+github.com/containers/common v0.49.1-0.20220729170140-87fab4b7019a h1:dMnPZyhZoN781bLvpGogv2c18pNblz65EV7t8iamz6Q=
+github.com/containers/common v0.49.1-0.20220729170140-87fab4b7019a/go.mod h1:ueM5hT0itKqCQvVJDs+EtjornAQtrHYxQJzP2gxeGIg=
 github.com/containers/image/v5 v5.22.0 h1:KemxPmD4D2YYOFZN2SgoTk7nBFcnwPiPW0MqjYtknSE=
 github.com/containers/image/v5 v5.22.0/go.mod h1:D8Ksv2RNB8qLJ7xe1P3rgJJOSQpahA6amv2Ax++/YO4=
 github.com/containers/libtrust v0.0.0-20200511145503-9c3a6c22cd9a h1:spAGlqziZjCJL25C6F1zsQY05tfCKE9F5YwtEWWe6hU=

--- a/tests/inspect.bats
+++ b/tests/inspect.bats
@@ -124,3 +124,15 @@ load helpers
 	run_buildah inspect --format "{{.Docker.Variant}}" $cid
 	[[ "$output" == "v7" ]]
 }
+
+@test "inspect manifest and verify OCI annotation" {
+    run_buildah manifest create foobar
+    run_buildah manifest add foobar busybox
+    # get digest of added instance
+    sha=$(echo $output | awk '{print $2}')
+    run_buildah manifest annotate --annotation hello=world foobar "$sha"
+    run_buildah manifest inspect foobar
+    # Must contain annotation key and value
+    expect_output --substring "hello"
+    expect_output --substring "world"
+}

--- a/vendor/github.com/containers/common/libimage/manifest_list.go
+++ b/vendor/github.com/containers/common/libimage/manifest_list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
+	structcopier "github.com/jinzhu/copier"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -37,6 +38,28 @@ type ManifestList struct {
 
 	// The underlying manifest list.
 	list manifests.List
+}
+
+// ManifestListDescriptor references a platform-specific manifest.
+// Contains exclusive field like `annotations` which is only present in
+// OCI spec and not in docker image spec.
+type ManifestListDescriptor struct {
+	manifest.Schema2Descriptor
+	Platform manifest.Schema2PlatformSpec `json:"platform"`
+	// Annotations contains arbitrary metadata for the image index.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// ManifestListData is a list of platform-specific manifests, specifically used to
+// generate output struct for `podman manifest inspect`. Reason for maintaining and
+// having this type is to ensure we can have a common type which contains exclusive
+// fields from both Docker manifest format and OCI manifest format.
+type ManifestListData struct {
+	SchemaVersion int                      `json:"schemaVersion"`
+	MediaType     string                   `json:"mediaType"`
+	Manifests     []ManifestListDescriptor `json:"manifests"`
+	// Annotations contains arbitrary metadata for the image index.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // ID returns the ID of the manifest list.
@@ -210,8 +233,21 @@ func (i *Image) IsManifestList(ctx context.Context) (bool, error) {
 }
 
 // Inspect returns a dockerized version of the manifest list.
-func (m *ManifestList) Inspect() (*manifest.Schema2List, error) {
-	return m.list.Docker(), nil
+func (m *ManifestList) Inspect() (*ManifestListData, error) {
+	inspectList := ManifestListData{}
+	dockerFormat := m.list.Docker()
+	err := structcopier.Copy(&inspectList, &dockerFormat)
+	if err != nil {
+		return &inspectList, err
+	}
+	// Get missing annotation field from OCIv1 Spec
+	// and populate inspect data.
+	ociFormat := m.list.OCIv1()
+	inspectList.Annotations = ociFormat.Annotations
+	for i, manifest := range ociFormat.Manifests {
+		inspectList.Manifests[i].Annotations = manifest.Annotations
+	}
+	return &inspectList, nil
 }
 
 // Options for adding a manifest list.

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.49.0"
+const Version = "0.49.1-dev"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.1.1
 ## explicit; go 1.17
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/common v0.49.0
+# github.com/containers/common v0.49.1-0.20220729170140-87fab4b7019a
 ## explicit; go 1.17
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
Verifies https://github.com/containers/common/pull/1105 by adding a new test `inspect manifest and verify OCI annotation`
and old tests should not break.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
manifest: inspect now supports OCI annotations
```