### PR TITLE
Fix stutters

### DIFF
--- a/add.go
+++ b/add.go
@@ -105,7 +105,7 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 	if lastModified != "" {
 		d, err := time.Parse(time.RFC1123, lastModified)
 		if err != nil {
-			return fmt.Errorf("error parsing last-modified time: %w", err)
+			return fmt.Errorf("parsing last-modified time: %w", err)
 		}
 		date = d
 	}
@@ -117,17 +117,17 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 		// we can figure out how much content there is.
 		f, err := ioutil.TempFile(mountpoint, "download")
 		if err != nil {
-			return fmt.Errorf("error creating temporary file to hold %q: %w", src, err)
+			return fmt.Errorf("creating temporary file to hold %q: %w", src, err)
 		}
 		defer os.Remove(f.Name())
 		defer f.Close()
 		size, err = io.Copy(f, response.Body)
 		if err != nil {
-			return fmt.Errorf("error writing %q to temporary file %q: %w", src, f.Name(), err)
+			return fmt.Errorf("writing %q to temporary file %q: %w", src, f.Name(), err)
 		}
 		_, err = f.Seek(0, io.SeekStart)
 		if err != nil {
-			return fmt.Errorf("error setting up to read %q from temporary file %q: %w", src, f.Name(), err)
+			return fmt.Errorf("setting up to read %q from temporary file %q: %w", src, f.Name(), err)
 		}
 		responseBody = f
 	}
@@ -155,11 +155,11 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 	}
 	err = tw.WriteHeader(&hdr)
 	if err != nil {
-		return fmt.Errorf("error writing header: %w", err)
+		return fmt.Errorf("writing header: %w", err)
 	}
 
 	if _, err := io.Copy(tw, responseBody); err != nil {
-		return fmt.Errorf("error writing content from %q to tar stream: %w", src, err)
+		return fmt.Errorf("writing content from %q to tar stream: %w", src, err)
 	}
 
 	return nil
@@ -208,13 +208,13 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		contextDir = string(os.PathSeparator)
 		currentDir, err = os.Getwd()
 		if err != nil {
-			return fmt.Errorf("error determining current working directory: %w", err)
+			return fmt.Errorf("determining current working directory: %w", err)
 		}
 	} else {
 		if !filepath.IsAbs(options.ContextDir) {
 			contextDir, err = filepath.Abs(options.ContextDir)
 			if err != nil {
-				return fmt.Errorf("error converting context directory path %q to an absolute path: %w", options.ContextDir, err)
+				return fmt.Errorf("converting context directory path %q to an absolute path: %w", options.ContextDir, err)
 			}
 		}
 	}
@@ -273,14 +273,14 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	if options.Chown != "" {
 		userUID, userGID, err = b.userForCopy(mountPoint, options.Chown)
 		if err != nil {
-			return fmt.Errorf("error looking up UID/GID for %q: %w", options.Chown, err)
+			return fmt.Errorf("looking up UID/GID for %q: %w", options.Chown, err)
 		}
 	}
 	var chmodDirsFiles *os.FileMode
 	if options.Chmod != "" {
 		p, err := strconv.ParseUint(options.Chmod, 8, 32)
 		if err != nil {
-			return fmt.Errorf("error parsing chmod %q: %w", options.Chmod, err)
+			return fmt.Errorf("parsing chmod %q: %w", options.Chmod, err)
 		}
 		perm := os.FileMode(p)
 		chmodDirsFiles = &perm
@@ -332,7 +332,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	}
 	destStats, err := copier.Stat(mountPoint, filepath.Join(mountPoint, b.WorkDir()), statOptions, []string{extractDirectory})
 	if err != nil {
-		return fmt.Errorf("error checking on destination %v: %w", extractDirectory, err)
+		return fmt.Errorf("checking on destination %v: %w", extractDirectory, err)
 	}
 	if (len(destStats) == 0 || len(destStats[0].Globbed) == 0) && !destMustBeDirectory && destCanBeFile {
 		// destination doesn't exist - extract to parent and rename the incoming file to the destination's name
@@ -357,7 +357,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 
 	pm, err := fileutils.NewPatternMatcher(options.Excludes)
 	if err != nil {
-		return fmt.Errorf("error processing excludes list %v: %w", options.Excludes, err)
+		return fmt.Errorf("processing excludes list %v: %w", options.Excludes, err)
 	}
 
 	// Make sure that, if it's a symlink, we'll chroot to the target of the link;
@@ -365,7 +365,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	evalOptions := copier.EvalOptions{}
 	evaluated, err := copier.Eval(mountPoint, extractDirectory, evalOptions)
 	if err != nil {
-		return fmt.Errorf("error checking on destination %v: %w", extractDirectory, err)
+		return fmt.Errorf("checking on destination %v: %w", extractDirectory, err)
 	}
 	extractDirectory = evaluated
 
@@ -383,7 +383,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		ChownNew: chownDirs,
 	}
 	if err := copier.Mkdir(mountPoint, extractDirectory, mkdirOptions); err != nil {
-		return fmt.Errorf("error ensuring target directory exists: %w", err)
+		return fmt.Errorf("ensuring target directory exists: %w", err)
 	}
 
 	// Copy each source in turn.
@@ -427,10 +427,10 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			}()
 			wg.Wait()
 			if getErr != nil {
-				getErr = fmt.Errorf("error reading %q: %w", src, getErr)
+				getErr = fmt.Errorf("reading %q: %w", src, getErr)
 			}
 			if putErr != nil {
-				putErr = fmt.Errorf("error storing %q: %w", src, putErr)
+				putErr = fmt.Errorf("storing %q: %w", src, putErr)
 			}
 			multiErr = multierror.Append(getErr, putErr)
 			if multiErr != nil && multiErr.ErrorOrNil() != nil {
@@ -459,7 +459,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		for _, glob := range localSourceStat.Globbed {
 			rel, err := filepath.Rel(contextDir, glob)
 			if err != nil {
-				return fmt.Errorf("error computing path of %q relative to %q: %w", glob, contextDir, err)
+				return fmt.Errorf("computing path of %q relative to %q: %w", glob, contextDir, err)
 			}
 			if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 				return fmt.Errorf("possible escaping context directory error: %q is outside of %q", glob, contextDir)
@@ -468,7 +468,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			if rel != "." {
 				excluded, err := pm.Matches(filepath.ToSlash(rel)) // nolint:staticcheck
 				if err != nil {
-					return fmt.Errorf("error checking if %q(%q) is excluded: %w", glob, rel, err)
+					return fmt.Errorf("checking if %q(%q) is excluded: %w", glob, rel, err)
 				}
 				if excluded {
 					// non-directories that are excluded are excluded, no question, but
@@ -562,16 +562,16 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			}()
 			wg.Wait()
 			if getErr != nil {
-				getErr = fmt.Errorf("error reading %q: %w", src, getErr)
+				getErr = fmt.Errorf("reading %q: %w", src, getErr)
 			}
 			if closeErr != nil {
-				closeErr = fmt.Errorf("error closing %q: %w", src, closeErr)
+				closeErr = fmt.Errorf("closing %q: %w", src, closeErr)
 			}
 			if renameErr != nil {
-				renameErr = fmt.Errorf("error renaming %q: %w", src, renameErr)
+				renameErr = fmt.Errorf("renaming %q: %w", src, renameErr)
 			}
 			if putErr != nil {
-				putErr = fmt.Errorf("error storing %q: %w", src, putErr)
+				putErr = fmt.Errorf("storing %q: %w", src, putErr)
 			}
 			multiErr = multierror.Append(getErr, closeErr, renameErr, putErr)
 			if multiErr != nil && multiErr.ErrorOrNil() != nil {

--- a/buildah.go
+++ b/buildah.go
@@ -408,7 +408,7 @@ func OpenBuilder(store storage.Store, container string) (*Builder, error) {
 	}
 	b := &Builder{}
 	if err = json.Unmarshal(buildstate, &b); err != nil {
-		return nil, fmt.Errorf("error parsing %q, read from %q: %w", string(buildstate), filepath.Join(cdir, stateFile), err)
+		return nil, fmt.Errorf("parsing %q, read from %q: %w", string(buildstate), filepath.Join(cdir, stateFile), err)
 	}
 	if b.Type != containerType {
 		return nil, fmt.Errorf("container %q is not a %s container (is a %q container)", container, define.Package, b.Type)
@@ -484,7 +484,7 @@ func OpenAllBuilders(store storage.Store) (builders []*Builder, err error) {
 		buildstate, err := ioutil.ReadFile(filepath.Join(cdir, stateFile))
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				logrus.Debugf("error reading %q: %v, ignoring container %q", filepath.Join(cdir, stateFile), err, container.ID)
+				logrus.Debugf("%v, ignoring container %q", err, container.ID)
 				continue
 			}
 			return nil, err
@@ -520,7 +520,7 @@ func (b *Builder) Save() error {
 		return err
 	}
 	if err = ioutils.AtomicWriteFile(filepath.Join(cdir, stateFile), buildstate, 0600); err != nil {
-		return fmt.Errorf("error saving builder state to %q: %w", filepath.Join(cdir, stateFile), err)
+		return fmt.Errorf("saving builder state to %q: %w", filepath.Join(cdir, stateFile), err)
 	}
 	return nil
 }

--- a/chroot/pty_ptmx.go
+++ b/chroot/pty_ptmx.go
@@ -18,28 +18,28 @@ func getPtyDescriptors() (int, int, error) {
 	// Create a pseudo-terminal -- open a copy of the master side.
 	controlFd, err := unix.Open("/dev/ptmx", os.O_RDWR, 0600)
 	if err != nil {
-		return -1, -1, fmt.Errorf("error opening PTY master using /dev/ptmx: %v", err)
+		return -1, -1, fmt.Errorf("opening PTY master using /dev/ptmx: %v", err)
 	}
 	// Set the kernel's lock to "unlocked".
 	locked := 0
 	if result, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(controlFd), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&locked))); int(result) == -1 {
-		return -1, -1, fmt.Errorf("error unlocking PTY descriptor: %v", err)
+		return -1, -1, fmt.Errorf("unlocking PTY descriptor: %v", err)
 	}
 	// Get a handle for the other end.
 	ptyFd, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(controlFd), unix.TIOCGPTPEER, unix.O_RDWR|unix.O_NOCTTY)
 	if int(ptyFd) == -1 {
 		if errno, isErrno := err.(syscall.Errno); !isErrno || (errno != syscall.EINVAL && errno != syscall.ENOTTY) {
-			return -1, -1, fmt.Errorf("error getting PTY descriptor: %v", err)
+			return -1, -1, fmt.Errorf("getting PTY descriptor: %v", err)
 		}
 		// EINVAL means the kernel's too old to understand TIOCGPTPEER.  Try TIOCGPTN.
 		ptyN, err := unix.IoctlGetInt(controlFd, unix.TIOCGPTN)
 		if err != nil {
-			return -1, -1, fmt.Errorf("error getting PTY number: %v", err)
+			return -1, -1, fmt.Errorf("getting PTY number: %v", err)
 		}
 		ptyName := fmt.Sprintf("/dev/pts/%d", ptyN)
 		fd, err := unix.Open(ptyName, unix.O_RDWR|unix.O_NOCTTY, 0620)
 		if err != nil {
-			return -1, -1, fmt.Errorf("error opening PTY %q: %v", ptyName, err)
+			return -1, -1, fmt.Errorf("opening PTY %q: %v", ptyName, err)
 		}
 		ptyFd = uintptr(fd)
 	}

--- a/chroot/run_common.go
+++ b/chroot/run_common.go
@@ -74,7 +74,7 @@ func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reade
 		return err
 	}
 	if err = ioutils.AtomicWriteFile(filepath.Join(bundlePath, "config.json"), specbytes, 0600); err != nil {
-		return fmt.Errorf("error storing runtime configuration: %w", err)
+		return fmt.Errorf("storing runtime configuration: %w", err)
 	}
 	logrus.Debugf("config = %v", string(specbytes))
 
@@ -92,14 +92,14 @@ func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reade
 	// Create a pipe for passing configuration down to the next process.
 	preader, pwriter, err := os.Pipe()
 	if err != nil {
-		return fmt.Errorf("error creating configuration pipe: %w", err)
+		return fmt.Errorf("creating configuration pipe: %w", err)
 	}
 	config, conferr := json.Marshal(runUsingChrootSubprocOptions{
 		Spec:       spec,
 		BundlePath: bundlePath,
 	})
 	if conferr != nil {
-		return fmt.Errorf("error encoding configuration for %q: %w", runUsingChrootCommand, conferr)
+		return fmt.Errorf("encoding configuration for %q: %w", runUsingChrootCommand, conferr)
 	}
 
 	// Set our terminal's mode to raw, to pass handling of special
@@ -488,7 +488,7 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 	// Create a pipe for passing configuration down to the next process.
 	preader, pwriter, err := os.Pipe()
 	if err != nil {
-		return 1, fmt.Errorf("error creating configuration pipe: %w", err)
+		return 1, fmt.Errorf("creating configuration pipe: %w", err)
 	}
 	config, conferr := json.Marshal(runUsingChrootExecSubprocOptions{
 		Spec:       spec,
@@ -514,7 +514,7 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 	}
 	cmd.ExtraFiles = append([]*os.File{preader}, cmd.ExtraFiles...)
 	if err := setPlatformUnshareOptions(spec, cmd); err != nil {
-		return 1, fmt.Errorf("error setting platform unshare options: %w", err)
+		return 1, fmt.Errorf("setting platform unshare options: %w", err)
 
 	}
 	interrupted := make(chan os.Signal, 100)
@@ -778,7 +778,7 @@ func parseRlimits(spec *specs.Spec) (map[int]unix.Rlimit, error) {
 	for _, limit := range spec.Process.Rlimits {
 		resource, recognized := rlimitsMap[strings.ToUpper(limit.Type)]
 		if !recognized {
-			return nil, fmt.Errorf("error parsing limit type %q", limit.Type)
+			return nil, fmt.Errorf("parsing limit type %q", limit.Type)
 		}
 		parsed[resource] = makeRlimit(limit)
 	}
@@ -795,7 +795,7 @@ func setRlimits(spec *specs.Spec, onlyLower, onlyRaise bool) error {
 	for resource, desired := range limits {
 		var current unix.Rlimit
 		if err := unix.Getrlimit(resource, &current); err != nil {
-			return fmt.Errorf("error reading %q limit: %w", rlimitsReverseMap[resource], err)
+			return fmt.Errorf("reading %q limit: %w", rlimitsReverseMap[resource], err)
 		}
 		if desired.Max > current.Max && onlyLower {
 			// this would raise a hard limit, and we're only here to lower them
@@ -806,7 +806,7 @@ func setRlimits(spec *specs.Spec, onlyLower, onlyRaise bool) error {
 			continue
 		}
 		if err := unix.Setrlimit(resource, &desired); err != nil {
-			return fmt.Errorf("error setting %q limit to soft=%d,hard=%d (was soft=%d,hard=%d): %w", rlimitsReverseMap[resource], desired.Cur, desired.Max, current.Cur, current.Max, err)
+			return fmt.Errorf("setting %q limit to soft=%d,hard=%d (was soft=%d,hard=%d): %w", rlimitsReverseMap[resource], desired.Cur, desired.Max, current.Cur, current.Max, err)
 		}
 	}
 	return nil

--- a/chroot/run_linux.go
+++ b/chroot/run_linux.go
@@ -158,7 +158,7 @@ func setApparmorProfile(spec *specs.Spec) error {
 		return nil
 	}
 	if err := apparmor.ApplyProfile(spec.Process.ApparmorProfile); err != nil {
-		return fmt.Errorf("error setting apparmor profile to %q: %w", spec.Process.ApparmorProfile, err)
+		return fmt.Errorf("setting apparmor profile to %q: %w", spec.Process.ApparmorProfile, err)
 	}
 	return nil
 }
@@ -167,14 +167,14 @@ func setApparmorProfile(spec *specs.Spec) error {
 func setCapabilities(spec *specs.Spec, keepCaps ...string) error {
 	currentCaps, err := capability.NewPid2(0)
 	if err != nil {
-		return fmt.Errorf("error reading capabilities of current process: %w", err)
+		return fmt.Errorf("reading capabilities of current process: %w", err)
 	}
 	if err := currentCaps.Load(); err != nil {
-		return fmt.Errorf("error loading capabilities: %w", err)
+		return fmt.Errorf("loading capabilities: %w", err)
 	}
 	caps, err := capability.NewPid2(0)
 	if err != nil {
-		return fmt.Errorf("error reading capabilities of current process: %w", err)
+		return fmt.Errorf("reading capabilities of current process: %w", err)
 	}
 	capMap := map[capability.CapType][]string{
 		capability.BOUNDING:    spec.Process.Capabilities.Bounding,
@@ -195,7 +195,7 @@ func setCapabilities(spec *specs.Spec, keepCaps ...string) error {
 				}
 			}
 			if cap == noCap {
-				return fmt.Errorf("error mapping capability %q to a number", capToSet)
+				return fmt.Errorf("mapping capability %q to a number", capToSet)
 			}
 			caps.Set(capType, cap)
 		}
@@ -208,7 +208,7 @@ func setCapabilities(spec *specs.Spec, keepCaps ...string) error {
 				}
 			}
 			if cap == noCap {
-				return fmt.Errorf("error mapping capability %q to a number", capToSet)
+				return fmt.Errorf("mapping capability %q to a number", capToSet)
 			}
 			if currentCaps.Get(capType, cap) {
 				caps.Set(capType, cap)
@@ -216,7 +216,7 @@ func setCapabilities(spec *specs.Spec, keepCaps ...string) error {
 		}
 	}
 	if err = caps.Apply(capability.CAPS | capability.BOUNDS | capability.AMBS); err != nil {
-		return fmt.Errorf("error setting capabilities: %w", err)
+		return fmt.Errorf("setting capabilities: %w", err)
 	}
 	return nil
 }
@@ -233,11 +233,11 @@ func makeReadOnly(mntpoint string, flags uintptr) error {
 	var fs unix.Statfs_t
 	// Make sure it's read-only.
 	if err := unix.Statfs(mntpoint, &fs); err != nil {
-		return fmt.Errorf("error checking if directory %q was bound read-only: %w", mntpoint, err)
+		return fmt.Errorf("checking if directory %q was bound read-only: %w", mntpoint, err)
 	}
 	if fs.Flags&unix.ST_RDONLY == 0 {
 		if err := unix.Mount(mntpoint, mntpoint, "bind", flags|unix.MS_REMOUNT, ""); err != nil {
-			return fmt.Errorf("error remounting %s in mount namespace read-only: %w", mntpoint, err)
+			return fmt.Errorf("remounting %s in mount namespace read-only: %w", mntpoint, err)
 		}
 	}
 	return nil
@@ -283,16 +283,16 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			}
 		}
 		if err != nil {
-			return undoBinds, fmt.Errorf("error bind mounting /dev from host into mount namespace: %w", err)
+			return undoBinds, fmt.Errorf("bind mounting /dev from host into mount namespace: %w", err)
 		}
 	}
 	// Make sure it's read-only.
 	if err = unix.Statfs(subDev, &fs); err != nil {
-		return undoBinds, fmt.Errorf("error checking if directory %q was bound read-only: %w", subDev, err)
+		return undoBinds, fmt.Errorf("checking if directory %q was bound read-only: %w", subDev, err)
 	}
 	if fs.Flags&unix.ST_RDONLY == 0 {
 		if err := unix.Mount(subDev, subDev, "bind", devFlags|unix.MS_REMOUNT, ""); err != nil {
-			return undoBinds, fmt.Errorf("error remounting /dev in mount namespace read-only: %w", err)
+			return undoBinds, fmt.Errorf("remounting /dev in mount namespace read-only: %w", err)
 		}
 	}
 	logrus.Debugf("bind mounted %q to %q", "/dev", filepath.Join(spec.Root.Path, "/dev"))
@@ -307,7 +307,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			}
 		}
 		if err != nil {
-			return undoBinds, fmt.Errorf("error bind mounting /proc from host into mount namespace: %w", err)
+			return undoBinds, fmt.Errorf("bind mounting /proc from host into mount namespace: %w", err)
 		}
 	}
 	logrus.Debugf("bind mounted %q to %q", "/proc", filepath.Join(spec.Root.Path, "/proc"))
@@ -322,7 +322,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			}
 		}
 		if err != nil {
-			return undoBinds, fmt.Errorf("error bind mounting /sys from host into mount namespace: %w", err)
+			return undoBinds, fmt.Errorf("bind mounting /sys from host into mount namespace: %w", err)
 		}
 	}
 	if err := makeReadOnly(subSys, sysFlags); err != nil {
@@ -380,14 +380,14 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 		case "bind":
 			srcinfo, err = os.Stat(m.Source)
 			if err != nil {
-				return undoBinds, fmt.Errorf("error examining %q for mounting in mount namespace: %w", m.Source, err)
+				return undoBinds, fmt.Errorf("examining %q for mounting in mount namespace: %w", m.Source, err)
 			}
 		case "overlay":
 			fallthrough
 		case "tmpfs":
 			srcinfo, err = os.Stat("/")
 			if err != nil {
-				return undoBinds, fmt.Errorf("error examining / to use as a template for a %s: %w", m.Type, err)
+				return undoBinds, fmt.Errorf("examining / to use as a template for a %s: %w", m.Type, err)
 			}
 		}
 		target := filepath.Join(spec.Root.Path, m.Destination)
@@ -405,20 +405,20 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 		if err != nil {
 			// If the target can't be stat()ted, check the error.
 			if !errors.Is(err, os.ErrNotExist) {
-				return undoBinds, fmt.Errorf("error examining %q for mounting in mount namespace: %w", target, err)
+				return undoBinds, fmt.Errorf("examining %q for mounting in mount namespace: %w", target, err)
 			}
 			// The target isn't there yet, so create it.
 			if srcinfo.IsDir() {
 				if err = os.MkdirAll(target, 0755); err != nil {
-					return undoBinds, fmt.Errorf("error creating mountpoint %q in mount namespace: %w", target, err)
+					return undoBinds, fmt.Errorf("creating mountpoint %q in mount namespace: %w", target, err)
 				}
 			} else {
 				if err = os.MkdirAll(filepath.Dir(target), 0755); err != nil {
-					return undoBinds, fmt.Errorf("error ensuring parent of mountpoint %q (%q) is present in mount namespace: %w", target, filepath.Dir(target), err)
+					return undoBinds, fmt.Errorf("ensuring parent of mountpoint %q (%q) is present in mount namespace: %w", target, filepath.Dir(target), err)
 				}
 				var file *os.File
 				if file, err = os.OpenFile(target, os.O_WRONLY|os.O_CREATE, 0755); err != nil {
-					return undoBinds, fmt.Errorf("error creating mountpoint %q in mount namespace: %w", target, err)
+					return undoBinds, fmt.Errorf("creating mountpoint %q in mount namespace: %w", target, err)
 				}
 				file.Close()
 			}
@@ -458,28 +458,28 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			// Do the bind mount.
 			logrus.Debugf("bind mounting %q on %q", m.Destination, filepath.Join(spec.Root.Path, m.Destination))
 			if err := unix.Mount(m.Source, target, "", requestFlags, ""); err != nil {
-				return undoBinds, fmt.Errorf("error bind mounting %q from host to %q in mount namespace (%q): %w", m.Source, m.Destination, target, err)
+				return undoBinds, fmt.Errorf("bind mounting %q from host to %q in mount namespace (%q): %w", m.Source, m.Destination, target, err)
 			}
 			logrus.Debugf("bind mounted %q to %q", m.Source, target)
 		case "tmpfs":
 			// Mount a tmpfs.
 			if err := mount.Mount(m.Source, target, m.Type, strings.Join(append(m.Options, "private"), ",")); err != nil {
-				return undoBinds, fmt.Errorf("error mounting tmpfs to %q in mount namespace (%q, %q): %w", m.Destination, target, strings.Join(m.Options, ","), err)
+				return undoBinds, fmt.Errorf("mounting tmpfs to %q in mount namespace (%q, %q): %w", m.Destination, target, strings.Join(m.Options, ","), err)
 			}
 			logrus.Debugf("mounted a tmpfs to %q", target)
 		case "overlay":
 			// Mount a overlay.
 			if err := mount.Mount(m.Source, target, m.Type, strings.Join(append(m.Options, "private"), ",")); err != nil {
-				return undoBinds, fmt.Errorf("error mounting overlay to %q in mount namespace (%q, %q): %w", m.Destination, target, strings.Join(m.Options, ","), err)
+				return undoBinds, fmt.Errorf("mounting overlay to %q in mount namespace (%q, %q): %w", m.Destination, target, strings.Join(m.Options, ","), err)
 			}
 			logrus.Debugf("mounted a overlay to %q", target)
 		}
 		if err = unix.Statfs(target, &fs); err != nil {
-			return undoBinds, fmt.Errorf("error checking if directory %q was bound read-only: %w", target, err)
+			return undoBinds, fmt.Errorf("checking if directory %q was bound read-only: %w", target, err)
 		}
 		if uintptr(fs.Flags)&expectedFlags != expectedFlags {
 			if err := unix.Mount(target, target, "bind", requestFlags|unix.MS_REMOUNT, ""); err != nil {
-				return undoBinds, fmt.Errorf("error remounting %q in mount namespace with expected flags: %w", target, err)
+				return undoBinds, fmt.Errorf("remounting %q in mount namespace with expected flags: %w", target, err)
 			}
 		}
 	}
@@ -494,7 +494,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 				// No target, no problem.
 				continue
 			}
-			return undoBinds, fmt.Errorf("error checking %q for symlinks before marking it read-only: %w", r, err)
+			return undoBinds, fmt.Errorf("checking %q for symlinks before marking it read-only: %w", r, err)
 		}
 		// Check if the location is already read-only.
 		var fs unix.Statfs_t
@@ -503,7 +503,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 				// No target, no problem.
 				continue
 			}
-			return undoBinds, fmt.Errorf("error checking if directory %q is already read-only: %w", target, err)
+			return undoBinds, fmt.Errorf("checking if directory %q is already read-only: %w", target, err)
 		}
 		if fs.Flags&unix.ST_RDONLY != 0 {
 			continue
@@ -515,23 +515,23 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 				// No target, no problem.
 				continue
 			}
