### PR TITLE
[release-1.26] tag v1.26.4 with some more backports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # Changelog
 
+## v1.26.4 (2022-08-03)
+
+    build: add --cpp-flag
+    build: add --build-context flag
+    build: add --omit-history flag
+    build: add --logsplit flag
+    copier: add `NoOverwriteNonDirDir` option
+
 ## v1.26.3 (2022-08-02)
 
     define.downloadToDirectory: fail early if bad HTTP response

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+- Changelog for v1.26.4 (2022-08-03)
+  * build: add --cpp-flag
+  * build: add --build-context flag
+  * build: add --omit-history flag
+  * build: add --logsplit flag
+  * copier: add `NoOverwriteNonDirDir` option
+
 - Changelog for v1.26.3 (2022-08-02)
   * define.downloadToDirectory: fail early if bad HTTP response
   * add: fail on bad http response instead of writing to container

--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -351,6 +351,7 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 		Compression:             compression,
 		ConfigureNetwork:        networkPolicy,
 		ContextDirectory:        contextDir,
+		CPPFlags:                iopts.CPPFlags,
 		DefaultMountsFilePath:   globalFlagResults.DefaultMountsFile,
 		Devices:                 iopts.Devices,
 		DropCapabilities:        iopts.CapDrop,

--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -253,6 +253,12 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 		reporter = f
 	}
 
