### PR TITLE
[release-1.21] tag v1.21.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ![buildah logo](https://cdn.rawgit.com/containers/buildah/master/logos/buildah-logo_large.png)
 
 # Changelog
+## v1.21.5 (2022-09-20)
+    run: add container gid to additional groups
+    run: do not set the inheritable capabilities
+    bump github.com/prometheus/client_golang to v1.11.1
+
 ## v1.21.4 (2021-07-22)
     tests: make it easer to override the location of the copy helper
     tests: add and use a "copy" helper instead of podman load/save

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+- Changelog for v1.21.5 (2022-09-20)
+  * run: add container gid to additional groups
+  * run: do not set the inheritable capabilities
+  * bump github.com/prometheus/client_golang to v1.11.1
+
 - Changelog for v1.21.4 (2021-07-22)
   * tests: make it easer to override the location of the copy helper
   * tests: add and use a "copy" helper instead of podman load/save

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in define/types.go too
-Version:        1.21.4
+Version:        1.21.5
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,6 +100,11 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Tue Sep 20 2022 Nalin Dahyabhai <nalin@redhat.com> 1.21.5-1
+- run: add container gid to additional groups
+- run: do not set the inheritable capabilities
+- bump github.com/prometheus/client_golang to v1.11.1
+
 * Thu Jul 22 2021 Nalin Dahyabhai <nalin@redhat.com> 1.21.4-1
 - tests: make it easer to override the location of the copy helper
 - tests: add and use a "copy" helper instead of podman load/save

--- a/define/types.go
+++ b/define/types.go
@@ -28,7 +28,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.21.4"
+	Version = "1.21.5"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
Tag a v1.21.5 release so that our consumers can pick up fixes for CVE-2022-27651 (setting inheritable capabilities), the related fix for GHSA-rc4r-wh2q-q6c4 (the run user's primary GID not being in the supplemental groups list), and CVE-2022-21698 (a denial of service).