### PR TITLE
[release-1.24] tag v1.24.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Changelog
 
+## v1.24.6 (2022-09-20)
+
+    run: add container gid to additional groups
+
 ## v1.24.5 (2022-07-14)
 
     Bump github.com/containers/storage to v1.38.5

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+- Changelog for v1.24.6 (2022-09-20)
+  * run: add container gid to additional groups
+
 - Changelog for v1.24.5 (2022-07-14)
   * Bump github.com/containers/storage to v1.38.5
   * drop commas from changelog dates because `rpmspec -q` doesn't like them

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in define/types.go too
-Version:        1.24.5
+Version:        1.24.6
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,6 +100,9 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Tue Sep 20 2022 Nalin Dahyabhai <nalin@redhat.com> 1.24.6-1
+- run: add container gid to additional groups
+
 * Thu Jul 14 2022 Nalin Dahyabhai <nalin@redhat.com> 1.24.5-1
 - bump github.com/containers/storage to v1.38.5
 - drop commas from changelog dates because `rpmspec -q` doesn't like them

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.24.5"
+	Version = "1.24.6"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
Tag a v1.24.6 release so that our consumers can pick up a fix for GHSA-rc4r-wh2q-q6c4 (the run user's primary GID not being in the supplemental groups list).