### PR TITLE
Minor test fix for podman-remote

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -120,7 +120,7 @@ symlink(subdir)"
 @test "bud with .dockerignore #4" {
   run_buildah 125 build -t testbud3 $WITH_POLICY_JSON -f Dockerfile.test $BUDFILES/dockerignore4
   expect_output --substring 'error building.*"COPY test1.txt /upload/test1.txt".*no such file or directory'
-  expect_output --substring $(realpath "$BUDFILES/dockerignore4/Dockerfile.test.dockerignore")
+  expect_output --substring '1 filtered out using /[^ ]*/Dockerfile.test.dockerignore'
 }
 
 @test "bud with .dockerignore #6" {


### PR DESCRIPTION
Minor fix to test introduced in #4239. Treadmill discovered
that the test fails under podman-remote, because absolute
file paths differ. Fix test so it works under buildah,
podman, and podman-remote.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```