-			return undoBinds, fmt.Errorf("error bind mounting %q onto itself in preparation for making it read-only: %w", target, err)
+			return undoBinds, fmt.Errorf("bind mounting %q onto itself in preparation for making it read-only: %w", target, err)
 		}
 		// Remount the location read-only.
 		if err = unix.Statfs(target, &fs); err != nil {
-			return undoBinds, fmt.Errorf("error checking if directory %q was bound read-only: %w", target, err)
+			return undoBinds, fmt.Errorf("checking if directory %q was bound read-only: %w", target, err)
 		}
 		if fs.Flags&unix.ST_RDONLY == 0 {
 			if err := unix.Mount(target, target, "", roFlags|unix.MS_BIND|unix.MS_REMOUNT, ""); err != nil {
-				return undoBinds, fmt.Errorf("error remounting %q in mount namespace read-only: %w", target, err)
+				return undoBinds, fmt.Errorf("remounting %q in mount namespace read-only: %w", target, err)
 			}
 		}
 		// Check again.
 		if err = unix.Statfs(target, &fs); err != nil {
-			return undoBinds, fmt.Errorf("error checking if directory %q was remounted read-only: %w", target, err)
+			return undoBinds, fmt.Errorf("checking if directory %q was remounted read-only: %w", target, err)
 		}
 		if fs.Flags&unix.ST_RDONLY == 0 {
-			return undoBinds, fmt.Errorf("error verifying that %q in mount namespace was remounted read-only: %w", target, err)
+			return undoBinds, fmt.Errorf("verifying that %q in mount namespace was remounted read-only: %w", target, err)
 		}
 	}
 
@@ -539,7 +539,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	roEmptyDir := filepath.Join(bundlePath, "empty")
 	if len(spec.Linux.MaskedPaths) > 0 {
 		if err := os.Mkdir(roEmptyDir, 0700); err != nil {
-			return undoBinds, fmt.Errorf("error creating empty directory %q: %w", roEmptyDir, err)
+			return undoBinds, fmt.Errorf("creating empty directory %q: %w", roEmptyDir, err)
 		}
 	}
 
@@ -560,19 +560,19 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 				// No target, no problem.
 				continue
 			}
