### PR TITLE
[release-1.20] run: add container gid to additional groups

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -1981,6 +1981,7 @@ func (b *Builder) configureUIDGID(g *generate.Generator, mountPoint string, opti
 	}
 	g.SetProcessUID(user.UID)
 	g.SetProcessGID(user.GID)
+	g.AddProcessAdditionalGid(user.GID)
 	for _, gid := range user.AdditionalGids {
 		g.AddProcessAdditionalGid(gid)
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -130,6 +130,22 @@ symlink(subdir)"
   check_options_flag_err "--userns=cnt1"
 }
 
+@test "build test has gid in supplemental groups" {
+  _prefetch alpine
+  run_buildah build $WITH_POLICY_JSON -t source -f ${TESTSDIR}/bud/supplemental-groups/Dockerfile
+  # gid 1000 must be in supplemental groups
+  expect_output --substring "Groups:	1000"
+}
+
+@test "build test if supplemental groups has gid with --isolation chroot" {
+  test -z "${BUILDAH_ISOLATION}" || skip "BUILDAH_ISOLATION=${BUILDAH_ISOLATION} overrides --isolation"
+
+  _prefetch alpine
+  run_buildah build --isolation chroot $WITH_POLICY_JSON -t source -f ${TESTSDIR}/bud/supplemental-groups/Dockerfile
+  # gid 1000 must be in supplemental groups
+  expect_output --substring "Groups:	1000"
+}
+
 @test "bud with --layers and --no-cache flags" {
   _prefetch alpine
   cp -a ${TESTSDIR}/bud/use-layers ${TESTDIR}/use-layers

--- a/tests/bud/supplemental-groups/Dockerfile
+++ b/tests/bud/supplemental-groups/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+USER 1000:1000
+RUN cat /proc/$$/status

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -274,6 +274,20 @@ function configure_and_check_user() {
   expect_output "888:888"
 }
 
+@test "run --user and verify gid in supplemental groups" {
+  skip_if_no_runtime
+
+  # Create the container.
+  _prefetch alpine
+  run_buildah from $WITH_POLICY_JSON alpine
+  ctr="$output"
+
+  # Run with uid:gid 1000:1000 and verify if gid is present in additional groups
+  run_buildah run --user 1000:1000 "$ctr" cat /proc/self/status
+  # gid 1000 must be in additional/supplemental groups
+  expect_output --substring "Groups:	1000 "
+}
+
 @test "run --mount" {
 	skip_if_no_runtime
 


### PR DESCRIPTION
When container is created with specific uid and gid also add container gid to supplementary/additional group.

Cherry-picked from #4207, related to GHSA-rc4r-wh2q-q6c4.