### PR TITLE
Cirrus: Lock cross-build task onto golang 1.18

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -126,10 +126,11 @@ cross_build_task:
 
     osx_instance:
         image: 'big-sur-base'
-
+    env:
+        PATH: "/usr/local/opt/go@1.18/bin:$PATH"
     script:
         - brew update
-        - brew install go
+        - brew install go@1.18
         - brew install go-md2man
         - brew install gpgme
         - go version


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Recently (as of this commit) the OSX CI environment was updated.  This
is causing the cross_build task to break.  Fix this by locking onto the
golang version it was passing with on release.

#### How to verify it

The `Cross` task will pass

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```