-			return undoBinds, fmt.Errorf("error examining %q for masking in mount namespace: %w", target, err)
+			return undoBinds, fmt.Errorf("examining %q for masking in mount namespace: %w", target, err)
 		}
 		if targetinfo.IsDir() {
 			// The target's a directory.  Check if it's a read-only filesystem.
 			var statfs unix.Statfs_t
 			if err = unix.Statfs(target, &statfs); err != nil {
-				return undoBinds, fmt.Errorf("error checking if directory %q is a mountpoint: %w", target, err)
+				return undoBinds, fmt.Errorf("checking if directory %q is a mountpoint: %w", target, err)
 			}
 			isReadOnly := statfs.Flags&unix.MS_RDONLY != 0
 			// Check if any of the IDs we're mapping could read it.
 			var stat unix.Stat_t
 			if err = unix.Stat(target, &stat); err != nil {
-				return undoBinds, fmt.Errorf("error checking permissions on directory %q: %w", target, err)
+				return undoBinds, fmt.Errorf("checking permissions on directory %q: %w", target, err)
 			}
 			isAccessible := false
 			if stat.Mode&unix.S_IROTH|unix.S_IXOTH != 0 {
@@ -603,13 +603,13 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			directory, err := os.Open(target)
 			if err != nil {
 				if !os.IsPermission(err) {
-					return undoBinds, fmt.Errorf("error opening directory %q: %w", target, err)
+					return undoBinds, fmt.Errorf("opening directory %q: %w", target, err)
 				}
 			} else {
 				names, err := directory.Readdirnames(0)
 				directory.Close()
 				if err != nil {
-					return undoBinds, fmt.Errorf("error reading contents of directory %q: %w", target, err)
+					return undoBinds, fmt.Errorf("reading contents of directory %q: %w", target, err)
 				}
 				hasContent = false
 				for _, name := range names {
@@ -628,14 +628,14 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			roFlags := uintptr(syscall.MS_BIND | syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC | syscall.MS_RDONLY)
 			if !isReadOnly || (hasContent && isAccessible) {
 				if err = unix.Mount(roEmptyDir, target, "bind", roFlags, ""); err != nil {
-					return undoBinds, fmt.Errorf("error masking directory %q in mount namespace: %w", target, err)
+					return undoBinds, fmt.Errorf("masking directory %q in mount namespace: %w", target, err)
 				}
 				if err = unix.Statfs(target, &fs); err != nil {
-					return undoBinds, fmt.Errorf("error checking if directory %q was mounted read-only in mount namespace: %w", target, err)
+					return undoBinds, fmt.Errorf("checking if directory %q was mounted read-only in mount namespace: %w", target, err)
 				}
 				if fs.Flags&unix.ST_RDONLY == 0 {
 					if err = unix.Mount(target, target, "", roFlags|syscall.MS_REMOUNT, ""); err != nil {
-						return undoBinds, fmt.Errorf("error making sure directory %q in mount namespace is read only: %w", target, err)
+						return undoBinds, fmt.Errorf("making sure directory %q in mount namespace is read only: %w", target, err)
 					}
 				}
 			}
@@ -643,7 +643,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			// If the target's is not a directory or os.DevNull, bind mount os.DevNull over it.
 			if !isDevNull(targetinfo) {
 				if err = unix.Mount(os.DevNull, target, "", uintptr(syscall.MS_BIND|syscall.MS_RDONLY|syscall.MS_PRIVATE), ""); err != nil {
-					return undoBinds, fmt.Errorf("error masking non-directory %q in mount namespace: %w", target, err)
+					return undoBinds, fmt.Errorf("masking non-directory %q in mount namespace: %w", target, err)
 				}
 			}
 		}

--- a/chroot/seccomp.go
+++ b/chroot/seccomp.go
@@ -111,11 +111,11 @@ func setSeccomp(spec *specs.Spec) error {
 
 	filter, err := libseccomp.NewFilter(mapAction(spec.Linux.Seccomp.DefaultAction, spec.Linux.Seccomp.DefaultErrnoRet))
 	if err != nil {
-		return fmt.Errorf("error creating seccomp filter with default action %q: %w", spec.Linux.Seccomp.DefaultAction, err)
+		return fmt.Errorf("creating seccomp filter with default action %q: %w", spec.Linux.Seccomp.DefaultAction, err)
 	}
 	for _, arch := range spec.Linux.Seccomp.Architectures {
 		if err = filter.AddArch(mapArch(arch)); err != nil {
-			return fmt.Errorf("error adding architecture %q(%q) to seccomp filter: %w", arch, mapArch(arch), err)
+			return fmt.Errorf("adding architecture %q(%q) to seccomp filter: %w", arch, mapArch(arch), err)
 		}
 	}
 	for _, rule := range spec.Linux.Seccomp.Syscalls {
@@ -131,7 +131,7 @@ func setSeccomp(spec *specs.Spec) error {
 		for scnum := range scnames {
 			if len(rule.Args) == 0 {
 				if err = filter.AddRule(scnum, mapAction(rule.Action, rule.ErrnoRet)); err != nil {
-					return fmt.Errorf("error adding a rule (%q:%q) to seccomp filter: %w", scnames[scnum], rule.Action, err)
+					return fmt.Errorf("adding a rule (%q:%q) to seccomp filter: %w", scnames[scnum], rule.Action, err)
 				}
 				continue
 			}
@@ -140,7 +140,7 @@ func setSeccomp(spec *specs.Spec) error {
 			for _, arg := range rule.Args {
 				condition, err := libseccomp.MakeCondition(arg.Index, mapOp(arg.Op), arg.Value, arg.ValueTwo)
 				if err != nil {
-					return fmt.Errorf("error building a seccomp condition %d:%v:%d:%d: %w", arg.Index, arg.Op, arg.Value, arg.ValueTwo, err)
+					return fmt.Errorf("building a seccomp condition %d:%v:%d:%d: %w", arg.Index, arg.Op, arg.Value, arg.ValueTwo, err)
 				}
 				if arg.Op != specs.OpEqualTo {
 					opsAreAllEquality = false
@@ -156,22 +156,22 @@ func setSeccomp(spec *specs.Spec) error {
 				if len(rule.Args) > 1 && opsAreAllEquality && err.Error() == "two checks on same syscall argument" {
 					for i := range conditions {
 						if err = filter.AddRuleConditional(scnum, mapAction(rule.Action, rule.ErrnoRet), conditions[i:i+1]); err != nil {
-							return fmt.Errorf("error adding a conditional rule (%q:%q[%d]) to seccomp filter: %w", scnames[scnum], rule.Action, i, err)
+							return fmt.Errorf("adding a conditional rule (%q:%q[%d]) to seccomp filter: %w", scnames[scnum], rule.Action, i, err)
 						}
 					}
 				} else {
-					return fmt.Errorf("error adding a conditional rule (%q:%q) to seccomp filter: %w", scnames[scnum], rule.Action, err)
+					return fmt.Errorf("adding a conditional rule (%q:%q) to seccomp filter: %w", scnames[scnum], rule.Action, err)
 				}
 			}
 		}
 	}
 	if err = filter.SetNoNewPrivsBit(spec.Process.NoNewPrivileges); err != nil {
-		return fmt.Errorf("error setting no-new-privileges bit to %v: %w", spec.Process.NoNewPrivileges, err)
+		return fmt.Errorf("setting no-new-privileges bit to %v: %w", spec.Process.NoNewPrivileges, err)
 	}
 	err = filter.Load()
 	filter.Release()
 	if err != nil {
-		return fmt.Errorf("error activating seccomp filter: %w", err)
+		return fmt.Errorf("activating seccomp filter: %w", err)
 	}
 	return nil
 }
@@ -189,7 +189,7 @@ func setupSeccomp(spec *specs.Spec, seccompProfilePath string) error {
 	default:
 		seccompProfile, err := ioutil.ReadFile(seccompProfilePath)
 		if err != nil {
-			return fmt.Errorf("opening seccomp profile (%s) failed: %w", seccompProfilePath, err)
+			return fmt.Errorf("opening seccomp profile failed: %w", err)
 		}
 		seccompConfig, err := seccomp.LoadProfile(string(seccompProfile), spec)
 		if err != nil {

--- a/chroot/selinux.go
+++ b/chroot/selinux.go
@@ -17,7 +17,7 @@ func setSelinuxLabel(spec *specs.Spec) error {
 	logrus.Debugf("setting selinux label")
 	if spec.Process.SelinuxLabel != "" && selinux.GetEnabled() {
 		if err := label.SetProcessLabel(spec.Process.SelinuxLabel); err != nil {
-			return fmt.Errorf("error setting process label to %q: %w", spec.Process.SelinuxLabel, err)
+			return fmt.Errorf("setting process label to %q: %w", spec.Process.SelinuxLabel, err)
 		}
 	}
 	return nil

--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -163,7 +163,7 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 		if from, err = openBuilder(getContext(), store, iopts.from); err != nil && errors.Is(err, storage.ErrContainerUnknown) {
 			systemContext, err2 := parse.SystemContextFromOptions(c)
 			if err2 != nil {
-				return fmt.Errorf("error building system context: %w", err2)
+				return fmt.Errorf("building system context: %w", err2)
 			}
 
 			decryptConfig, err2 := util.DecryptConfig(iopts.decryptionKeys)
@@ -201,11 +201,11 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 			}()
 		}
 		if err != nil {
-			return fmt.Errorf("error reading build container %q: %w", iopts.from, err)
+			return fmt.Errorf("reading build container %q: %w", iopts.from, err)
 		}
 		fromMountPoint, err := from.Mount(from.MountLabel)
 		if err != nil {
-			return fmt.Errorf("error mounting %q container %q: %w", iopts.from, from.Container, err)
+			return fmt.Errorf("mounting %q container %q: %w", iopts.from, from.Container, err)
 		}
 		unmountFrom = true
 		defer func() {
@@ -228,7 +228,7 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 
 	builder, err := openBuilder(getContext(), store, name)
 	if err != nil {
-		return fmt.Errorf("error reading build container %q: %w", name, err)
+		return fmt.Errorf("reading build container %q: %w", name, err)
 	}
 
 	builder.ContentDigester.Restart()
@@ -252,20 +252,20 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 	extractLocalArchives := verb == "ADD"
 	err = builder.Add(dest, extractLocalArchives, options, args...)
 	if err != nil {
-		return fmt.Errorf("error adding content to container %q: %w", builder.Container, err)
+		return fmt.Errorf("adding content to container %q: %w", builder.Container, err)
 	}
 	if unmountFrom {
 		if err := from.Unmount(); err != nil {
-			return fmt.Errorf("error unmounting %q container %q: %w", iopts.from, from.Container, err)
+			return fmt.Errorf("unmounting %q container %q: %w", iopts.from, from.Container, err)
 		}
 		if err := from.Save(); err != nil {
-			return fmt.Errorf("error saving information about %q container %q: %w", iopts.from, from.Container, err)
+			return fmt.Errorf("saving information about %q container %q: %w", iopts.from, from.Container, err)
 		}
 		unmountFrom = false
 	}
 	if removeFrom {
 		if err := from.Delete(); err != nil {
-			return fmt.Errorf("error deleting %q temporary working container %q: %w", iopts.from, from.Container, err)
+			return fmt.Errorf("deleting %q temporary working container %q: %w", iopts.from, from.Container, err)
 		}
 		removeFrom = false
 	}

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -166,12 +166,12 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 
 	builder, err := openBuilder(ctx, store, name)
 	if err != nil {
-		return fmt.Errorf("error reading build container %q: %w", name, err)
+		return fmt.Errorf("reading build container %q: %w", name, err)
 	}
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 
 	// If the user specified an image, we may need to massage it a bit if
@@ -183,11 +183,11 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 				return err2
 			}
 			if len(candidates) == 0 {
-				return fmt.Errorf("error parsing target image name %q", image)
+				return fmt.Errorf("parsing target image name %q", image)
 			}
 			dest2, err2 := storageTransport.Transport.ParseStoreReference(store, candidates[0].String())
 			if err2 != nil {
-				return fmt.Errorf("error parsing target image name %q: %w", image, err)
+				return fmt.Errorf("parsing target image name %q: %w", image, err)
 			}
 			dest = dest2
 		}
@@ -224,7 +224,7 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 		referenceFile := iopts.referenceTime
 		finfo, err := os.Stat(referenceFile)
 		if err != nil {
-			return fmt.Errorf("error reading timestamp of file %q: %w", referenceFile, err)
+			return fmt.Errorf("reading timestamp of file %q: %w", referenceFile, err)
 		}
 		timestamp := finfo.ModTime().UTC()
 		options.HistoryTimestamp = &timestamp
@@ -249,7 +249,7 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 	}
 	id, ref, _, err := builder.Commit(ctx, dest, options)
 	if err != nil {
-		return util.GetFailureCause(err, fmt.Errorf("error committing container %q to %q: %w", builder.Container, image, err))
+		return util.GetFailureCause(err, fmt.Errorf("committing container %q to %q: %w", builder.Container, image, err))
 	}
 	if ref != nil && id != "" {
 		logrus.Debugf("wrote image %s with ID %s", ref, id)

--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -131,7 +131,7 @@ func openBuilder(ctx context.Context, store storage.Store, name string) (builder
 		return nil, err
 	}
 	if builder == nil {
-		return nil, errors.New("error finding build container")
+		return nil, errors.New("finding build container")
 	}
 	return builder, nil
 }
@@ -150,7 +150,7 @@ func openImage(ctx context.Context, sc *types.SystemContext, store storage.Store
 		return nil, err
 	}
 	if builder == nil {
-		return nil, errors.New("error mocking up build configuration")
+		return nil, errors.New("mocking up build configuration")
 	}
 	return builder, nil
 }

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -117,7 +117,7 @@ func updateCmd(builder *buildah.Builder, cmd string) error {
 	}
 	cmdSpec, err := shellwords.Parse(cmd)
 	if err != nil {
-		return fmt.Errorf("error parsing --cmd %q: %w", cmd, err)
+		return fmt.Errorf("parsing --cmd %q: %w", cmd, err)
 	}
 	builder.SetCmd(cmdSpec)
 	return nil
@@ -203,7 +203,7 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 		shell := iopts.shell
 		shellSpec, err := shellwords.Parse(shell)
 		if err != nil {
-			return fmt.Errorf("error parsing --shell %q: %w", shell, err)
+			return fmt.Errorf("parsing --shell %q: %w", shell, err)
 		}
 		builder.SetShell(shellSpec)
 		conditionallyAddHistory(builder, c, "/bin/sh -c #(nop) SHELL %s", shell)
@@ -251,7 +251,7 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 		default:
 			value := os.Getenv(env[0])
 			if value == "" {
-				return fmt.Errorf("error setting env %q: no value given", env[0])
+				return fmt.Errorf("setting env %q: no value given", env[0])
 			}
 			builder.SetEnv(env[0], value)
 		}
@@ -363,14 +363,14 @@ func updateHealthcheck(builder *buildah.Builder, c *cobra.Command, iopts configR
 		if c.Flag("healthcheck").Changed {
 			test, err := shellwords.Parse(iopts.healthcheck)
 			if err != nil {
-				return fmt.Errorf("error parsing --healthcheck %q: %w", iopts.healthcheck, err)
+				return fmt.Errorf("parsing --healthcheck %q: %w", iopts.healthcheck, err)
 			}
 			healthcheck.Test = test
 		}
 		if c.Flag("healthcheck-interval").Changed {
 			duration, err := time.ParseDuration(iopts.healthcheckInterval)
 			if err != nil {
-				return fmt.Errorf("error parsing --healthcheck-interval %q: %w", iopts.healthcheckInterval, err)
+				return fmt.Errorf("parsing --healthcheck-interval %q: %w", iopts.healthcheckInterval, err)
 			}
 			healthcheck.Interval = duration
 			args = args + "--interval=" + iopts.healthcheckInterval + " "
@@ -384,7 +384,7 @@ func updateHealthcheck(builder *buildah.Builder, c *cobra.Command, iopts configR
 		if c.Flag("healthcheck-start-period").Changed {
 			duration, err := time.ParseDuration(iopts.healthcheckStartPeriod)
 			if err != nil {
-				return fmt.Errorf("error parsing --healthcheck-start-period %q: %w", iopts.healthcheckStartPeriod, err)
+				return fmt.Errorf("parsing --healthcheck-start-period %q: %w", iopts.healthcheckStartPeriod, err)
 			}
 			healthcheck.StartPeriod = duration
 			args = args + "--start-period=" + iopts.healthcheckStartPeriod + " "
@@ -392,7 +392,7 @@ func updateHealthcheck(builder *buildah.Builder, c *cobra.Command, iopts configR
 		if c.Flag("healthcheck-timeout").Changed {
 			duration, err := time.ParseDuration(iopts.healthcheckTimeout)
 			if err != nil {
-				return fmt.Errorf("error parsing --healthcheck-timeout %q: %w", iopts.healthcheckTimeout, err)
+				return fmt.Errorf("parsing --healthcheck-timeout %q: %w", iopts.healthcheckTimeout, err)
 			}
 			healthcheck.Timeout = duration
 			args = args + "--timeout=" + iopts.healthcheckTimeout + " "
@@ -427,7 +427,7 @@ func configCmd(c *cobra.Command, args []string, iopts configResults) error {
 
 	builder, err := openBuilder(getContext(), store, name)
 	if err != nil {
-		return fmt.Errorf("error reading build container %q: %w", name, err)
+		return fmt.Errorf("reading build container %q: %w", name, err)
 	}
 
 	if err := updateConfig(builder, c, iopts); err != nil {

--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -124,7 +124,7 @@ func containersCmd(c *cobra.Command, args []string, iopts containersResults) err
 	if c.Flag("filter").Changed {
 		params, err = parseCtrFilter(iopts.filter)
 		if err != nil {
-			return fmt.Errorf("error parsing filter: %w", err)
+			return fmt.Errorf("parsing filter: %w", err)
 		}
 	}
 
@@ -154,7 +154,7 @@ func outputContainers(store storage.Store, opts containerOptions, params *contai
 
 	builders, err := openBuilders(store)
 	if err != nil {
-		return fmt.Errorf("error reading build containers: %w", err)
+		return fmt.Errorf("reading build containers: %w", err)
 	}
 	var (
 		containerOutput []containerOutputParams
@@ -192,7 +192,7 @@ func outputContainers(store storage.Store, opts containerOptions, params *contai
 		}
 		containers, err2 := store.Containers()
 		if err2 != nil {
-			return fmt.Errorf("error reading list of all containers: %w", err2)
+			return fmt.Errorf("reading list of all containers: %w", err2)
 		}
 		for _, container := range containers {
 			name := ""
@@ -260,9 +260,9 @@ func containersToGeneric(templParams []containerOutputParams) (genericParams []i
 
 func containerOutputUsingTemplate(format string, params containerOutputParams) error {
 	if matched, err := regexp.MatchString("{{.*}}", format); err != nil {
-		return fmt.Errorf("error validating format provided: %s: %w", format, err)
+		return fmt.Errorf("validating format provided: %s: %w", format, err)
 	} else if !matched {
-		return fmt.Errorf("error invalid format provided: %s", format)
+		return fmt.Errorf("invalid format provided: %s", format)
 	}
 
 	tmpl, err := template.New("container").Parse(format)

--- a/cmd/buildah/containers_test.go
+++ b/cmd/buildah/containers_test.go
@@ -43,7 +43,7 @@ func TestContainerTemplateOutputInvalidFormat(t *testing.T) {
 	formatString := "ContainerID"
 
 	err := containerOutputUsingTemplate(formatString, params)
-	if err == nil || err.Error() != "error invalid format provided: ContainerID" {
+	if err == nil || err.Error() != "invalid format provided: ContainerID" {
 		t.Fatalf("expected error invalid format")
 	}
 }

--- a/cmd/buildah/dumpbolt.go
+++ b/cmd/buildah/dumpbolt.go
@@ -24,7 +24,7 @@ var (
 func dumpBoltCmd(c *cobra.Command, args []string) error {
 	db, err := bolt.Open(args[0], 0600, &bolt.Options{ReadOnly: true})
 	if err != nil {
-		return fmt.Errorf("error opening database %q: %w", args[0], err)
+		return fmt.Errorf("opening database %q: %w", args[0], err)
 	}
 	defer db.Close()
 

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -210,7 +210,7 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 	}
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 	platforms, err := parse.PlatformsFromOptions(c)
 	if err != nil {
@@ -269,11 +269,11 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 
 	namespaceOptions, networkPolicy, err := parse.NamespaceOptions(c)
 	if err != nil {
-		return fmt.Errorf("error parsing namespace-related options: %w", err)
+		return fmt.Errorf("parsing namespace-related options: %w", err)
 	}
 	usernsOption, idmappingOptions, err := parse.IDMappingOptions(c, isolation)
 	if err != nil {
-		return fmt.Errorf("error parsing ID mapping options: %w", err)
+		return fmt.Errorf("parsing ID mapping options: %w", err)
 	}
 	namespaceOptions.AddOrReplace(usernsOption...)
 

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -125,7 +125,7 @@ func imagesCmd(c *cobra.Command, args []string, iopts *imageResults) error {
 	}
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
 	if err != nil {

--- a/cmd/buildah/info.go
+++ b/cmd/buildah/info.go
@@ -52,7 +52,7 @@ func infoCmd(c *cobra.Command, iopts infoResults) error {
 
 	infoArr, err := buildah.Info(store)
 	if err != nil {
-		return fmt.Errorf("error getting info: %w", err)
+		return fmt.Errorf("getting info: %w", err)
 	}
 
 	if iopts.debug {
@@ -67,9 +67,9 @@ func infoCmd(c *cobra.Command, iopts infoResults) error {
 	if iopts.format != "" {
 		format := iopts.format
 		if matched, err := regexp.MatchString("{{.*}}", format); err != nil {
-			return fmt.Errorf("error validating format provided: %s: %w", format, err)
+			return fmt.Errorf("validating format provided: %s: %w", format, err)
 		} else if !matched {
-			return fmt.Errorf("error invalid format provided: %s", format)
+			return fmt.Errorf("invalid format provided: %s", format)
 		}
 		t, err := template.New("format").Parse(format)
 		if err != nil {

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -68,7 +68,7 @@ func inspectCmd(c *cobra.Command, args []string, iopts inspectResults) error {
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 
 	name := args[0]
@@ -85,7 +85,7 @@ func inspectCmd(c *cobra.Command, args []string, iopts inspectResults) error {
 		builder, err = openBuilder(ctx, store, name)
 		if err != nil {
 			if c.Flag("type").Changed {
-				return fmt.Errorf("error reading build container: %w", err)
+				return fmt.Errorf("reading build container: %w", err)
 			}
 			builder, err = openImage(ctx, systemContext, store, name)
 			if err != nil {
@@ -109,9 +109,9 @@ func inspectCmd(c *cobra.Command, args []string, iopts inspectResults) error {
 	if iopts.format != "" {
 		format := iopts.format
 		if matched, err := regexp.MatchString("{{.*}}", format); err != nil {
-			return fmt.Errorf("error validating format provided: %s: %w", format, err)
+			return fmt.Errorf("validating format provided: %s: %w", format, err)
 		} else if !matched {
-			return fmt.Errorf("error invalid format provided: %s", format)
+			return fmt.Errorf("invalid format provided: %s", format)
 		}
 		t, err := template.New("format").Parse(format)
 		if err != nil {

--- a/cmd/buildah/login.go
+++ b/cmd/buildah/login.go
@@ -60,7 +60,7 @@ func loginCmd(c *cobra.Command, args []string, iopts *loginReply) error {
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 	ctx := getContext()
 	iopts.loginOpts.GetLoginSet = c.Flag("get-login").Changed

--- a/cmd/buildah/logout.go
+++ b/cmd/buildah/logout.go
@@ -49,7 +49,7 @@ func logoutCmd(c *cobra.Command, args []string, iopts *auth.LogoutOptions) error
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 	return auth.Logout(systemContext, iopts, args)
 }

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -233,9 +233,9 @@ func main() {
 
 	if err := rootCmd.Execute(); err != nil {
 		if logrus.IsLevelEnabled(logrus.TraceLevel) {
-			fmt.Fprintf(os.Stderr, "%+v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
 		} else {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}
 		exitCode = cli.ExecErrorCodeGeneric
 		var ee *exec.ExitError

--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -264,7 +264,7 @@ func manifestExistsCmd(c *cobra.Command, args []string) error {
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
 	if err != nil {
@@ -296,7 +296,7 @@ func manifestCreateCmd(c *cobra.Command, args []string, opts manifestCreateOpts)
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
 	if err != nil {
@@ -308,7 +308,7 @@ func manifestCreateCmd(c *cobra.Command, args []string, opts manifestCreateOpts)
 
 	names, err := util.ExpandNames([]string{listImageSpec}, systemContext, store)
 	if err != nil {
-		return fmt.Errorf("error encountered while expanding image name %q: %w", listImageSpec, err)
+		return fmt.Errorf("encountered while expanding image name %q: %w", listImageSpec, err)
 	}
 	if manifestListID, err = list.SaveToImage(store, "", names, manifest.DockerV2ListMediaType); err != nil {
 		if errors.Is(err, storage.ErrDuplicateName) && opts.amend {
@@ -391,7 +391,7 @@ func manifestAddCmd(c *cobra.Command, args []string, opts manifestAddOpts) error
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
 	if err != nil {
@@ -516,7 +516,7 @@ func manifestRemoveCmd(c *cobra.Command, args []string, opts manifestRemoveOpts)
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 
 	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
@@ -545,7 +545,7 @@ func manifestRmCmd(c *cobra.Command, args []string) error {
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 
 	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
@@ -605,7 +605,7 @@ func manifestAnnotateCmd(c *cobra.Command, args []string, opts manifestAnnotateO
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
 	if err != nil {
@@ -717,7 +717,7 @@ func manifestInspectCmd(c *cobra.Command, args []string, opts manifestInspectOpt
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 
 	return manifestInspect(getContext(), store, systemContext, imageSpec)
@@ -733,7 +733,7 @@ func manifestInspect(ctx context.Context, store storage.Store, systemContext *ty
 		var b bytes.Buffer
 		err = json.Indent(&b, manifest, "", "    ")
 		if err != nil {
-			return fmt.Errorf("error rendering manifest for display: %w", err)
+			return fmt.Errorf("rendering manifest for display: %w", err)
 		}
 
 		fmt.Printf("%s\n", b.String())
@@ -774,7 +774,7 @@ func manifestInspect(ctx context.Context, store storage.Store, systemContext *ty
 		refs = append(refs, ref)
 	}
 	if len(refs) == 0 {
-		return fmt.Errorf("error locating images with names %v", imageSpec)
+		return fmt.Errorf("locating images with names %v", imageSpec)
 	}
 
 	var (
@@ -851,7 +851,7 @@ func manifestPushCmd(c *cobra.Command, args []string, opts pushOptions) error {
 	}
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 
 	return manifestPush(systemContext, store, listImageSpec, destSpec, opts)

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -85,7 +85,7 @@ func mountCmd(c *cobra.Command, args []string, opts mountOptions) error {
 				if lastError != nil {
 					fmt.Fprintln(os.Stderr, lastError)
 				}
-				lastError = fmt.Errorf("error reading build container %q: %w", name, err)
+				lastError = fmt.Errorf("reading build container %q: %w", name, err)
 				continue
 			}
 			mountPoint, err := builder.Mount(builder.MountLabel)
@@ -93,7 +93,7 @@ func mountCmd(c *cobra.Command, args []string, opts mountOptions) error {
 				if lastError != nil {
 					fmt.Fprintln(os.Stderr, lastError)
 				}
-				lastError = fmt.Errorf("error mounting %q container %q: %w", name, builder.Container, err)
+				lastError = fmt.Errorf("mounting %q container %q: %w", name, builder.Container, err)
 				continue
 			}
 			if len(args) > 1 {
@@ -113,7 +113,7 @@ func mountCmd(c *cobra.Command, args []string, opts mountOptions) error {
 	} else {
 		builders, err := openBuilders(store)
 		if err != nil {
-			return fmt.Errorf("error reading build containers: %w", err)
+			return fmt.Errorf("reading build containers: %w", err)
 		}
 
 		for _, builder := range builders {

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -100,7 +100,7 @@ func pullCmd(c *cobra.Command, args []string, iopts pullOptions) error {
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 	platforms, err := parse.PlatformsFromOptions(c)
 	if err != nil {

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -171,7 +171,7 @@ func pushCmd(c *cobra.Command, args []string, iopts pushOptions) error {
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 
 	var manifestType string
@@ -235,7 +235,7 @@ func pushCmd(c *cobra.Command, args []string, iopts pushOptions) error {
 				return nil
 			}
 		}
-		return util.GetFailureCause(err, fmt.Errorf("error pushing image %q to %q: %w", src, destSpec, err))
+		return util.GetFailureCause(err, fmt.Errorf("pushing image %q to %q: %w", src, destSpec, err))
 	}
 	if ref != nil {
 		logrus.Debugf("pushed image %q with digest %s", ref, digest.String())

--- a/cmd/buildah/rename.go
+++ b/cmd/buildah/rename.go
@@ -38,7 +38,7 @@ func renameCmd(c *cobra.Command, args []string) error {
 
 	builder, err = openBuilder(getContext(), store, name)
 	if err != nil {
-		return fmt.Errorf("error reading build container %q: %w", name, err)
+		return fmt.Errorf("reading build container %q: %w", name, err)
 	}
 
 	oldName := builder.Container
@@ -52,7 +52,7 @@ func renameCmd(c *cobra.Command, args []string) error {
 
 	err = store.SetNames(builder.ContainerID, []string{newName})
 	if err != nil {
-		return fmt.Errorf("error renaming container %q to the name %q: %w", oldName, newName, err)
+		return fmt.Errorf("renaming container %q to the name %q: %w", oldName, newName, err)
 	}
 	builder.Container = newName
 	return builder.Save()

--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -40,7 +40,7 @@ func init() {
 }
 
 func rmCmd(c *cobra.Command, args []string, iopts rmResults) error {
-	delContainerErrStr := "error removing container"
+	delContainerErrStr := "removing container"
 	if len(args) == 0 && !iopts.all {
 		return errors.New("container ID must be specified")
 	}
@@ -61,7 +61,7 @@ func rmCmd(c *cobra.Command, args []string, iopts rmResults) error {
 	if iopts.all {
 		builders, err := openBuilders(store)
 		if err != nil {
-			return fmt.Errorf("error reading build containers: %w", err)
+			return fmt.Errorf("reading build containers: %w", err)
 		}
 
 		for _, builder := range builders {

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -108,7 +108,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 
 	builder, err := openBuilder(getContext(), store, name)
 	if err != nil {
-		return fmt.Errorf("error reading build container %q: %w", name, err)
+		return fmt.Errorf("reading build container %q: %w", name, err)
 	}
 
 	isolation, err := parse.IsolationOption(c.Flag("isolation").Value.String())
@@ -157,7 +157,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 	mounts, mountedImages, lockedTargets, err := internalParse.GetVolumes(systemContext, store, iopts.volumes, iopts.mounts, iopts.contextDir)
 	if err != nil {

--- a/cmd/buildah/tag.go
+++ b/cmd/buildah/tag.go
@@ -29,7 +29,7 @@ func tagCmd(c *cobra.Command, args []string) error {
 	}
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return fmt.Errorf("error building system context: %w", err)
+		return fmt.Errorf("building system context: %w", err)
 	}
 	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
 	if err != nil {

--- a/cmd/buildah/umount.go
+++ b/cmd/buildah/umount.go
@@ -77,7 +77,7 @@ func umountCmd(c *cobra.Command, args []string) error {
 	} else {
 		builders, err := openBuilders(store)
 		if err != nil {
-			return fmt.Errorf("error reading build Containers: %w", err)
+			return fmt.Errorf("reading build Containers: %w", err)
 		}
 		for _, builder := range builders {
 			if builder.MountPoint == "" {

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -47,12 +47,12 @@ func unshareMount(c *cobra.Command, mounts []string) ([]string, func(), error) {
 		for _, mounted := range mountedContainers {
 			builder, err := openBuilder(getContext(), store, mounted)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, fmt.Errorf("error loading information about build container %q: %w", mounted, err))
+				fmt.Fprintln(os.Stderr, fmt.Errorf("loading information about build container %q: %w", mounted, err))
 				continue
 			}
 			err = builder.Unmount()
 			if err != nil {
-				fmt.Fprintln(os.Stderr, fmt.Errorf("error unmounting build container %q: %w", mounted, err))
+				fmt.Fprintln(os.Stderr, fmt.Errorf("unmounting build container %q: %w", mounted, err))
 				continue
 			}
 		}
@@ -72,12 +72,12 @@ func unshareMount(c *cobra.Command, mounts []string) ([]string, func(), error) {
 		builder, err := openBuilder(getContext(), store, container)
 		if err != nil {
 			unmount()
-			return nil, nil, fmt.Errorf("error loading information about build container %q: %w", container, err)
+			return nil, nil, fmt.Errorf("loading information about build container %q: %w", container, err)
 		}
 		mountPoint, err := builder.Mount(builder.MountLabel)
 		if err != nil {
 			unmount()
-			return nil, nil, fmt.Errorf("error mounting build container %q: %w", container, err)
+			return nil, nil, fmt.Errorf("mounting build container %q: %w", container, err)
 		}
 		logrus.Debugf("mounted container %q at %q", container, mountPoint)
 		mountedContainers = append(mountedContainers, container)

--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ import (
 func unmarshalConvertedConfig(ctx context.Context, dest interface{}, img types.Image, wantedManifestMIMEType string) error {
 	_, actualManifestMIMEType, err := img.Manifest(ctx)
 	if err != nil {
-		return fmt.Errorf("error getting manifest MIME type for %q: %w", transports.ImageName(img.Reference()), err)
+		return fmt.Errorf("getting manifest MIME type for %q: %w", transports.ImageName(img.Reference()), err)
 	}
 	if wantedManifestMIMEType != actualManifestMIMEType {
 		layerInfos := img.LayerInfos()
@@ -46,16 +46,16 @@ func unmarshalConvertedConfig(ctx context.Context, dest interface{}, img types.I
 			ManifestMIMEType: wantedManifestMIMEType,
 		})
 		if err != nil {
-			return fmt.Errorf("error converting image %q from %q to %q: %w", transports.ImageName(img.Reference()), actualManifestMIMEType, wantedManifestMIMEType, err)
+			return fmt.Errorf("converting image %q from %q to %q: %w", transports.ImageName(img.Reference()), actualManifestMIMEType, wantedManifestMIMEType, err)
 		}
 		img = secondUpdatedImg
 	}
 	config, err := img.ConfigBlob(ctx)
 	if err != nil {
-		return fmt.Errorf("error reading %s config from %q: %w", wantedManifestMIMEType, transports.ImageName(img.Reference()), err)
+		return fmt.Errorf("reading %s config from %q: %w", wantedManifestMIMEType, transports.ImageName(img.Reference()), err)
 	}
 	if err := json.Unmarshal(config, dest); err != nil {
-		return fmt.Errorf("error parsing %s configuration %q from %q: %w", wantedManifestMIMEType, string(config), transports.ImageName(img.Reference()), err)
+		return fmt.Errorf("parsing %s configuration %q from %q: %w", wantedManifestMIMEType, string(config), transports.ImageName(img.Reference()), err)
 	}
 	return nil
 }
@@ -64,11 +64,11 @@ func (b *Builder) initConfig(ctx context.Context, img types.Image, sys *types.Sy
 	if img != nil { // A pre-existing image, as opposed to a "FROM scratch" new one.
 		rawManifest, manifestMIMEType, err := img.Manifest(ctx)
 		if err != nil {
-			return fmt.Errorf("error reading image manifest for %q: %w", transports.ImageName(img.Reference()), err)
+			return fmt.Errorf("reading image manifest for %q: %w", transports.ImageName(img.Reference()), err)
 		}
 		rawConfig, err := img.ConfigBlob(ctx)
 		if err != nil {
-			return fmt.Errorf("error reading image configuration for %q: %w", transports.ImageName(img.Reference()), err)
+			return fmt.Errorf("reading image configuration for %q: %w", transports.ImageName(img.Reference()), err)
 		}
 		b.Manifest = rawManifest
 		b.Config = rawConfig
@@ -89,7 +89,7 @@ func (b *Builder) initConfig(ctx context.Context, img types.Image, sys *types.Sy
 			// Attempt to recover format-specific data from the manifest.
 			v1Manifest := ociv1.Manifest{}
 			if err := json.Unmarshal(b.Manifest, &v1Manifest); err != nil {
-				return fmt.Errorf("error parsing OCI manifest %q: %w", string(b.Manifest), err)
+				return fmt.Errorf("parsing OCI manifest %q: %w", string(b.Manifest), err)
 			}
 			for k, v := range v1Manifest.Annotations {
 				// NOTE: do not override annotations that are

--- a/copier/copier.go
+++ b/copier/copier.go
@@ -463,7 +463,7 @@ func convertToRelSubdirectory(root, directory string) (relative string, err erro
 	}
 	rel, err := filepath.Rel(root, directory)
 	if err != nil {
-		return "", fmt.Errorf("error computing path of %q relative to %q: %w", directory, root, err)
+		return "", fmt.Errorf("computing path of %q relative to %q: %w", directory, root, err)
 	}
 	return cleanerReldirectory(rel), nil
 }
@@ -471,7 +471,7 @@ func convertToRelSubdirectory(root, directory string) (relative string, err erro
 func currentVolumeRoot() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("error getting current working directory: %w", err)
+		return "", fmt.Errorf("getting current working directory: %w", err)
 	}
 	return filepath.VolumeName(cwd) + string(os.PathSeparator), nil
 }
@@ -479,7 +479,7 @@ func currentVolumeRoot() (string, error) {
 func isVolumeRoot(candidate string) (bool, error) {
 	abs, err := filepath.Abs(candidate)
 	if err != nil {
-		return false, fmt.Errorf("error converting %q to an absolute path: %w", candidate, err)
+		return false, fmt.Errorf("converting %q to an absolute path: %w", candidate, err)
 	}
 	return abs == filepath.VolumeName(abs)+string(os.PathSeparator), nil
 }
@@ -493,7 +493,7 @@ func copier(bulkReader io.Reader, bulkWriter io.Writer, req request) (*response,
 		if req.Root == "" {
 			wd, err := os.Getwd()
 			if err != nil {
-				return nil, fmt.Errorf("error getting current working directory: %w", err)
+				return nil, fmt.Errorf("getting current working directory: %w", err)
 			}
 			req.Directory = wd
 		} else {
@@ -503,19 +503,19 @@ func copier(bulkReader io.Reader, bulkWriter io.Writer, req request) (*response,
 	if req.Root == "" {
 		root, err := currentVolumeRoot()
 		if err != nil {
-			return nil, fmt.Errorf("error determining root of current volume: %w", err)
+			return nil, fmt.Errorf("determining root of current volume: %w", err)
 		}
 		req.Root = root
 	}
 	if filepath.IsAbs(req.Directory) {
 		_, err := convertToRelSubdirectory(req.Root, req.Directory)
 		if err != nil {
-			return nil, fmt.Errorf("error rewriting %q to be relative to %q: %w", req.Directory, req.Root, err)
+			return nil, fmt.Errorf("rewriting %q to be relative to %q: %w", req.Directory, req.Root, err)
 		}
 	}
 	isAlreadyRoot, err := isVolumeRoot(req.Root)
 	if err != nil {
-		return nil, fmt.Errorf("error checking if %q is a root directory: %w", req.Root, err)
+		return nil, fmt.Errorf("checking if %q is a root directory: %w", req.Root, err)
 	}
 	if !isAlreadyRoot && canChroot {
 		return copierWithSubprocess(bulkReader, bulkWriter, req)
@@ -610,7 +610,7 @@ func copierWithSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req reques
 	cmd.Stderr = &errorBuffer
 	cmd.ExtraFiles = []*os.File{bulkReaderRead, bulkWriterWrite}
 	if err = cmd.Start(); err != nil {
-		return nil, fmt.Errorf("error starting subprocess: %w", err)
+		return nil, fmt.Errorf("starting subprocess: %w", err)
 	}
 	cmdToWaitFor := cmd
 	defer func() {
@@ -632,7 +632,7 @@ func copierWithSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req reques
 	bulkWriterWrite = nil
 	killAndReturn := func(err error, step string) (*response, error) { // nolint: unparam
 		if err2 := cmd.Process.Kill(); err2 != nil {
-			return nil, fmt.Errorf("error killing subprocess: %v; %s: %w", err2, step, err)
+			return nil, fmt.Errorf("killing subprocess: %v; %s: %w", err2, step, err)
 		}
 		return nil, fmt.Errorf("%v: %w", step, err)
 	}
@@ -690,10 +690,10 @@ func copierWithSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req reques
 		}
 	}
 	if readError != nil {
-		return nil, fmt.Errorf("error passing bulk input to subprocess: %w", readError)
+		return nil, fmt.Errorf("passing bulk input to subprocess: %w", readError)
 	}
 	if writeError != nil {
-		return nil, fmt.Errorf("error passing bulk output from subprocess: %w", writeError)
+		return nil, fmt.Errorf("passing bulk output from subprocess: %w", writeError)
 	}
 	return resp, nil
 }
@@ -845,7 +845,7 @@ func copierHandler(bulkReader io.Reader, bulkWriter io.Writer, req request) (*re
 	excludes := req.Excludes()
 	pm, err := fileutils.NewPatternMatcher(excludes)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error processing excludes list %v: %w", excludes, err)
+		return nil, nil, fmt.Errorf("processing excludes list %v: %w", excludes, err)
 	}
 
 	var idMappings *idtools.IDMappings
@@ -915,7 +915,7 @@ func pathIsExcluded(root, path string, pm *fileutils.PatternMatcher) (string, bo
 func resolvePath(root, path string, evaluateFinalComponent bool, pm *fileutils.PatternMatcher) (string, error) {
 	rel, err := convertToRelSubdirectory(root, path)
 	if err != nil {
-		return "", fmt.Errorf("error making path %q relative to %q", path, root)
+		return "", fmt.Errorf("making path %q relative to %q", path, root)
 	}
 	workingPath := root
 	followed := 0
@@ -952,7 +952,7 @@ func resolvePath(root, path string, evaluateFinalComponent bool, pm *fileutils.P
 				// resolve the remaining components
 				rel, err := convertToRelSubdirectory(root, filepath.Join(workingPath, target))
 				if err != nil {
-					return "", fmt.Errorf("error making path %q relative to %q", filepath.Join(workingPath, target), root)
+					return "", fmt.Errorf("making path %q relative to %q", filepath.Join(workingPath, target), root)
 				}
 				workingPath = root
 				components = append(strings.Split(filepath.Clean(string(os.PathSeparator)+rel), string(os.PathSeparator)), components[1:]...)
@@ -1357,7 +1357,7 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 	// build the header using the name provided
 	hdr, err := tar.FileInfoHeader(srcfi, symlinkTarget)
 	if err != nil {
-		return fmt.Errorf("error generating tar header for %s (%s): %w", contentPath, symlinkTarget, err)
+		return fmt.Errorf("generating tar header for %s (%s): %w", contentPath, symlinkTarget, err)
 	}
 	if name != "" {
 		hdr.Name = filepath.ToSlash(name)
@@ -1379,7 +1379,7 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 	if !options.StripXattrs {
 		xattrs, err = Lgetxattrs(contentPath)
 		if err != nil {
-			return fmt.Errorf("error getting extended attributes for %q: %w", contentPath, err)
+			return fmt.Errorf("getting extended attributes for %q: %w", contentPath, err)
 		}
 	}
 	hdr.Xattrs = xattrs // nolint:staticcheck
@@ -1391,12 +1391,12 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 		if options.ExpandArchives && isArchivePath(contentPath) {
 			f, err := os.Open(contentPath)
 			if err != nil {
-				return fmt.Errorf("error opening file for reading archive contents: %w", err)
+				return fmt.Errorf("opening file for reading archive contents: %w", err)
 			}
 			defer f.Close()
 			rc, _, err := compression.AutoDecompress(f)
 			if err != nil {
-				return fmt.Errorf("error decompressing %s: %w", contentPath, err)
+				return fmt.Errorf("decompressing %s: %w", contentPath, err)
 			}
 			defer rc.Close()
 			tr := tar.NewReader(rc)
@@ -1406,22 +1406,22 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 					hdr.Name = handleRename(options.Rename, hdr.Name)
 				}
 				if err = tw.WriteHeader(hdr); err != nil {
-					return fmt.Errorf("error writing tar header from %q to pipe: %w", contentPath, err)
+					return fmt.Errorf("writing tar header from %q to pipe: %w", contentPath, err)
 				}
 				if hdr.Size != 0 {
 					n, err := io.Copy(tw, tr)
 					if err != nil {
-						return fmt.Errorf("error extracting content from archive %s: %s: %w", contentPath, hdr.Name, err)
+						return fmt.Errorf("extracting content from archive %s: %s: %w", contentPath, hdr.Name, err)
 					}
 					if n != hdr.Size {
-						return fmt.Errorf("error extracting contents of archive %s: incorrect length for %q", contentPath, hdr.Name)
+						return fmt.Errorf("extracting contents of archive %s: incorrect length for %q", contentPath, hdr.Name)
 					}
 					tw.Flush()
 				}
 				hdr, err = tr.Next()
 			}
 			if err != io.EOF {
-				return fmt.Errorf("error extracting contents of archive %s: %w", contentPath, err)
+				return fmt.Errorf("extracting contents of archive %s: %w", contentPath, err)
 			}
 			return nil
 		}
@@ -1443,7 +1443,7 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 		hostPair := idtools.IDPair{UID: hdr.Uid, GID: hdr.Gid}
 		hdr.Uid, hdr.Gid, err = idMappings.ToContainer(hostPair)
 		if err != nil {
-			return fmt.Errorf("error mapping host filesystem owners %#v to container filesystem owners: %w", hostPair, err)
+			return fmt.Errorf("mapping host filesystem owners %#v to container filesystem owners: %w", hostPair, err)
 		}
 	}
 	// force ownership and/or permissions, if requested
@@ -1467,29 +1467,29 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 		// open the file first so that we don't write a header for it if we can't actually read it
 		f, err = os.Open(contentPath)
 		if err != nil {
-			return fmt.Errorf("error opening file for adding its contents to archive: %w", err)
+			return fmt.Errorf("opening file for adding its contents to archive: %w", err)
 		}
 		defer f.Close()
 	} else if hdr.Typeflag == tar.TypeDir {
 		// open the directory file first to make sure we can access it.
 		f, err = os.Open(contentPath)
 		if err != nil {
-			return fmt.Errorf("error opening directory for adding its contents to archive: %w", err)
+			return fmt.Errorf("opening directory for adding its contents to archive: %w", err)
 		}
 		defer f.Close()
 	}
 	// output the header
 	if err = tw.WriteHeader(hdr); err != nil {
-		return fmt.Errorf("error writing header for %s (%s): %w", contentPath, hdr.Name, err)
+		return fmt.Errorf("writing header for %s (%s): %w", contentPath, hdr.Name, err)
 	}
 	if hdr.Typeflag == tar.TypeReg {
 		// output the content
 		n, err := io.Copy(tw, f)
 		if err != nil {
-			return fmt.Errorf("error copying %s: %w", contentPath, err)
+			return fmt.Errorf("copying %s: %w", contentPath, err)
 		}
 		if n != hdr.Size {
-			return fmt.Errorf("error copying %s: incorrect size (expected %d bytes, read %d bytes)", contentPath, n, hdr.Size)
+			return fmt.Errorf("copying %s: incorrect size (expected %d bytes, read %d bytes)", contentPath, n, hdr.Size)
 		}
 		tw.Flush()
 	}
@@ -1671,7 +1671,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				containerPair := idtools.IDPair{UID: hdr.Uid, GID: hdr.Gid}
 				hostPair, err := idMappings.ToHost(containerPair)
 				if err != nil {
-					return fmt.Errorf("error mapping container filesystem owner 0,0 to host filesystem owners: %w", err)
+					return fmt.Errorf("mapping container filesystem owner 0,0 to host filesystem owners: %w", err)
 				}
 				hdr.Uid, hdr.Gid = hostPair.UID, hostPair.GID
 			}
@@ -1736,7 +1736,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 					hdr.Linkname = handleRename(req.PutOptions.Rename, hdr.Linkname)
 				}
 				if linkTarget, err = resolvePath(targetDirectory, filepath.Join(req.Root, filepath.FromSlash(hdr.Linkname)), true, nil); err != nil {
-					return fmt.Errorf("error resolving hardlink target path %q under root %q", hdr.Linkname, req.Root)
+					return fmt.Errorf("resolving hardlink target path %q under root %q", hdr.Linkname, req.Root)
 				}
 				if err = os.Link(linkTarget, path); err != nil && errors.Is(err, os.ErrExist) {
 					if req.PutOptions.NoOverwriteDirNonDir {
@@ -1869,7 +1869,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 					mode |= syscall.S_ISVTX
 				}
 				if err = syscall.Chmod(path, uint32(mode)); err != nil {
-					return fmt.Errorf("error setting additional permissions on %q to 0%o: %w", path, mode, err)
+					return fmt.Errorf("setting additional permissions on %q to 0%o: %w", path, mode, err)
 				}
 			}
 			// set xattrs, including some that might have been reset by chown()
@@ -1885,13 +1885,13 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				hdr.AccessTime = hdr.ModTime
 			}
 			if err = lutimes(hdr.Typeflag == tar.TypeSymlink, path, hdr.AccessTime, hdr.ModTime); err != nil {
-				return fmt.Errorf("error setting access and modify timestamps on %q to %s and %s: %w", path, hdr.AccessTime, hdr.ModTime, err)
+				return fmt.Errorf("setting access and modify timestamps on %q to %s and %s: %w", path, hdr.AccessTime, hdr.ModTime, err)
 			}
 		nextHeader:
 			hdr, err = tr.Next()
 		}
 		if err != io.EOF {
-			return fmt.Errorf("error reading tar stream: expected EOF: %w", err)
+			return fmt.Errorf("reading tar stream: expected EOF: %w", err)
 		}
 		return nil
 	}

--- a/copier/copier_linux_test.go
+++ b/copier/copier_linux_test.go
@@ -41,7 +41,7 @@ func getWrapped(root string, directory string, getOptions GetOptions, globs []st
 	}
 	encoded, err := json.Marshal(&options)
 	if err != nil {
-		return fmt.Errorf("error marshalling options: %w", err)
+		return fmt.Errorf("marshalling options: %w", err)
 	}
 	cmd := reexec.Command("get")
 	cmd.Env = append(cmd.Env, "OPTIONS="+string(encoded))

--- a/copier/syscall_unix.go
+++ b/copier/syscall_unix.go
@@ -17,13 +17,13 @@ var canChroot = os.Getuid() == 0
 func chroot(root string) (bool, error) {
 	if canChroot {
 		if err := os.Chdir(root); err != nil {
-			return false, fmt.Errorf("error changing to intended-new-root directory %q: %w", root, err)
+			return false, fmt.Errorf("changing to intended-new-root directory %q: %w", root, err)
 		}
 		if err := unix.Chroot(root); err != nil {
-			return false, fmt.Errorf("error chrooting to directory %q: %w", root, err)
+			return false, fmt.Errorf("chrooting to directory %q: %w", root, err)
 		}
 		if err := os.Chdir(string(os.PathSeparator)); err != nil {
-			return false, fmt.Errorf("error changing to just-became-root directory %q: %w", root, err)
+			return false, fmt.Errorf("changing to just-became-root directory %q: %w", root, err)
 		}
 		return true, nil
 	}

--- a/copier/xattrs.go
+++ b/copier/xattrs.go
@@ -54,7 +54,7 @@ func Lgetxattrs(path string) (map[string]string, error) {
 				list = list[:0]
 				break
 			}
-			return nil, fmt.Errorf("error listing extended attributes of %q: %w", path, err)
+			return nil, fmt.Errorf("listing extended attributes of %q: %w", path, err)
 		}
 		list = list[:size]
 		break
@@ -75,7 +75,7 @@ func Lgetxattrs(path string) (map[string]string, error) {
 						attributeSize *= 2
 						continue
 					}
-					return nil, fmt.Errorf("error getting value of extended attribute %q on %q: %w", attribute, path, err)
+					return nil, fmt.Errorf("getting value of extended attribute %q on %q: %w", attribute, path, err)
 				}
 				m[attribute] = string(attributeValue[:size])
 				break
@@ -93,7 +93,7 @@ func Lsetxattrs(path string, xattrs map[string]string) error {
 	for attribute, value := range xattrs {
 		if isRelevantXattr(attribute) {
 			if err := unix.Lsetxattr(path, attribute, []byte(value), 0); err != nil {
-				return fmt.Errorf("error setting value of extended attribute %q on %q: %w", attribute, path, err)
+				return fmt.Errorf("setting value of extended attribute %q on %q: %w", attribute, path, err)
 			}
 		}
 	}

--- a/define/types.go
+++ b/define/types.go
@@ -123,11 +123,11 @@ func TempDirForURL(dir, prefix, url string) (name string, subdir string, err err
 	}
 	name, err = ioutil.TempDir(dir, prefix)
 	if err != nil {
-		return "", "", fmt.Errorf("error creating temporary directory for %q: %w", url, err)
+		return "", "", fmt.Errorf("creating temporary directory for %q: %w", url, err)
 	}
 	urlParsed, err := urlpkg.Parse(url)
 	if err != nil {
-		return "", "", fmt.Errorf("error parsing url %q: %w", url, err)
+		return "", "", fmt.Errorf("parsing url %q: %w", url, err)
 	}
 	if strings.HasPrefix(url, "git://") || strings.HasSuffix(urlParsed.Path, ".git") {
 		combinedOutput, gitSubDir, err := cloneToDirectory(url, name)

--- a/delete.go
+++ b/delete.go
@@ -6,7 +6,7 @@ import "fmt"
 // be used after this method is called.
 func (b *Builder) Delete() error {
 	if err := b.store.DeleteContainer(b.ContainerID); err != nil {
-		return fmt.Errorf("error deleting build container %q: %w", b.ContainerID, err)
+		return fmt.Errorf("deleting build container %q: %w", b.ContainerID, err)
 	}
 	b.MountPoint = ""
 	b.Container = ""

--- a/digester.go
+++ b/digester.go
@@ -75,7 +75,7 @@ func (t *tarFilterer) Close() error {
 	err := t.pipeWriter.Close()
 	t.wg.Wait()
 	if err != nil {
-		return fmt.Errorf("error closing filter pipe: %w", err)
+		return fmt.Errorf("closing filter pipe: %w", err)
 	}
 	return t.err
 }
@@ -110,7 +110,7 @@ func newTarFilterer(writeCloser io.WriteCloser, filter func(hdr *tar.Header) (sk
 				if !skip {
 					err = tarWriter.WriteHeader(hdr)
 					if err != nil {
-						err = fmt.Errorf("error filtering tar header for %q: %w", hdr.Name, err)
+						err = fmt.Errorf("filtering tar header for %q: %w", hdr.Name, err)
 						break
 					}
 					if hdr.Size != 0 {
@@ -122,11 +122,11 @@ func newTarFilterer(writeCloser io.WriteCloser, filter func(hdr *tar.Header) (sk
 							n, copyErr = io.Copy(tarWriter, tarReader)
 						}
 						if copyErr != nil {
-							err = fmt.Errorf("error copying content for %q: %w", hdr.Name, copyErr)
+							err = fmt.Errorf("copying content for %q: %w", hdr.Name, copyErr)
 							break
 						}
 						if n != hdr.Size {
-							err = fmt.Errorf("error filtering content for %q: expected %d bytes, got %d bytes", hdr.Name, hdr.Size, n)
+							err = fmt.Errorf("filtering content for %q: expected %d bytes, got %d bytes", hdr.Name, hdr.Size, n)
 							break
 						}
 					}
@@ -134,7 +134,7 @@ func newTarFilterer(writeCloser io.WriteCloser, filter func(hdr *tar.Header) (sk
 				hdr, err = tarReader.Next()
 			}
 			if err != io.EOF {
-				filterer.err = fmt.Errorf("error reading tar archive: %w", err)
+				filterer.err = fmt.Errorf("reading tar archive: %w", err)
 				break
 			}
 			filterer.closedLock.Lock()

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -68,7 +68,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 	}
 
 	if len(paths) == 0 {
-		return "", nil, errors.New("error building: no dockerfiles specified")
+		return "", nil, errors.New("building: no dockerfiles specified")
 	}
 	if len(options.Platforms) > 1 && options.IIDFile != "" {
 		return "", nil, fmt.Errorf("building multiple images, but iidfile %q can only be used to store one image ID", options.IIDFile)
@@ -138,7 +138,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 			dinfo, err = contents.Stat()
 			if err != nil {
 				contents.Close()
-				return "", nil, fmt.Errorf("error reading info about %q: %w", dfile, err)
+				return "", nil, fmt.Errorf("reading info about %q: %w", dfile, err)
 			}
 			if dinfo.Mode().IsRegular() && dinfo.Size() == 0 {
 				contents.Close()
@@ -171,7 +171,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 	if options.JobSemaphore == nil {
 		if options.Jobs != nil {
 			if *options.Jobs < 0 {
-				return "", nil, errors.New("error building: invalid value for jobs.  It must be a positive integer")
+				return "", nil, errors.New("building: invalid value for jobs.  It must be a positive integer")
 			}
 			if *options.Jobs > 0 {
 				options.JobSemaphore = semaphore.NewWeighted(int64(*options.Jobs))
@@ -374,7 +374,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logrus.Logger, logPrefix string, options define.BuildOptions, containerFiles []string, dockerfilecontents [][]byte) (string, reference.Canonical, error) {
 	mainNode, err := imagebuilder.ParseDockerfile(bytes.NewReader(dockerfilecontents[0]))
 	if err != nil {
-		return "", nil, fmt.Errorf("error parsing main Dockerfile: %s: %w", containerFiles[0], err)
+		return "", nil, fmt.Errorf("parsing main Dockerfile: %s: %w", containerFiles[0], err)
 	}
 
 	warnOnUnsetBuildArgs(logger, mainNode, options.Args)
@@ -417,7 +417,7 @@ func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logr
 		additionalNode, err := imagebuilder.ParseDockerfile(bytes.NewReader(d))
 		if err != nil {
 			containerFiles := containerFiles[1:]
-			return "", nil, fmt.Errorf("error parsing additional Dockerfile %s: %w", containerFiles[i], err)
+			return "", nil, fmt.Errorf("parsing additional Dockerfile %s: %w", containerFiles[i], err)
 		}
 		mainNode.Children = append(mainNode.Children, additionalNode.Children...)
 	}
@@ -443,7 +443,7 @@ func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logr
 				labelLine = fmt.Sprintf("LABEL %q=%q\n", key, value)
 				additionalNode, err := imagebuilder.ParseDockerfile(strings.NewReader(labelLine))
 				if err != nil {
-					return "", nil, fmt.Errorf("error while adding additional LABEL steps: %w", err)
+					return "", nil, fmt.Errorf("while adding additional LABEL steps: %w", err)
 				}
 				mainNode.Children = append(mainNode.Children, additionalNode.Children...)
 			}
@@ -452,7 +452,7 @@ func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logr
 
 	exec, err := newExecutor(logger, logPrefix, store, options, mainNode, containerFiles)
 	if err != nil {
-		return "", nil, fmt.Errorf("error creating build executor: %w", err)
+		return "", nil, fmt.Errorf("creating build executor: %w", err)
 	}
 	b := imagebuilder.NewBuilder(options.Args)
 	defaultContainerConfig, err := config.Default()
@@ -462,7 +462,7 @@ func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logr
 	b.Env = append(defaultContainerConfig.GetDefaultEnv(), b.Env...)
 	stages, err := imagebuilder.NewStages(mainNode, b)
 	if err != nil {
-		return "", nil, fmt.Errorf("error reading multiple stages: %w", err)
+		return "", nil, fmt.Errorf("reading multiple stages: %w", err)
 	}
 	if options.Target != "" {
 		stagesTargeted, ok := stages.ThroughTarget(options.Target)
@@ -506,7 +506,7 @@ func preprocessContainerfileContents(logger *logrus.Logger, containerfile string
 	cppPath, err := exec.LookPath(cppCommand)
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
-			err = fmt.Errorf("error: %v: .in support requires %s to be installed", err, cppCommand)
+			err = fmt.Errorf("%v: .in support requires %s to be installed", err, cppCommand)
 		}
 		return nil, err
 	}
@@ -518,7 +518,7 @@ func preprocessContainerfileContents(logger *logrus.Logger, containerfile string
 	if flags, ok := os.LookupEnv("BUILDAH_CPPFLAGS"); ok {
 		args, err := shellwords.Parse(flags)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing BUILDAH_CPPFLAGS %q: %v", flags, err)
+			return nil, fmt.Errorf("parsing BUILDAH_CPPFLAGS %q: %v", flags, err)
 		}
 		cppArgs = append(cppArgs, args...)
 	}
@@ -536,7 +536,7 @@ func preprocessContainerfileContents(logger *logrus.Logger, containerfile string
 			logger.Warnf("Ignoring %s\n", stderrBuffer.String())
 		}
 		if stdoutBuffer.Len() == 0 {
-			return nil, fmt.Errorf("error preprocessing %s: preprocessor produced no output: %w", containerfile, err)
+			return nil, fmt.Errorf("preprocessing %s: preprocessor produced no output: %w", containerfile, err)
 		}
 	}
 	return &stdoutBuffer, nil
@@ -677,14 +677,14 @@ func platformsForBaseImages(ctx context.Context, logger *logrus.Logger, dockerfi
 func baseImages(dockerfilenames []string, dockerfilecontents [][]byte, from string, args map[string]string, additionalBuildContext map[string]*define.AdditionalBuildContext) ([]string, error) {
 	mainNode, err := imagebuilder.ParseDockerfile(bytes.NewReader(dockerfilecontents[0]))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing main Dockerfile: %s: %w", dockerfilenames[0], err)
+		return nil, fmt.Errorf("parsing main Dockerfile: %s: %w", dockerfilenames[0], err)
 	}
 
 	for i, d := range dockerfilecontents[1:] {
 		additionalNode, err := imagebuilder.ParseDockerfile(bytes.NewReader(d))
 		if err != nil {
 			dockerfilenames := dockerfilenames[1:]
-			return nil, fmt.Errorf("error parsing additional Dockerfile %s: %w", dockerfilenames[i], err)
+			return nil, fmt.Errorf("parsing additional Dockerfile %s: %w", dockerfilenames[i], err)
 		}
 		mainNode.Children = append(mainNode.Children, additionalNode.Children...)
 	}
@@ -697,7 +697,7 @@ func baseImages(dockerfilenames []string, dockerfilecontents [][]byte, from stri
 	b.Env = defaultContainerConfig.GetDefaultEnv()
 	stages, err := imagebuilder.NewStages(mainNode, b)
 	if err != nil {
-		return nil, fmt.Errorf("error reading multiple stages: %w", err)
+		return nil, fmt.Errorf("reading multiple stages: %w", err)
 	}
 	var baseImages []string
 	nicknames := make(map[string]bool)

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -404,7 +404,7 @@ func (b *Executor) waitForStage(ctx context.Context, name string, stages imagebu
 		b.stagesSemaphore.Release(1)
 		time.Sleep(time.Millisecond * 10)
 		if err := b.stagesSemaphore.Acquire(ctx, 1); err != nil {
-			return true, fmt.Errorf("error reacquiring job semaphore: %w", err)
+			return true, fmt.Errorf("reacquiring job semaphore: %w", err)
 		}
 	}
 }
@@ -419,20 +419,20 @@ func (b *Executor) getImageTypeAndHistoryAndDiffIDs(ctx context.Context, imageID
 	}
 	imageRef, err := is.Transport.ParseStoreReference(b.store, "@"+imageID)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("error getting image reference %q: %w", imageID, err)
+		return "", nil, nil, fmt.Errorf("getting image reference %q: %w", imageID, err)
 	}
 	ref, err := imageRef.NewImage(ctx, nil)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("error creating new image from reference to image %q: %w", imageID, err)
+		return "", nil, nil, fmt.Errorf("creating new image from reference to image %q: %w", imageID, err)
 	}
 	defer ref.Close()
 	oci, err := ref.OCIConfig(ctx)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("error getting possibly-converted OCI config of image %q: %w", imageID, err)
+		return "", nil, nil, fmt.Errorf("getting possibly-converted OCI config of image %q: %w", imageID, err)
 	}
 	manifestBytes, manifestFormat, err := ref.Manifest(ctx)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("error getting manifest of image %q: %w", imageID, err)
+		return "", nil, nil, fmt.Errorf("getting manifest of image %q: %w", imageID, err)
 	}
 	if manifestFormat == "" && len(manifestBytes) > 0 {
 		manifestFormat = manifest.GuessMIMEType(manifestBytes)
@@ -541,7 +541,7 @@ func markDependencyStagesForTarget(dependencyMap map[string]*stageDependencyInfo
 // over each of the one or more parsed Dockerfiles and stages.
 func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (imageID string, ref reference.Canonical, err error) {
 	if len(stages) == 0 {
-		return "", nil, errors.New("error building: no stages to build")
+		return "", nil, errors.New("building: no stages to build")
 	}
 	var cleanupImages []string
 	cleanupStages := make(map[int]*StageExecutor)
@@ -876,18 +876,18 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 		case is.Transport.Name():
 			img, err := is.Transport.GetStoreImage(b.store, dest)
 			if err != nil {
-				return imageID, ref, fmt.Errorf("error locating just-written image %q: %w", transports.ImageName(dest), err)
+				return imageID, ref, fmt.Errorf("locating just-written image %q: %w", transports.ImageName(dest), err)
 			}
 			if len(b.additionalTags) > 0 {
 				if err = util.AddImageNames(b.store, "", b.systemContext, img, b.additionalTags); err != nil {
-					return imageID, ref, fmt.Errorf("error setting image names to %v: %w", append(img.Names, b.additionalTags...), err)
+					return imageID, ref, fmt.Errorf("setting image names to %v: %w", append(img.Names, b.additionalTags...), err)
 				}
 				logrus.Debugf("assigned names %v to image %q", img.Names, img.ID)
 			}
 			// Report back the caller the tags applied, if any.
 			img, err = is.Transport.GetStoreImage(b.store, dest)
 			if err != nil {
-				return imageID, ref, fmt.Errorf("error locating just-written image %q: %w", transports.ImageName(dest), err)
+				return imageID, ref, fmt.Errorf("locating just-written image %q: %w", transports.ImageName(dest), err)
 			}
 			for _, name := range img.Names {
 				fmt.Fprintf(b.out, "Successfully tagged %s\n", name)

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -93,10 +93,10 @@ func (s *StageExecutor) Preserve(path string) error {
 		// except ensure that it exists.
 		createdDirPerms := os.FileMode(0755)
 		if err := copier.Mkdir(s.mountPoint, filepath.Join(s.mountPoint, path), copier.MkdirOptions{ChmodNew: &createdDirPerms}); err != nil {
-			return fmt.Errorf("error ensuring volume path exists: %w", err)
+			return fmt.Errorf("ensuring volume path exists: %w", err)
 		}
 		if err := s.volumeCacheInvalidate(path); err != nil {
-			return fmt.Errorf("error ensuring volume path %q is preserved: %w", filepath.Join(s.mountPoint, path), err)
+			return fmt.Errorf("ensuring volume path %q is preserved: %w", filepath.Join(s.mountPoint, path), err)
 		}
 		return nil
 	}
@@ -123,14 +123,14 @@ func (s *StageExecutor) Preserve(path string) error {
 		archivedPath = evaluated
 		path = string(os.PathSeparator) + symLink
 	} else {
-		return fmt.Errorf("error evaluating path %q: %w", path, err)
+		return fmt.Errorf("evaluating path %q: %w", path, err)
 	}
 
 	st, err := os.Stat(archivedPath)
 	if errors.Is(err, os.ErrNotExist) {
 		createdDirPerms := os.FileMode(0755)
 		if err = copier.Mkdir(s.mountPoint, archivedPath, copier.MkdirOptions{ChmodNew: &createdDirPerms}); err != nil {
-			return fmt.Errorf("error ensuring volume path exists: %w", err)
+			return fmt.Errorf("ensuring volume path exists: %w", err)
 		}
 		st, err = os.Stat(archivedPath)
 	}
@@ -142,7 +142,7 @@ func (s *StageExecutor) Preserve(path string) error {
 	if !s.volumes.Add(path) {
 		// This path is not a subdirectory of a volume path that we're
 		// already preserving, so adding it to the list should work.
-		return fmt.Errorf("error adding %q to the volume cache", path)
+		return fmt.Errorf("adding %q to the volume cache", path)
 	}
 	s.volumeCache[path] = cacheFile
 	// Now prune cache files for volumes that are now supplanted by this one.
@@ -207,14 +207,14 @@ func (s *StageExecutor) volumeCacheSaveVFS() (mounts []specs.Mount, err error) {
 	for cachedPath, cacheFile := range s.volumeCache {
 		archivedPath, err := copier.Eval(s.mountPoint, filepath.Join(s.mountPoint, cachedPath), copier.EvalOptions{})
 		if err != nil {
-			return nil, fmt.Errorf("error evaluating volume path: %w", err)
+			return nil, fmt.Errorf("evaluating volume path: %w", err)
 		}
 		relativePath, err := filepath.Rel(s.mountPoint, archivedPath)
 		if err != nil {
-			return nil, fmt.Errorf("error converting %q into a path relative to %q: %w", archivedPath, s.mountPoint, err)
+			return nil, fmt.Errorf("converting %q into a path relative to %q: %w", archivedPath, s.mountPoint, err)
 		}
 		if strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) {
-			return nil, fmt.Errorf("error converting %q into a path relative to %q", archivedPath, s.mountPoint)
+			return nil, fmt.Errorf("converting %q into a path relative to %q", archivedPath, s.mountPoint)
 		}
 		_, err = os.Stat(cacheFile)
 		if err == nil {
@@ -226,7 +226,7 @@ func (s *StageExecutor) volumeCacheSaveVFS() (mounts []specs.Mount, err error) {
 		}
 		createdDirPerms := os.FileMode(0755)
 		if err := copier.Mkdir(s.mountPoint, archivedPath, copier.MkdirOptions{ChmodNew: &createdDirPerms}); err != nil {
-			return nil, fmt.Errorf("error ensuring volume path exists: %w", err)
+			return nil, fmt.Errorf("ensuring volume path exists: %w", err)
 		}
 		logrus.Debugf("caching contents of volume %q in %q", archivedPath, cacheFile)
 		cache, err := os.Create(cacheFile)
@@ -236,12 +236,12 @@ func (s *StageExecutor) volumeCacheSaveVFS() (mounts []specs.Mount, err error) {
 		defer cache.Close()
 		rc, err := chrootarchive.Tar(archivedPath, nil, s.mountPoint)
 		if err != nil {
-			return nil, fmt.Errorf("error archiving %q: %w", archivedPath, err)
+			return nil, fmt.Errorf("archiving %q: %w", archivedPath, err)
 		}
 		defer rc.Close()
 		_, err = io.Copy(cache, rc)
 		if err != nil {
-			return nil, fmt.Errorf("error archiving %q to %q: %w", archivedPath, cacheFile, err)
+			return nil, fmt.Errorf("archiving %q to %q: %w", archivedPath, cacheFile, err)
 		}
 		mount := specs.Mount{
 			Source:      archivedPath,
@@ -259,7 +259,7 @@ func (s *StageExecutor) volumeCacheRestoreVFS() (err error) {
 	for cachedPath, cacheFile := range s.volumeCache {
 		archivedPath, err := copier.Eval(s.mountPoint, filepath.Join(s.mountPoint, cachedPath), copier.EvalOptions{})
 		if err != nil {
-			return fmt.Errorf("error evaluating volume path: %w", err)
+			return fmt.Errorf("evaluating volume path: %w", err)
 		}
 		logrus.Debugf("restoring contents of volume %q from %q", archivedPath, cacheFile)
 		cache, err := os.Open(cacheFile)
@@ -276,7 +276,7 @@ func (s *StageExecutor) volumeCacheRestoreVFS() (err error) {
 		}
 		err = chrootarchive.Untar(cache, archivedPath, nil)
 		if err != nil {
-			return fmt.Errorf("error extracting archive at %q: %w", archivedPath, err)
+			return fmt.Errorf("extracting archive at %q: %w", archivedPath, err)
 		}
 		if st, ok := s.volumeCacheInfo[cachedPath]; ok {
 			if err := os.Chmod(archivedPath, st.Mode()); err != nil {
@@ -593,7 +593,7 @@ func (s *StageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 	if stdin == nil {
 		devNull, err := os.Open(os.DevNull)
 		if err != nil {
-			return fmt.Errorf("error opening %q for reading: %v", os.DevNull, err)
+			return fmt.Errorf("opening %q for reading: %v", os.DevNull, err)
 		}
 		defer devNull.Close()
 		stdin = devNull
@@ -686,7 +686,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		base, err := ib.From(node)
 		if err != nil {
 			logrus.Debugf("prepare(node.Children=%#v)", node.Children)
-			return nil, fmt.Errorf("error determining starting point for build: %w", err)
+			return nil, fmt.Errorf("determining starting point for build: %w", err)
 		}
 		from = base
 	}
@@ -755,7 +755,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 
 	builder, err = buildah.NewBuilder(ctx, s.executor.store, builderOptions)
 	if err != nil {
-		return nil, fmt.Errorf("error creating build container: %w", err)
+		return nil, fmt.Errorf("creating build container: %w", err)
 	}
 
 	// If executor's ProcessLabel and MountLabel is empty means this is the first stage
@@ -817,7 +817,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 			if err2 := builder.Delete(); err2 != nil {
 				logrus.Debugf("error deleting container which we failed to update: %v", err2)
 			}
-			return nil, fmt.Errorf("error updating build context: %w", err)
+			return nil, fmt.Errorf("updating build context: %w", err)
 		}
 	}
 	mountPoint, err := builder.Mount(builder.MountLabel)
@@ -825,7 +825,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		if err2 := builder.Delete(); err2 != nil {
 			logrus.Debugf("error deleting container which we failed to mount: %v", err2)
 		}
-		return nil, fmt.Errorf("error mounting new container: %w", err)
+		return nil, fmt.Errorf("mounting new container: %w", err)
 	}
 	if rebase {
 		// Make this our "current" working container.
@@ -1014,7 +1014,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// the case, we need to commit() to create a new image.
 			logCommit(s.output, -1)
 			if imgID, ref, err = s.commit(ctx, s.getCreatedBy(nil, ""), false, s.output, s.executor.squash); err != nil {
-				return "", nil, fmt.Errorf("error committing base container: %w", err)
+				return "", nil, fmt.Errorf("committing base container: %w", err)
 			}
 			// Generate build output if needed.
 			if canGenerateBuildOutput {
@@ -1064,7 +1064,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		// Resolve any arguments in this instruction.
 		step := ib.Step()
 		if err := step.Resolve(node); err != nil {
-			return "", nil, fmt.Errorf("error resolving step %+v: %w", *node, err)
+			return "", nil, fmt.Errorf("resolving step %+v: %w", *node, err)
 		}
 		logrus.Debugf("Parsed Step: %+v", *step)
 		if !s.executor.quiet {
@@ -1150,7 +1150,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			err := ib.Run(step, s, noRunsRemaining)
 			if err != nil {
 				logrus.Debugf("Error building at step %+v: %v", *step, err)
-				return "", nil, fmt.Errorf("error building at STEP \"%s\": %w", step.Message, err)
+				return "", nil, fmt.Errorf("building at STEP \"%s\": %w", step.Message, err)
 			}
 			// In case we added content, retrieve its digest.
 			addedContentSummary := s.getContentSummaryAfterAddingContent()
@@ -1175,7 +1175,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 					logCommit(s.output, i)
 					imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), false, s.output, s.executor.squash)
 					if err != nil {
-						return "", nil, fmt.Errorf("error committing container for step %+v: %w", *step, err)
+						return "", nil, fmt.Errorf("committing container for step %+v: %w", *step, err)
 					}
 					logImageID(imgID)
 					// Generate build output if needed.
@@ -1236,7 +1236,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			if canMatchCacheOnlyAfterRun {
 				if err = ib.Run(step, s, noRunsRemaining); err != nil {
 					logrus.Debugf("Error building at step %+v: %v", *step, err)
-					return "", nil, fmt.Errorf("error building at STEP \"%s\": %w", step.Message, err)
+					return "", nil, fmt.Errorf("building at STEP \"%s\": %w", step.Message, err)
 				}
 				// Retrieve the digest info for the content that we just copied
 				// into the rootfs.
@@ -1251,7 +1251,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			}
 			cacheID, err = s.intermediateImageExists(ctx, node, addedContentSummary, s.stepRequiresLayer(step))
 			if err != nil {
-				return "", nil, fmt.Errorf("error checking if cached image exists from a previous build: %w", err)
+				return "", nil, fmt.Errorf("checking if cached image exists from a previous build: %w", err)
 			}
 			// All the best effort to find cache on localstorage have failed try pulling
 			// cache from remote repo if `--cache-from` was configured.
@@ -1263,7 +1263,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 					logCachePulled(cacheKey)
 					cacheID, err = s.intermediateImageExists(ctx, node, addedContentSummary, s.stepRequiresLayer(step))
 					if err != nil {
-						return "", nil, fmt.Errorf("error checking if cached image exists from a previous build: %w", err)
+						return "", nil, fmt.Errorf("checking if cached image exists from a previous build: %w", err)
 					}
 					if cacheID != "" {
 						pulledAndUsedCacheImage = true
@@ -1282,7 +1282,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// Process the instruction directly.
 			if err = ib.Run(step, s, noRunsRemaining); err != nil {
 				logrus.Debugf("Error building at step %+v: %v", *step, err)
-				return "", nil, fmt.Errorf("error building at STEP \"%s\": %w", step.Message, err)
+				return "", nil, fmt.Errorf("building at STEP \"%s\": %w", step.Message, err)
 			}
 
 			// In case we added content, retrieve its digest.
@@ -1300,7 +1300,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			if checkForLayers {
 				cacheID, err = s.intermediateImageExists(ctx, node, addedContentSummary, s.stepRequiresLayer(step))
 				if err != nil {
-					return "", nil, fmt.Errorf("error checking if cached image exists from a previous build: %w", err)
+					return "", nil, fmt.Errorf("checking if cached image exists from a previous build: %w", err)
 				}
 			}
 		} else {
@@ -1318,7 +1318,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				err := ib.Run(step, s, noRunsRemaining)
 				if err != nil {
 					logrus.Debugf("Error building at step %+v: %v", *step, err)
-					return "", nil, fmt.Errorf("error building at STEP \"%s\": %w", step.Message, err)
+					return "", nil, fmt.Errorf("building at STEP \"%s\": %w", step.Message, err)
 				}
 			}
 		}
@@ -1351,7 +1351,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// can be part of build-cache.
 			imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), !s.stepRequiresLayer(step), commitName, false)
 			if err != nil {
-				return "", nil, fmt.Errorf("error committing container for step %+v: %w", *step, err)
+				return "", nil, fmt.Errorf("committing container for step %+v: %w", *step, err)
 			}
 			// Generate build output if needed.
 			if canGenerateBuildOutput {
@@ -1385,7 +1385,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				// is the last instruction of the last stage.
 				imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), !s.stepRequiresLayer(step), commitName, true)
 				if err != nil {
-					return "", nil, fmt.Errorf("error committing final squash step %+v: %w", *step, err)
+					return "", nil, fmt.Errorf("committing final squash step %+v: %w", *step, err)
 				}
 				// Generate build output if needed.
 				if canGenerateBuildOutput {
@@ -1436,7 +1436,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// ID that we really should not be pulling anymore (see
 			// containers/podman/issues/10307).
 			if _, err := s.prepare(ctx, imgID, false, true, define.PullNever); err != nil {
-				return "", nil, fmt.Errorf("error preparing container for next step: %w", err)
+				return "", nil, fmt.Errorf("preparing container for next step: %w", err)
 			}
 		}
 	}
@@ -1648,27 +1648,27 @@ func (s *StageExecutor) tagExistingImage(ctx context.Context, cacheID, output st
 	// Look up the source image, expecting it to be in local storage
 	src, err := is.Transport.ParseStoreReference(s.executor.store, cacheID)
 	if err != nil {
-		return "", nil, fmt.Errorf("error getting source imageReference for %q: %w", cacheID, err)
+		return "", nil, fmt.Errorf("getting source imageReference for %q: %w", cacheID, err)
 	}
 	options := cp.Options{
 		RemoveSignatures: true, // more like "ignore signatures", since they don't get removed when src and dest are the same image
 	}
 	manifestBytes, err := cp.Image(ctx, policyContext, dest, src, &options)
 	if err != nil {
-		return "", nil, fmt.Errorf("error copying image %q: %w", cacheID, err)
+		return "", nil, fmt.Errorf("copying image %q: %w", cacheID, err)
 	}
 	manifestDigest, err := manifest.Digest(manifestBytes)
 	if err != nil {
-		return "", nil, fmt.Errorf("error computing digest of manifest for image %q: %w", cacheID, err)
+		return "", nil, fmt.Errorf("computing digest of manifest for image %q: %w", cacheID, err)
 	}
 	img, err := is.Transport.GetStoreImage(s.executor.store, dest)
 	if err != nil {
-		return "", nil, fmt.Errorf("error locating new copy of image %q (i.e., %q): %w", cacheID, transports.ImageName(dest), err)
+		return "", nil, fmt.Errorf("locating new copy of image %q (i.e., %q): %w", cacheID, transports.ImageName(dest), err)
 	}
 	var ref reference.Canonical
 	if dref := dest.DockerReference(); dref != nil {
 		if ref, err = reference.WithDigest(dref, manifestDigest); err != nil {
-			return "", nil, fmt.Errorf("error computing canonical reference for new image %q (i.e., %q): %w", cacheID, transports.ImageName(dest), err)
+			return "", nil, fmt.Errorf("computing canonical reference for new image %q (i.e., %q): %w", cacheID, transports.ImageName(dest), err)
 		}
 	}
 	return img.ID, ref, nil
@@ -1688,7 +1688,7 @@ func (s *StageExecutor) generateCacheKey(ctx context.Context, currNode *parser.N
 	if s.builder.FromImageID != "" {
 		manifestType, baseHistory, diffIDs, err = s.executor.getImageTypeAndHistoryAndDiffIDs(ctx, s.builder.FromImageID)
 		if err != nil {
-			return "", fmt.Errorf("error getting history of base image %q: %w", s.builder.FromImageID, err)
+			return "", fmt.Errorf("getting history of base image %q: %w", s.builder.FromImageID, err)
 		}
 		for i := 0; i < len(diffIDs); i++ {
 			fmt.Fprintln(hash, diffIDs[i].String())
@@ -1788,14 +1788,14 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 	// Get the list of images available in the image store
 	images, err := s.executor.store.Images()
 	if err != nil {
-		return "", fmt.Errorf("error getting image list from store: %w", err)
+		return "", fmt.Errorf("getting image list from store: %w", err)
 	}
 	var baseHistory []v1.History
 	var baseDiffIDs []digest.Digest
 	if s.builder.FromImageID != "" {
 		_, baseHistory, baseDiffIDs, err = s.executor.getImageTypeAndHistoryAndDiffIDs(ctx, s.builder.FromImageID)
 		if err != nil {
-			return "", fmt.Errorf("error getting history of base image %q: %w", s.builder.FromImageID, err)
+			return "", fmt.Errorf("getting history of base image %q: %w", s.builder.FromImageID, err)
 		}
 	}
 	for _, image := range images {
@@ -1815,7 +1815,7 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 		if image.TopLayer != "" {
 			imageTopLayer, err = s.executor.store.Layer(image.TopLayer)
 			if err != nil {
-				return "", fmt.Errorf("error getting top layer info: %w", err)
+				return "", fmt.Errorf("getting top layer info: %w", err)
 			}
 			// Figure out which layer from this image we should
 			// compare our container's base layer to.
@@ -2010,7 +2010,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	if imageRef != nil {
 		if dref := imageRef.DockerReference(); dref != nil {
 			if ref, err = reference.WithDigest(dref, manifestDigest); err != nil {
-				return "", nil, fmt.Errorf("error computing canonical reference for new image %q: %w", imgID, err)
+				return "", nil, fmt.Errorf("computing canonical reference for new image %q: %w", imgID, err)
 			}
 		}
 	}

--- a/import.go
+++ b/import.go
@@ -34,14 +34,14 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 	}
 	src, err := ref.NewImageSource(ctx, systemContext)
 	if err != nil {
-		return nil, fmt.Errorf("error instantiating image source: %w", err)
+		return nil, fmt.Errorf("instantiating image source: %w", err)
 	}
 	defer src.Close()
 
 	imageDigest := ""
 	manifestBytes, manifestType, err := src.GetManifest(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error loading image manifest for %q: %w", transports.ImageName(ref), err)
+		return nil, fmt.Errorf("loading image manifest for %q: %w", transports.ImageName(ref), err)
 	}
 	if manifestDigest, err := manifest.Digest(manifestBytes); err == nil {
 		imageDigest = manifestDigest.String()
@@ -51,18 +51,18 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 	if manifest.MIMETypeIsMultiImage(manifestType) {
 		list, err := manifest.ListFromBlob(manifestBytes, manifestType)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing image manifest for %q as list: %w", transports.ImageName(ref), err)
+			return nil, fmt.Errorf("parsing image manifest for %q as list: %w", transports.ImageName(ref), err)
 		}
 		instance, err := list.ChooseInstance(systemContext)
 		if err != nil {
-			return nil, fmt.Errorf("error finding an appropriate image in manifest list %q: %w", transports.ImageName(ref), err)
+			return nil, fmt.Errorf("finding an appropriate image in manifest list %q: %w", transports.ImageName(ref), err)
 		}
 		instanceDigest = &instance
 	}
 
 	image, err := image.FromUnparsedImage(ctx, systemContext, image.UnparsedInstance(src, instanceDigest))
 	if err != nil {
-		return nil, fmt.Errorf("error instantiating image for %q instance %q: %w", transports.ImageName(ref), instanceDigest, err)
+		return nil, fmt.Errorf("instantiating image for %q instance %q: %w", transports.ImageName(ref), instanceDigest, err)
 	}
 
 	imageName := ""
@@ -73,7 +73,7 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 		if img.TopLayer != "" {
 			layer, err4 := store.Layer(img.TopLayer)
 			if err4 != nil {
-				return nil, fmt.Errorf("error reading information about image's top layer: %w", err4)
+				return nil, fmt.Errorf("reading information about image's top layer: %w", err4)
 			}
 			uidmap, gidmap = convertStorageIDMaps(layer.UIDMap, layer.GIDMap)
 		}
@@ -110,7 +110,7 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 	}
 
 	if err := builder.initConfig(ctx, image, systemContext); err != nil {
-		return nil, fmt.Errorf("error preparing image configuration: %w", err)
+		return nil, fmt.Errorf("preparing image configuration: %w", err)
 	}
 
 	return builder, nil
@@ -147,7 +147,7 @@ func importBuilder(ctx context.Context, store storage.Store, options ImportOptio
 
 	err = builder.Save()
 	if err != nil {
-		return nil, fmt.Errorf("error saving builder state: %w", err)
+		return nil, fmt.Errorf("saving builder state: %w", err)
 	}
 
 	return builder, nil
@@ -167,7 +167,7 @@ func importBuilderFromImage(ctx context.Context, store storage.Store, options Im
 
 	builder, err := importBuilderDataFromImage(ctx, store, systemContext, img.ID, "", "")
 	if err != nil {
-		return nil, fmt.Errorf("error importing build settings from image %q: %w", options.Image, err)
+		return nil, fmt.Errorf("importing build settings from image %q: %w", options.Image, err)
 	}
 
 	builder.setupLogger()

--- a/internal/source/add.go
+++ b/internal/source/add.go
@@ -62,7 +62,7 @@ func Add(ctx context.Context, sourcePath string, artifactPath string, options Ad
 
 	tarStream, err := archive.TarWithOptions(artifactPath, &archive.TarOptions{Compression: archive.Gzip})
 	if err != nil {
-		return fmt.Errorf("error creating compressed tar stream: %w", err)
+		return fmt.Errorf("creating compressed tar stream: %w", err)
 	}
 
 	info := types.BlobInfo{
@@ -70,7 +70,7 @@ func Add(ctx context.Context, sourcePath string, artifactPath string, options Ad
 	}
 	addedBlob, err := ociDest.PutBlob(ctx, tarStream, info, nil, false)
 	if err != nil {
-		return fmt.Errorf("error adding source artifact: %w", err)
+		return fmt.Errorf("adding source artifact: %w", err)
 	}
 
 	// Add the new layers to the source image's manifest.
@@ -97,7 +97,7 @@ func Add(ctx context.Context, sourcePath string, artifactPath string, options Ad
 	// manually.  Not an issue, since paths are predictable for an OCI
 	// layout.
 	if err := removeBlob(oldManifestDigest, sourcePath); err != nil {
-		return fmt.Errorf("error removing old manifest: %w", err)
+		return fmt.Errorf("removing old manifest: %w", err)
 	}
 
 	manifestDescriptor := specV1.Descriptor{

--- a/internal/source/create.go
+++ b/internal/source/create.go
@@ -33,7 +33,7 @@ func (o *CreateOptions) createdTime() *time.Time {
 // that `sourcePath` must not exist.
 func Create(ctx context.Context, sourcePath string, options CreateOptions) error {
 	if _, err := os.Stat(sourcePath); err == nil {
-		return fmt.Errorf("error creating source image: %q already exists", sourcePath)
+		return fmt.Errorf("creating source image: %q already exists", sourcePath)
 	}
 
 	ociDest, err := openOrCreateSourceImage(ctx, sourcePath)

--- a/internal/source/pull.go
+++ b/internal/source/pull.go
@@ -57,11 +57,11 @@ func Pull(ctx context.Context, imageInput string, sourcePath string, options Pul
 
 	policy, err := signature.DefaultPolicy(sysCtx)
 	if err != nil {
-		return fmt.Errorf("error obtaining default signature policy: %w", err)
+		return fmt.Errorf("obtaining default signature policy: %w", err)
 	}
 	policyContext, err := signature.NewPolicyContext(policy)
 	if err != nil {
-		return fmt.Errorf("error creating new signature policy context: %w", err)
+		return fmt.Errorf("creating new signature policy context: %w", err)
 	}
 
 	copyOpts := copy.Options{
@@ -71,7 +71,7 @@ func Pull(ctx context.Context, imageInput string, sourcePath string, options Pul
 		copyOpts.ReportWriter = os.Stderr
 	}
 	if _, err := copy.Image(ctx, policyContext, ociDest.Reference(), srcRef, &copyOpts); err != nil {
-		return fmt.Errorf("error pulling source image: %w", err)
+		return fmt.Errorf("pulling source image: %w", err)
 	}
 
 	return nil
@@ -84,7 +84,7 @@ func stringToImageReference(imageInput string) (types.ImageReference, error) {
 
 	ref, err := alltransports.ParseImageName("docker://" + imageInput)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing image name: %w", err)
+		return nil, fmt.Errorf("parsing image name: %w", err)
 	}
 
 	return ref, nil
@@ -93,7 +93,7 @@ func stringToImageReference(imageInput string) (types.ImageReference, error) {
 func validateSourceImageReference(ctx context.Context, ref types.ImageReference, sysCtx *types.SystemContext) error {
 	src, err := ref.NewImageSource(ctx, sysCtx)
 	if err != nil {
-		return fmt.Errorf("error creating image source from reference: %w", err)
+		return fmt.Errorf("creating image source from reference: %w", err)
 	}
 	defer src.Close()
 

--- a/internal/source/push.go
+++ b/internal/source/push.go
@@ -48,11 +48,11 @@ func Push(ctx context.Context, sourcePath string, imageInput string, options Pus
 
 	policy, err := signature.DefaultPolicy(sysCtx)
 	if err != nil {
-		return fmt.Errorf("error obtaining default signature policy: %w", err)
+		return fmt.Errorf("obtaining default signature policy: %w", err)
 	}
 	policyContext, err := signature.NewPolicyContext(policy)
 	if err != nil {
-		return fmt.Errorf("error creating new signature policy context: %w", err)
+		return fmt.Errorf("creating new signature policy context: %w", err)
 	}
 
 	copyOpts := &copy.Options{
@@ -62,7 +62,7 @@ func Push(ctx context.Context, sourcePath string, imageInput string, options Pus
 		copyOpts.ReportWriter = os.Stderr
 	}
 	if _, err := copy.Image(ctx, policyContext, destRef, ociSource.Reference(), copyOpts); err != nil {
-		return fmt.Errorf("error pushing source image: %w", err)
+		return fmt.Errorf("pushing source image: %w", err)
 	}
 
 	return nil

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -33,11 +33,11 @@ type ImageConfig struct {
 func writeManifest(ctx context.Context, manifest *specV1.Manifest, ociDest types.ImageDestination) (*digest.Digest, int64, error) {
 	rawData, err := json.Marshal(&manifest)
 	if err != nil {
-		return nil, -1, fmt.Errorf("error marshalling manifest: %w", err)
+		return nil, -1, fmt.Errorf("marshalling manifest: %w", err)
 	}
 
 	if err := ociDest.PutManifest(ctx, rawData, nil); err != nil {
-		return nil, -1, fmt.Errorf("error writing manifest: %w", err)
+		return nil, -1, fmt.Errorf("writing manifest: %w", err)
 	}
 
 	manifestDigest := digest.FromBytes(rawData)
@@ -57,7 +57,7 @@ func readManifestFromImageSource(ctx context.Context, src types.ImageSource) (*s
 
 	manifest := specV1.Manifest{}
 	if err := json.Unmarshal(rawData, &manifest); err != nil {
-		return nil, nil, -1, fmt.Errorf("error reading manifest: %w", err)
+		return nil, nil, -1, fmt.Errorf("reading manifest: %w", err)
 	}
 
 	manifestDigest := digest.FromBytes(rawData)
@@ -99,7 +99,7 @@ func openOrCreateSourceImage(ctx context.Context, sourcePath string) (types.Imag
 func addConfig(ctx context.Context, config *ImageConfig, ociDest types.ImageDestination) (*types.BlobInfo, error) {
 	rawData, err := json.Marshal(config)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling config: %w", err)
+		return nil, fmt.Errorf("marshalling config: %w", err)
 	}
 
 	info := types.BlobInfo{
@@ -107,7 +107,7 @@ func addConfig(ctx context.Context, config *ImageConfig, ociDest types.ImageDest
 	}
 	addedBlob, err := ociDest.PutBlob(ctx, bytes.NewReader(rawData), info, nil, true)
 	if err != nil {
-		return nil, fmt.Errorf("error adding config: %w", err)
+		return nil, fmt.Errorf("adding config: %w", err)
 	}
 
 	return &addedBlob, nil

--- a/mount.go
+++ b/mount.go
@@ -7,13 +7,13 @@ import "fmt"
 func (b *Builder) Mount(label string) (string, error) {
 	mountpoint, err := b.store.Mount(b.ContainerID, label)
 	if err != nil {
-		return "", fmt.Errorf("error mounting build container %q: %w", b.ContainerID, err)
+		return "", fmt.Errorf("mounting build container %q: %w", b.ContainerID, err)
 	}
 	b.MountPoint = mountpoint
 
 	err = b.Save()
 	if err != nil {
-		return "", fmt.Errorf("error saving updated state for build container %q: %w", b.ContainerID, err)
+		return "", fmt.Errorf("saving updated state for build container %q: %w", b.ContainerID, err)
 	}
 	return mountpoint, nil
 }
@@ -21,7 +21,7 @@ func (b *Builder) Mount(label string) (string, error) {
 func (b *Builder) setMountPoint(mountPoint string) error {
 	b.MountPoint = mountPoint
 	if err := b.Save(); err != nil {
-		return fmt.Errorf("error saving updated state for build container %q: %w", b.ContainerID, err)
+		return fmt.Errorf("saving updated state for build container %q: %w", b.ContainerID, err)
 	}
 	return nil
 }
@@ -30,17 +30,17 @@ func (b *Builder) setMountPoint(mountPoint string) error {
 func (b *Builder) Mounted() (bool, error) {
 	mountCnt, err := b.store.Mounted(b.ContainerID)
 	if err != nil {
-		return false, fmt.Errorf("error determining if mounting build container %q is mounted: %w", b.ContainerID, err)
+		return false, fmt.Errorf("determining if mounting build container %q is mounted: %w", b.ContainerID, err)
 	}
 	mounted := mountCnt > 0
 	if mounted && b.MountPoint == "" {
 		ctr, err := b.store.Container(b.ContainerID)
 		if err != nil {
-			return mountCnt > 0, fmt.Errorf("error determining if mounting build container %q is mounted: %w", b.ContainerID, err)
+			return mountCnt > 0, fmt.Errorf("determining if mounting build container %q is mounted: %w", b.ContainerID, err)
 		}
 		layer, err := b.store.Layer(ctr.LayerID)
 		if err != nil {
-			return mountCnt > 0, fmt.Errorf("error determining if mounting build container %q is mounted: %w", b.ContainerID, err)
+			return mountCnt > 0, fmt.Errorf("determining if mounting build container %q is mounted: %w", b.ContainerID, err)
 		}
 		return mounted, b.setMountPoint(layer.MountPoint)
 	}

--- a/new.go
+++ b/new.go
@@ -190,12 +190,12 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 	if ref != nil {
 		srcSrc, err := ref.NewImageSource(ctx, systemContext)
 		if err != nil {
-			return nil, fmt.Errorf("error instantiating image for %q: %w", transports.ImageName(ref), err)
+			return nil, fmt.Errorf("instantiating image for %q: %w", transports.ImageName(ref), err)
 		}
 		defer srcSrc.Close()
 		manifestBytes, manifestType, err := srcSrc.GetManifest(ctx, nil)
 		if err != nil {
-			return nil, fmt.Errorf("error loading image manifest for %q: %w", transports.ImageName(ref), err)
+			return nil, fmt.Errorf("loading image manifest for %q: %w", transports.ImageName(ref), err)
 		}
 		if manifestDigest, err := manifest.Digest(manifestBytes); err == nil {
 			imageDigest = manifestDigest.String()
@@ -204,17 +204,17 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		if manifest.MIMETypeIsMultiImage(manifestType) {
 			list, err := manifest.ListFromBlob(manifestBytes, manifestType)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing image manifest for %q as list: %w", transports.ImageName(ref), err)
+				return nil, fmt.Errorf("parsing image manifest for %q as list: %w", transports.ImageName(ref), err)
 			}
 			instance, err := list.ChooseInstance(systemContext)
 			if err != nil {
-				return nil, fmt.Errorf("error finding an appropriate image in manifest list %q: %w", transports.ImageName(ref), err)
+				return nil, fmt.Errorf("finding an appropriate image in manifest list %q: %w", transports.ImageName(ref), err)
 			}
 			instanceDigest = &instance
 		}
 		src, err = image.FromUnparsedImage(ctx, systemContext, image.UnparsedInstance(srcSrc, instanceDigest))
 		if err != nil {
-			return nil, fmt.Errorf("error instantiating image for %q instance %q: %w", transports.ImageName(ref), instanceDigest, err)
+			return nil, fmt.Errorf("instantiating image for %q instance %q: %w", transports.ImageName(ref), instanceDigest, err)
 		}
 	}
 
@@ -263,7 +263,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 			break
 		}
 		if !errors.Is(err, storage.ErrDuplicateName) || options.Container != "" {
-			return nil, fmt.Errorf("error creating container: %w", err)
+			return nil, fmt.Errorf("creating container: %w", err)
 		}
 		tmpName = fmt.Sprintf("%s-%d", name, rand.Int()%conflict)
 		conflict = conflict * 10
@@ -333,16 +333,16 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 	if options.Mount {
 		_, err = builder.Mount(container.MountLabel())
 		if err != nil {
-			return nil, fmt.Errorf("error mounting build container %q: %w", builder.ContainerID, err)
+			return nil, fmt.Errorf("mounting build container %q: %w", builder.ContainerID, err)
 		}
 	}
 
 	if err := builder.initConfig(ctx, src, systemContext); err != nil {
-		return nil, fmt.Errorf("error preparing image configuration: %w", err)
+		return nil, fmt.Errorf("preparing image configuration: %w", err)
 	}
 	err = builder.Save()
 	if err != nil {
-		return nil, fmt.Errorf("error saving builder state for container %q: %w", builder.ContainerID, err)
+		return nil, fmt.Errorf("saving builder state for container %q: %w", builder.ContainerID, err)
 	}
 
 	return builder, nil

--- a/pkg/chrootuser/user.go
+++ b/pkg/chrootuser/user.go
@@ -76,9 +76,9 @@ func GetUser(rootdir, userspec string) (uint32, uint32, string, error) {
 		return uint32(uid64), uint32(gid64), homedir, nil
 	}
 
-	err = fmt.Errorf("error determining run uid: %w", uerr)
+	err = fmt.Errorf("determining run uid: %w", uerr)
 	if uerr == nil {
-		err = fmt.Errorf("error determining run gid: %w", gerr)
+		err = fmt.Errorf("determining run gid: %w", gerr)
 	}
 
 	return 0, 0, homedir, err
@@ -94,7 +94,7 @@ func GetGroup(rootdir, groupspec string) (uint32, error) {
 		gid64, gerr = lookupGroupInContainer(rootdir, groupspec)
 	}
 	if gerr != nil {
-		return 0, fmt.Errorf("error looking up group for gid %q: %w", groupspec, gerr)
+		return 0, fmt.Errorf("looking up group for gid %q: %w", groupspec, gerr)
 	}
 	return uint32(gid64), nil
 }
@@ -103,7 +103,7 @@ func GetGroup(rootdir, groupspec string) (uint32, error) {
 func GetAdditionalGroupsForUser(rootdir string, userid uint64) ([]uint32, error) {
 	gids, err := lookupAdditionalGroupsForUIDInContainer(rootdir, userid)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up supplemental groups for uid %d: %w", userid, err)
+		return nil, fmt.Errorf("looking up supplemental groups for uid %d: %w", userid, err)
 	}
 	return gids, nil
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -148,7 +148,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		// The context directory could be a URL.  Try to handle that.
 		tempDir, subDir, err := define.TempDirForURL("", "buildah", cliArgs[0])
 		if err != nil {
-			return options, nil, nil, fmt.Errorf("error prepping temporary context directory: %w", err)
+			return options, nil, nil, fmt.Errorf("prepping temporary context directory: %w", err)
 		}
 		if tempDir != "" {
 			// We had to download it to a temporary directory.
@@ -159,7 +159,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 			// Nope, it was local.  Use it as is.
 			absDir, err := filepath.Abs(cliArgs[0])
 			if err != nil {
-				return options, nil, nil, fmt.Errorf("error determining path to directory: %w", err)
+				return options, nil, nil, fmt.Errorf("determining path to directory: %w", err)
 			}
 			contextDir = absDir
 		}
@@ -177,7 +177,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 
 	contextDir, err = filepath.EvalSymlinks(contextDir)
 	if err != nil {
-		return options, nil, nil, fmt.Errorf("error evaluating symlinks in build context path: %w", err)
+		return options, nil, nil, fmt.Errorf("evaluating symlinks in build context path: %w", err)
 	}
 
 	var stdin io.Reader
@@ -198,7 +198,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return options, nil, nil, fmt.Errorf("error building system context: %w", err)
+		return options, nil, nil, fmt.Errorf("building system context: %w", err)
 	}
 
 	isolation, err := parse.IsolationOption(iopts.Isolation)
@@ -254,7 +254,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 	}
 	usernsOption, idmappingOptions, err := parse.IDMappingOptions(c, isolation)
 	if err != nil {
-		return options, nil, nil, fmt.Errorf("error parsing ID mapping options: %w", err)
+		return options, nil, nil, fmt.Errorf("parsing ID mapping options: %w", err)
 	}
 	namespaceOptions.AddOrReplace(usernsOption...)
 

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -812,15 +812,15 @@ func parseIDMap(spec []string) (m [][3]uint32, err error) {
 		for len(args) >= 3 {
 			cid, err := strconv.ParseUint(args[0], 10, 32)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing container ID %q from mapping %q as a number: %w", args[0], s, err)
+				return nil, fmt.Errorf("parsing container ID %q from mapping %q as a number: %w", args[0], s, err)
 			}
 			hostid, err := strconv.ParseUint(args[1], 10, 32)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing host ID %q from mapping %q as a number: %w", args[1], s, err)
+				return nil, fmt.Errorf("parsing host ID %q from mapping %q as a number: %w", args[1], s, err)
 			}
 			size, err := strconv.ParseUint(args[2], 10, 32)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing %q from mapping %q as a number: %w", args[2], s, err)
+				return nil, fmt.Errorf("parsing %q from mapping %q as a number: %w", args[2], s, err)
 			}
 			m = append(m, [3]uint32{uint32(cid), uint32(hostid), uint32(size)})
 			args = args[3:]

--- a/pkg/parse/parse_unix.go
+++ b/pkg/parse/parse_unix.go
@@ -20,7 +20,7 @@ func DeviceFromPath(device string) (define.ContainerDevices, error) {
 	}
 	srcInfo, err := os.Stat(src)
 	if err != nil {
-		return nil, fmt.Errorf("error getting info of source device %s: %w", src, err)
+		return nil, fmt.Errorf("getting info of source device %s: %w", src, err)
 	}
 
 	if !srcInfo.IsDir() {
@@ -37,7 +37,7 @@ func DeviceFromPath(device string) (define.ContainerDevices, error) {
 	// If source device is a directory
 	srcDevices, err := devices.GetDevices(src)
 	if err != nil {
-		return nil, fmt.Errorf("error getting source devices from directory %s: %w", src, err)
+		return nil, fmt.Errorf("getting source devices from directory %s: %w", src, err)
 	}
 	for _, d := range srcDevices {
 		d.Path = filepath.Join(dst, filepath.Base(d.Path))

--- a/pkg/rusage/rusage_unix.go
+++ b/pkg/rusage/rusage_unix.go
@@ -17,7 +17,7 @@ func get() (Rusage, error) {
 	var rusage syscall.Rusage
 	err := syscall.Getrusage(syscall.RUSAGE_CHILDREN, &rusage)
 	if err != nil {
-		return Rusage{}, fmt.Errorf("error getting resource usage: %w", err)
+		return Rusage{}, fmt.Errorf("getting resource usage: %w", err)
 	}
 	r := Rusage{
 		Date:     time.Now(),

--- a/pkg/rusage/rusage_unsupported.go
+++ b/pkg/rusage/rusage_unsupported.go
@@ -9,7 +9,7 @@ import (
 )
 
 func get() (Rusage, error) {
-	return Rusage{}, fmt.Errorf("error getting resource usage: %w", syscall.ENOTSUP)
+	return Rusage{}, fmt.Errorf("getting resource usage: %w", syscall.ENOTSUP)
 }
 
 // Supported returns true if resource usage counters are supported on this OS.

--- a/push.go
+++ b/push.go
@@ -32,7 +32,7 @@ func cacheLookupReferenceFunc(directory string, compress types.LayerCompression)
 		}
 		ref, err := blobcache.NewBlobCache(ref, directory, compress)
 		if err != nil {
-			return nil, fmt.Errorf("error using blobcache %q: %w", directory, err)
+			return nil, fmt.Errorf("using blobcache %q: %w", directory, err)
 		}
 		return ref, nil
 	}
@@ -135,7 +135,7 @@ func Push(ctx context.Context, image string, dest types.ImageReference, options 
 
 	manifestDigest, err := manifest.Digest(manifestBytes)
 	if err != nil {
-		return nil, "", fmt.Errorf("error computing digest of manifest of new image %q: %w", transports.ImageName(dest), err)
+		return nil, "", fmt.Errorf("computing digest of manifest of new image %q: %w", transports.ImageName(dest), err)
 	}
 
 	var ref reference.Canonical

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -90,7 +90,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 
 	gp, err := generate.New("freebsd")
 	if err != nil {
-		return fmt.Errorf("error generating new 'freebsd' runtime spec: %w", err)
+		return fmt.Errorf("generating new 'freebsd' runtime spec: %w", err)
 	}
 	g := &gp
 
@@ -123,7 +123,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	}
 	mountPoint, err := b.Mount(b.MountLabel)
 	if err != nil {
-		return fmt.Errorf("error mounting container %q: %w", b.ContainerID, err)
+		return fmt.Errorf("mounting container %q: %w", b.ContainerID, err)
 	}
 	defer func() {
 		if err := b.Unmount(); err != nil {
@@ -216,7 +216,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 
 	runArtifacts, err := b.setupMounts(mountPoint, spec, path, options.Mounts, bindFiles, volumes, b.CommonBuildOpts.Volumes, options.RunMounts, runMountInfo)
 	if err != nil {
-		return fmt.Errorf("error resolving mountpoints for container %q: %w", b.ContainerID, err)
+		return fmt.Errorf("resolving mountpoints for container %q: %w", b.ContainerID, err)
 	}
 	if runArtifacts.SSHAuthSock != "" {
 		sshenv := "SSH_AUTH_SOCK=" + runArtifacts.SSHAuthSock
@@ -316,7 +316,7 @@ func (b *Builder) runSetupVolumeMounts(mountLabel string, volumeMounts []string,
 	// Make sure the overlay directory is clean before running
 	_, err := b.store.ContainerDirectory(b.ContainerID)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up container directory for %s: %w", b.ContainerID, err)
+		return nil, fmt.Errorf("looking up container directory for %s: %w", b.ContainerID, err)
 	}
 
 	parseMount := func(mountType, host, container string, options []string) (specs.Mount, error) {
@@ -542,7 +542,7 @@ func runMakeStdioPipe(uid, gid int) ([][]int, error) {
 	for i := range stdioPipe {
 		stdioPipe[i] = make([]int, 2)
 		if err := unix.Pipe(stdioPipe[i]); err != nil {
-			return nil, fmt.Errorf("error creating pipe for container FD %d: %w", i, err)
+			return nil, fmt.Errorf("creating pipe for container FD %d: %w", i, err)
 		}
 	}
 	return stdioPipe, nil

--- a/run_linux.go
+++ b/run_linux.go
@@ -88,7 +88,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 
 	gp, err := generate.New("linux")
 	if err != nil {
-		return fmt.Errorf("error generating new 'linux' runtime spec: %w", err)
+		return fmt.Errorf("generating new 'linux' runtime spec: %w", err)
 	}
 	g := &gp
 
@@ -122,7 +122,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	setupSelinux(g, b.ProcessLabel, b.MountLabel)
 	mountPoint, err := b.Mount(b.MountLabel)
 	if err != nil {
-		return fmt.Errorf("error mounting container %q: %w", b.ContainerID, err)
+		return fmt.Errorf("mounting container %q: %w", b.ContainerID, err)
 	}
 	defer func() {
 		if err := b.Unmount(); err != nil {
@@ -327,7 +327,7 @@ rootless=%d
 
 	runArtifacts, err := b.setupMounts(mountPoint, spec, path, options.Mounts, bindFiles, volumes, b.CommonBuildOpts.Volumes, options.RunMounts, runMountInfo)
 	if err != nil {
-		return fmt.Errorf("error resolving mountpoints for container %q: %w", b.ContainerID, err)
+		return fmt.Errorf("resolving mountpoints for container %q: %w", b.ContainerID, err)
 	}
 	if runArtifacts.SSHAuthSock != "" {
 		sshenv := "SSH_AUTH_SOCK=" + runArtifacts.SSHAuthSock
@@ -506,7 +506,7 @@ func setupRootlessNetwork(pid int) (teardown func(), err error) {
 	b := make([]byte, 1)
 	for {
 		if err := rootlessSlirpSyncR.SetDeadline(time.Now().Add(1 * time.Second)); err != nil {
-			return nil, fmt.Errorf("error setting slirp4netns pipe timeout: %w", err)
+			return nil, fmt.Errorf("setting slirp4netns pipe timeout: %w", err)
 		}
 		if _, err := rootlessSlirpSyncR.Read(b); err == nil {
 			break
@@ -552,7 +552,7 @@ func (b *Builder) runConfigureNetwork(pid int, isolation define.Isolation, optio
 	netns := fmt.Sprintf("/proc/%d/ns/net", pid)
 	netFD, err := unix.Open(netns, unix.O_RDONLY, 0)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error opening network namespace: %w", err)
+		return nil, nil, fmt.Errorf("opening network namespace: %w", err)
 	}
 	mynetns := fmt.Sprintf("/proc/%d/fd/%d", unix.Getpid(), netFD)
 
@@ -589,17 +589,17 @@ func runMakeStdioPipe(uid, gid int) ([][]int, error) {
 	for i := range stdioPipe {
 		stdioPipe[i] = make([]int, 2)
 		if err := unix.Pipe(stdioPipe[i]); err != nil {
-			return nil, fmt.Errorf("error creating pipe for container FD %d: %w", i, err)
+			return nil, fmt.Errorf("creating pipe for container FD %d: %w", i, err)
 		}
 	}
 	if err := unix.Fchown(stdioPipe[unix.Stdin][0], uid, gid); err != nil {
-		return nil, fmt.Errorf("error setting owner of stdin pipe descriptor: %w", err)
+		return nil, fmt.Errorf("setting owner of stdin pipe descriptor: %w", err)
 	}
 	if err := unix.Fchown(stdioPipe[unix.Stdout][1], uid, gid); err != nil {
-		return nil, fmt.Errorf("error setting owner of stdout pipe descriptor: %w", err)
+		return nil, fmt.Errorf("setting owner of stdout pipe descriptor: %w", err)
 	}
 	if err := unix.Fchown(stdioPipe[unix.Stderr][1], uid, gid); err != nil {
-		return nil, fmt.Errorf("error setting owner of stderr pipe descriptor: %w", err)
+		return nil, fmt.Errorf("setting owner of stderr pipe descriptor: %w", err)
 	}
 	return stdioPipe, nil
 }
@@ -633,20 +633,20 @@ func setupNamespaces(logger *logrus.Logger, g *generate.Generator, namespaceOpti
 		}
 		if namespaceOption.Host {
 			if err := g.RemoveLinuxNamespace(namespaceOption.Name); err != nil {
-				return false, nil, false, fmt.Errorf("error removing %q namespace for run: %w", namespaceOption.Name, err)
+				return false, nil, false, fmt.Errorf("removing %q namespace for run: %w", namespaceOption.Name, err)
 			}
 		} else if err := g.AddOrReplaceLinuxNamespace(namespaceOption.Name, namespaceOption.Path); err != nil {
 			if namespaceOption.Path == "" {
-				return false, nil, false, fmt.Errorf("error adding new %q namespace for run: %w", namespaceOption.Name, err)
+				return false, nil, false, fmt.Errorf("adding new %q namespace for run: %w", namespaceOption.Name, err)
 			}
-			return false, nil, false, fmt.Errorf("error adding %q namespace %q for run: %w", namespaceOption.Name, namespaceOption.Path, err)
+			return false, nil, false, fmt.Errorf("adding %q namespace %q for run: %w", namespaceOption.Name, namespaceOption.Path, err)
 		}
 	}
 
 	// If we've got mappings, we're going to have to create a user namespace.
 	if len(idmapOptions.UIDMap) > 0 || len(idmapOptions.GIDMap) > 0 || configureUserns {
 		if err := g.AddOrReplaceLinuxNamespace(string(specs.UserNamespace), ""); err != nil {
-			return false, nil, false, fmt.Errorf("error adding new %q namespace for run: %w", string(specs.UserNamespace), err)
+			return false, nil, false, fmt.Errorf("adding new %q namespace for run: %w", string(specs.UserNamespace), err)
 		}
 		hostUidmap, hostGidmap, err := unshare.GetHostIDMappings("")
 		if err != nil {
@@ -670,17 +670,17 @@ func setupNamespaces(logger *logrus.Logger, g *generate.Generator, namespaceOpti
 		}
 		if !specifiedNetwork {
 			if err := g.AddOrReplaceLinuxNamespace(string(specs.NetworkNamespace), ""); err != nil {
-				return false, nil, false, fmt.Errorf("error adding new %q namespace for run: %w", string(specs.NetworkNamespace), err)
+				return false, nil, false, fmt.Errorf("adding new %q namespace for run: %w", string(specs.NetworkNamespace), err)
 			}
 			configureNetwork = (policy != define.NetworkDisabled)
 		}
 	} else {
 		if err := g.RemoveLinuxNamespace(string(specs.UserNamespace)); err != nil {
-			return false, nil, false, fmt.Errorf("error removing %q namespace for run: %w", string(specs.UserNamespace), err)
+			return false, nil, false, fmt.Errorf("removing %q namespace for run: %w", string(specs.UserNamespace), err)
 		}
 		if !specifiedNetwork {
 			if err := g.RemoveLinuxNamespace(string(specs.NetworkNamespace)); err != nil {
-				return false, nil, false, fmt.Errorf("error removing %q namespace for run: %w", string(specs.NetworkNamespace), err)
+				return false, nil, false, fmt.Errorf("removing %q namespace for run: %w", string(specs.NetworkNamespace), err)
 			}
 		}
 	}
@@ -798,10 +798,10 @@ func (b *Builder) runSetupVolumeMounts(mountLabel string, volumeMounts []string,
 	// Make sure the overlay directory is clean before running
 	containerDir, err := b.store.ContainerDirectory(b.ContainerID)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up container directory for %s: %w", b.ContainerID, err)
+		return nil, fmt.Errorf("looking up container directory for %s: %w", b.ContainerID, err)
 	}
 	if err := overlay.CleanupContent(containerDir); err != nil {
-		return nil, fmt.Errorf("error cleaning up overlay content for %s: %w", b.ContainerID, err)
+		return nil, fmt.Errorf("cleaning up overlay content for %s: %w", b.ContainerID, err)
 	}
 
 	parseMount := func(mountType, host, container string, options []string) (specs.Mount, error) {
@@ -968,16 +968,16 @@ func setupReadOnlyPaths(g *generate.Generator) {
 func setupCapAdd(g *generate.Generator, caps ...string) error {
 	for _, cap := range caps {
 		if err := g.AddProcessCapabilityBounding(cap); err != nil {
-			return fmt.Errorf("error adding %q to the bounding capability set: %w", cap, err)
+			return fmt.Errorf("adding %q to the bounding capability set: %w", cap, err)
 		}
 		if err := g.AddProcessCapabilityEffective(cap); err != nil {
-			return fmt.Errorf("error adding %q to the effective capability set: %w", cap, err)
+			return fmt.Errorf("adding %q to the effective capability set: %w", cap, err)
 		}
 		if err := g.AddProcessCapabilityPermitted(cap); err != nil {
-			return fmt.Errorf("error adding %q to the permitted capability set: %w", cap, err)
+			return fmt.Errorf("adding %q to the permitted capability set: %w", cap, err)
 		}
 		if err := g.AddProcessCapabilityAmbient(cap); err != nil {
-			return fmt.Errorf("error adding %q to the ambient capability set: %w", cap, err)
+			return fmt.Errorf("adding %q to the ambient capability set: %w", cap, err)
 		}
 	}
 	return nil
@@ -986,16 +986,16 @@ func setupCapAdd(g *generate.Generator, caps ...string) error {
 func setupCapDrop(g *generate.Generator, caps ...string) error {
 	for _, cap := range caps {
 		if err := g.DropProcessCapabilityBounding(cap); err != nil {
-			return fmt.Errorf("error removing %q from the bounding capability set: %w", cap, err)
+			return fmt.Errorf("removing %q from the bounding capability set: %w", cap, err)
 		}
 		if err := g.DropProcessCapabilityEffective(cap); err != nil {
-			return fmt.Errorf("error removing %q from the effective capability set: %w", cap, err)
+			return fmt.Errorf("removing %q from the effective capability set: %w", cap, err)
 		}
 		if err := g.DropProcessCapabilityPermitted(cap); err != nil {
-			return fmt.Errorf("error removing %q from the permitted capability set: %w", cap, err)
+			return fmt.Errorf("removing %q from the permitted capability set: %w", cap, err)
 		}
 		if err := g.DropProcessCapabilityAmbient(cap); err != nil {
-			return fmt.Errorf("error removing %q from the ambient capability set: %w", cap, err)
+			return fmt.Errorf("removing %q from the ambient capability set: %w", cap, err)
 		}
 	}
 	return nil

--- a/seccomp.go
+++ b/seccomp.go
@@ -24,7 +24,7 @@ func setupSeccomp(spec *specs.Spec, seccompProfilePath string) error {
 	default:
 		seccompProfile, err := ioutil.ReadFile(seccompProfilePath)
 		if err != nil {
-			return fmt.Errorf("opening seccomp profile (%s) failed: %w", seccompProfilePath, err)
+			return fmt.Errorf("opening seccomp profile failed: %w", err)
 		}
 		seccompConfig, err := seccomp.LoadProfile(string(seccompProfile), spec)
 		if err != nil {

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -221,7 +221,7 @@ stuff/mystuff"
   cid=$output
 
   run_buildah 125 copy --ignorefile ${mytest}/.ignore $cid ${mytest} /stuff
-  expect_output -- "--ignorefile option requires that you specify a context dir using --contextdir" "container file list"
+  expect_output -- "Error: --ignorefile option requires that you specify a context dir using --contextdir" "container file list"
 
   run_buildah add --contextdir=${mytest} --ignorefile ${mytest}/.ignore $cid ${mytest} /stuff
 

--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -26,7 +26,7 @@ load helpers
   run_buildah 0 login --cert-dir $REGISTRY_DIR --username testuserfoo --password testpassword localhost:$REGISTRY_PORT
 
   run_buildah 125 logout --authfile /tmp/nonexistent localhost:$REGISTRY_PORT
-  expect_output "checking authfile: stat /tmp/nonexistent: no such file or directory"
+  expect_output "Error: checking authfile: stat /tmp/nonexistent: no such file or directory"
 
   run_buildah 0 logout localhost:$REGISTRY_PORT
 }
@@ -136,7 +136,7 @@ EOM
   expect_output --substring "Storing signatures"
 
   run_buildah 125 login --tls-verify=false --username testuser --password WRONGPASSWORD localhost:$REGISTRY_PORT
-  expect_output 'error logging into "localhost:'"$REGISTRY_PORT"'": invalid username/password' \
+  expect_output --substring 'logging into "localhost:'"$REGISTRY_PORT"'": invalid username/password' \
                 "buildah login, wrong credentials"
 
   run_buildah 0 logout localhost:$REGISTRY_PORT

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -22,7 +22,7 @@ load helpers
 @test "bud with .dockerignore #1" {
   _prefetch alpine busybox
   run_buildah 125 build -t testbud $WITH_POLICY_JSON -f $BUDFILES/dockerignore/Dockerfile $BUDFILES/dockerignore
-  expect_output --substring 'error building.*"COPY subdir \./".*no such file or directory'
+  expect_output --substring 'building.*"COPY subdir \./".*no such file or directory'
 
   run_buildah build -t testbud $WITH_POLICY_JSON -f $BUDFILES/dockerignore/Dockerfile.succeed $BUDFILES/dockerignore
 
@@ -42,7 +42,7 @@ load helpers
 @test "bud with .containerignore" {
   _prefetch alpine busybox
   run_buildah 125 build -t testbud $WITH_POLICY_JSON -f $BUDFILES/containerignore/Dockerfile $BUDFILES/containerignore
-  expect_output --substring 'error building.*"COPY subdir \./".*no such file or directory'
+  expect_output --substring 'building.*"COPY subdir \./".*no such file or directory'
 
   run_buildah build -t testbud $WITH_POLICY_JSON -f $BUDFILES/containerignore/Dockerfile.succeed $BUDFILES/containerignore
 
@@ -113,20 +113,20 @@ symlink(subdir)"
 
 @test "bud with .dockerignore #2" {
   run_buildah 125 build -t testbud3 $WITH_POLICY_JSON $BUDFILES/dockerignore3
-  expect_output --substring 'error building.*"COPY test1.txt /upload/test1.txt".*no such file or directory'
+  expect_output --substring 'building.*"COPY test1.txt /upload/test1.txt".*no such file or directory'
   expect_output --substring $(realpath "$BUDFILES/dockerignore3/.dockerignore")
 }
 
 @test "bud with .dockerignore #4" {
   run_buildah 125 build -t testbud3 $WITH_POLICY_JSON -f Dockerfile.test $BUDFILES/dockerignore4
-  expect_output --substring 'error building.*"COPY test1.txt /upload/test1.txt".*no such file or directory'
+  expect_output --substring 'building.*"COPY test1.txt /upload/test1.txt".*no such file or directory'
   expect_output --substring '1 filtered out using /[^ ]*/Dockerfile.test.dockerignore'
 }
 
 @test "bud with .dockerignore #6" {
   _prefetch alpine busybox
   run_buildah 125 build -t testbud $WITH_POLICY_JSON -f $BUDFILES/dockerignore6/Dockerfile $BUDFILES/dockerignore6
-  expect_output --substring 'error building.*"COPY subdir \./".*no such file or directory'
+  expect_output --substring 'building.*"COPY subdir \./".*no such file or directory'
 
   run_buildah build -t testbud $WITH_POLICY_JSON -f $BUDFILES/dockerignore6/Dockerfile.succeed $BUDFILES/dockerignore6
 
@@ -2044,7 +2044,7 @@ function _test_http() {
   _prefetch alpine
   target=alpine-image
   run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/symlink/Dockerfile.symlink-points-to-itself $BUDFILES/symlink
-  assert "$output" =~ "error building .* open /test-log/test: too many levels of symbolic links"
+  assert "$output" =~ "building .* open /test-log/test: too many levels of symbolic links"
 }
 
 @test "bud multi-stage with symlink to absolute path" {
@@ -2090,7 +2090,7 @@ function _test_http() {
   target=alpine-image
   run_buildah 2 bud $WITH_POLICY_JSON -t ${target} -f Dockerfile.entrypoint-empty-run $BUDFILES/run-scenarios
   expect_output --substring " -c requires an argument"
-  expect_output --substring "error building at STEP.*: exit status 2"
+  expect_output --substring "building at STEP.*: exit status 2"
 }
 
 @test "bud with CMD and RUN" {
@@ -2106,7 +2106,7 @@ function _test_http() {
   target=alpine-image
   run_buildah 2 bud $WITH_POLICY_JSON -t ${target} -f Dockerfile.cmd-empty-run $BUDFILES/run-scenarios
   expect_output --substring " -c requires an argument"
-  expect_output --substring "error building at STEP.*: exit status 2"
+  expect_output --substring "building at STEP.*: exit status 2"
 }
 
 @test "bud with ENTRYPOINT, CMD and RUN" {
@@ -2122,7 +2122,7 @@ function _test_http() {
   target=alpine-image
   run_buildah 2 bud $WITH_POLICY_JSON -t ${target} -f $BUDFILES/run-scenarios/Dockerfile.entrypoint-cmd-empty-run $BUDFILES/run-scenarios
   expect_output --substring " -c requires an argument"
-  expect_output --substring "error building at STEP.*: exit status 2"
+  expect_output --substring "building at STEP.*: exit status 2"
 }
 
 # Determines if a variable set with ENV is available to following commands in the Dockerfile
@@ -2401,7 +2401,7 @@ _EOF
   imgName=alpine-image
   ctrName=alpine-chown
   run_buildah 125 build $WITH_POLICY_JSON -t ${imgName} -f $BUDFILES/copy-chown/Dockerfile.bad2 $BUDFILES/copy-chown
-  expect_output --substring "error looking up UID/GID for \":\": can't find uid for user"
+  expect_output --substring "looking up UID/GID for \":\": can't find uid for user"
 }
 
 @test "bud with chmod copy" {
@@ -3414,7 +3414,7 @@ _EOF
 @test "bud with Containerfile should fail with nonexistent authfile" {
   target=alpine-image
   run_buildah 125 build --authfile /tmp/nonexistent $WITH_POLICY_JSON -t ${target} $BUDFILES/containerfile
-  expect_output "checking authfile: stat /tmp/nonexistent: no such file or directory"
+  expect_output "Error: checking authfile: stat /tmp/nonexistent: no such file or directory"
 }
 
 
@@ -3434,7 +3434,7 @@ COPY https://getfedora.org/index.html .
 EOM
 
   run_buildah 125 build $WITH_POLICY_JSON -t foo -f ${TEST_SCRATCH_DIR}/budcopy/Dockerfile.url
-  expect_output --substring "error building .* source can.t be a URL for COPY"
+  expect_output --substring "building .* source can.t be a URL for COPY"
 }
 
 @test "bud quiet" {
@@ -3946,7 +3946,7 @@ _EOF
 
   # fail without --stdin
   run_buildah 1 bud -t testbud $WITH_POLICY_JSON ${mytmpdir} <<< input
-  expect_output --substring "error building .*: exit status 1"
+  expect_output --substring "building .*: exit status 1"
 
   run_buildah build --stdin -t testbud $WITH_POLICY_JSON ${mytmpdir} <<< input
   expect_output --substring "test got <input>"
@@ -4414,7 +4414,7 @@ _EOF
 
   run_buildah 1 build --no-cache --no-hosts \
                   $WITH_POLICY_JSON --file ${mytmpdir}/Containerfile .
-  expect_output --substring 'error building at STEP "RUN grep "myhostname" /etc/hosts'
+  expect_output --substring 'building at STEP "RUN grep "myhostname" /etc/hosts'
 }
 
 @test "bud with --cgroup-parent" {
@@ -4680,7 +4680,7 @@ _EOF
   run_buildah build -t test2 -f Containerfile.missing $WITH_POLICY_JSON $BUDFILES/copy-globs
 
   run_buildah 125 build -t test3 -f Containerfile.bad $WITH_POLICY_JSON $BUDFILES/copy-globs
-  expect_output --substring 'error building.*"COPY \*foo /testdir".*no such file or directory'
+  expect_output --substring 'building.*"COPY \*foo /testdir".*no such file or directory'
 }
 
 @test "bud with containerfile secret" {
@@ -4837,7 +4837,7 @@ _EOF
 @test "bud-multiple-platform-no-partial-manifest-list" {
   outputlist=localhost/testlist
   run_buildah 1 bud $WITH_POLICY_JSON --platform=linux/arm,linux/amd64 --manifest $outputlist -f $BUDFILES/multiarch/Dockerfile.fail $BUDFILES/multiarch
-  expect_output --substring "error building at STEP \"RUN test .arch. = x86_64"
+  expect_output --substring "building at STEP \"RUN test .arch. = x86_64"
   run_buildah 125 manifest inspect $outputlist
   expect_output --substring "reading image .* pinging container registry"
 }
@@ -4861,7 +4861,7 @@ _EOF
   fi
   outputlist=localhost/testlist
   run_buildah 125 build $WITH_POLICY_JSON --jobs=0 --platform=linux/arm64,linux/amd64 --manifest $outputlist -f $BUDFILES/multiarch/Dockerfile.fail-multistage $BUDFILES/multiarch
-  expect_output --substring 'error building at STEP "RUN false"'
+  expect_output --substring 'building at STEP "RUN false"'
 }
 
 @test "bud-multiple-platform-no-run" {
@@ -5338,7 +5338,7 @@ _EOF
   echo 'FROM alpine' | tee ${TEST_SCRATCH_DIR}/Dockerfile1
   echo '# escape=|\nFROM alpine' | tee ${TEST_SCRATCH_DIR}/Dockerfile2
   run_buildah 125 build -f ${TEST_SCRATCH_DIR}/Dockerfile1 -f ${TEST_SCRATCH_DIR}/Dockerfile2 ${TEST_SCRATCH_DIR}
-  assert "$output" =~ "error parsing additional Dockerfile .*Dockerfile2: invalid ESCAPE"
+  assert "$output" =~ "parsing additional Dockerfile .*Dockerfile2: invalid ESCAPE"
 }
 
 @test "build-with-network-test" {

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -95,7 +95,7 @@ load helpers
   cid=$output
   run_buildah commit $WITH_POLICY_JSON --rm $cid alpine-image
   run_buildah 125 rm $cid
-  expect_output --substring "error removing container \"alpine-working-container\": container not known"
+  expect_output --substring "removing container \"alpine-working-container\": container not known"
 }
 
 @test "commit-alternate-storage" {

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -23,19 +23,19 @@ load helpers
   run_buildah config --annotation ANNOTATION $cid
 
   run_buildah 125 config --healthcheck 'AB "CD' $cid
-  expect_output --substring 'error parsing --healthcheck "AB \\"CD": invalid command line string'
+  expect_output --substring 'parsing --healthcheck "AB \\"CD": invalid command line string'
 
   run_buildah 125 config --healthcheck-interval ABCD $cid
-  expect_output --substring 'error parsing --healthcheck-interval "ABCD": time: invalid duration "?ABCD"?'
+  expect_output --substring 'parsing --healthcheck-interval "ABCD": time: invalid duration "?ABCD"?'
 
   run_buildah 125 config --cmd 'AB "CD' $cid
-  expect_output --substring 'error parsing --cmd "AB \\"CD": invalid command line string'
+  expect_output --substring 'parsing --cmd "AB \\"CD": invalid command line string'
 
   run_buildah 125 config --env ENV $cid
-  expect_output --substring 'error setting env "ENV": no value given'
+  expect_output --substring 'setting env "ENV": no value given'
 
   run_buildah 125 config --shell 'AB "CD' $cid
-  expect_output --substring 'error parsing --shell "AB \\"CD": invalid command line string'
+  expect_output --substring 'parsing --shell "AB \\"CD": invalid command line string'
 }
 
 function check_matrix() {

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1539,33 +1539,33 @@ var internalTestCases = []testCase{
 			content := []byte("test content")
 
 			if err := os.Mkdir(filepath.Join(contextDir, "archive"), 0755); err != nil {
-				return fmt.Errorf("error creating subdirectory of temporary context directory: %w", err)
+				return fmt.Errorf("creating subdirectory of temporary context directory: %w", err)
 			}
 			filename := filepath.Join(contextDir, "archive", "should-be-owned-by-root")
 			if err = ioutil.WriteFile(filename, content, 0640); err != nil {
-				return fmt.Errorf("error creating file owned by root in temporary context directory: %w", err)
+				return fmt.Errorf("creating file owned by root in temporary context directory: %w", err)
 			}
 			if err = os.Chown(filename, 0, 0); err != nil {
-				return fmt.Errorf("error setting ownership on file owned by root in temporary context directory: %w", err)
+				return fmt.Errorf("setting ownership on file owned by root in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on file owned by root file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on file owned by root file in temporary context directory: %w", err)
 			}
 			filename = filepath.Join(contextDir, "archive", "should-be-owned-by-99")
 			if err = ioutil.WriteFile(filename, content, 0640); err != nil {
-				return fmt.Errorf("error creating file owned by 99 in temporary context directory: %w", err)
+				return fmt.Errorf("creating file owned by 99 in temporary context directory: %w", err)
 			}
 			if err = os.Chown(filename, 99, 99); err != nil {
-				return fmt.Errorf("error setting ownership on file owned by 99 in temporary context directory: %w", err)
+				return fmt.Errorf("setting ownership on file owned by 99 in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on file owned by 99 in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on file owned by 99 in temporary context directory: %w", err)
 			}
 
 			filename = filepath.Join(contextDir, "archive.tar")
 			f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				return fmt.Errorf("error creating archive file: %w", err)
+				return fmt.Errorf("creating archive file: %w", err)
 			}
 			defer f.Close()
 			tw := tar.NewWriter(f)
@@ -1580,11 +1580,11 @@ var internalTestCases = []testCase{
 				Gid:      0,
 			})
 			if err != nil {
-				return fmt.Errorf("error writing archive file header: %w", err)
+				return fmt.Errorf("writing archive file header: %w", err)
 			}
 			n, err := tw.Write(content)
 			if err != nil {
-				return fmt.Errorf("error writing archive file contents: %w", err)
+				return fmt.Errorf("writing archive file contents: %w", err)
 			}
 			if n != len(content) {
 				return errors.New("short write writing archive file contents")
@@ -1599,11 +1599,11 @@ var internalTestCases = []testCase{
 				Gid:      99,
 			})
 			if err != nil {
-				return fmt.Errorf("error writing archive file header: %w", err)
+				return fmt.Errorf("writing archive file header: %w", err)
 			}
 			n, err = tw.Write(content)
 			if err != nil {
-				return fmt.Errorf("error writing archive file contents: %w", err)
+				return fmt.Errorf("writing archive file contents: %w", err)
 			}
 			if n != len(content) {
 				return errors.New("short write writing archive file contents")
@@ -1625,27 +1625,27 @@ var internalTestCases = []testCase{
 			content := []byte("test content")
 
 			if err := os.Mkdir(filepath.Join(contextDir, "subdir"), 0755); err != nil {
-				return fmt.Errorf("error creating subdirectory of temporary context directory: %w", err)
+				return fmt.Errorf("creating subdirectory of temporary context directory: %w", err)
 			}
 			filename := filepath.Join(contextDir, "subdir", "would-be-owned-by-root")
 			if err = ioutil.WriteFile(filename, content, 0640); err != nil {
-				return fmt.Errorf("error creating file owned by root in temporary context directory: %w", err)
+				return fmt.Errorf("creating file owned by root in temporary context directory: %w", err)
 			}
 			if err = os.Chown(filename, 0, 0); err != nil {
-				return fmt.Errorf("error setting ownership on file owned by root in temporary context directory: %w", err)
+				return fmt.Errorf("setting ownership on file owned by root in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on file owned by root file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on file owned by root file in temporary context directory: %w", err)
 			}
 			filename = filepath.Join(contextDir, "subdir", "would-be-owned-by-99")
 			if err = ioutil.WriteFile(filename, content, 0640); err != nil {
-				return fmt.Errorf("error creating file owned by 99 in temporary context directory: %w", err)
+				return fmt.Errorf("creating file owned by 99 in temporary context directory: %w", err)
 			}
 			if err = os.Chown(filename, 99, 99); err != nil {
-				return fmt.Errorf("error setting ownership on file owned by 99 in temporary context directory: %w", err)
+				return fmt.Errorf("setting ownership on file owned by 99 in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on file owned by 99 in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on file owned by 99 in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -1664,27 +1664,27 @@ var internalTestCases = []testCase{
 			content := []byte("test content")
 
 			if err := os.Mkdir(filepath.Join(contextDir, "subdir"), 0755); err != nil {
-				return fmt.Errorf("error creating subdirectory of temporary context directory: %w", err)
+				return fmt.Errorf("creating subdirectory of temporary context directory: %w", err)
 			}
 			filename := filepath.Join(contextDir, "subdir", "would-be-owned-by-root")
 			if err = ioutil.WriteFile(filename, content, 0640); err != nil {
-				return fmt.Errorf("error creating file owned by root in temporary context directory: %w", err)
+				return fmt.Errorf("creating file owned by root in temporary context directory: %w", err)
 			}
 			if err = os.Chown(filename, 0, 0); err != nil {
-				return fmt.Errorf("error setting ownership on file owned by root in temporary context directory: %w", err)
+				return fmt.Errorf("setting ownership on file owned by root in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on file owned by root file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on file owned by root file in temporary context directory: %w", err)
 			}
 			filename = filepath.Join(contextDir, "subdir", "would-be-owned-by-99")
 			if err = ioutil.WriteFile(filename, content, 0640); err != nil {
-				return fmt.Errorf("error creating file owned by 99 in temporary context directory: %w", err)
+				return fmt.Errorf("creating file owned by 99 in temporary context directory: %w", err)
 			}
 			if err = os.Chown(filename, 99, 99); err != nil {
-				return fmt.Errorf("error setting ownership on file owned by 99 in temporary context directory: %w", err)
+				return fmt.Errorf("setting ownership on file owned by 99 in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on file owned by 99 in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on file owned by 99 in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -1725,43 +1725,43 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			filename := filepath.Join(contextDir, "should-be-setuid-file")
 			if err = ioutil.WriteFile(filename, []byte("test content"), 0644); err != nil {
-				return fmt.Errorf("error creating setuid test file in temporary context directory: %w", err)
+				return fmt.Errorf("creating setuid test file in temporary context directory: %w", err)
 			}
 			if err = syscall.Chmod(filename, syscall.S_ISUID|0755); err != nil {
-				return fmt.Errorf("error setting setuid bit on test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting setuid bit on test file in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on setuid test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on setuid test file in temporary context directory: %w", err)
 			}
 			filename = filepath.Join(contextDir, "should-be-setgid-file")
 			if err = ioutil.WriteFile(filename, []byte("test content"), 0644); err != nil {
-				return fmt.Errorf("error creating setgid test file in temporary context directory: %w", err)
+				return fmt.Errorf("creating setgid test file in temporary context directory: %w", err)
 			}
 			if err = syscall.Chmod(filename, syscall.S_ISGID|0755); err != nil {
-				return fmt.Errorf("error setting setgid bit on test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting setgid bit on test file in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on setgid test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on setgid test file in temporary context directory: %w", err)
 			}
 			filename = filepath.Join(contextDir, "should-be-sticky-file")
 			if err = ioutil.WriteFile(filename, []byte("test content"), 0644); err != nil {
-				return fmt.Errorf("error creating sticky test file in temporary context directory: %w", err)
+				return fmt.Errorf("creating sticky test file in temporary context directory: %w", err)
 			}
 			if err = syscall.Chmod(filename, syscall.S_ISVTX|0755); err != nil {
-				return fmt.Errorf("error setting permissions on sticky test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting permissions on sticky test file in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on sticky test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on sticky test file in temporary context directory: %w", err)
 			}
 			filename = filepath.Join(contextDir, "should-not-be-setuid-setgid-sticky-file")
 			if err = ioutil.WriteFile(filename, []byte("test content"), 0644); err != nil {
-				return fmt.Errorf("error creating non-suid non-sgid non-sticky test file in temporary context directory: %w", err)
+				return fmt.Errorf("creating non-suid non-sgid non-sticky test file in temporary context directory: %w", err)
 			}
 			if err = syscall.Chmod(filename, 0640); err != nil {
-				return fmt.Errorf("error setting permissions on plain test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting permissions on plain test file in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on plain test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on plain test file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -1786,16 +1786,16 @@ var internalTestCases = []testCase{
 
 			filename := filepath.Join(contextDir, "xattrs-file")
 			if err = ioutil.WriteFile(filename, []byte("test content"), 0644); err != nil {
-				return fmt.Errorf("error creating test file with xattrs in temporary context directory: %w", err)
+				return fmt.Errorf("creating test file with xattrs in temporary context directory: %w", err)
 			}
 			if err = copier.Lsetxattrs(filename, map[string]string{"user.a": "test"}); err != nil {
-				return fmt.Errorf("error setting xattrs on test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting xattrs on test file in temporary context directory: %w", err)
 			}
 			if err = syscall.Chmod(filename, 0640); err != nil {
-				return fmt.Errorf("error setting permissions on test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting permissions on test file in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on test file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -1813,7 +1813,7 @@ var internalTestCases = []testCase{
 			filename := filepath.Join(contextDir, "archive.tar")
 			f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				return fmt.Errorf("error creating new archive file in temporary context directory: %w", err)
+				return fmt.Errorf("creating new archive file in temporary context directory: %w", err)
 			}
 			defer f.Close()
 			tw := tar.NewWriter(f)
@@ -1828,10 +1828,10 @@ var internalTestCases = []testCase{
 				ModTime:  testDate,
 			}
 			if err = tw.WriteHeader(&hdr); err != nil {
-				return fmt.Errorf("error writing tar archive header: %w", err)
+				return fmt.Errorf("writing tar archive header: %w", err)
 			}
 			if _, err = io.Copy(tw, bytes.NewReader([]byte("whatever"))); err != nil {
-				return fmt.Errorf("error writing tar archive content: %w", err)
+				return fmt.Errorf("writing tar archive content: %w", err)
 			}
 			hdr = tar.Header{
 				Name:     "setgid-file",
@@ -1843,10 +1843,10 @@ var internalTestCases = []testCase{
 				ModTime:  testDate,
 			}
 			if err = tw.WriteHeader(&hdr); err != nil {
-				return fmt.Errorf("error writing tar archive header: %w", err)
+				return fmt.Errorf("writing tar archive header: %w", err)
 			}
 			if _, err = io.Copy(tw, bytes.NewReader([]byte("whatever"))); err != nil {
-				return fmt.Errorf("error writing tar archive content: %w", err)
+				return fmt.Errorf("writing tar archive content: %w", err)
 			}
 			hdr = tar.Header{
 				Name:     "sticky-file",
@@ -1858,10 +1858,10 @@ var internalTestCases = []testCase{
 				ModTime:  testDate,
 			}
 			if err = tw.WriteHeader(&hdr); err != nil {
-				return fmt.Errorf("error writing tar archive header: %w", err)
+				return fmt.Errorf("writing tar archive header: %w", err)
 			}
 			if _, err = io.Copy(tw, bytes.NewReader([]byte("whatever"))); err != nil {
-				return fmt.Errorf("error writing tar archive content: %w", err)
+				return fmt.Errorf("writing tar archive content: %w", err)
 			}
 			return nil
 		},
@@ -1885,7 +1885,7 @@ var internalTestCases = []testCase{
 			filename := filepath.Join(contextDir, "archive.tar")
 			f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				return fmt.Errorf("error creating new archive file in temporary context directory: %w", err)
+				return fmt.Errorf("creating new archive file in temporary context directory: %w", err)
 			}
 			defer f.Close()
 			tw := tar.NewWriter(f)
@@ -1901,10 +1901,10 @@ var internalTestCases = []testCase{
 				Xattrs:   map[string]string{"user.a": "test"},
 			}
 			if err = tw.WriteHeader(&hdr); err != nil {
-				return fmt.Errorf("error writing tar archive header: %w", err)
+				return fmt.Errorf("writing tar archive header: %w", err)
 			}
 			if _, err = io.Copy(tw, bytes.NewReader([]byte("whatever"))); err != nil {
-				return fmt.Errorf("error writing tar archive content: %w", err)
+				return fmt.Errorf("writing tar archive content: %w", err)
 			}
 			return nil
 		},
@@ -1945,16 +1945,16 @@ var internalTestCases = []testCase{
 
 			filename := filepath.Join(contextDir, "xattrs-file")
 			if err = ioutil.WriteFile(filename, []byte("test content"), 0644); err != nil {
-				return fmt.Errorf("error creating test file with xattrs in temporary context directory: %w", err)
+				return fmt.Errorf("creating test file with xattrs in temporary context directory: %w", err)
 			}
 			if err = copier.Lsetxattrs(filename, map[string]string{"user.a": "test"}); err != nil {
-				return fmt.Errorf("error setting xattrs on test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting xattrs on test file in temporary context directory: %w", err)
 			}
 			if err = syscall.Chmod(filename, 0640); err != nil {
-				return fmt.Errorf("error setting permissions on test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting permissions on test file in temporary context directory: %w", err)
 			}
 			if err = os.Chtimes(filename, testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on test file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on test file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2112,10 +2112,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/*-a", "!**/*-c"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0600); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2132,10 +2132,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/*-a", "!**/*-c"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0644); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2152,10 +2152,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/*-a", "!**/*-c"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0600); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2172,10 +2172,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"!**/*-c"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0640); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2192,10 +2192,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("!**/*-c\n")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0100); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2212,10 +2212,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("subdir-c")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0200); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2232,10 +2232,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("subdir-c")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0400); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2252,10 +2252,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-c")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0200); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2272,10 +2272,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-c")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0400); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2292,10 +2292,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("subdir-*")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0000); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2312,10 +2312,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("subdir-*")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0660); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2332,10 +2332,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-*")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0000); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2352,10 +2352,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-*")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0660); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2372,10 +2372,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-f")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0666); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2392,10 +2392,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-f")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0640); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2412,10 +2412,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-b")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0705); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2432,10 +2432,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte("**/subdir-b")
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0750); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2452,10 +2452,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/subdir-e", "!**/subdir-f"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0750); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2472,10 +2472,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/subdir-e", "!**/subdir-f"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0750); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2492,10 +2492,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/subdir-f", "!**/subdir-g"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0750); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},
@@ -2512,10 +2512,10 @@ var internalTestCases = []testCase{
 		tweakContextDir: func(t *testing.T, contextDir, storageDriver, storageRoot string) (err error) {
 			dockerignore := []byte(strings.Join([]string{"**/subdir-f", "!**/subdir-g"}, "\n"))
 			if err := ioutil.WriteFile(filepath.Join(contextDir, ".dockerignore"), dockerignore, 0750); err != nil {
-				return fmt.Errorf("error writing .dockerignore file: %w", err)
+				return fmt.Errorf("writing .dockerignore file: %w", err)
 			}
 			if err = os.Chtimes(filepath.Join(contextDir, ".dockerignore"), testDate, testDate); err != nil {
-				return fmt.Errorf("error setting date on .dockerignore file in temporary context directory: %w", err)
+				return fmt.Errorf("setting date on .dockerignore file in temporary context directory: %w", err)
 			}
 			return nil
 		},

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -347,7 +347,7 @@ stuff/mystuff"
   cid=$output
 
   run_buildah 125 copy --ignorefile ${mytest}/.ignore $cid ${mytest} /stuff
-  expect_output -- "--ignorefile option requires that you specify a context dir using --contextdir" "container file list"
+  expect_output -- "Error: --ignorefile option requires that you specify a context dir using --contextdir" "container file list"
 
   run_buildah copy --contextdir=${mytest} --ignorefile ${mytest}/.ignore $cid ${mytest} /stuff
 

--- a/tests/copy/copy.go
+++ b/tests/copy/copy.go
@@ -94,27 +94,27 @@ func main() {
 			}
 			src, err := alltransports.ParseImageName(args[0])
 			if err != nil {
-				return fmt.Errorf("error parsing source name: %w", err)
+				return fmt.Errorf("parsing source name: %w", err)
 			}
 			if len(args) < 1 {
 				return errors.New("no destination name provided")
 			}
 			dest, err := alltransports.ParseImageName(args[1])
 			if err != nil {
-				return fmt.Errorf("error parsing destination name: %w", err)
+				return fmt.Errorf("parsing destination name: %w", err)
 			}
 
 			policy, err := signature.DefaultPolicy(&systemContext)
 			if err != nil {
-				return fmt.Errorf("error reading signature policy: %w", err)
+				return fmt.Errorf("reading signature policy: %w", err)
 			}
 			policyContext, err := signature.NewPolicyContext(policy)
 			if err != nil {
-				return fmt.Errorf("error creating new signature policy context: %w", err)
+				return fmt.Errorf("creating new signature policy context: %w", err)
 			}
 			defer func() {
 				if err := policyContext.Destroy(); err != nil {
-					logrus.Error(fmt.Errorf("error destroying signature policy context: %w", err))
+					logrus.Error(fmt.Errorf("destroying signature policy context: %w", err))
 				}
 			}()
 

--- a/tests/e2e/buildah_suite_test.go
+++ b/tests/e2e/buildah_suite_test.go
@@ -205,11 +205,11 @@ func (p *BuildAhTest) CreateArtifact(image string) error {
 	}
 	policy, err := signature.DefaultPolicy(&systemContext)
 	if err != nil {
-		return fmt.Errorf("error loading signature policy: %w", err)
+		return fmt.Errorf("loading signature policy: %w", err)
 	}
 	policyContext, err := signature.NewPolicyContext(policy)
 	if err != nil {
-		return fmt.Errorf("error loading signature policy: %w", err)
+		return fmt.Errorf("loading signature policy: %w", err)
 	}
 	defer func() {
 		_ = policyContext.Destroy()
@@ -218,14 +218,14 @@ func (p *BuildAhTest) CreateArtifact(image string) error {
 
 	importRef, err := docker.ParseReference("//" + image)
 	if err != nil {
-		return fmt.Errorf("error parsing image name %v: %w", image, err)
+		return fmt.Errorf("parsing image name %v: %w", image, err)
 	}
 
 	imageDir := strings.Replace(image, "/", "_", -1)
 	exportDir := filepath.Join(p.ArtifactPath, imageDir)
 	exportRef, err := directory.NewReference(exportDir)
 	if err != nil {
-		return fmt.Errorf("error creating image reference for %v: %w", exportDir, err)
+		return fmt.Errorf("creating image reference for %v: %w", exportDir, err)
 	}
 
 	_, err = copy.Image(context.Background(), policyContext, exportRef, importRef, options)
@@ -245,7 +245,7 @@ func (p *BuildAhTest) RestoreArtifact(image string) error {
 
 	options := &copy.Options{}
 	if err != nil {
-		return fmt.Errorf("error opening storage: %w", err)
+		return fmt.Errorf("opening storage: %w", err)
 	}
 	defer func() {
 		_, _ = store.Shutdown(false)
@@ -254,32 +254,32 @@ func (p *BuildAhTest) RestoreArtifact(image string) error {
 	storage.Transport.SetStore(store)
 	ref, err := storage.Transport.ParseStoreReference(store, image)
 	if err != nil {
-		return fmt.Errorf("error parsing image name: %w", err)
+		return fmt.Errorf("parsing image name: %w", err)
 	}
 
 	imageDir := strings.Replace(image, "/", "_", -1)
 	importDir := filepath.Join(p.ArtifactPath, imageDir)
 	importRef, err := directory.NewReference(importDir)
 	if err != nil {
-		return fmt.Errorf("error creating image reference for %v: %w", image, err)
+		return fmt.Errorf("creating image reference for %v: %w", image, err)
 	}
 	systemContext := types.SystemContext{
 		SignaturePolicyPath: p.SignaturePath,
 	}
 	policy, err := signature.DefaultPolicy(&systemContext)
 	if err != nil {
-		return fmt.Errorf("error loading signature policy: %w", err)
+		return fmt.Errorf("loading signature policy: %w", err)
 	}
 	policyContext, err := signature.NewPolicyContext(policy)
 	if err != nil {
-		return fmt.Errorf("error loading signature policy: %w", err)
+		return fmt.Errorf("loading signature policy: %w", err)
 	}
 	defer func() {
 		_ = policyContext.Destroy()
 	}()
 	_, err = copy.Image(context.Background(), policyContext, ref, importRef, options)
 	if err != nil {
-		return fmt.Errorf("error importing %s: %w", importDir, err)
+		return fmt.Errorf("importing %s: %w", importDir, err)
 	}
 	return nil
 }

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -390,7 +390,7 @@ load helpers
 
 @test "from with nonexistent authfile: fails" {
   run_buildah 125 from --authfile /no/such/file --pull $WITH_POLICY_JSON alpine
-  expect_output "checking authfile: stat /no/such/file: no such file or directory"
+  expect_output "Error: checking authfile: stat /no/such/file: no such file or directory"
 }
 
 @test "from --pull-always: emits 'Getting' even if image is cached" {

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -48,7 +48,7 @@ load helpers
   cid2=$output
 
   run_buildah 125 images --noheading --filter since registry.k8s.io/pause
-  expect_output 'invalid image filter "since": must be in the format "filter=value or filter!=value"'
+  expect_output 'Error: invalid image filter "since": must be in the format "filter=value or filter!=value"'
 
 
   run_buildah images --noheading --filter since=registry.k8s.io/pause
@@ -153,7 +153,7 @@ load helpers
 
 @test "specify a nonexistent image" {
   run_buildah 125 images alpine
-  expect_output --from="${lines[0]}" "alpine: image not known"
+  expect_output --from="${lines[0]}" "Error: alpine: image not known"
   expect_line_count 1
 }
 

--- a/tests/namespaces.bats
+++ b/tests/namespaces.bats
@@ -461,16 +461,16 @@ _EOF
 
 @test "invalid userns-uid-map userns-gid-map" {
 	run_buildah 125 from --userns-uid-map 16  --userns-gid-map 0:48:16 scratch
-	expect_output 'initializing ID mappings: userns-uid-map setting is malformed expected ["uint32:uint32:uint32"]: ["16"]'
+	expect_output 'Error: initializing ID mappings: userns-uid-map setting is malformed expected ["uint32:uint32:uint32"]: ["16"]'
 
 	run_buildah 125 from --userns-uid-map 0:32:16  --userns-gid-map 16 scratch
-	expect_output 'initializing ID mappings: userns-gid-map setting is malformed expected ["uint32:uint32:uint32"]: ["16"]'
+	expect_output 'Error: initializing ID mappings: userns-gid-map setting is malformed expected ["uint32:uint32:uint32"]: ["16"]'
 
 	run_buildah 125 bud --userns-uid-map a  --userns-gid-map bogus bud/from-scratch
-	expect_output 'initializing ID mappings: userns-uid-map setting is malformed expected ["uint32:uint32:uint32"]: ["a"]'
+	expect_output 'Error: initializing ID mappings: userns-uid-map setting is malformed expected ["uint32:uint32:uint32"]: ["a"]'
 
 	run_buildah 125 bud --userns-uid-map 0:32:16 --userns-gid-map bogus bud/from-scratch
-	expect_output 'initializing ID mappings: userns-gid-map setting is malformed expected ["uint32:uint32:uint32"]: ["bogus"]'
+	expect_output 'Error: initializing ID mappings: userns-gid-map setting is malformed expected ["uint32:uint32:uint32"]: ["bogus"]'
 
 	run_buildah from --userns-uid-map 0:32:16  scratch
 }

--- a/tests/rename.bats
+++ b/tests/rename.bats
@@ -23,7 +23,7 @@ load helpers
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
   cid=$output
   run_buildah 125 rename ${cid} ${cid}
-  expect_output 'renaming a container with the same name as its current name'
+  expect_output 'Error: renaming a container with the same name as its current name'
 }
 
 @test "rename same name as other container name" {

--- a/tests/rm.bats
+++ b/tests/rm.bats
@@ -12,9 +12,9 @@ load helpers
 
 @test "remove multiple containers errors" {
   run_buildah 125 rm mycontainer1 mycontainer2 mycontainer3
-  expect_output --from="${lines[0]}" "error removing container \"mycontainer1\": container not known" "output line 1"
-  expect_output --from="${lines[1]}" "error removing container \"mycontainer2\": container not known" "output line 2"
-  expect_output --from="${lines[2]}" "error removing container \"mycontainer3\": container not known" "output line 3"
+  expect_output --from="${lines[0]}" "removing container \"mycontainer1\": container not known" "output line 1"
+  expect_output --from="${lines[1]}" "removing container \"mycontainer2\": container not known" "output line 2"
+  expect_output --from="${lines[2]}" "Error: removing container \"mycontainer3\": container not known" "output line 3"
   expect_line_count 3
 }
 

--- a/tests/source.bats
+++ b/tests/source.bats
@@ -46,7 +46,7 @@ load helpers
 
   # Directory mustn't exist
   run_buildah 125 source create $srcdir
-  expect_output --substring "error creating source image: "
+  expect_output --substring "creating source image: "
   expect_output --substring " already exists"
 }
 

--- a/tests/tools/vendor/github.com/golangci/gofmt/gofmt/golangci.go
+++ b/tests/tools/vendor/github.com/golangci/gofmt/gofmt/golangci.go
@@ -39,7 +39,7 @@ func Run(filename string, needSimplify bool) ([]byte, error) {
 	// formatting has changed
 	data, err := diff(src, res, filename)
 	if err != nil {
-		return nil, fmt.Errorf("error computing diff: %s", err)
+		return nil, fmt.Errorf("computing diff: %s", err)
 	}
 
 	return data, nil

--- a/tests/tools/vendor/github.com/golangci/gofmt/goimports/golangci.go
+++ b/tests/tools/vendor/github.com/golangci/gofmt/goimports/golangci.go
@@ -26,7 +26,7 @@ func Run(filename string) ([]byte, error) {
 	// formatting has changed
 	data, err := diff(src, res, filename)
 	if err != nil {
-		return nil, fmt.Errorf("error computing diff: %s", err)
+		return nil, fmt.Errorf("computing diff: %s", err)
 	}
 
 	return data, nil

--- a/tests/tools/vendor/github.com/golangci/golangci-lint/pkg/config/reader.go
+++ b/tests/tools/vendor/github.com/golangci/golangci-lint/pkg/config/reader.go
@@ -122,7 +122,7 @@ func (r *FileReader) validateConfig() error {
 	}
 	for i, rule := range c.Issues.ExcludeRules {
 		if err := rule.Validate(); err != nil {
-			return fmt.Errorf("error in exclude rule #%d: %v", i, err)
+			return fmt.Errorf("in exclude rule #%d: %v", i, err)
 		}
 	}
 	if len(c.Severity.Rules) > 0 && c.Severity.Default == "" {
@@ -130,11 +130,11 @@ func (r *FileReader) validateConfig() error {
 	}
 	for i, rule := range c.Severity.Rules {
 		if err := rule.Validate(); err != nil {
-			return fmt.Errorf("error in severity rule #%d: %v", i, err)
+			return fmt.Errorf("in severity rule #%d: %v", i, err)
 		}
 	}
 	if err := c.LintersSettings.Govet.Validate(); err != nil {
-		return fmt.Errorf("error in govet config: %v", err)
+		return fmt.Errorf("in govet config: %v", err)
 	}
 	return nil
 }

--- a/tests/tools/vendor/github.com/golangci/golangci-lint/pkg/golinters/gofumpt.go
+++ b/tests/tools/vendor/github.com/golangci/golangci-lint/pkg/golinters/gofumpt.go
@@ -85,19 +85,19 @@ func runGofumpt(lintCtx *linter.Context, pass *analysis.Pass, diff differ, optio
 
 		output, err := format.Source(input, options)
 		if err != nil {
-			return nil, fmt.Errorf("error while running gofumpt: %w", err)
+			return nil, fmt.Errorf("while running gofumpt: %w", err)
 		}
 
 		if !bytes.Equal(input, output) {
 			out := bytes.Buffer{}
 			_, err = out.WriteString(fmt.Sprintf("--- %[1]s\n+++ %[1]s\n", f))
 			if err != nil {
-				return nil, fmt.Errorf("error while running gofumpt: %w", err)
+				return nil, fmt.Errorf("while running gofumpt: %w", err)
 			}
 
 			err = diff.Diff(&out, bytes.NewReader(input), bytes.NewReader(output))
 			if err != nil {
-				return nil, fmt.Errorf("error while running gofumpt: %w", err)
+				return nil, fmt.Errorf("while running gofumpt: %w", err)
 			}
 
 			diff := out.String()

--- a/tests/tools/vendor/github.com/golangci/revgrep/revgrep.go
+++ b/tests/tools/vendor/github.com/golangci/revgrep/revgrep.go
@@ -235,7 +235,7 @@ func (c *Checker) Check(reader io.Reader, writer io.Writer) (issues []Issue, err
 	}
 
 	if err := scanner.Err(); err != nil {
-		returnErr = fmt.Errorf("error reading standard input: %w", err)
+		returnErr = fmt.Errorf("reading standard input: %w", err)
 	}
 
 	return issues, returnErr
@@ -363,7 +363,7 @@ func GitPatch(revisionFrom, revisionTo string) (io.Reader, []string, error) {
 	// make a patch for untracked files
 	ls, err := exec.Command("git", "ls-files", "--others", "--exclude-standard").CombinedOutput()
 	if err != nil {
-		return nil, nil, fmt.Errorf("error executing git ls-files: %w", err)
+		return nil, nil, fmt.Errorf("executing git ls-files: %w", err)
 	}
 
 	var newFiles []string
@@ -386,7 +386,7 @@ func GitPatch(revisionFrom, revisionTo string) (io.Reader, []string, error) {
 
 		cmd.Stdout = &patch
 		if err := cmd.Run(); err != nil {
-			return nil, nil, fmt.Errorf("error executing git diff %q %q: %w", revisionFrom, revisionTo, err)
+			return nil, nil, fmt.Errorf("executing git diff %q %q: %w", revisionFrom, revisionTo, err)
 		}
 
 		if revisionTo == "" {
@@ -400,7 +400,7 @@ func GitPatch(revisionFrom, revisionTo string) (io.Reader, []string, error) {
 	cmd := exec.Command("git", "diff", "--color=never", "--relative", "--")
 	cmd.Stdout = &patch
 	if err := cmd.Run(); err != nil {
-		return nil, nil, fmt.Errorf("error executing git diff: %w", err)
+		return nil, nil, fmt.Errorf("executing git diff: %w", err)
 	}
 	unstaged := patch.Len() > 0
 
@@ -415,7 +415,7 @@ func GitPatch(revisionFrom, revisionTo string) (io.Reader, []string, error) {
 	cmd = exec.Command("git", "diff", "--color=never", "--relative", "HEAD~", "--")
 	cmd.Stdout = &patch
 	if err := cmd.Run(); err != nil {
-		return nil, nil, fmt.Errorf("error executing git diff HEAD~: %w", err)
+		return nil, nil, fmt.Errorf("executing git diff HEAD~: %w", err)
 	}
 
 	return &patch, nil, nil

--- a/tests/tools/vendor/github.com/mitchellh/mapstructure/mapstructure.go
+++ b/tests/tools/vendor/github.com/mitchellh/mapstructure/mapstructure.go
@@ -458,7 +458,7 @@ func (d *Decoder) decode(name string, input interface{}, outVal reflect.Value) e
 		var err error
 		input, err = DecodeHookExec(d.config.DecodeHook, inputVal, outVal)
 		if err != nil {
-			return fmt.Errorf("error decoding '%s': %s", name, err)
+			return fmt.Errorf("decoding '%s': %s", name, err)
 		}
 	}
 

--- a/tests/tools/vendor/github.com/onsi/ginkgo/ginkgo/unfocus_command.go
+++ b/tests/tools/vendor/github.com/onsi/ginkgo/ginkgo/unfocus_command.go
@@ -115,12 +115,12 @@ func writeBackup(path string, data []byte) (string, error) {
 	t, err := ioutil.TempFile(filepath.Dir(path), filepath.Base(path))
 
 	if err != nil {
-		return "", fmt.Errorf("error creating temporary file: %w", err)
+		return "", fmt.Errorf("creating temporary file: %w", err)
 	}
 	defer t.Close()
 
 	if _, err := io.Copy(t, bytes.NewReader(data)); err != nil {
-		return "", fmt.Errorf("error writing to temporary file: %w", err)
+		return "", fmt.Errorf("writing to temporary file: %w", err)
 	}
 
 	return t.Name(), nil
@@ -129,7 +129,7 @@ func writeBackup(path string, data []byte) (string, error) {
 func updateFile(path string, data []byte, eliminations []int64) error {
 	to, err := os.Create(path)
 	if err != nil {
-		return fmt.Errorf("error opening file for writing '%s': %w\n", path, err)
+		return fmt.Errorf("opening file for writing '%s': %w\n", path, err)
 	}
 	defer to.Close()
 
@@ -137,18 +137,18 @@ func updateFile(path string, data []byte, eliminations []int64) error {
 	var cursor int64
 	for _, byteToEliminate := range eliminations {
 		if _, err := io.CopyN(to, from, byteToEliminate-cursor); err != nil {
-			return fmt.Errorf("error copying data: %w", err)
+			return fmt.Errorf("copying data: %w", err)
 		}
 
 		cursor = byteToEliminate + 1
 
 		if _, err := from.Seek(1, io.SeekCurrent); err != nil {
-			return fmt.Errorf("error seeking to position in buffer: %w", err)
+			return fmt.Errorf("seeking to position in buffer: %w", err)
 		}
 	}
 
 	if _, err := io.Copy(to, from); err != nil {
-		return fmt.Errorf("error copying end data: %w", err)
+		return fmt.Errorf("copying end data: %w", err)
 	}
 
 	return nil

--- a/tests/tools/vendor/github.com/prometheus/client_golang/prometheus/registry.go
+++ b/tests/tools/vendor/github.com/prometheus/client_golang/prometheus/registry.go
@@ -596,7 +596,7 @@ func processMetric(
 	}
 	dtoMetric := &dto.Metric{}
 	if err := metric.Write(dtoMetric); err != nil {
-		return fmt.Errorf("error collecting metric %v: %s", desc, err)
+		return fmt.Errorf("collecting metric %v: %s", desc, err)
 	}
 	metricFamily, ok := metricFamiliesByName[desc.fqName]
 	if ok { // Existing name.

--- a/tests/tools/vendor/github.com/prometheus/common/model/value.go
+++ b/tests/tools/vendor/github.com/prometheus/common/model/value.go
@@ -324,7 +324,7 @@ func (s *Scalar) UnmarshalJSON(b []byte) error {
 
 	value, err := strconv.ParseFloat(f, 64)
 	if err != nil {
-		return fmt.Errorf("error parsing sample value: %s", err)
+		return fmt.Errorf("parsing sample value: %s", err)
 	}
 	s.Value = SampleValue(value)
 	return nil

--- a/tests/tools/vendor/github.com/prometheus/procfs/arp.go
+++ b/tests/tools/vendor/github.com/prometheus/procfs/arp.go
@@ -36,7 +36,7 @@ type ARPEntry struct {
 func (fs FS) GatherARPEntries() ([]ARPEntry, error) {
 	data, err := ioutil.ReadFile(fs.proc.Path("net/arp"))
 	if err != nil {
-		return nil, fmt.Errorf("error reading arp %q: %w", fs.proc.Path("net/arp"), err)
+		return nil, fmt.Errorf("reading arp %q: %w", fs.proc.Path("net/arp"), err)
 	}
 
 	return parseARPEntries(data)

--- a/tests/tools/vendor/github.com/prometheus/procfs/crypto.go
+++ b/tests/tools/vendor/github.com/prometheus/procfs/crypto.go
@@ -55,12 +55,12 @@ func (fs FS) Crypto() ([]Crypto, error) {
 	path := fs.proc.Path("crypto")
 	b, err := util.ReadFileNoStat(path)
 	if err != nil {
-		return nil, fmt.Errorf("error reading crypto %q: %w", path, err)
+		return nil, fmt.Errorf("reading crypto %q: %w", path, err)
 	}
 
 	crypto, err := parseCrypto(bytes.NewReader(b))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing crypto %q: %w", path, err)
+		return nil, fmt.Errorf("parsing crypto %q: %w", path, err)
 	}
 
 	return crypto, nil

--- a/tests/tools/vendor/github.com/prometheus/procfs/mdstat.go
+++ b/tests/tools/vendor/github.com/prometheus/procfs/mdstat.go
@@ -70,7 +70,7 @@ func (fs FS) MDStat() ([]MDStat, error) {
 	}
 	mdstat, err := parseMDStat(data)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing mdstat %q: %w", fs.proc.Path("mdstat"), err)
+		return nil, fmt.Errorf("parsing mdstat %q: %w", fs.proc.Path("mdstat"), err)
 	}
 	return mdstat, nil
 }
@@ -96,7 +96,7 @@ func parseMDStat(mdStatData []byte) ([]MDStat, error) {
 		state := deviceFields[2]  // active or inactive
 
 		if len(lines) <= i+3 {
-			return nil, fmt.Errorf("error parsing %q: too few lines for md device", mdName)
+			return nil, fmt.Errorf("parsing %q: too few lines for md device", mdName)
 		}
 
 		// Failed disks have the suffix (F) & Spare disks have the suffix (S).
@@ -105,7 +105,7 @@ func parseMDStat(mdStatData []byte) ([]MDStat, error) {
 		active, total, down, size, err := evalStatusLine(lines[i], lines[i+1])
 
 		if err != nil {
-			return nil, fmt.Errorf("error parsing md device lines: %w", err)
+			return nil, fmt.Errorf("parsing md device lines: %w", err)
 		}
 
 		syncLineIdx := i + 2
@@ -140,7 +140,7 @@ func parseMDStat(mdStatData []byte) ([]MDStat, error) {
 			} else {
 				syncedBlocks, pct, finish, speed, err = evalRecoveryLine(lines[syncLineIdx])
 				if err != nil {
-					return nil, fmt.Errorf("error parsing sync line in md device %q: %w", mdName, err)
+					return nil, fmt.Errorf("parsing sync line in md device %q: %w", mdName, err)
 				}
 			}
 		}
@@ -210,7 +210,7 @@ func evalRecoveryLine(recoveryLine string) (syncedBlocks int64, pct float64, fin
 
 	syncedBlocks, err = strconv.ParseInt(matches[1], 10, 64)
 	if err != nil {
-		return 0, 0, 0, 0, fmt.Errorf("error parsing int from recoveryLine %q: %w", recoveryLine, err)
+		return 0, 0, 0, 0, fmt.Errorf("parsing int from recoveryLine %q: %w", recoveryLine, err)
 	}
 
 	// Get percentage complete
@@ -220,7 +220,7 @@ func evalRecoveryLine(recoveryLine string) (syncedBlocks int64, pct float64, fin
 	}
 	pct, err = strconv.ParseFloat(strings.TrimSpace(matches[1]), 64)
 	if err != nil {
-		return syncedBlocks, 0, 0, 0, fmt.Errorf("error parsing float from recoveryLine %q: %w", recoveryLine, err)
+		return syncedBlocks, 0, 0, 0, fmt.Errorf("parsing float from recoveryLine %q: %w", recoveryLine, err)
 	}
 
 	// Get time expected left to complete
@@ -230,7 +230,7 @@ func evalRecoveryLine(recoveryLine string) (syncedBlocks int64, pct float64, fin
 	}
 	finish, err = strconv.ParseFloat(matches[1], 64)
 	if err != nil {
-		return syncedBlocks, pct, 0, 0, fmt.Errorf("error parsing float from recoveryLine %q: %w", recoveryLine, err)
+		return syncedBlocks, pct, 0, 0, fmt.Errorf("parsing float from recoveryLine %q: %w", recoveryLine, err)
 	}
 
 	// Get recovery speed
@@ -240,7 +240,7 @@ func evalRecoveryLine(recoveryLine string) (syncedBlocks int64, pct float64, fin
 	}
 	speed, err = strconv.ParseFloat(matches[1], 64)
 	if err != nil {
-		return syncedBlocks, pct, finish, 0, fmt.Errorf("error parsing float from recoveryLine %q: %w", recoveryLine, err)
+		return syncedBlocks, pct, finish, 0, fmt.Errorf("parsing float from recoveryLine %q: %w", recoveryLine, err)
 	}
 
 	return syncedBlocks, pct, finish, speed, nil

--- a/tests/tools/vendor/github.com/prometheus/procfs/net_sockstat.go
+++ b/tests/tools/vendor/github.com/prometheus/procfs/net_sockstat.go
@@ -90,7 +90,7 @@ func parseSockstat(r io.Reader) (*NetSockstat, error) {
 		// The remaining fields are key/value pairs.
 		kvs, err := parseSockstatKVs(fields[1:])
 		if err != nil {
-			return nil, fmt.Errorf("error parsing sockstat key/value pairs from %q: %w", s.Text(), err)
+			return nil, fmt.Errorf("parsing sockstat key/value pairs from %q: %w", s.Text(), err)
 		}
 
 		// The first field is the protocol. We must trim its colon suffix.

--- a/tests/tools/vendor/github.com/prometheus/procfs/zoneinfo.go
+++ b/tests/tools/vendor/github.com/prometheus/procfs/zoneinfo.go
@@ -74,11 +74,11 @@ var nodeZoneRE = regexp.MustCompile(`(\d+), zone\s+(\w+)`)
 func (fs FS) Zoneinfo() ([]Zoneinfo, error) {
 	data, err := ioutil.ReadFile(fs.proc.Path("zoneinfo"))
 	if err != nil {
-		return nil, fmt.Errorf("error reading zoneinfo %q: %w", fs.proc.Path("zoneinfo"), err)
+		return nil, fmt.Errorf("reading zoneinfo %q: %w", fs.proc.Path("zoneinfo"), err)
 	}
 	zoneinfo, err := parseZoneinfo(data)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing zoneinfo %q: %w", fs.proc.Path("zoneinfo"), err)
+		return nil, fmt.Errorf("parsing zoneinfo %q: %w", fs.proc.Path("zoneinfo"), err)
 	}
 	return zoneinfo, nil
 }

--- a/tests/tools/vendor/gopkg.in/ini.v1/data_source.go
+++ b/tests/tools/vendor/gopkg.in/ini.v1/data_source.go
@@ -71,6 +71,6 @@ func parseDataSource(source interface{}) (dataSource, error) {
 	case io.Reader:
 		return &sourceReadCloser{ioutil.NopCloser(s)}, nil
 	default:
-		return nil, fmt.Errorf("error parsing data source: unknown type %q", s)
+		return nil, fmt.Errorf("parsing data source: unknown type %q", s)
 	}
 }

--- a/tests/tools/vendor/gopkg.in/ini.v1/section.go
+++ b/tests/tools/vendor/gopkg.in/ini.v1/section.go
@@ -131,7 +131,7 @@ func (s *Section) GetKey(name string) (*Key, error) {
 			}
 			break
 		}
-		return nil, fmt.Errorf("error when getting key of section %q: key %q not exists", s.name, name)
+		return nil, fmt.Errorf("when getting key of section %q: key %q not exists", s.name, name)
 	}
 	return key, nil
 }

--- a/tests/tools/vendor/honnef.co/go/tools/config/config.go
+++ b/tests/tools/vendor/honnef.co/go/tools/config/config.go
@@ -67,7 +67,7 @@ var Analyzer = &analysis.Analyzer{
 		}
 		cfg, err := Load(dir)
 		if err != nil {
-			return nil, fmt.Errorf("error loading staticcheck.conf: %s", err)
+			return nil, fmt.Errorf("loading staticcheck.conf: %s", err)
 		}
 		return &cfg, nil
 	},

--- a/tests/tools/vendor/honnef.co/go/tools/pattern/parser.go
+++ b/tests/tools/vendor/honnef.co/go/tools/pattern/parser.go
@@ -226,7 +226,7 @@ func (p *Parser) accept(typ itemType) (item, bool) {
 
 func (p *Parser) unexpectedToken(valid string) error {
 	if p.cur.typ == itemError {
-		return fmt.Errorf("error lexing input: %s", p.cur.val)
+		return fmt.Errorf("lexing input: %s", p.cur.val)
 	}
 	var got string
 	switch p.cur.typ {

--- a/unmount.go
+++ b/unmount.go
@@ -6,12 +6,12 @@ import "fmt"
 func (b *Builder) Unmount() error {
 	_, err := b.store.Unmount(b.ContainerID, false)
 	if err != nil {
-		return fmt.Errorf("error unmounting build container %q: %w", b.ContainerID, err)
+		return fmt.Errorf("unmounting build container %q: %w", b.ContainerID, err)
 	}
 	b.MountPoint = ""
 	err = b.Save()
 	if err != nil {
-		return fmt.Errorf("error saving updated state for build container %q: %w", b.ContainerID, err)
+		return fmt.Errorf("saving updated state for build container %q: %w", b.ContainerID, err)
 	}
 	return nil
 }

--- a/util.go
+++ b/util.go
@@ -151,7 +151,7 @@ func ReserveSELinuxLabels(store storage.Store, id string) error {
 	if selinuxGetEnabled() {
 		containers, err := store.Containers()
 		if err != nil {
-			return fmt.Errorf("error getting list of containers: %w", err)
+			return fmt.Errorf("getting list of containers: %w", err)
 		}
 
 		for _, c := range containers {
@@ -169,7 +169,7 @@ func ReserveSELinuxLabels(store storage.Store, id string) error {
 				}
 				// Prevent different containers from using same MCS label
 				if err := label.ReserveLabel(b.ProcessLabel); err != nil {
-					return fmt.Errorf("error reserving SELinux label %q: %w", b.ProcessLabel, err)
+					return fmt.Errorf("reserving SELinux label %q: %w", b.ProcessLabel, err)
 				}
 			}
 		}
@@ -219,10 +219,10 @@ func extractWithTar(root, src, dest string) error {
 	wg.Wait()
 
 	if getErr != nil {
-		return fmt.Errorf("error reading %q: %w", src, getErr)
+		return fmt.Errorf("reading %q: %w", src, getErr)
 	}
 	if putErr != nil {
-		return fmt.Errorf("error copying contents of %q to %q: %w", src, dest, putErr)
+		return fmt.Errorf("copying contents of %q to %q: %w", src, dest, putErr)
 	}
 	return nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -118,18 +118,18 @@ func ExpandNames(names []string, systemContext *types.SystemContext, store stora
 		var name reference.Named
 		nameList, _, err := resolveName(n, systemContext, store)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing name %q: %w", n, err)
+			return nil, fmt.Errorf("parsing name %q: %w", n, err)
 		}
 		if len(nameList) == 0 {
 			named, err := reference.ParseNormalizedNamed(n)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing name %q: %w", n, err)
+				return nil, fmt.Errorf("parsing name %q: %w", n, err)
 			}
 			name = named
 		} else {
 			named, err := reference.ParseNormalizedNamed(nameList[0])
 			if err != nil {
-				return nil, fmt.Errorf("error parsing name %q: %w", nameList[0], err)
+				return nil, fmt.Errorf("parsing name %q: %w", nameList[0], err)
 			}
 			name = named
 		}
@@ -169,7 +169,7 @@ func ResolveNameToReferences(
 ) (refs []types.ImageReference, err error) {
 	names, transport, err := resolveName(image, systemContext, store)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing name %q: %w", image, err)
+		return nil, fmt.Errorf("parsing name %q: %w", image, err)
 	}
 
 	if transport != DefaultTransport {
@@ -185,7 +185,7 @@ func ResolveNameToReferences(
 		refs = append(refs, ref)
 	}
 	if len(refs) == 0 {
-		return nil, fmt.Errorf("error locating images with names %v", names)
+		return nil, fmt.Errorf("locating images with names %v", names)
 	}
 	return refs, nil
 }
@@ -206,7 +206,7 @@ func AddImageNames(store storage.Store, firstRegistry string, systemContext *typ
 
 	for _, tag := range addNames {
 		if err := localImage.Tag(tag); err != nil {
-			return fmt.Errorf("error tagging image %s: %w", image.ID, err)
+			return fmt.Errorf("tagging image %s: %w", image.ID, err)
 		}
 	}
 


### PR DESCRIPTION
Podman adds an Error: to every error message. So starting an error
message with "error" ends up being reported to the user as

Error: error ...

This patch removes the stutter.

Also ioutil.ReadFile errors report the Path, so wrapping the err message
with the path causes a stutter.

Signed-off-by: Daniel J Walsh dwalsh@redhat.com

[NO NEW TESTS NEEDED]

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

