### PR TITLE
cmd/buildah: add "manifest create --amend"

### DIFF
--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -44,6 +44,7 @@ type pushOptions struct {
 	tlsVerify          bool
 	encryptionKeys     []string
 	encryptLayers      []int
+	insecure           bool
 }
 
 func init() {

--- a/docs/buildah-manifest-create.1.md
+++ b/docs/buildah-manifest-create.1.md
@@ -1,4 +1,4 @@
-# buildah-manifest-create "1" "September 2019" "buildah"
+# buildah-manifest-create "16" "August 2022" "buildah"
 
 ## NAME
 
@@ -29,10 +29,22 @@ If any of the images which should be added to the new list or index are
 themselves lists or indexes, add all of their contents.  By default, only one
 image from such a list will be added to the newly-created list or index.
 
+**--amend**
+
+If a manifest list named *listNameOrIndexName* already exists, modify the
+preexisting list instead of exiting with an error.  The contents of
+*listNameOrIndexName* are not modified if no *imageName*s are given.
+
+**--tls-verify** *bool-value*
+
+Require HTTPS and verification of certificates when talking to container registries (defaults to true).  TLS verification cannot be used when talking to an insecure registry.
+
 ## EXAMPLE
 
 ```
 buildah manifest create mylist:v1.11
+941c1259e4b85bebf23580a044e4838aa3c1e627528422c9bf9262ff1661fca9
+buildah manifest create --amend mylist:v1.11
 941c1259e4b85bebf23580a044e4838aa3c1e627528422c9bf9262ff1661fca9
 ```
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -454,7 +454,7 @@ func VerifyFlagsArgsOrder(args []string) error {
 	return nil
 }
 
-// aliasFlags is a function to handle backwards compatibility with old flags
+// AliasFlags is a function to handle backwards compatibility with old flags
 func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 	switch name {
 	case "net":

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -345,6 +345,15 @@ func SystemContextFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name strin
 		ctx.OCIInsecureSkipTLSVerify = !tlsVerify
 		ctx.DockerDaemonInsecureSkipTLSVerify = !tlsVerify
 	}
+	insecure, err := flags.GetBool("insecure")
+	if err == nil && findFlagFunc("insecure").Changed {
+		if ctx.DockerInsecureSkipTLSVerify != types.OptionalBoolUndefined {
+			return nil, errors.New("--insecure may not be used with --tls-verify")
+		}
+		ctx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(insecure)
+		ctx.OCIInsecureSkipTLSVerify = insecure
+		ctx.DockerDaemonInsecureSkipTLSVerify = insecure
+	}
 	disableCompression, err := flags.GetBool("disable-compression")
 	if err == nil {
 		if disableCompression {

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -13,6 +13,11 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 
 @test "manifest-create" {
     run_buildah manifest create foo
+    listid="$output"
+    run_buildah 125 manifest create foo
+    assert "$output" =~ "that name is already in use"
+    run_buildah manifest create --amend foo
+    assert "$output" == "$listid"
 }
 
 @test "manifest-inspect-id" {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When `buildah manifest create` is given the `--amend` flag and a list with the name that was specified for the to-be-created list already exists, just reuse the list.

Make the `--insecure` flag, if we see it, conflict with `--tls-verify`, but have the reverse of the effect that `--tls-verify` does, and teach the `buildah manifest` `add`, `create`, and `push` subcommands about it.

#### How to verify it

Extended integration test!

#### Which issue(s) this PR fixes:

Related to https://github.com/containers/podman/issues/15346.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah manifest create` now accepts a `--amend` flag.
```