### PR TITLE
[release-1.11-rhel] Fix ADD with URL

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -65,7 +65,7 @@ load helpers
   expect_line_count 8
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test2 ${TESTDIR}/use-layers
   run_buildah --log-level=error images -a
-  expect_line_count 9
+  expect_line_count 10
   run_buildah --log-level=error inspect --format "{{index .Docker.ContainerConfig.Env 1}}" test1
   expect_output "foo=bar"
   run_buildah --log-level=error inspect --format "{{index .Docker.ContainerConfig.Env 1}}" test2
@@ -77,25 +77,25 @@ load helpers
 
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test3 -f Dockerfile.2 ${TESTDIR}/use-layers
   run_buildah --log-level=error images -a
-  expect_line_count 11
+  expect_line_count 12
 
   mkdir -p ${TESTDIR}/use-layers/mount/subdir
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test4 -f Dockerfile.3 ${TESTDIR}/use-layers
   run_buildah --log-level=error images -a
-  expect_line_count 13
+  expect_line_count 14
 
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test5 -f Dockerfile.3 ${TESTDIR}/use-layers
   run_buildah --log-level=error images -a
-  expect_line_count 14
+  expect_line_count 15
 
   touch ${TESTDIR}/use-layers/mount/subdir/file.txt
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test6 -f Dockerfile.3 ${TESTDIR}/use-layers
   run_buildah --log-level=error images -a
-  expect_line_count 16
+  expect_line_count 17
 
   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --no-cache -t test7 -f Dockerfile.2 ${TESTDIR}/use-layers
   run_buildah --log-level=error images -a
-  expect_line_count 17
+  expect_line_count 18
 
   buildah rmi -a -f
 }

--- a/tests/bud/use-layers/Dockerfile
+++ b/tests/bud/use-layers/Dockerfile
@@ -3,5 +3,5 @@ RUN mkdir /hello
 VOLUME /var/lib/testdata
 RUN touch file.txt
 EXPOSE 8080
-ADD Dockerfile.2 /tmp/
+ADD  https://github.com/containers/buildah/blob/master/README.md /tmp/
 ENV foo=bar


### PR DESCRIPTION
Podman 1.6.4 and Buildah 1.11 in RHEL 7.9 had a fixed dragged
in accidentally to handle a Containerfile ADD command that had
a URL in it as part of a separate unrelated fix.  When we
cleaned up the repo recently, that fix was removed
as part of the cleanup effort as it had no corresponding
issue or BZ.

During testing, this issue popped up.  Now that we have a BZ to
attribute it to, putting the fix back in place "legally".

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2112217

and backports:  https://github.com/containers/buildah/pull/2019 which
was spun up from this issue:  https://github.com/containers/podman/issues/4686

At the time of the fix, Buildah v1.7 was under development and the fix
was put into place there and for any newer versions.

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

