### PR TITLE
Makefile: always call $(GO) instead of `go`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,8 @@ BUILDAH := buildah
 GO := go
 GO_LDFLAGS := $(shell if $(GO) version|grep -q gccgo; then echo "-gccgoflags"; else echo "-ldflags"; fi)
 GO_GCFLAGS := $(shell if $(GO) version|grep -q gccgo; then echo "-gccgoflags"; else echo "-gcflags"; fi)
-GO110 := 1.10
-GOVERSION := $(findstring $(GO110),$(shell go version))
 # test for go module support
-ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
+ifeq ($(shell $(GO) help mod >/dev/null 2>&1 && echo true), true)
 export GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
 export GO_TEST=GO111MODULE=on $(GO) test -mod=vendor
 else
@@ -31,9 +29,12 @@ GIT_COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),${COMMIT
 SOURCE_DATE_EPOCH ?= $(if $(shell date +%s),$(shell date +%s),$(error "date failed"))
 STATIC_STORAGETAGS = "containers_image_openpgp exclude_graphdriver_devicemapper $(STORAGE_TAGS)"
 
-CNI_COMMIT := $(shell sed -n 's;\tgithub.com/containernetworking/cni \([^ \n]*\).*$\;\1;p' go.mod)
-#RUNC_COMMIT := $(shell sed -n 's;\tgithub.com/opencontainers/runc \([^ \n]*\).*$\;\1;p' go.mod)
-RUNC_COMMIT := v1.0.0-rc8
+# we get GNU make 3.x in MacOS build envs, which wants # to be escaped in
+# strings, while the 4.x we have on Linux doesn't. this is the documented
+# workaround
+COMMENT := \#
+CNI_COMMIT := $(shell sed -n 's;^$(COMMENT) github.com/containernetworking/cni \([^ \n]*\).*$$;\1;p' vendor/modules.txt)
+RUNC_COMMIT := $(shell sed -n 's;^$(COMMENT) github.com/opencontainers/runc \([^ \n]*\).*$$;\1;p' vendor/modules.txt)
 LIBSECCOMP_COMMIT := release-2.3
 
 EXTRA_LDFLAGS ?=


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

In a couple of places, we were still calling `go` directly instead of through the `$(GO)` variable, which was a mistake.  Drop one of them entirely because the resulting value wasn't being used anywhere.

Update the definitions of CNI_COMMIT and RUNC_COMMIT to search `vendor/modules.txt` instead of `go.mod`, which can be overridden and which might therefore produce incorrect values.

#### How to verify it

Use `make GO=/path/to/other/version/of/go` to override how the Makefile invokes the Go compiler.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```