### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/chroot/run_test.go
+++ b/chroot/run_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -43,16 +42,10 @@ func testMinimal(t *testing.T, modify func(g *generate.Generator, rootDir, bundl
 		t.Fatalf("setupSeccomp(%q): %v", "", err)
 	}
 
-	tempDir, err := ioutil.TempDir("", "chroot-test")
-	if err != nil {
-		t.Fatalf("ioutil.TempDir(%q, %q): %v", "", "chrootTest", err)
-	}
-	defer os.RemoveAll(tempDir)
-	info, err := os.Stat(tempDir)
-	if err != nil {
-		t.Fatalf("error checking permissions on %q: %v", tempDir, err)
-	}
-	if err = os.Chmod(tempDir, info.Mode()|0111); err != nil {
+	// t.TempDir returns /tmp/TestName/001.
+	// /tmp/TestName/001 has permission 0777, but /tmp/TestName is 0700
+	tempDir := t.TempDir()
+	if err = os.Chmod(filepath.Dir(tempDir), 0711); err != nil {
 		t.Fatalf("error loosening permissions on %q: %v", tempDir, err)
 	}
 

--- a/copier/copier_linux_test.go
+++ b/copier/copier_linux_test.go
@@ -117,10 +117,8 @@ func TestGetPermissionErrorChroot(t *testing.T) {
 
 func testGetPermissionError(t *testing.T) {
 	dropCaps := []capability.Cap{capability.CAP_DAC_OVERRIDE, capability.CAP_DAC_READ_SEARCH}
-	tmp, err := ioutil.TempDir("", "copier-test-")
-	require.NoErrorf(t, err, "error creating temporary directory")
-	defer os.RemoveAll(tmp)
-	err = os.Mkdir(filepath.Join(tmp, "unreadable-directory"), 0000)
+	tmp := t.TempDir()
+	err := os.Mkdir(filepath.Join(tmp, "unreadable-directory"), 0000)
 	require.NoError(t, err, "error creating an unreadable directory")
 	err = os.Mkdir(filepath.Join(tmp, "readable-directory"), 0755)
 	require.NoError(t, err, "error creating a readable directory")
@@ -160,11 +158,9 @@ func TestGetNoCrossDevice(t *testing.T) {
 		t.Skip("test requires root privileges, skipping")
 	}
 
-	tmpdir, err := ioutil.TempDir("", "copier-test-noxdev-")
-	require.NoError(t, err, "error creating temporary directory")
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
-	err = unix.Unshare(unix.CLONE_NEWNS)
+	err := unix.Unshare(unix.CLONE_NEWNS)
 	require.NoError(t, err, "error creating new mount namespace")
 
 	subdir := filepath.Join(tmpdir, "subdir")

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -123,17 +123,13 @@ func makeArchive(headers []tar.Header, contents map[string][]byte) io.ReadCloser
 // makeContextFromArchive creates a temporary directory, and a subdirectory
 // inside of it, from an archive and returns its location.  It can be removed
 // once it's no longer needed.
-func makeContextFromArchive(archive io.ReadCloser, subdir string) (string, error) {
-	tmp, err := ioutil.TempDir("", "copier-test-")
-	if err != nil {
-		return "", err
-	}
+func makeContextFromArchive(t *testing.T, archive io.ReadCloser, subdir string) (string, error) {
+	tmp := t.TempDir()
 	uidMap := []idtools.IDMap{{HostID: os.Getuid(), ContainerID: 0, Size: 1}}
 	gidMap := []idtools.IDMap{{HostID: os.Getgid(), ContainerID: 0, Size: 1}}
-	err = Put(tmp, path.Join(tmp, subdir), PutOptions{UIDMap: uidMap, GIDMap: gidMap}, archive)
+	err := Put(tmp, path.Join(tmp, subdir), PutOptions{UIDMap: uidMap, GIDMap: gidMap}, archive)
 	archive.Close()
 	if err != nil {
-		os.RemoveAll(tmp)
 		return "", err
 	}
 	return tmp, err
@@ -442,9 +438,8 @@ func testPut(t *testing.T) {
 					t.Skipf("test archive %q can only be tested with root privileges, skipping", testArchives[i].name)
 				}
 
-				dir, err := makeContextFromArchive(makeArchive(testArchives[i].headers, testArchives[i].contents), topdir)
+				dir, err := makeContextFromArchive(t, makeArchive(testArchives[i].headers, testArchives[i].contents), topdir)
 				require.NoErrorf(t, err, "error creating context from archive %q, topdir=%q", testArchives[i].name, topdir)
-				defer os.RemoveAll(dir)
 
 				// enumerate what we expect to have created
 				expected := make([]enumeratedFile, 0, len(testArchives[i].headers)+1)
@@ -504,12 +499,10 @@ func testPut(t *testing.T) {
 					t.Skipf("test archive %q can only be tested with root privileges, skipping", testArchives[i].name)
 				}
 
-				tmp, err := ioutil.TempDir("", "copier-test-")
-				require.NoErrorf(t, err, "error creating temporary directory")
-				defer os.RemoveAll(tmp)
+				tmp := t.TempDir()
 
 				archive := makeArchive(testArchives[i].headers, testArchives[i].contents)
-				err = Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, Rename: renames.renames}, archive)
+				err := Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, Rename: renames.renames}, archive)
 				require.NoErrorf(t, err, "error extracting archive %q to directory %q", testArchives[i].name, tmp)
 
 				var found []string
@@ -550,10 +543,8 @@ func testPut(t *testing.T) {
 					{Name: "test/content", Typeflag: tar.TypeReg, Size: 0, Mode: 0755, ModTime: testDate},
 					{Name: "test", Typeflag: typeFlag, Size: 0, Mode: 0755, Linkname: "target", ModTime: testDate},
 				})
-				tmp, err := ioutil.TempDir("", "copier-test-")
-				require.NoErrorf(t, err, "error creating temporary directory")
-				defer os.RemoveAll(tmp)
-				err = Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, NoOverwriteDirNonDir: !overwrite}, bytes.NewReader(archive))
+				tmp := t.TempDir()
+				err := Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, NoOverwriteDirNonDir: !overwrite}, bytes.NewReader(archive))
 				if overwrite {
 					if !errors.Is(err, syscall.EPERM) {
 						assert.Nilf(t, err, "expected to overwrite directory with type %c: %v", typeFlag, err)
@@ -578,10 +569,8 @@ func testPut(t *testing.T) {
 					{Name: "test", Typeflag: tar.TypeDir, Size: 0, Mode: 0755, ModTime: testDate},
 					{Name: "test/content", Typeflag: tar.TypeReg, Size: 0, Mode: 0755, ModTime: testDate},
 				})
-				tmp, err := ioutil.TempDir("", "copier-test-")
-				require.NoErrorf(t, err, "error creating temporary directory")
-				defer os.RemoveAll(tmp)
-				err = Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, NoOverwriteNonDirDir: !overwrite}, bytes.NewReader(archive))
+				tmp := t.TempDir()
+				err := Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, NoOverwriteNonDirDir: !overwrite}, bytes.NewReader(archive))
 				if overwrite {
 					if !errors.Is(err, syscall.EPERM) {
 						assert.Nilf(t, err, "expected to overwrite file with type %c: %v", typeFlag, err)
@@ -603,10 +592,8 @@ func testPut(t *testing.T) {
 					{Name: "link", Typeflag: tar.TypeLink, Size: 0, Mode: 0600, ModTime: testDate, Linkname: "test"},
 					{Name: "unrelated", Typeflag: tar.TypeReg, Size: 0, Mode: 0600, ModTime: testDate},
 				})
-				tmp, err := ioutil.TempDir("", "copier-test-")
-				require.NoErrorf(t, err, "error creating temporary directory")
-				defer os.RemoveAll(tmp)
-				err = Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, IgnoreDevices: ignoreDevices}, bytes.NewReader(archive))
+				tmp := t.TempDir()
+				err := Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, IgnoreDevices: ignoreDevices}, bytes.NewReader(archive))
 				require.Nilf(t, err, "expected to extract content with typeflag %c without an error: %v", typeFlag, err)
 				fileList, err := enumerateFiles(tmp)
 				require.Nilf(t, err, "unexpected error scanning the contents of extraction directory for typeflag %c: %v", typeFlag, err)