+	if c.Flag("logsplit").Changed {
+		if !c.Flag("logfile").Changed {
+			return errors.Errorf("cannot use --logsplit without --logfile")
+		}
+	}
+
 	store, err := getStore(c)
 	if err != nil {
 		return err
@@ -383,6 +389,8 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildOptions) error {
 		IgnoreFile:              iopts.IgnoreFile,
 		Labels:                  iopts.Label,
 		Layers:                  layers,
+		LogFile:                 iopts.Logfile,
+		LogSplitByPlatform:      iopts.LogSplitByPlatform,
 		LogRusage:               iopts.LogRusage,
 		Manifest:                iopts.Manifest,
 		MaxPullPushRetries:      maxPullPushRetries,

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -23,6 +23,7 @@ import (
 
 type commitInputOptions struct {
 	authfile           string
+	omitHistory        bool
 	blobCache          string
 	certDir            string
 	creds              string
@@ -108,6 +109,7 @@ func commitListFlagSet(cmd *cobra.Command, opts *commitInputOptions) {
 		panic(fmt.Sprintf("error marking reference-time as hidden: %v", err))
 	}
 
+	flags.BoolVar(&opts.omitHistory, "omit-history", false, "omit build history information from the built image (default false)")
 	flags.BoolVar(&opts.identityLabel, "identity-label", true, "add default builder label (default true)")
 	flags.BoolVar(&opts.rm, "rm", false, "remove the container and its content after committing it to an image. Default leaves the container and its content in place.")
 	flags.StringVar(&opts.signaturePolicy, "signature-policy", "", "`pathname` of signature policy file (not usually used)")
@@ -209,6 +211,7 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 		IIDFile:               iopts.iidfile,
 		Squash:                iopts.squash,
 		BlobDirectory:         iopts.blobCache,
+		OmitHistory:           iopts.omitHistory,
 		SignBy:                iopts.signBy,
 		OciEncryptConfig:      encConfig,
 		OciEncryptLayers:      encLayers,

--- a/commit.go
+++ b/commit.go
@@ -69,6 +69,10 @@ type CommitOptions struct {
 	// Squash tells the builder to produce an image with a single layer
 	// instead of with possibly more than one layer.
 	Squash bool
+	// OmitHistory tells the builder to ignore the history of build layers and
+	// base while preparing image-spec, setting this to true will ensure no history
+	// is added to the image-spec. (default false)
+	OmitHistory bool
 	// BlobDirectory is the name of a directory in which we'll look for
 	// prebuilt copies of layer blobs that we might otherwise need to
 	// regenerate from on-disk layers.  If blobs are available, the

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in define/types.go too
-Version:        1.26.3
+Version:        1.26.4
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,6 +100,13 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Wed Aug 3 2022 Nalin Dahyabhai <nalin@redhat.com> 1.26.4-1
+- build: add --cpp-flag
+- build: add --build-context flag
+- build: add --omit-history flag
+- build: add --logsplit flag
+- copier: add `NoOverwriteNonDirDir` option
+
 * Tue Aug 02 2022 Aditya R <arajan@redhat.com> 1.26.3-1
 - define.downloadToDirectory: fail early if bad HTTP response
 - add: fail on bad http response instead of writing to container

--- a/copier/copier.go
+++ b/copier/copier.go
@@ -352,6 +352,7 @@ type PutOptions struct {
 	IgnoreXattrErrors    bool              // ignore any errors encountered when attempting to set extended attributes
 	IgnoreDevices        bool              // ignore items which are character or block devices
 	NoOverwriteDirNonDir bool              // instead of quietly overwriting directories with non-directories, return an error
+	NoOverwriteNonDirDir bool              // instead of quietly overwriting non-directories with directories, return an error
 	Rename               map[string]string // rename items with the specified names, or under the specified names
 }
 
@@ -1793,12 +1794,15 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				}
 			case tar.TypeDir:
 				if err = os.Mkdir(path, 0700); err != nil && os.IsExist(err) {
-					var st os.FileInfo
-					if st, err = os.Lstat(path); err == nil && !st.IsDir() {
-						// it's not a directory, so remove it and mkdir
+					if st, stErr := os.Lstat(path); stErr == nil && !st.IsDir() {
+						if req.PutOptions.NoOverwriteNonDirDir {
+							break
+						}
 						if err = os.Remove(path); err == nil {
 							err = os.Mkdir(path, 0700)
 						}
+					} else {
+						err = stErr
 					}
 					// either we removed it and retried, or it was a directory,
 					// in which case we want to just add the new stuff under it

--- a/define/build.go
+++ b/define/build.go
@@ -187,6 +187,8 @@ type BuildOptions struct {
 	DropCapabilities []string
 	// CommonBuildOpts is *required*.
 	CommonBuildOpts *CommonBuildOptions
+	// CPPFlags are additional arguments to pass to the C Preprocessor (cpp).
+	CPPFlags []string
 	// DefaultMountsFilePath is the file path holding the mounts to be mounted in "host-path:container-path" format
 	DefaultMountsFilePath string
 	// IIDFile tells the builder to write the image ID to the specified file

--- a/define/build.go
+++ b/define/build.go
@@ -11,6 +11,21 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+// AdditionalBuildContext contains verbose details about a parsed build context from --build-context
+type AdditionalBuildContext struct {
+	// Value is the URL of an external tar archive.
+	IsURL bool
+	// Value is the name of an image which may or may not have already been pulled.
+	IsImage bool
+	// Value holds a URL, an image name, or an absolute filesystem path.
+	Value string
+	// Absolute filesystem path to downloaded and exported build context
+	// from external tar archive. This will be populated only if following
+	// buildcontext is created from IsURL and was downloaded before in any
+	// of the RUN step.
+	DownloadedCache string
+}
+
 // CommonBuildOptions are resources that can be defined by flags for both buildah from and build
 type CommonBuildOptions struct {
 	// AddHost is the list of hostnames to add to the build container's /etc/hosts.
@@ -121,6 +136,8 @@ type BuildOptions struct {
 	Compression archive.Compression
 	// Arguments which can be interpolated into Dockerfiles
 	Args map[string]string
+	// Map of external additional build contexts
+	AdditionalBuildContexts map[string]*AdditionalBuildContext
 	// Name of the image to write to.
 	Output string
 	// BuildOutput specifies if any custom build output is selected for following build.

--- a/define/build.go
+++ b/define/build.go
@@ -30,6 +30,10 @@ type AdditionalBuildContext struct {
 type CommonBuildOptions struct {
 	// AddHost is the list of hostnames to add to the build container's /etc/hosts.
 	AddHost []string
+	// OmitHistory tells the builder to ignore the history of build layers and
+	// base while preparing image-spec, setting this to true will ensure no history
+	// is added to the image-spec. (default false)
+	OmitHistory bool
 	// CgroupParent is the path to cgroups under which the cgroup for the container will be created.
 	CgroupParent string
 	// CPUPeriod limits the CPU CFS (Completely Fair Scheduler) period

--- a/define/build.go
+++ b/define/build.go
@@ -151,6 +151,12 @@ type BuildOptions struct {
 	// Additional tags to add to the image that we write, if we know of a
 	// way to add them.
 	AdditionalTags []string
+	// Logfile specifies if log output is redirected to an external file
+	// instead of stdout, stderr.
+	LogFile string
+	// LogByPlatform tells imagebuildah to split log to different log files
+	// for each platform if logging to external file was selected.
+	LogSplitByPlatform bool
 	// Log is a callback that will print a progress message.  If no value
 	// is supplied, the message will be sent to Err (or os.Stderr, if Err
 	// is nil) by default.

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.26.3"
+	Version = "1.26.4"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -450,6 +450,15 @@ Do not create _/etc/hosts_ for the container.
 By default, Buildah manages _/etc/hosts_, adding the container's own IP address.
 **--no-hosts** disables this, and the image's _/etc/hosts_ will be preserved unmodified. Conflicts with the --add-host option.
 
+**--omit-history** *bool-value*
+
+Omit build history information in the built image. (default false).
+
+This option is useful for the cases where end users explicitly
+want to set `--omit-history` to omit the optional `History` from
+built images or when working with images built using build tools that
+do not include `History` information in their images.
+
 **--os**="OS"
 
 Set the OS of the image to be built, and that of the base image to be pulled, if the build uses one, instead of using the current operating system of the host.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -114,6 +114,13 @@ This option is added to be aligned with other containers CLIs.
 Buildah doesn't send a copy of the context directory to a daemon or a remote server.
 Thus, compressing the data before sending it is irrelevant to Buildah.
 
+**--cpp-flag**=""
+
+Set additional flags to pass to the C Preprocessor cpp(1).
+Containerfiles ending with a ".in" suffix will be preprocessed via cpp(1). This option can be used to pass additional flags to cpp.
+Note: You can also set default CPPFLAGS by setting the BUILDAH\_CPPFLAGS
+environment variable (e.g., `export BUILDAH_CPPFLAGS="-DDEBUG"`).
+
 **--cpu-period**=*0*
 
 Set the CPU period for the Completely Fair Scheduler (CFS), which is a
@@ -853,7 +860,7 @@ buildah build --no-cache --rm=false -t imageName .
 
 buildah build --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc .
 
-buildah build -f Containerfile.in -t imageName .
+buildah build -f Containerfile.in --cpp-flag="-DDEBUG" -t imageName .
 
 buildah build --network mynet .
 

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -68,6 +68,32 @@ resulting image's configuration.
 Please refer to the [BUILD TIME VARIABLES](#build-time-variables) section for the
 list of variables that can be overridden within the Containerfile at run time.
 
+**--build-context** *name=value*
+
+Specify an additional build context using its short name and its location. Additional
+build contexts can be referenced in the same manner as we access different stages in `COPY`
+instruction.
+
+Valid values could be:
+* Local directory – e.g. --build-context project2=../path/to/project2/src
+* HTTP URL to a tarball – e.g. --build-context src=https://example.org/releases/src.tar
+* Container image – specified with a container-image:// prefix, e.g. --build-context alpine=container-image://alpine:3.15, (also accepts docker://, docker-image://)
+
+On the Containerfile side, you can reference the build context on all commands that accept the “from” parameter.
+Here’s how that might look:
+
+```Dockerfile
+FROM [name]
+COPY --from=[name] ...
+RUN --mount=from=[name] …
+```
+
+The value of `[name]` is matched with the following priority order:
+
+* Named build context defined with --build-context [name]=..
+* Stage defined with AS [name] inside Containerfile
+* Image [name], either local or in a remote registry
+
 **--cache-from**
 
 Images to utilise as potential cache sources. Buildah does not currently support --cache-from so this is a NOOP.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -398,6 +398,11 @@ environment variable. `export BUILDAH_LAYERS=true`
 Log output which would be sent to standard output and standard error to the
 specified file instead of to standard output and standard error.
 
+**--logsplit** *bool-value*
+
+If --logfile and --platform is specified following flag allows end-users to split log file for each
+platform into different files with naming convention as `${logfile}_${platform-os}_${platform-arch}`.
+
 **--manifest** *listName*
 
 Name of the manifest list to which the built image will be added.  Creates the

--- a/docs/buildah-commit.1.md
+++ b/docs/buildah-commit.1.md
@@ -78,6 +78,15 @@ Write the image ID to the file.
 Name of the manifest list to which the built image will be added. Creates the manifest list
 if it does not exist. This option is useful for building multi architecture images.
 
+**--omit-history** *bool-value*
+
+Omit build history information in the built image. (default false).
+
+This option is useful for the cases where end users explicitly
+want to set `--omit-history` to omit the optional `History` from
+built images or when working with images built using build tools that
+do not include `History` information in their images.
+
 **--quiet**, **-q**
 
 When writing the output image, suppress progress output.

--- a/image.go
+++ b/image.go
@@ -70,6 +70,7 @@ type containerImageRef struct {
 	annotations           map[string]string
 	preferredManifestType string
 	squash                bool
+	omitHistory           bool
 	emptyLayer            bool
 	idMappingOptions      *define.IDMappingOptions
 	parent                string
@@ -221,7 +222,7 @@ func (i *containerImageRef) createConfigsAndManifests() (v1.Image, v1.Manifest, 
 	oimage.RootFS.DiffIDs = []digest.Digest{}
 	// Only clear the history if we're squashing, otherwise leave it be so that we can append
 	// entries to it.
-	if i.squash {
+	if i.squash || i.omitHistory {
 		oimage.History = []v1.History{}
 	}
 
@@ -244,7 +245,7 @@ func (i *containerImageRef) createConfigsAndManifests() (v1.Image, v1.Manifest, 
 	// Only clear the history if we're squashing, otherwise leave it be so
 	// that we can append entries to it.  Clear the parent, too, we no
 	// longer include its layers and history.
-	if i.squash {
+	if i.squash || i.omitHistory {
 		dimage.Parent = ""
 		dimage.History = []docker.V2S2History{}
 	}
@@ -530,43 +531,47 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, sc *types.System
 			dimage.History = append(dimage.History, dnews)
 		}
 	}
-	appendHistory(i.preEmptyLayers)
-	created := time.Now().UTC()
-	if i.created != nil {
-		created = (*i.created).UTC()
-	}
-	comment := i.historyComment
-	// Add a comment for which base image is being used
-	if strings.Contains(i.parent, i.fromImageID) && i.fromImageName != i.fromImageID {
-		comment += "FROM " + i.fromImageName
-	}
-	onews := v1.History{
-		Created:    &created,
-		CreatedBy:  i.createdBy,
-		Author:     oimage.Author,
-		Comment:    comment,
-		EmptyLayer: i.emptyLayer,
-	}
-	oimage.History = append(oimage.History, onews)
-	dnews := docker.V2S2History{
-		Created:    created,
-		CreatedBy:  i.createdBy,
-		Author:     dimage.Author,
-		Comment:    comment,
-		EmptyLayer: i.emptyLayer,
-	}
-	dimage.History = append(dimage.History, dnews)
-	appendHistory(i.postEmptyLayers)
+	// Only attempt to append history if history was not disabled explicitly.
+	if !i.omitHistory {
+		appendHistory(i.preEmptyLayers)
+		created := time.Now().UTC()
+		if i.created != nil {
+			created = (*i.created).UTC()
+		}
+		comment := i.historyComment
+		// Add a comment for which base image is being used
+		if strings.Contains(i.parent, i.fromImageID) && i.fromImageName != i.fromImageID {
+			comment += "FROM " + i.fromImageName
+		}
+		onews := v1.History{
+			Created:    &created,
+			CreatedBy:  i.createdBy,
+			Author:     oimage.Author,
+			Comment:    comment,
+			EmptyLayer: i.emptyLayer,
+		}
+		oimage.History = append(oimage.History, onews)
+		dnews := docker.V2S2History{
+			Created:    created,
+			CreatedBy:  i.createdBy,
+			Author:     dimage.Author,
+			Comment:    comment,
+			EmptyLayer: i.emptyLayer,
+		}
+		dimage.History = append(dimage.History, dnews)
+		appendHistory(i.postEmptyLayers)
 
-	// Sanity check that we didn't just create a mismatch between non-empty layers in the
-	// history and the number of diffIDs.
-	expectedDiffIDs := expectedOCIDiffIDs(oimage)
-	if len(oimage.RootFS.DiffIDs) != expectedDiffIDs {
-		return nil, errors.Errorf("internal error: history lists %d non-empty layers, but we have %d layers on disk", expectedDiffIDs, len(oimage.RootFS.DiffIDs))
-	}
-	expectedDiffIDs = expectedDockerDiffIDs(dimage)
-	if len(dimage.RootFS.DiffIDs) != expectedDiffIDs {
-		return nil, errors.Errorf("internal error: history lists %d non-empty layers, but we have %d layers on disk", expectedDiffIDs, len(dimage.RootFS.DiffIDs))
+		// Sanity check that we didn't just create a mismatch between non-empty layers in the
+		// history and the number of diffIDs. Following sanity check is ignored if build history
+		// is disabled explicitly by the user.
+		expectedDiffIDs := expectedOCIDiffIDs(oimage)
+		if len(oimage.RootFS.DiffIDs) != expectedDiffIDs {
+			return nil, errors.Errorf("internal error: history lists %d non-empty layers, but we have %d layers on disk", expectedDiffIDs, len(oimage.RootFS.DiffIDs))
+		}
+		expectedDiffIDs = expectedDockerDiffIDs(dimage)
+		if len(dimage.RootFS.DiffIDs) != expectedDiffIDs {
+			return nil, errors.Errorf("internal error: history lists %d non-empty layers, but we have %d layers on disk", expectedDiffIDs, len(dimage.RootFS.DiffIDs))
+		}
 	}
 
 	// Encode the image configuration blob.
@@ -819,6 +824,7 @@ func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageR
 		annotations:           b.Annotations(),
 		preferredManifestType: manifestType,
 		squash:                options.Squash,
+		omitHistory:           options.OmitHistory,
 		emptyLayer:            options.EmptyLayer && !options.Squash,
 		idMappingOptions:      &b.IDMappingOptions,
 		parent:                parent,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1708,6 +1708,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		PreferredManifestType: s.executor.outputFormat,
 		SystemContext:         s.executor.systemContext,
 		Squash:                squash,
+		OmitHistory:           s.executor.commonBuildOptions.OmitHistory,
 		EmptyLayer:            emptyLayer,
 		BlobDirectory:         s.executor.blobDirectory,
 		SignBy:                s.executor.signBy,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -369,18 +369,73 @@ func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) err
 			if fromErr != nil {
 				return errors.Wrapf(fromErr, "unable to resolve argument %q", copy.From)
 			}
-			if isStage, err := s.executor.waitForStage(s.ctx, from, s.stages[:s.index]); isStage && err != nil {
-				return err
-			}
-			if other, ok := s.executor.stages[from]; ok && other.index < s.index {
-				contextDir = other.mountPoint
-				idMappingOptions = &other.builder.IDMappingOptions
-			} else if builder, ok := s.executor.containerMap[copy.From]; ok {
-				contextDir = builder.MountPoint
-				idMappingOptions = &builder.IDMappingOptions
+			var additionalBuildContext *define.AdditionalBuildContext
+			if foundContext, ok := s.executor.additionalBuildContexts[from]; ok {
+				additionalBuildContext = foundContext
 			} else {
-				return errors.Errorf("the stage %q has not been built", copy.From)
+				// Maybe index is given in COPY --from=index
+				// if that's the case check if provided index
+				// exists and if stage short_name matches any
+				// additionalContext replace stage with addtional
+				// build context.
+				if _, err := strconv.Atoi(from); err == nil {
+					if stage, ok := s.executor.stages[from]; ok {
+						if foundContext, ok := s.executor.additionalBuildContexts[stage.name]; ok {
+							additionalBuildContext = foundContext
+						}
+					}
+				}
 			}
+			if additionalBuildContext != nil {
+				if !additionalBuildContext.IsImage {
+					contextDir = additionalBuildContext.Value
+					if additionalBuildContext.IsURL {
+						// Check if following buildContext was already
+						// downloaded before in any other RUN step. If not
+						// download it and populate DownloadCache field for
+						// future RUN steps.
+						if additionalBuildContext.DownloadedCache == "" {
+							// additional context contains a tar file
+							// so download and explode tar to buildah
+							// temp and point context to that.
+							path, subdir, err := define.TempDirForURL(internalUtil.GetTempDir(), internal.BuildahExternalArtifactsDir, additionalBuildContext.Value)
+							if err != nil {
+								return errors.Wrapf(err, "unable to download context from external source %q", additionalBuildContext.Value)
+							}
+							// point context dir to the extracted path
+							contextDir = filepath.Join(path, subdir)
+							// populate cache for next RUN step
+							additionalBuildContext.DownloadedCache = contextDir
+						} else {
+							contextDir = additionalBuildContext.DownloadedCache
+						}
+					}
+				} else {
+					copy.From = additionalBuildContext.Value
+				}
+			}
+			if additionalBuildContext == nil {
+				if isStage, err := s.executor.waitForStage(s.ctx, from, s.stages[:s.index]); isStage && err != nil {
+					return err
+				}
+				if other, ok := s.executor.stages[from]; ok && other.index < s.index {
+					contextDir = other.mountPoint
+					idMappingOptions = &other.builder.IDMappingOptions
+				} else if builder, ok := s.executor.containerMap[copy.From]; ok {
+					contextDir = builder.MountPoint
+					idMappingOptions = &builder.IDMappingOptions
+				} else {
+					return errors.Errorf("the stage %q has not been built", copy.From)
+				}
+			} else if additionalBuildContext.IsImage {
+				// Image was selected as additionalContext so only process image.
+				mountPoint, err := s.getImageRootfs(s.ctx, copy.From)
+				if err != nil {
+					return err
+				}
+				contextDir = mountPoint
+			}
+			// Original behaviour of buildah still stays true for COPY irrespective of additional context.
 			preserveOwnership = true
 			copyExcludes = excludes
 		} else {
@@ -445,6 +500,55 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 					from, fromErr := imagebuilder.ProcessWord(kv[1], s.stage.Builder.Arguments())
 					if fromErr != nil {
 						return nil, errors.Wrapf(fromErr, "unable to resolve argument %q", kv[1])
+					}
+					// If additional buildContext contains this
+					// give priority to that and break if additional
+					// is not an external image.
+					if additionalBuildContext, ok := s.executor.additionalBuildContexts[from]; ok {
+						if additionalBuildContext.IsImage {
+							mountPoint, err := s.getImageRootfs(s.ctx, additionalBuildContext.Value)
+							if err != nil {
+								return nil, errors.Errorf("%s from=%s: image found with that name", flag, from)
+							}
+							// The `from` in stageMountPoints should point
+							// to `mountPoint` replaced from additional
+							// build-context. Reason: Parser will use this
+							//  `from` to refer from stageMountPoints map later.
+							stageMountPoints[from] = internal.StageMountDetails{IsStage: false, MountPoint: mountPoint}
+							break
+						} else {
+							// Most likely this points to path on filesystem
+							// or external tar archive, Treat it as a stage
+							// nothing is different for this. So process and
+							// point mountPoint to path on host and it will
+							// be automatically handled correctly by since
+							// GetBindMount will honor IsStage:false while
+							// processing stageMountPoints.
+							mountPoint := additionalBuildContext.Value
+							if additionalBuildContext.IsURL {
+								// Check if following buildContext was already
+								// downloaded before in any other RUN step. If not
+								// download it and populate DownloadCache field for
+								// future RUN steps.
+								if additionalBuildContext.DownloadedCache == "" {
+									// additional context contains a tar file
+									// so download and explode tar to buildah
+									// temp and point context to that.
+									path, subdir, err := define.TempDirForURL(internalUtil.GetTempDir(), internal.BuildahExternalArtifactsDir, additionalBuildContext.Value)
+									if err != nil {
+										return nil, errors.Wrapf(err, "unable to download context from external source %q", additionalBuildContext.Value)
+									}
+									// point context dir to the extracted path
+									mountPoint = filepath.Join(path, subdir)
+									// populate cache for next RUN step
+									additionalBuildContext.DownloadedCache = mountPoint
+								} else {
+									mountPoint = additionalBuildContext.DownloadedCache
+								}
+							}
+							stageMountPoints[from] = internal.StageMountDetails{IsStage: true, MountPoint: mountPoint}
+							break
+						}
 					}
 					// If the source's name corresponds to the
 					// result of an earlier stage, wait for that
@@ -923,6 +1027,25 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				if fromErr != nil {
 					return "", nil, errors.Wrapf(fromErr, "unable to resolve argument %q", arr[1])
 				}
+				// If additional buildContext contains this
+				// give priority to that and break if additional
+				// is not an external image.
+				if additionalBuildContext, ok := s.executor.additionalBuildContexts[from]; ok {
+					if !additionalBuildContext.IsImage {
+						// We don't need to pull this
+						// since this additional context
+						// is not an image.
+						break
+					} else {
+						// replace with image set in build context
+						from = additionalBuildContext.Value
+						if _, err := s.getImageRootfs(ctx, from); err != nil {
+							return "", nil, errors.Errorf("%s --from=%s: no stage or image found with that name", command, from)
+						}
+						break
+					}
+				}
+
 				// If the source's name corresponds to the
 				// result of an earlier stage, wait for that
 				// stage to finish being built.

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -309,7 +309,7 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		// add subdirectory if specified
 
 		// cache parent directory
-		cacheParent := filepath.Join(getTempDir(), BuildahCacheDir)
+		cacheParent := filepath.Join(internalUtil.GetTempDir(), BuildahCacheDir)
 		// create cache on host if not present
 		err = os.MkdirAll(cacheParent, os.FileMode(0755))
 		if err != nil {
@@ -596,13 +596,4 @@ func GetTmpfsMount(args []string) (specs.Mount, error) {
 	}
 
 	return newMount, nil
-}
-
-/* This is internal function and could be changed at any time */
-/* for external usage please refer to buildah/pkg/parse.GetTempDir() */
-func getTempDir() string {
-	if tmpdir, ok := os.LookupEnv("TMPDIR"); ok {
-		return tmpdir
-	}
-	return "/var/tmp"
 }

--- a/internal/types.go
+++ b/internal/types.go
@@ -1,5 +1,11 @@
 package internal
 
+const (
+	// Temp directory which stores external artifacts which are download for a build.
+	// Example: tar files from external sources.
+	BuildahExternalArtifactsDir = "buildah-external-artifacts"
+)
+
 // Types is internal packages are suspected to change with releases avoid using these outside of buildah
 
 // StageMountDetails holds the Stage/Image mountpoint returned by StageExecutor

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -32,6 +32,14 @@ func LookupImage(ctx *types.SystemContext, store storage.Store, image string) (*
 	return localImage, nil
 }
 
+// GetTempDir returns base for a temporary directory on host.
+func GetTempDir() string {
+	if tmpdir, ok := os.LookupEnv("TMPDIR"); ok {
+		return tmpdir
+	}
+	return "/var/tmp"
+}
+
 // ExportFromReader reads bytes from given reader and exports to external tar, directory or stdout.
 func ExportFromReader(input io.Reader, opts define.BuildOutputOption) error {
 	var err error

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -57,6 +57,7 @@ type BudResults struct {
 	CertDir             string
 	Compress            bool
 	Creds               string
+	CPPFlags            []string
 	DisableCompression  bool
 	DisableContentTrust bool
 	IgnoreFile          string
@@ -194,6 +195,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.CacheFrom, "cache-from", "", "images to utilise as potential cache sources. The build process does not currently support caching so this is a NOOP.")
 	fs.StringVar(&flags.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	fs.BoolVar(&flags.Compress, "compress", false, "this is a legacy option, which has no effect on the image")
+	fs.StringArrayVar(&flags.CPPFlags, "cpp-flag", []string{}, "set additional flag to pass to C preprocessor (cpp)")
 	fs.StringVar(&flags.Creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	fs.BoolVarP(&flags.DisableCompression, "disable-compression", "D", true, "don't compress layers by default")
 	fs.BoolVar(&flags.DisableContentTrust, "disable-content-trust", false, "this is a Docker specific option and is a NOOP")
@@ -261,17 +263,18 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 // GetBudFlagsCompletions returns the FlagCompletions for the common build flags
 func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion := commonComp.FlagCompletions{}
-	flagCompletion["arch"] = commonComp.AutocompleteNone
 	flagCompletion["annotation"] = commonComp.AutocompleteNone
+	flagCompletion["arch"] = commonComp.AutocompleteNone
 	flagCompletion["authfile"] = commonComp.AutocompleteDefault
 	flagCompletion["build-arg"] = commonComp.AutocompleteNone
 	flagCompletion["cache-from"] = commonComp.AutocompleteNone
 	flagCompletion["cert-dir"] = commonComp.AutocompleteDefault
+	flagCompletion["cpp-flag"] = commonComp.AutocompleteNone
 	flagCompletion["creds"] = commonComp.AutocompleteNone
 	flagCompletion["env"] = commonComp.AutocompleteNone
 	flagCompletion["file"] = commonComp.AutocompleteDefault
-	flagCompletion["from"] = commonComp.AutocompleteDefault
 	flagCompletion["format"] = commonComp.AutocompleteNone
+	flagCompletion["from"] = commonComp.AutocompleteDefault
 	flagCompletion["ignorefile"] = commonComp.AutocompleteDefault
 	flagCompletion["iidfile"] = commonComp.AutocompleteDefault
 	flagCompletion["jobs"] = commonComp.AutocompleteNone
@@ -281,18 +284,18 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["os"] = commonComp.AutocompleteNone
 	flagCompletion["os-feature"] = commonComp.AutocompleteNone
 	flagCompletion["os-version"] = commonComp.AutocompleteNone
+	flagCompletion["output"] = commonComp.AutocompleteNone
 	flagCompletion["pull"] = commonComp.AutocompleteDefault
 	flagCompletion["runtime-flag"] = commonComp.AutocompleteNone
 	flagCompletion["secret"] = commonComp.AutocompleteNone
-	flagCompletion["ssh"] = commonComp.AutocompleteNone
 	flagCompletion["sign-by"] = commonComp.AutocompleteNone
 	flagCompletion["signature-policy"] = commonComp.AutocompleteNone
+	flagCompletion["ssh"] = commonComp.AutocompleteNone
 	flagCompletion["tag"] = commonComp.AutocompleteNone
 	flagCompletion["target"] = commonComp.AutocompleteNone
 	flagCompletion["timestamp"] = commonComp.AutocompleteNone
-	flagCompletion["variant"] = commonComp.AutocompleteNone
 	flagCompletion["unsetenv"] = commonComp.AutocompleteNone
-	flagCompletion["output"] = commonComp.AutocompleteNone
+	flagCompletion["variant"] = commonComp.AutocompleteNone
 	return flagCompletion
 }
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -53,6 +53,7 @@ type BudResults struct {
 	Annotation          []string
 	Authfile            string
 	BuildArg            []string
+	BuildContext        []string
 	CacheFrom           string
 	CertDir             string
 	Compress            bool
@@ -192,6 +193,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringArrayVar(&flags.Annotation, "annotation", []string{}, "set metadata for an image (default [])")
 	fs.StringVar(&flags.Authfile, "authfile", "", "path of the authentication file.")
 	fs.StringArrayVar(&flags.BuildArg, "build-arg", []string{}, "`argument=value` to supply to the builder")
+	fs.StringArrayVar(&flags.BuildContext, "build-context", []string{}, "`argument=value` to supply additional build context to the builder")
 	fs.StringVar(&flags.CacheFrom, "cache-from", "", "images to utilise as potential cache sources. The build process does not currently support caching so this is a NOOP.")
 	fs.StringVar(&flags.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	fs.BoolVar(&flags.Compress, "compress", false, "this is a legacy option, which has no effect on the image")
@@ -267,6 +269,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["arch"] = commonComp.AutocompleteNone
 	flagCompletion["authfile"] = commonComp.AutocompleteDefault
 	flagCompletion["build-arg"] = commonComp.AutocompleteNone
+	flagCompletion["build-context"] = commonComp.AutocompleteNone
 	flagCompletion["cache-from"] = commonComp.AutocompleteNone
 	flagCompletion["cert-dir"] = commonComp.AutocompleteDefault
 	flagCompletion["cpp-flag"] = commonComp.AutocompleteNone

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -68,6 +68,7 @@ type BudResults struct {
 	Iidfile             string
 	Label               []string
 	Logfile             string
+	LogSplitByPlatform  bool
 	Manifest            string
 	NoHosts             bool
 	NoCache             bool
@@ -211,6 +212,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.IntVar(&flags.Jobs, "jobs", 1, "how many stages to run in parallel")
 	fs.StringArrayVar(&flags.Label, "label", []string{}, "set metadata for an image (default [])")
 	fs.StringVar(&flags.Logfile, "logfile", "", "log to `file` instead of stdout/stderr")
+	fs.BoolVar(&flags.LogSplitByPlatform, "logsplit", false, "split logfile to different files for each platform")
 	fs.Int("loglevel", 0, "NO LONGER USED, flag ignored, and hidden")
 	if err := fs.MarkHidden("loglevel"); err != nil {
 		panic(fmt.Sprintf("error marking the loglevel flag as hidden: %v", err))

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -72,6 +72,7 @@ type BudResults struct {
 	NoHosts             bool
 	NoCache             bool
 	Timestamp           int64
+	OmitHistory         bool
 	Pull                string
 	PullAlways          bool
 	PullNever           bool
@@ -239,6 +240,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 		panic(fmt.Sprintf("error marking the pull-never flag as hidden: %v", err))
 	}
 	fs.BoolVarP(&flags.Quiet, "quiet", "q", false, "refrain from announcing build instructions and image read/write progress")
+	fs.BoolVar(&flags.OmitHistory, "omit-history", false, "omit build history information from built image (default true)")
 	fs.BoolVar(&flags.IdentityLabel, "identity-label", true, "add default identity label (default true)")
 	fs.BoolVar(&flags.Rm, "rm", true, "remove intermediate containers after a successful build")
 	// "runtime" definition moved to avoid name collision in podman build.  Defined in cmd/buildah/build.go.

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -137,6 +137,7 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 	cpuShares, _ := flags.GetUint64("cpu-shares")
 	httpProxy, _ := flags.GetBool("http-proxy")
 	identityLabel, _ := flags.GetBool("identity-label")
+	omitHistory, _ := flags.GetBool("omit-history")
 
 	ulimit := []string{}
 	if flags.Changed("ulimit") {
@@ -162,6 +163,7 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 		Memory:        memoryLimit,
 		MemorySwap:    memorySwap,
 		NoHosts:       noHosts,
+		OmitHistory:   omitHistory,
 		ShmSize:       findFlagFunc("shm-size").Value.String(),
 		Ulimit:        ulimit,
 		Volumes:       volumes,

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2413,6 +2413,18 @@ _EOF
   [ "${status}" -eq 0 ]
   expect_output --substring "FROM alpine"
   expect_output --substring "success"
+  expect_output --substring "debug=no"
+  run_buildah build $WITH_POLICY_JSON -t ${target} --cpp-flag "-DDEBUG" -f $BUDFILES/containerfile/Containerfile.in $BUDFILES/containerfile
+  [ "${status}" -eq 0 ]
+  expect_output --substring "FROM alpine"
+  expect_output --substring "success"
+  expect_output --substring "debug=yes"
+
+  BUILDAH_CPPFLAGS="-DDEBUG" run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/containerfile/Containerfile.in $BUDFILES/containerfile
+  [ "${status}" -eq 0 ]
+  expect_output --substring "FROM alpine"
+  expect_output --substring "success"
+  expect_output --substring "debug=yes"
 }
 
 @test "bud with Dockerfile" {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -202,7 +202,28 @@ _EOF
   expect_output --substring $targetarch
 }
 
-# Test pinning image using addtional build context
+# Test build with --add-history=false
+@test "build-with-omit-history-to-true should not add history" {
+  mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+
+  cat > ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile1 << _EOF
+FROM alpine
+RUN echo hello
+RUN echo world
+_EOF
+
+  # Built image must not contain history for the layers which we have just built.
+  run_buildah build $WITH_POLICY_JSON --omit-history -t source -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile1
+  run_buildah inspect --format "{{index .Docker.History}}" source
+  expect_output "[]"
+  run_buildah inspect --format "{{index .OCIv1.History}}" source
+  expect_output "[]"
+  run_buildah inspect --format "{{index .History}}" source
+  expect_output "[]"
+}
+
+
+# Test pinning image using additional build context
 @test "build-with-additional-build-context and COPY, test pinning image" {
   mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1704,6 +1704,25 @@ function _test_http() {
   test -s ${TEST_SCRATCH_DIR}/logfile
 }
 
+@test "bud-logfile-with-split-logfile-by-platform" {
+  mytmpdir=${TEST_SCRATCH_DIR}/my-dir
+  mkdir -p $mytmpdir
+
+  cat > $mytmpdir/Containerfile << _EOF
+FROM alpine
+COPY . .
+_EOF
+
+  rm -f ${TEST_SCRATCH_DIR}/logfile
+  run_buildah build --logfile ${TEST_SCRATCH_DIR}/logfile --logsplit --platform linux/arm64,linux/amd64 $WITH_POLICY_JSON ${mytmpdir}
+  run cat ${TEST_SCRATCH_DIR}/logfile_linux_arm64
+  expect_output --substring "FROM alpine"
+  expect_output --substring "[linux/arm64]"
+  run cat ${TEST_SCRATCH_DIR}/logfile_linux_amd64
+  expect_output --substring "FROM alpine"
+  expect_output --substring "[linux/amd64]"
+}
+
 @test "bud with ARGS" {
   _prefetch alpine
   target=alpine-image

--- a/tests/bud/containerfile/Containerfile.in
+++ b/tests/bud/containerfile/Containerfile.in
@@ -1,2 +1,7 @@
 # include "Containerfile"
 RUN echo "success"
+#if DEBUG
+RUN echo "debug=yes"
+# else
+RUN echo "debug=no"
+#endif

--- a/tests/history.bats
+++ b/tests/history.bats
@@ -53,6 +53,14 @@ function testconfighistory() {
   expect_output --substring "ONBUILD CMD /foo"
 }
 
+@test "commit-with-omit-history-set-to-true" {
+  run_buildah from --name onbuildctr --format docker scratch
+  run_buildah config --onbuild "CMD /foo" --add-history onbuildctr
+  run_buildah commit --omit-history $WITH_POLICY_JSON onbuildctr onbuildimg
+  run_buildah inspect --format "{{index .Docker.History}}" onbuildimg
+  expect_output "[]"
+}
+
 @test "history-port" {
   testconfighistory "--port 80/tcp" "EXPOSE 80/tcp"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Podman 4.2 wants to use some features that we haven't backported to 1.26 yet, and here they are:
* splitting build logs by platform when we're building for multiple platforms with --logsplit (#4034)
* the copier package's `NoOverwriteNonDirDir` option (#4043)
* being able to use and refer to additional build contexts in Dockerfiles using --build-context (#3978)
* being able to pass additional flags to the C preprocessor when it's used to preprocess a Dockerfile with --cpp-flag (#3994)
* being able to prevent adding history entries to new images with --omit-history (#4028)

#### How to verify it

The backports include their tests.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah build` now recognizes a `--cpp-flag` option
`buildah build` now recognizes a `--build-context` option
`buildah build` now recognizes a `--omit-history` flag
`buildah build` now recognizes a `--logsplit` flag
```