### PR TITLE
build: support `--skip-unused-stages` for multi-stage builds.

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -186,6 +186,10 @@ type BuildOptions struct {
 	// specified, indicating that the shared, system-wide default policy
 	// should be used.
 	SignaturePolicyPath string
+	// SkipUnusedStages allows users to skip stages in a multi-stage builds
+	// which do not contribute anything to the target stage. Expected default
+	// value is true.
+	SkipUnusedStages types.OptionalBool
 	// ReportWriter is an io.Writer which will be used to report the
 	// progress of the (possible) pulling of the source image and the
 	// writing of the new image.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -684,6 +684,10 @@ If you omit the unit, the system uses bytes. If you omit the size entirely, the 
 
 Sign the built image using the GPG key that matches the specified fingerprint.
 
+**--skip-unused-stages** *bool-value*
+
+Skip stages in multi-stage builds which don't affect the target stage. (Default is `true`).
+
 **--squash**
 
 Squash all of the image's new layers into a single new layer; any preexisting layers

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/buildah/pkg/util"
 	"github.com/containers/common/pkg/auth"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/types"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -390,6 +391,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		RusageLogFile:           iopts.RusageLogFile,
 		SignBy:                  iopts.SignBy,
 		SignaturePolicyPath:     iopts.SignaturePolicy,
+		SkipUnusedStages:        types.NewOptionalBool(iopts.SkipUnusedStages),
 		Squash:                  iopts.Squash,
 		SystemContext:           systemContext,
 		Target:                  iopts.Target,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -89,6 +89,7 @@ type BudResults struct {
 	SignaturePolicy     string
 	SignBy              string
 	Squash              bool
+	SkipUnusedStages    bool
 	Stdin               bool
 	Tag                 []string
 	BuildOutput         string
@@ -260,6 +261,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	if err := fs.MarkHidden("signature-policy"); err != nil {
 		panic(fmt.Sprintf("error marking the signature-policy flag as hidden: %v", err))
 	}
+	fs.BoolVar(&flags.SkipUnusedStages, "skip-unused-stages", true, "skips stages in multi-stage builds which do not affect the final target")
 	fs.BoolVar(&flags.Squash, "squash", false, "squash newly built layers into a single new layer")
 	fs.StringArrayVar(&flags.SSH, "ssh", []string{}, "SSH agent socket or keys to expose to the build. (format: default|<id>[=<socket>|<key>[,<key>]])")
 	fs.BoolVar(&flags.Stdin, "stdin", false, "pass stdin into containers")
@@ -307,6 +309,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["secret"] = commonComp.AutocompleteNone
 	flagCompletion["sign-by"] = commonComp.AutocompleteNone
 	flagCompletion["signature-policy"] = commonComp.AutocompleteNone
+	flagCompletion["skip-unused-stages"] = commonComp.AutocompleteNone
 	flagCompletion["ssh"] = commonComp.AutocompleteNone
 	flagCompletion["tag"] = commonComp.AutocompleteNone
 	flagCompletion["target"] = commonComp.AutocompleteNone


### PR DESCRIPTION
In multi-stage builds buildah will skip stages which are unused (i.e stages which don't contribute anything to target stage directly or indirectly) however in certain cases users need to process these unused stages hence add support for `--skip-unused-stages` which allows users to control this behavior. Defaults to `true`.

Ref: https://github.com/GoogleContainerTools/kaniko#flag---skip-unused-stages

Closes: https://github.com/containers/buildah/issues/4243

```release-note
build: support `--skip-unused-stages` while allows users to toggle skipping unused stages
```

