### PR TITLE
[release-1.26] tag v1.26.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+## v1.26.5 (2022-09-20)
+
+    build: error out if path to containerfile is a directory
+    "make cross": ignore loong64 from target list
+    run: add container gid to additional groups
+
 ## v1.26.4 (2022-08-03)
 
     build: add --cpp-flag

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+- Changelog for v1.26.5 (2022-09-20)
+  * build: error out if path to containerfile is a directory
+  * "make cross": ignore loong64 from target list
+  * run: add container gid to additional groups
+
 - Changelog for v1.26.4 (2022-08-03)
   * build: add --cpp-flag
   * build: add --build-context flag

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in define/types.go too
-Version:        1.26.4
+Version:        1.26.5
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,6 +100,11 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Tue Sep 20 2022 Nalin Dahyabhai <nalin@redhat.com> 1.26.5-1
+- build: error out if path to containerfile is a directory
+- "make cross": ignore loong64 from target list
+- run: add container gid to additional groups
+
 * Wed Aug 3 2022 Nalin Dahyabhai <nalin@redhat.com> 1.26.4-1
 - build: add --cpp-flag
 - build: add --build-context flag

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.26.4"
+	Version = "1.26.5"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
Tag a v1.26.5 release so that our consumers can pick up a fix for GHSA-rc4r-wh2q-q6c4 (the run user's primary GID not being in the supplemental groups list).