### PR TITLE
[CI:DOCS] docs: specify `git://` protocol is not supported for github hosted repo

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -1006,9 +1006,9 @@ buildah build -o - . > out.tar
 
   This will clone the specified GitHub repository from the URL and use it as context. The Containerfile or Dockerfile at the root of the repository is used as the context of the build. This only works if the GitHub repository is a dedicated repository.
 
-  buildah build github.com/scollier/purpletest
+  buildah build https://github.com/scollier/purpletest
 
-  Note: You can set an arbitrary Git repository via the git:// scheme.
+  Note: Github does not support using `git://` for performing `clone` operation due to recent changes in their security guidance (https://github.blog/2021-09-01-improving-git-protocol-security-github/). Use an `https://` URL if the source repository is hosted on Github.
 
 ### Building an image using a URL to a tarball'ed context
 


### PR DESCRIPTION
Build from URL does not supports `git://` if source is hosted on Github.
Reason: https://github.blog/2021-09-01-improving-git-protocol-security-github/

[CI:DOCS]
[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]

Closes: https://github.com/containers/buildah/issues/4103