### PR TITLE
[release-1.27] build: support `--skip-unused-stages` for multi-stage builds.

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -186,6 +186,10 @@ type BuildOptions struct {
 	// specified, indicating that the shared, system-wide default policy
 	// should be used.
 	SignaturePolicyPath string
+	// SkipUnusedStages allows users to skip stages in a multi-stage builds
+	// which do not contribute anything to the target stage. Expected default
+	// value is true.
+	SkipUnusedStages types.OptionalBool
 	// ReportWriter is an io.Writer which will be used to report the
 	// progress of the (possible) pulling of the source image and the
 	// writing of the new image.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -669,6 +669,10 @@ If you omit the unit, the system uses bytes. If you omit the size entirely, the 
 
 Sign the built image using the GPG key that matches the specified fingerprint.
 
+**--skip-unused-stages** *bool-value*
+
+Skip stages in multi-stage builds which don't affect the target stage. (Default is `true`).
+
 **--squash**
 
 Squash all of the image's new layers into a single new layer; any preexisting layers

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/buildah/pkg/util"
 	"github.com/containers/common/pkg/auth"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/types"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -370,6 +371,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		RusageLogFile:           iopts.RusageLogFile,
 		SignBy:                  iopts.SignBy,
 		SignaturePolicyPath:     iopts.SignaturePolicy,
+		SkipUnusedStages:        types.NewOptionalBool(iopts.SkipUnusedStages),
 		Squash:                  iopts.Squash,
 		SystemContext:           systemContext,
 		Target:                  iopts.Target,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -307,7 +307,6 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["secret"] = commonComp.AutocompleteNone
 	flagCompletion["sign-by"] = commonComp.AutocompleteNone
 	flagCompletion["signature-policy"] = commonComp.AutocompleteNone
-	flagCompletion["skip-unused-stages"] = commonComp.AutocompleteNone
 	flagCompletion["ssh"] = commonComp.AutocompleteNone
 	flagCompletion["tag"] = commonComp.AutocompleteNone
 	flagCompletion["target"] = commonComp.AutocompleteNone

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -89,6 +89,7 @@ type BudResults struct {
 	SignaturePolicy     string
 	SignBy              string
 	Squash              bool
+	SkipUnusedStages    bool
 	Stdin               bool
 	Tag                 []string
 	BuildOutput         string
@@ -258,6 +259,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	if err := fs.MarkHidden("signature-policy"); err != nil {
 		panic(fmt.Sprintf("error marking the signature-policy flag as hidden: %v", err))
 	}
+	fs.BoolVar(&flags.SkipUnusedStages, "skip-unused-stages", true, "skips stages in multi-stage builds which do not affect the final target")
 	fs.BoolVar(&flags.Squash, "squash", false, "squash newly built layers into a single new layer")
 	fs.StringArrayVar(&flags.SSH, "ssh", []string{}, "SSH agent socket or keys to expose to the build. (format: default|<id>[=<socket>|<key>[,<key>]])")
 	fs.BoolVar(&flags.Stdin, "stdin", false, "pass stdin into containers")
@@ -305,6 +307,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["secret"] = commonComp.AutocompleteNone
 	flagCompletion["sign-by"] = commonComp.AutocompleteNone
 	flagCompletion["signature-policy"] = commonComp.AutocompleteNone
+	flagCompletion["skip-unused-stages"] = commonComp.AutocompleteNone
 	flagCompletion["ssh"] = commonComp.AutocompleteNone
 	flagCompletion["tag"] = commonComp.AutocompleteNone
 	flagCompletion["target"] = commonComp.AutocompleteNone

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -382,6 +382,38 @@ _EOF
   expect_output --substring "Groups:	1000"
 }
 
+@test "build-test skipping unwanted stages with --skip-unused-stages=false and --skip-unused-stages=true" {
+  mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+
+  cat > ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile << _EOF
+FROM alpine
+RUN echo "first unwanted stage"
+
+FROM alpine as one
+RUN echo "needed stage"
+
+FROM alpine
+RUN echo "another unwanted stage"
+
+FROM one
+RUN echo "target stage"
+_EOF
+
+  # with --skip-unused-stages=false
+  run_buildah build $WITH_POLICY_JSON --skip-unused-stages=false -t source -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile
+  expect_output --substring "needed stage"
+  expect_output --substring "target stage"
+  # this is expected since user specified `--skip-unused-stages=false`
+  expect_output --substring "first unwanted stage"
+  expect_output --substring "another unwanted stage"
+
+  # with --skip-unused-stages=true
+  run_buildah build $WITH_POLICY_JSON --skip-unused-stages=true -t source -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile
+  expect_output --substring "needed stage"
+  expect_output --substring "target stage"
+  assert "$output" !~ "unwanted stage"
+}
+
 # Test skipping images with FROM
 @test "build-test skipping unwanted stages with FROM" {
   mkdir -p ${TEST_SCRATCH_DIR}/bud/platform


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

In multi-stage builds buildah will skip stages which are unused (i.e stages which don't contribute anything to target stage directly or indirectly) however in certain cases users need to process these unused stages hence add support for --skip-unused-stages which allows users to control this behavior. Defaults to true.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Related to #4243.

#### Special notes for your reviewer:

Cherry-picked from #4249 and #4256.

#### Does this PR introduce a user-facing change?

```release-note
build: support `--skip-unused-stages` to allow users to control whether or not unused stages are skipped
```