### PR TITLE
make,cross: ignore `loong64` from target list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,8 @@ bin/buildah: $(SOURCES) cmd/buildah/*.go
 .PHONY: buildah
 buildah: bin/buildah
 
-ALL_CROSS_TARGETS := $(addprefix bin/buildah.,$(subst /,.,$(shell $(GO) tool dist list)))
+# TODO: remove `grep -v loong64` from `ALL_CROSS_TARGETS` once go.etcd.io/bbolt 1.3.7 is out.
+ALL_CROSS_TARGETS := $(addprefix bin/buildah.,$(subst /,.,$(shell $(GO) tool dist list | grep -v loong64)))
 LINUX_CROSS_TARGETS := $(filter bin/buildah.linux.%,$(ALL_CROSS_TARGETS))
 DARWIN_CROSS_TARGETS := $(filter bin/buildah.darwin.%,$(ALL_CROSS_TARGETS))
 WINDOWS_CROSS_TARGETS := $(addsuffix .exe,$(filter bin/buildah.windows.%,$(ALL_CROSS_TARGETS)))


### PR DESCRIPTION
Released and used version of https://github.com/etcd-io/bbolt/tree/v1.3.6
does not defines certain constants for `loong64` ARCH so avoid building
for `loong64` in `make cross` and `cross-build` CI test.

**Note: Remove this commit once `v1.3.7` is out since this is fixed on master
branch. https://github.com/etcd-io/bbolt/blob/master/bolt_loong64.go**

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]

See discussion here: https://github.com/containers/buildah/pull/4170#issuecomment-1207905624

Fixes and unblocks CI failing with 
```console
GOOS=linux GOARCH=loong64 GO111MODULE=on go build -mod=vendor -ldflags '-X main.GitCommit=20a8e76610f7d2c2dc11813fca33dbf678d8006a -X main.buildInfo=1659871364 -X main.cniVersion=v1.1.2 ' -o bin/buildah.linux.loong64 -tags "containers_image_openpgp" ./cmd/buildah
# go.etcd.io/bbolt
vendor/go.etcd.io/bbolt/db.go:133:13: undeclared name maxMapSize for array length
vendor/go.etcd.io/bbolt/db.go:422:12: undefined: maxMapSize
vendor/go.etcd.io/bbolt/db.go:440:10: undefined: maxMapSize
vendor/go.etcd.io/bbolt/db.go:441:8: undefined: maxMapSize
vendor/go.etcd.io/bbolt/db.go:932:2: pos declared but not used
vendor/go.etcd.io/bbolt/bolt_unix.go:68:15: undeclared name maxMapSize for array length
vendor/go.etcd.io/bbolt/tx.go:532:12: undefined: maxAllocSize
vendor/go.etcd.io/bbolt/tx.go:533:10: undefined: maxAllocSize
vendor/go.etcd.io/bbolt/unsafe.go:27:12: undeclared name maxAllocSize for array length
make: *** [bin/buildah.linux.loong64] Error 2
```


