### PR TITLE
[release-1.23] tag v1.23.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 # Changelog
 
+## v1.23.5 (2022-09-20)
+
+    run: add container gid to additional groups
+    Bump golang.org/x/crypto to 7b82a4e
+
 ## v1.23.4 (2022-04-07)
 
     chroot: run gofmt on run.go
     vendor: bump c/image to v5.16.0-rhel/8b06d33
     Use race-free c/storage by bumping it to 1.36.3
+    run: do not set the inheritable capabilities
 
 ## v1.23.3 (2022-02-03)
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,14 @@
+- Changelog for v1.23.5 (2022-09-20)
+
+  * run: add container gid to additional groups
+  * Bump golang.org/x/crypto to 7b82a4e
+
 - Changelog for v1.23.4 (2022-04-07)
 
-    chroot: run gofmt on run.go
-    vendor: bump c/image to v5.16.0-rhel/8b06d33
-    Use race-free c/storage by bumping it to 1.36.3
+  * chroot: run gofmt on run.go
+  * vendor: bump c/image to v5.16.0-rhel/8b06d33
+  * Use race-free c/storage by bumping it to 1.36.3
+  * run: do not set the inheritable capabilities
 
 - Changelog for v1.23.3 (2022-02-03)
 

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in define/types.go too
-Version:        1.23.4
+Version:        1.23.5
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,10 +100,15 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Tue Sep 20 2022 Nalin Dahyabhai <nalin@redhat.com> 1.23.5-1
+- run: add container gid to additional groups
+- Bump golang.org/x/crypto to 7b82a4e
+
 * Thu April 7, 2022 Dan Walsh <dwalsh@redhat.com> 1.23.4-1
 - chroot: run gofmt on run.go
 - vendor: bump c/image to v5.16.0-rhel/8b06d33
 - Use race-free c/storage by bumping it to 1.36.3
+- run: do not set the inheritable capabilities
 
 * Thu Feb 3, 2022 Nalin Dahyabhai <nalin@redhat.com> 1.23.3-1
 - bump(github.com/modern-go/reflect2) to v1.0.2

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.23.4"
+	Version = "1.23.5"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
Tag a v1.23.5 release so that our consumers can pick up fixes for GHSA-rc4r-wh2q-q6c4 (the run user's primary GID not being in the supplemental groups list) and CVE-2022-27191 (a cryptographic flaw).