### PR TITLE
parse: make processing fields for `--mount` order agnostic

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -488,7 +488,7 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 			if len(arr) < 2 {
 				return nil, fmt.Errorf("Invalid --mount command: %s", flag)
 			}
-			tokens := strings.Split(arr[1], ",")
+			tokens := strings.Split(flag, ",")
 			for _, val := range tokens {
 				kv := strings.SplitN(val, "=", 2)
 				switch kv[0] {

--- a/tests/bud/buildkit-mount/Dockerfile6
+++ b/tests/bud/buildkit-mount/Dockerfile6
@@ -1,0 +1,4 @@
+FROM alpine
+RUN mkdir /test
+# use option z if selinux is enabled
+RUN --mount=target=/test,z cat /test/input_file

--- a/tests/bud/buildkit-mount/Dockerfilecachewritesharing
+++ b/tests/bud/buildkit-mount/Dockerfilecachewritesharing
@@ -2,6 +2,6 @@ FROM alpine
 RUN mkdir /test
 # use option z if selinux is enabled
 # This locks cache
-RUN --mount=type=cache,target=/test,sharing=locked,z echo hello > /test/world && cat /test/world
+RUN --mount=target=/test,type=cache,sharing=locked,z echo hello > /test/world && cat /test/world
 # Cache must be unlocked so it can be locked again
-RUN --mount=type=cache,target=/test,sharing=locked,z echo world > /test/world && cat /test/world
+RUN --mount=target=/test,sharing=locked,type=cache,z echo world > /test/world && cat /test/world


### PR DESCRIPTION
Field processing in `--mount` must not be hardcode to expect first field to be `type` instead it should be order agnostic.

Closes: https://github.com/containers/podman/issues/15748

```release-note
run,build: now --mount processes flags in no fixed orger
```

