### PR TITLE
commit: use race-free `RemoveNames` instead of `SetNames` for pruning names

### DIFF
--- a/tests/bud/check-race/Containerfile
+++ b/tests/bud/check-race/Containerfile
@@ -1,0 +1,2 @@
+FROM alpine
+RUN for i in $(seq 0 1000); do touch /$i; done


### PR DESCRIPTION
PR https://github.com/containers/storage/pull/1153 added a dedicated API
to remove names assigned to image so use `RemoveNames`
instead of racy `SetNames`.

##### How to verify

* Refer to newly added integration test.

##### Reproduce on local using

```console
printf 'from quay.io/jitesoft/alpine:latest\nrun for i in $(seq 0 10000); do touch /$i; done\n' >Containerfile && for i in `seq 1 25`; do ./buildah build --squash --iidfile id.$i --timestamp 0 . & done; wait; ls -al
```



Closes: https://github.com/containers/podman/issues/15162