### PR TITLE
buildah bud --network=none should have no network

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -602,6 +602,7 @@ func (s *StageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 		Args:             s.executor.runtimeArgs,
 		Cmd:              config.Cmd,
 		ContextDir:       s.executor.contextDir,
+		ConfigureNetwork: s.executor.configureNetwork,
 		Entrypoint:       config.Entrypoint,
 		Env:              config.Env,
 		Hostname:         config.Hostname,
@@ -624,10 +625,9 @@ func (s *StageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 		User:             config.User,
 		WorkingDir:       config.WorkingDir,
 	}
+
 	if config.NetworkDisabled {
 		options.ConfigureNetwork = buildah.NetworkDisabled
-	} else {
-		options.ConfigureNetwork = buildah.NetworkEnabled
 	}
 
 	args := run.Args

--- a/run_linux.go
+++ b/run_linux.go
@@ -726,7 +726,9 @@ func (b *Builder) configureNamespaces(g *generate.Generator, options *RunOptions
 			options.ConfigureNetwork = networkPolicy
 		}
 	}
-
+	if networkPolicy == NetworkDisabled {
+		namespaceOptions.AddOrReplace(define.NamespaceOptions{{Name: string(specs.NetworkNamespace), Host: false}}...)
+	}
 	configureNetwork, configureNetworks, configureUTS, err := setupNamespaces(options.Logger, g, namespaceOptions, b.IDMappingOptions, networkPolicy)
 	if err != nil {
 		return false, nil, err

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5308,3 +5308,16 @@ _EOF
   run_buildah 125 build -f ${TEST_SCRATCH_DIR}/Dockerfile1 -f ${TEST_SCRATCH_DIR}/Dockerfile2 ${TEST_SCRATCH_DIR}
   assert "$output" =~ "error parsing additional Dockerfile .*Dockerfile2: invalid ESCAPE"
 }
+
+@test "build-with-network-test" {
+  skip_if_in_container # Test only works in OCI isolation, which doesn't work in CI/CD systems. Buildah defaults to chroot isolation
+  _prefetch alpine
+  cat > ${TEST_SCRATCH_DIR}/Containerfile << _EOF
+FROM alpine
+RUN ping -c 1 4.2.2.2
+_EOF
+  run_buildah build $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
+
+  run_buildah 1 build --network=none $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
+  expect_output --substring "Network unreachable"
+}


### PR DESCRIPTION
Fixes: https://github.com/containers/buildah/issues/4227

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

