### PR TITLE
[release-1.27] release: bump to `v1.27.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Changelog
 
+## v1.27.1 (2022-09-09)
+
+   run: add container gid to additional groups.
+
 ## v1.27.0 (2022-08-01)
 
     build: support filtering cache by duration using `--cache-ttl`.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+- Changelog for v1.27.1 (2022-09-09)
+  * run: add container gid to additional groups.
+
 - Changelog for v1.27.0 (2022-08-01)
   * build: support filtering cache by duration using `--cache-ttl`.
   * build: support building from commit when using git repo as build context.

--- a/define/types.go
+++ b/define/types.go
@@ -30,7 +30,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.27.0"
+	Version = "1.27.1"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
Bump to release v1.27.1

```
- Changelog for v1.27.1 (2022-09-09)
  * run: add container gid to additional groups.
 ```
 
 Needed for: https://github.com/containers/podman/pull/15696

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]
