### PR TITLE
mount,cache: enable `SElinux` shared content label (`z`) option by default

### DIFF
--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -155,7 +155,7 @@ Current supported mount TYPES are bind, cache, secret and tmpfs. <sup>[[1]](#Foo
 
               · from: stage name for the root of the source. Defaults to host cache directory.
 
-              · z: Set shared SELinux label on mounted destination. Use if SELinux is enabled on host machine.
+              · z: Set shared SELinux label on mounted destination. Enabled by default if SELinux is enabled on the host machine.
 
               · Z: Set private SELinux label on mounted destination. Use if SELinux is enabled on host machine.
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4959,6 +4959,18 @@ _EOF
   run_buildah rmi -f testbud2
 }
 
+@test "bud-with-mount-cache-like-buildkit-verify-default-selinux-option" {
+  skip_if_no_runtime
+  skip_if_in_container
+  cp -R $BUDFILES/buildkit-mount ${TEST_SCRATCH_DIR}/buildkit-mount2
+  _prefetch alpine
+  # try writing something to persistent cache
+  run_buildah build -t testbud $WITH_POLICY_JSON -f ${TEST_SCRATCH_DIR}/buildkit-mount2/Dockerfilecachewritewithoutz
+  # try reading something from persistent cache in a different build
+  run_buildah build -t testbud2 $WITH_POLICY_JSON -f ${TEST_SCRATCH_DIR}/buildkit-mount2/Dockerfilecachereadwithoutz
+  expect_output --substring "hello"
+}
+
 @test "bud-with-mount-cache-like-buildkit-locked-across-steps" {
   # Note: this test is just testing syntax for sharing, actual behaviour test needs parallel build in order to test locking.
   skip_if_no_runtime

--- a/tests/bud/buildkit-mount/Dockerfilecachereadwithoutz
+++ b/tests/bud/buildkit-mount/Dockerfilecachereadwithoutz
@@ -1,0 +1,3 @@
+FROM alpine
+RUN mkdir /test2
+RUN --mount=type=cache,target=/test2 cat /test2/world

--- a/tests/bud/buildkit-mount/Dockerfilecachewritewithoutz
+++ b/tests/bud/buildkit-mount/Dockerfilecachewritewithoutz
@@ -1,0 +1,3 @@
+FROM alpine
+RUN mkdir /test2
+RUN --mount=type=cache,target=/test2 echo hello > /test2/world


### PR DESCRIPTION
`--mount=type=cache` is buildah's internal construct and actual location
is not managed by user so enable `z` by default when `SELinux` is enabled
on the host machine, instead of asking users to do it.

Helps in: **Bugzilla#2111275**

