### PR TITLE
Don't call os.Exit(1) from manifest exist

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -60,6 +60,7 @@ var rootCmd = &cobra.Command{
 
 var (
 	globalFlagResults globalFlags
+	exitCode          int
 )
 
 func init() {
@@ -236,7 +237,7 @@ func main() {
 		} else {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 		}
-		exitCode := cli.ExecErrorCodeGeneric
+		exitCode = cli.ExecErrorCodeGeneric
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {
 			if w, ok := ee.Sys().(syscall.WaitStatus); ok {
@@ -246,6 +247,6 @@ func main() {
 		if err := shutdownStore(rootCmd); err != nil {
 			logrus.Warnf("failed to shutdown storage: %q", err)
 		}
-		os.Exit(exitCode)
 	}
+	os.Exit(exitCode)
 }

--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -274,12 +274,10 @@ func manifestExistsCmd(c *cobra.Command, args []string) error {
 	_, err = runtime.LookupManifestList(name)
 	if err != nil {
 		if errors.Is(err, storage.ErrImageUnknown) {
-			if err := shutdownStore(c); err != nil {
-				return err
-			}
-			os.Exit(1)
+			exitCode = 1
+		} else {
+			return err
 		}
-		return err
 	}
 	return nil
 }


### PR DESCRIPTION
[NO NEW TESTS NEEDED]

Follow up on https://github.com/containers/buildah/pull/4220/files#r963671974

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

