### PR TITLE
Don't try to call runLabelStdioPipes if spec.Linux is not set

### DIFF
--- a/run_common.go
+++ b/run_common.go
@@ -477,8 +477,10 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 			if stdioPipe, err = runMakeStdioPipe(int(uid), int(gid)); err != nil {
 				return 1, err
 			}
-			if err = runLabelStdioPipes(stdioPipe, spec.Process.SelinuxLabel, spec.Linux.MountLabel); err != nil {
-				return 1, err
+			if spec.Linux != nil {
+				if err = runLabelStdioPipes(stdioPipe, spec.Process.SelinuxLabel, spec.Linux.MountLabel); err != nil {
+					return 1, err
+				}
 			}
 			errorFds = []int{stdioPipe[unix.Stdout][0], stdioPipe[unix.Stderr][0]}
 			closeBeforeReadingErrorFds = []int{stdioPipe[unix.Stdout][1], stdioPipe[unix.Stderr][1]}


### PR DESCRIPTION
On FreeBSD, the Linux section of the spec is not populated. FreeBSD does
have a similar labelling facility in its MAC framework but that would be
better managed via a future addition of a FreeBSD section to the runtime
spec rather than trying to make it look like Linux.

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

This fixes non-tty run operations with buildah on FreeBSD. This got missed when turning the original prototype into a reviewable form.

#### How to verify it

On a FreeBSD system do this:
```
c=$(sudo buildah from quay.io/dougrabson/freebsd-minimal:13.1)
sudo buildah run --tty=false $c freebsd-version
sudo buildah rm $c
```

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

