### PR TITLE
Prevent use of --dns* options with --net=none

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -300,7 +300,7 @@ solely for scripting compatibility.
 
 **--dns**=[]
 
-Set custom DNS servers
+Set custom DNS servers.  Invalid if using **--dns** with **--network=none**.
 
 This option can be used to override the DNS configuration passed to the container. Typically this is necessary when the host DNS configuration is invalid for the container (e.g., 127.0.0.1). When this is the case the `--dns` flag is necessary for every run.
 
@@ -308,11 +308,11 @@ The special value **none** can be specified to disable creation of /etc/resolv.c
 
 **--dns-option**=[]
 
-Set custom DNS options
+Set custom DNS options. Invalid if using **--dns-option** with **--network=none**.
 
 **--dns-search**=[]
 
-Set custom DNS search domains
+Set custom DNS search domains. Invalid if using **--dns-search** with **--network=none**.
 
 **--env** *env[=value]*
 
@@ -489,7 +489,7 @@ Sets the configuration for network namespaces when handling `RUN` instructions.
 
 Valid _mode_ values are:
 
-- **none**: no networking;
+- **none**: no networking. Invalid if using **--dns**, **--dns-opt**, or **--dns-search**;
 - **host**: use the host network stack. Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure;
 - **ns:**_path_: path to a network namespace to join;
 - **private**: create a new namespace for the container (default)

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -47,6 +47,18 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 	output := ""
 	cleanTmpFile := false
 	tags := []string{}
+	if iopts.Network == "none" {
+		if c.Flag("dns").Changed {
+			return options, nil, nil, errors.New("the --dns option can not be used with --network=none")
+		}
+		if c.Flag("dns-option").Changed {
+			return options, nil, nil, errors.New("the --dns-option option can not be used with --network=none")
+		}
+		if c.Flag("dns-search").Changed {
+			return options, nil, nil, errors.New("the --dns-search option can not be used with --network=none")
+		}
+
+	}
 	if c.Flag("tag").Changed {
 		tags = iopts.Tag
 		if len(tags) > 0 {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -13,6 +13,12 @@ load helpers
 
 @test "bud with --dns* flags" {
   _prefetch alpine
+
+  for dnsopt in --dns --dns-option --dns-search; do
+    run_buildah 125 build $dnsopt=example.com --network=none $WITH_POLICY_JSON -f $BUDFILES/dns/Dockerfile  $BUDFILES/dns
+    expect_output "the $dnsopt option can not be used with --network=none" "dns options should not be allowed with --network=none"
+  done
+
   run_buildah build --dns-search=example.com --dns=223.5.5.5 --dns-option=use-vc  $WITH_POLICY_JSON -f $BUDFILES/dns/Dockerfile  $BUDFILES/dns
   expect_output --substring "search example.com"
   expect_output --substring "nameserver 223.5.5.5"


### PR DESCRIPTION
This is blocked in Podman for run and create but not for build, we should block it also for build.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

