### PR TITLE
[release-1.27] tag v1.27.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 # Changelog
 
+## v1.27.2 (2022-09-20)
+
+    build: backport the --skip-unused-stages flag.
+
 ## v1.27.1 (2022-09-09)
 
-   run: add container gid to additional groups.
+    run: add container gid to additional groups.
 
 ## v1.27.0 (2022-08-01)
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+- Changelog for v1.27.2 (2022-09-20)
+  * build: backport the --skip-unused-stages flag.
+
 - Changelog for v1.27.1 (2022-09-09)
   * run: add container gid to additional groups.
 

--- a/define/types.go
+++ b/define/types.go
@@ -30,7 +30,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.27.1"
+	Version = "1.27.2"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
Tag a v1.27.2 release to pick up the `--skip-unused-stages` flag and the API flag it wraps.