@@ -627,9 +614,7 @@ func testPut(t *testing.T) {
 					archive := makeArchiveSlice([]tar.Header{
 						{Name: "test", Typeflag: tar.TypeReg, Size: 0, Mode: mode, ModTime: testDate},
 					})
-					tmp, err := ioutil.TempDir("", "copier-test-")
-					require.NoErrorf(t, err, "error creating temporary directory")
-					defer os.RemoveAll(tmp)
+					tmp := t.TempDir()
 					putOptions := PutOptions{
 						UIDMap:         uidMap,
 						GIDMap:         gidMap,
@@ -637,7 +622,7 @@ func testPut(t *testing.T) {
 						StripSetgidBit: stripSetgidBit,
 						StripStickyBit: stripStickyBit,
 					}
-					err = Put(tmp, tmp, putOptions, bytes.NewReader(archive))
+					err := Put(tmp, tmp, putOptions, bytes.NewReader(archive))
 					require.Nilf(t, err, "unexpected error writing sample file", err)
 					st, err := os.Stat(filepath.Join(tmp, "test"))
 					require.Nilf(t, err, "unexpected error checking permissions of file", err)
@@ -685,9 +670,8 @@ func testStat(t *testing.T) {
 					continue
 				}
 
-				dir, err := makeContextFromArchive(makeArchive(testArchive.headers, testArchive.contents), topdir)
+				dir, err := makeContextFromArchive(t, makeArchive(testArchive.headers, testArchive.contents), topdir)
 				require.NoErrorf(t, err, "error creating context from archive %q", testArchive.name)
-				defer os.RemoveAll(dir)
 
 				root := dir
 
@@ -783,9 +767,8 @@ func testGetSingle(t *testing.T) {
 					continue
 				}
 
-				dir, err := makeContextFromArchive(makeArchive(testArchive.headers, testArchive.contents), topdir)
+				dir, err := makeContextFromArchive(t, makeArchive(testArchive.headers, testArchive.contents), topdir)
 				require.NoErrorf(t, err, "error creating context from archive %q", testArchive.name)
-				defer os.RemoveAll(dir)
 
 				root := dir
 
@@ -1388,9 +1371,8 @@ func testGetMultiple(t *testing.T) {
 
 	for _, topdir := range []string{"", ".", "top"} {
 		for _, testArchive := range getTestArchives {
-			dir, err := makeContextFromArchive(makeArchive(testArchive.headers, testArchive.contents), topdir)
+			dir, err := makeContextFromArchive(t, makeArchive(testArchive.headers, testArchive.contents), topdir)
 			require.NoErrorf(t, err, "error creating context from archive %q", testArchive.name)
-			defer os.RemoveAll(dir)
 
 			root := dir
 
@@ -1470,11 +1452,7 @@ func TestEvalNoChroot(t *testing.T) {
 }
 
 func testEval(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "copier-test-")
-	if err != nil {
-		require.NoError(t, err, "error creating temporary directory")
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	options := EvalOptions{}
 	linkname := filepath.Join(tmp, "link")
 	vectors := []struct {
@@ -1507,7 +1485,7 @@ func testEval(t *testing.T) {
 	}
 	for _, vector := range vectors {
 		t.Run(fmt.Sprintf("id=%s", vector.id), func(t *testing.T) {
-			err = os.Symlink(vector.linkTarget, linkname)
+			err := os.Symlink(vector.linkTarget, linkname)
 			if err != nil && errors.Is(err, os.ErrExist) {
 				os.Remove(linkname)
 				err = os.Symlink(vector.linkTarget, linkname)
@@ -1625,9 +1603,8 @@ func testMkdir(t *testing.T) {
 		t.Run(testArchives[i].name, func(t *testing.T) {
 			for _, testCase := range testArchives[i].testCases {
 				t.Run(testCase.name, func(t *testing.T) {
-					dir, err := makeContextFromArchive(makeArchive(testArchives[i].headers, nil), "")
+					dir, err := makeContextFromArchive(t, makeArchive(testArchives[i].headers, nil), "")
 					require.NoErrorf(t, err, "error creating context from archive %q, topdir=%q", testArchives[i].name, "")
-					defer os.RemoveAll(dir)
 					root := dir
 					options := MkdirOptions{ChownNew: &idtools.IDPair{UID: os.Getuid(), GID: os.Getgid()}}
 					var beforeNames, afterNames []string
@@ -1841,9 +1818,8 @@ func testRemove(t *testing.T) {
 		t.Run(testArchives[i].name, func(t *testing.T) {
 			for _, testCase := range testArchives[i].testCases {
 				t.Run(testCase.name, func(t *testing.T) {
-					dir, err := makeContextFromArchive(makeArchive(testArchives[i].headers, nil), "")
+					dir, err := makeContextFromArchive(t, makeArchive(testArchives[i].headers, nil), "")
 					require.NoErrorf(t, err, "error creating context from archive %q, topdir=%q", testArchives[i].name, "")
-					defer os.RemoveAll(dir)
 					root := dir
 					options := RemoveOptions{All: testCase.all}
 					beforeNames := make(map[string]struct{})

--- a/copier/xattrs_test.go
+++ b/copier/xattrs_test.go
@@ -25,11 +25,7 @@ func TestXattrs(t *testing.T) {
 		"user.a": "attribute value a",
 		"user.b": "attribute value b",
 	}
-	tmp, err := ioutil.TempDir("", "copier-xattr-test-")
-	if !assert.Nil(t, err, "error creating test directory: %v", err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	for attribute, value := range testValues {
 		t.Run(fmt.Sprintf("attribute=%s", attribute), func(t *testing.T) {
 			f, err := ioutil.TempFile(tmp, "copier-xattr-test-")

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -126,28 +126,21 @@ func TestMain(m *testing.M) {
 
 func TestConformance(t *testing.T) {
 	var tempdir string
-	var err error
 	if buildahDir == "" {
 		if tempdir == "" {
-			tempdir, err = ioutil.TempDir("", "buildah-conformance-")
-			require.Nil(t, err, "error creating temporary directory")
-			defer os.RemoveAll(tempdir)
+			tempdir = t.TempDir()
 		}
 		buildahDir = filepath.Join(tempdir, "buildah")
 	}
 	if dockerDir == "" {
 		if tempdir == "" {
-			tempdir, err = ioutil.TempDir("", "buildah-conformance-")
-			require.Nil(t, err, "error creating temporary directory")
-			defer os.RemoveAll(tempdir)
+			tempdir = t.TempDir()
 		}
 		dockerDir = filepath.Join(tempdir, "docker")
 	}
 	if imagebuilderDir == "" {
 		if tempdir == "" {
-			tempdir, err = ioutil.TempDir("", "buildah-conformance-")
-			require.Nil(t, err, "error creating temporary directory")
-			defer os.RemoveAll(tempdir)
+			tempdir = t.TempDir()
 		}
 		imagebuilderDir = filepath.Join(tempdir, "imagebuilder")
 	}
@@ -167,9 +160,7 @@ func testConformanceInternal(t *testing.T, dateStamp string, testIndex int) {
 	require.Nil(t, err, "error finding current directory")
 
 	// create a temporary directory to hold our build context
-	tempdir, err := ioutil.TempDir("", "buildah-conformance-")
-	require.Nil(t, err, "error creating temporary directory")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
 	// create subdirectories to use as the build context and for buildah storage
 	contextDir := filepath.Join(tempdir, "context")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:

A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

#### How to verify it

CI covers the test

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

