### PR TITLE
Fix broken command completion

### DIFF
--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -309,7 +309,6 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["secret"] = commonComp.AutocompleteNone
 	flagCompletion["sign-by"] = commonComp.AutocompleteNone
 	flagCompletion["signature-policy"] = commonComp.AutocompleteNone
-	flagCompletion["skip-unused-stages"] = commonComp.AutocompleteNone
 	flagCompletion["ssh"] = commonComp.AutocompleteNone
 	flagCompletion["tag"] = commonComp.AutocompleteNone
 	flagCompletion["target"] = commonComp.AutocompleteNone


### PR DESCRIPTION
PR #4249 added --skip-unused-stages (cool) but also added what seems to be an unnecessary command-completion incantation. This incantation breaks podman unit tests when vendored in the treadmill.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```