### PR TITLE
build: make `--cache-ttl=0` equivalent to `--no-cache`

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -134,6 +134,9 @@ Limit the use of cached images to only consider images with created timestamps l
 For example if `--cache-ttl=1h` is specified, Buildah will only consider intermediate cache images which are created
 under the duration of one hour, and intermediate cache images outside this duration will be ignored.
 
+Note: Setting `--cache-ttl=0` manually is equivalent to using `--no-cache` in the implementation since this would
+effectively mean that user is not willing to use cache at all.
+
 **--cap-add**=*CAP\_xxx*
 
 When executing RUN instructions, run the command specified in the instruction


### PR DESCRIPTION
If user explicitly specified `--cache-ttl=0` or duration
which equals to 0 it would effectively mean that user 
is asking to use no cache at all. In such use cases
buildah can skip looking for cache entierly by setting
`--no-cache=true` internally.

Closes: https://github.com/containers/buildah/issues/4244


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
buildah build: make `--cache-ttl=0` equivalent to `--no-cache`
```

