### PR TITLE
mount,cache: allow setting `--mount=type=cache` ownership using `uid`,`gid`,`U` and `chown`

### DIFF
--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -149,9 +149,11 @@ Current supported mount TYPES are bind, cache, secret and tmpfs. <sup>[[1]](#Foo
 
               · ro, readonly: read only cache if set.
 
-              · uid: uid for cache directory.
+              · uid: uid for cache directory (cannot be used with `U`).
 
-              · gid: gid for cache directory.
+              · gid: gid for cache directory (cannot be used with `U`).
+
+              · U, chown: true or false (default). Reset the ownership of the cache's contents to match the UID and GID of the container's configured user.
 
               · from: stage name for the root of the source. Defaults to host cache directory.
 


### PR DESCRIPTION
* Adds support for `chown` option to `--mount=type=cache`
* Conflict option `uid` or `gid` with `U` or `chown`.
* Allow correctly chowing the permission of central cache using `uid`
  and `gid`.

Verify cases where user inside container is not root, so following
Container file which was not functional before should work now.

Further tests cases are added to verify all the possible behaviour.

```Dockerfile
FROM ubi8/ubi

ARG UID=0
ARG GID=0

USER ${UID}:${GID}
RUN --mount=type=cache,uid=${UID},gid=${GID},target=/mycache,z touch /mycache/test.txt
RUN --mount=type=cache,uid=${UID},gid=${GID},target=/mycache,z mkdir -p /mycache/foo/bar
```

#### Closes: Bugzilla#2111275
