### PR TITLE
[CI:DOCS] Update install.md: Debian 11 (Bullseye) is stable

### DIFF
--- a/install.md
+++ b/install.md
@@ -23,11 +23,11 @@ sudo yum -y install buildah
 #### [Debian](https://debian.org)
 
 The buildah package is available in
-the [Bullseye (testing) branch](https://packages.debian.org/bullseye/buildah), which
-will be the next stable release (Debian 11) as well as Debian Unstable/Sid.
+the [Bullseye](https://packages.debian.org/bullseye/buildah), which
+is the current stable release (Debian 11), as well as Debian Unstable/Sid.
 
 ```bash
-# Debian Testing/Bullseye or Unstable/Sid
+# Debian Stable/Bullseye or Unstable/Sid
 sudo apt-get update
 sudo apt-get -y install buildah
 ```


### PR DESCRIPTION
Signed-off-by: Enrico204 <enrico204@gmail.com>

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Debian 11 "Bullseye" has been released as stable. This PR modifies the `install.md` file to reflect that (currently, Debian 11 is indicated as "testing")

#### How to verify it

n/a

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```

