### PR TITLE
[release-1.11-rhel] Cirrus: Disable CI testing on Ubuntu

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,8 +63,6 @@ testing_task:
         matrix:  # Duplicate this task for each matrix product.
             image_name: "${FEDORA_CACHE_IMAGE_NAME}"
             image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
-            image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
-            image_name: "${PRIOR_UBUNTU_CACHE_IMAGE_NAME}"
 
     # Separate scripts for separate outputs, makes debugging easier.
     setup_script: '${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
@@ -73,13 +71,11 @@ testing_task:
     # Log collection when job was successful
     df_script: '${_DFCMD} || true'
     rh_audit_log_script: '${_RAUDITCMD} || true'
-    ubuntu_audit_log_script: '${_UAUDITCMD} || true'
     journal_log_script: '${_JOURNALCMD} || true'
 
     on_failure:  # Script names must be different from above
         failure_df_script: '${_DFCMD} || true'
         failure_rh_audit_log_script: '${_RAUDITCMD} || true'
-        failure_ubuntu_audit_log_script: '${_UAUDITCMD} || true'
         failure_journal_log_script: '${_JOURNALCMD} || true'
 
 


### PR DESCRIPTION

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Unfortunately much bit-rot has infected CI on this branch.  Without
lots of work there is no hope of resurrecting Ubuntu VMs for CI.  Mainly
this is due to runtime package installs, on an EOL release.  The
repositories have long-since been removed, and I'm loathe to manually
fiddle with the images to make alternatives function.  Primarily because
future buildah releases on this distro will never happen.  "Fix" this by
simply disabling Ubuntu in CI.

#### How to verify it

CI will pass

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Ref: https://github.com/containers/buildah/pull/4173

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

