### PR TITLE
[release-1.26] Backport misc fixes from upstream.

### DIFF
--- a/add.go
+++ b/add.go
@@ -88,6 +88,11 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 		return err
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("invalid response status %d", response.StatusCode)
+	}
+
 	// Figure out what to name the new content.
 	name := renameTarget
 	if name == "" {

--- a/define/types.go
+++ b/define/types.go
@@ -190,6 +190,9 @@ func downloadToDirectory(url, dir string) error {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("invalid response status %d", resp.StatusCode)
+	}
 	if resp.ContentLength == 0 {
 		return errors.Errorf("no contents in %q", url)
 	}

--- a/run_linux.go
+++ b/run_linux.go
@@ -2726,10 +2726,6 @@ func getSecretMount(tokens []string, secrets map[string]define.Secret, mountlabe
 			return nil, "", err
 		}
 		ctrFileOnHost = filepath.Join(containerWorkingDir, "secrets", id)
-		_, err = os.Stat(ctrFileOnHost)
-		if !os.IsNotExist(err) {
-			return nil, "", err
-		}
 	default:
 		return nil, "", errors.New("invalid source secret type")
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1345,7 +1345,7 @@ function _test_http() {
   target=url-image
   url=https://raw.githubusercontent.com/containers/buildah/main/tests/bud/from-scratch/Dockerfile.bogus
   run_buildah 125 build $WITH_POLICY_JSON -t ${target} ${url}
-  expect_output "no FROM statement found"
+  expect_output --substring "invalid response status 404"
 }
 
 # When provided with a -f flag and directory, buildah will look for the alternate Dockerfile name in the supplied directory

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -202,6 +202,18 @@ _EOF
   expect_output --substring $targetarch
 }
 
+@test "build with add resolving to invalid HTTP status code" {
+  mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+
+  cat > ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile << _EOF
+FROM alpine
+ADD https://google.com/test /
+_EOF
+
+  run_buildah 125 build $WITH_POLICY_JSON -t source -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile
+  expect_output --substring "invalid response status"
+}
+
 @test "bud with --layers and --no-cache flags" {
   cp -a $BUDFILES/use-layers ${TEST_SCRATCH_DIR}/use-layers
 


### PR DESCRIPTION
Backports fixes from `upstream` (`1.27.0-dev`) to `release-1.26`:
https://github.com/containers/buildah/pull/4013 squash, layers: never use build cache when computing last step of last stage
https://github.com/containers/buildah/pull/4086 add: fail on bad HTTP response instead of writing to container for URL sources
https://github.com/containers/buildah/pull/3998 run: allow re-using secret artifact from host in new RUN steps