### PR TITLE
integration tests: quote "?" in shell scripts

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4090,7 +4090,7 @@ _EOF
     found_runtime=y
     if is_cgroupsv2; then
       # The result with cgroup v2 depends on the version of runc.
-      run_buildah ? bud --runtime=runc --runtime-flag=debug \
+      run_buildah '?' bud --runtime=runc --runtime-flag=debug \
                         -q -t alpine-bud-runc $WITH_POLICY_JSON --file ${mytmpdir}/Containerfile .
       if [ "$status" -eq 0 ]; then
         expect_output --substring "$flag_accepted_rx"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -775,7 +775,7 @@ _EOF
 
 	if [ -n "$(command -v runc)" ]; then
 		found_runtime=y
-		run_buildah ? run --runtime=runc --runtime-flag=debug $cid true
+		run_buildah '?' run --runtime=runc --runtime-flag=debug $cid true
 		if [ "$status" -eq 0 ]; then
 			[ -n "$output" ]
 		else


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When passing the value ? to a shell function as an argument, don't forget to quote it, so that it doesn't get expanded as a filename pattern by the shell.

#### How to verify it

Tests should continue to pass.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```