### PR TITLE
manifest: add support for `buildah manifest exists`

### DIFF
--- a/docs/buildah-manifest-exists.1.md
+++ b/docs/buildah-manifest-exists.1.md
@@ -1,0 +1,40 @@
+% buildah-manifest-exists(1)
+
+## NAME
+buildah\-manifest\-exists - Check if the given manifest list exists in local storage
+
+## SYNOPSIS
+**buildah manifest exists** *manifest*
+
+## DESCRIPTION
+**buildah manifest exists** checks if a manifest list exists in local storage. Buildah will
+return an exit code of `0` when the manifest list is found. A `1` will be returned otherwise.
+An exit code of `125` indicates there was another issue.
+
+
+## OPTIONS
+
+#### **--help**, **-h**
+
+Print usage statement.
+
+## EXAMPLE
+
+Check if a manifest list called `list1` exists (the manifest list does actually exist).
+```
+$ buildah manifest exists list1
+$ echo $?
+0
+$
+```
+
+Check if an manifest called `mylist` exists (the manifest list does not actually exist).
+```
+$ buildah manifest exists mylist
+$ echo $?
+1
+$
+```
+
+## SEE ALSO
+**[buildah(1)](buildah.1.md)**, **[buildah-manifest(1)](buildah-manifest.1.md)**

--- a/docs/buildah-manifest.1.md
+++ b/docs/buildah-manifest.1.md
@@ -22,6 +22,7 @@ The `buildah manifest` command provides subcommands which can be used to:
 | add      | [buildah-manifest-add(1)](buildah-manifest-add.1.md)           | Add an image to a manifest list or image index.                             |
 | annotate | [buildah-manifest-annotate(1)](buildah-manifest-annotate.1.md) | Add or update information about an image in a manifest list or image index. |
 | create   | [buildah-manifest-create(1)](buildah-manifest-create.1.md)     | Create a manifest list or image index.                                      |
+| exists   | [buildah-manifest-exists(1)](buildah-manifest-exists.1.md)     | Check if a manifest list exists in local storage.                           |
 | inspect  | [buildah-manifest-inspect(1)](buildah-manifest-inspect.1.md)   | Display the contents of a manifest list or image index.                     |
 | push     | [buildah-manifest-push(1)](buildah-manifest-push.1.md)         | Push a manifest list or image index to a registry or other location.        |
 | remove   | [buildah-manifest-remove(1)](buildah-manifest-remove.1.md)     | Remove an image from a manifest list or image index.                        |

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -18,6 +18,10 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     assert "$output" =~ "that name is already in use"
     run_buildah manifest create --amend foo
     assert "$output" == "$listid"
+    # since manifest exists in local storage this should exit with `0`
+    run_buildah manifest exists foo
+    # since manifest does not exist in local storage this should exit with `1`
+    run_buildah 1 manifest exists foo2
 }
 
 @test "manifest-inspect-id" {
@@ -29,6 +33,10 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 @test "manifest-add" {
     run_buildah manifest create foo
     run_buildah manifest add foo ${IMAGE_LIST}
+    # since manifest exists in local storage this should exit with `0`
+    run_buildah manifest exists foo
+    # since manifest does not exist in local storage this should exit with `1`
+    run_buildah 1 manifest exists foo2
     run_buildah manifest rm foo
 }
 
@@ -211,4 +219,8 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest inspect test
     # must contain amd64
     expect_output --substring "amd64"
+    # since manifest exists in local storage this should exit with `0`
+    run_buildah manifest exists test:latest
+    # since manifest does not exist in local storage this should exit with `1`
+    run_buildah 1 manifest exists test2
 }


### PR DESCRIPTION
Adds support for `buildah manifest exists <name>` which tells user if
requested manifest is present in local storage or not, if manifest is
present in local-storage command exits with exit code 0 otherwise 1.

Similar to: https://docs.podman.io/en/latest/markdown/podman-manifest-exists.1.html

Closes: https://github.com/containers/buildah/issues/4217

```release-note
manifest: add support for buildah manifest exists
```

