### PR TITLE
build: support filtering cache by duration using `--cache-ttl`

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -143,6 +143,10 @@ type BuildOptions struct {
 	// CacheTo specifies any remote repository which can be treated as
 	// potential cache destination.
 	CacheTo reference.Named
+	// CacheTTL specifies duration, if specified using `--cache-ttl` then
+	// cache intermediate images under this duration will be considered as
+	// valid cache sources and images outside this duration will be ignored.
+	CacheTTL time.Duration
 	// Compression specifies the type of compression which is applied to
 	// layer blobs.  The default is to not use compression, but
 	// archive.Gzip is recommended.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -128,6 +128,12 @@ buildah build -t test --layers --cache-to registry/myrepo/cache --cache-from reg
 
 Note: `--cache-to` option is ignored unless `--layers` is specified.
 
+**--cache-ttl** *duration*
+
+Limit the use of cached images to only consider images with created timestamps less than *duration* ago.
+For example if `--cache-ttl=1h` is specified, Buildah will only consider intermediate cache images which are created
+under the duration of one hour, and intermediate cache images outside this duration will be ignored.
+
 **--cap-add**=*CAP\_xxx*
 
 When executing RUN instructions, run the command specified in the instruction

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -60,6 +60,7 @@ var builtinAllowedBuildArgs = map[string]bool{
 type Executor struct {
 	cacheFrom                      reference.Named
 	cacheTo                        reference.Named
+	cacheTTL                       time.Duration
 	containerSuffix                string
 	logger                         *logrus.Logger
 	stages                         map[string]*StageExecutor
@@ -216,6 +217,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 	exec := Executor{
 		cacheFrom:                      options.CacheFrom,
 		cacheTo:                        options.CacheTo,
+		cacheTTL:                       options.CacheTTL,
 		containerSuffix:                options.ContainerSuffix,
 		logger:                         logger,
 		stages:                         make(map[string]*StageExecutor),

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1799,6 +1799,17 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 		}
 	}
 	for _, image := range images {
+		// If s.executor.cacheTTL was specified
+		// then ignore processing image if it
+		// was created before the specified
+		// duration.
+		if int64(s.executor.cacheTTL) != 0 {
+			timeNow := time.Now()
+			imageDuration := timeNow.Sub(image.Created)
+			if s.executor.cacheTTL < imageDuration {
+				continue
+			}
+		}
 		var imageTopLayer *storage.Layer
 		var imageParentLayerID string
 		if image.TopLayer != "" {

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -303,6 +303,13 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 			return options, nil, nil, fmt.Errorf("unable to parse value provided `%s` to --cache-from: %w", iopts.CacheTo, err)
 		}
 	}
+	var cacheTTL time.Duration
+	if c.Flag("cache-ttl").Changed {
+		cacheTTL, err = time.ParseDuration(iopts.CacheTTL)
+		if err != nil {
+			return options, nil, nil, fmt.Errorf("unable to parse value provided %q as --cache-ttl: %w", iopts.CacheTTL, err)
+		}
+	}
 	options = define.BuildOptions{
 		AddCapabilities:         iopts.CapAdd,
 		AdditionalBuildContexts: additionalBuildContext,
@@ -315,6 +322,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		BuildOutput:             iopts.BuildOutput,
 		CacheFrom:               cacheFrom,
 		CacheTo:                 cacheTo,
+		CacheTTL:                cacheTTL,
 		CNIConfigDir:            iopts.CNIConfigDir,
 		CNIPluginPath:           iopts.CNIPlugInPath,
 		CPPFlags:                iopts.CPPFlags,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -55,6 +55,7 @@ type BudResults struct {
 	BuildContext        []string
 	CacheFrom           string
 	CacheTo             string
+	CacheTTL            string
 	CertDir             string
 	Compress            bool
 	Creds               string
@@ -200,6 +201,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringArrayVar(&flags.BuildContext, "build-context", []string{}, "`argument=value` to supply additional build context to the builder")
 	fs.StringVar(&flags.CacheFrom, "cache-from", "", "remote repository to utilise as potential cache source.")
 	fs.StringVar(&flags.CacheTo, "cache-to", "", "remote repository to utilise as potential cache destination.")
+	fs.StringVar(&flags.CacheTTL, "cache-ttl", "", "only consider cache images under specified duration.")
 	fs.StringVar(&flags.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	fs.BoolVar(&flags.Compress, "compress", false, "this is a legacy option, which has no effect on the image")
 	fs.StringArrayVar(&flags.CPPFlags, "cpp-flag", []string{}, "set additional flag to pass to C preprocessor (cpp)")
@@ -279,6 +281,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["build-context"] = commonComp.AutocompleteNone
 	flagCompletion["cache-from"] = commonComp.AutocompleteNone
 	flagCompletion["cache-to"] = commonComp.AutocompleteNone
+	flagCompletion["cache-ttl"] = commonComp.AutocompleteNone
 	flagCompletion["cert-dir"] = commonComp.AutocompleteDefault
 	flagCompletion["cpp-flag"] = commonComp.AutocompleteNone
 	flagCompletion["creds"] = commonComp.AutocompleteNone


### PR DESCRIPTION
`build` or `bud` now supports a new flag `--cache-ttl` which accepts
duration and allows end users to ignore cache images which are not under
the specified duration.

Following flag is useful for setups/platforms which heavily relies on
`--layer` and buildah caching but want recompute certain `RUN` steps
after specified duration to make sure specific `RUN` steps are always
updated. Example `RUN dnf update` or `RUN dnf install`

Closes: https://github.com/containers/buildah/issues/4160
Somewhat similar to kaniko's: https://github.com/GoogleContainerTools/kaniko#--cache-ttl-duration