### PR TITLE
Allow chflags operations inside the container

### DIFF
--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -251,6 +251,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		jconf.Set("enforce_statfs", 0)
 		jconf.Set("devfs_ruleset", 4)
 		jconf.Set("allow.raw_sockets", true)
+		jconf.Set("allow.chflags", true)
 		jconf.Set("allow.mount", true)
 		jconf.Set("allow.mount.devfs", true)
 		jconf.Set("allow.mount.nullfs", true)


### PR DESCRIPTION
On FreeBSD, this is required when installing some packages from
FreeBSD-base which have files protected with the immutable flag (e.g.
/usr/bin/passwd).

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### How to verify it

Run this on a FreeBSD system - the FreeBSD-utilities package has files with immutable set:
```
c=$(sudo buildah from quay.io/dougrabson/freebsd-minimal:13.1)
sudo buildah run $c pkg install -y -r FreeBSD-base FreeBSD-utilities
```

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```

