### PR TITLE
[release-1.19] Bump Buildah to v1.19.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ![buildah logo](https://cdn.rawgit.com/containers/buildah/master/logos/buildah-logo_large.png)
 
 # Changelog
+## v1.19.10 (2022-09-09)
+  * [release-1.19] github.com/prometheus/client_golang to v1.11.1
+  * [release-1.19]Bump c/storage to 1.24.10
+  * Tests: disable three gating-test failures
+  * [release-1.19] CVE-2022-27651: do not set the inheritable capabilities
+  * Cirrus: Disable conformance test
+  * chroot isolation: environment value leakage to intermediate processes
 
 ## v1.19.9 (2021-06-21)
   * chroot: fix environment value leakage to intermediate processes

--- a/buildah.go
+++ b/buildah.go
@@ -28,7 +28,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.19.9"
+	Version = "1.19.10"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+- Changelog for v1.19.10 (2022-09-09)
+  * [release-1.19] github.com/prometheus/client_golang to v1.11.1
+  * [release-1.19]Bump c/storage to 1.24.10
+  * Tests: disable three gating-test failures
+  * [release-1.19] CVE-2022-27651: do not set the inheritable capabilities
+  * Cirrus: Disable conformance test
+  * chroot isolation: environment value leakage to intermediate processes
+
 - Changelog for v1.19.9 (2021-06-21)
   * chroot: fix environment value leakage to intermediate processes
   (CVE-2021-3602).

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in buildah.go too
-Version:        1.19.9
+Version:        1.19.10
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,6 +100,14 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Mon Sep 9 2022 Tom Sweeney <tsweeney@redhat.com> 1.19.10-1
+- [release-1.19] github.com/prometheus/client_golang to v1.11.1
+- [release-1.19]Bump c/storage to 1.24.10
+- Tests: disable three gating-test failures
+- [release-1.19] CVE-2022-27651: do not set the inheritable capabilities
+- Cirrus: Disable conformance test
+- chroot isolation: environment value leakage to intermediate processes
+
 * Mon Jun 21 2021 Nalin Dahyabhai <nalin@redhat.com> 1.19.9-1
 - chroot: fix environment value leakage to intermediate processes
   (CVE-2021-3602).
@@ -1848,7 +1856,7 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 
 * Thu Feb 22 2018 Dan Walsh <dwalsh@redhat.com> 0.13-1
 - Vendor in latest containers/storage
-- This fixes a large SELinux bug.  
+- This fixes a large SELinux bug.
 - run: do not open /etc/hosts if not needed
 - Add the following flags to buildah bud and from
     --add-host
@@ -1966,7 +1974,7 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 - Bump for inclusion of OCI 1.0 Runtime and Image Spec
 
 * Tue Jul 18 2017 Dan Walsh <dwalsh@redhat.com> 0.2.0-1.gitac2aad6
-- buildah run: Add support for -- ending options parsing 
+- buildah run: Add support for -- ending options parsing
 - buildah Add/Copy support for glob syntax
 - buildah commit: Add flag to remove containers on commit
 - buildah push: Improve man page and help information


### PR DESCRIPTION
Bump Buildah to v1.19.10 so it can be vendored
into the Podman v3.0 branch for RHEL.  This addresses CVE-2022-27649 and https://bugzilla.redhat.com/show_bug.cgi?id=2125741

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

