### PR TITLE
Use constants from containers/common for finding seccomp.json

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/buildah/define"
 	internalParse "github.com/containers/buildah/internal/parse"
 	"github.com/containers/buildah/pkg/sshagent"
+	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/parse"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
@@ -35,9 +36,9 @@ import (
 
 const (
 	// SeccompDefaultPath defines the default seccomp path
-	SeccompDefaultPath = "/usr/share/containers/seccomp.json"
+	SeccompDefaultPath = config.SeccompDefaultPath
 	// SeccompOverridePath if this exists it overrides the default seccomp path
-	SeccompOverridePath = "/etc/containers/seccomp.json"
+	SeccompOverridePath = config.SeccompOverridePath
 	// TypeBind is the type for mounting host dir
 	TypeBind = "bind"
 	// TypeTmpfs is the type for mounting tmpfs


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Use values from containers/common for locating seccomp.json.  At the moment this isn't actually a change, but we don't want to fall out of step again.

#### How to verify it

Tests should continue to pass.

#### Which issue(s) this PR fixes:

None, but it should prevent another #4219 later.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```