### PR TITLE
copier: work around freebsd bug for "mkdir /"

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -1794,7 +1794,9 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 					}
 				}
 			case tar.TypeDir:
-				if err = os.Mkdir(path, 0700); err != nil && errors.Is(err, os.ErrExist) {
+				// FreeBSD can return EISDIR for "mkdir /":
+				// https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=59739.
+				if err = os.Mkdir(path, 0700); err != nil && (errors.Is(err, os.ErrExist) || errors.Is(err, syscall.EISDIR)) {
 					if st, stErr := os.Lstat(path); stErr == nil && !st.IsDir() {
 						if req.PutOptions.NoOverwriteNonDirDir {
 							break


### PR DESCRIPTION
This call to os.Mkdir got missed the first time I tried to add the workaround for the FreeBSD EISDIR bug since I was only testing with 'buildah run'. Trying to use 'buildah add' triggers the same bug whan trying to extract an archive into a container's filesystem.

Signed-off-by: Doug Rabson <dfr@rabson.org>

/kind bug

#### What this PR does / why we need it:

This works around a kernel bug in FreeBSD (https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=59739) where it can return EISDIR instead of EEXIST when calling mkdir on the root directory (including the 'root' of a chroot or jail).

#### How to verify it

Run 'buildah add <containername> <non-empty-tarfile> /'

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
[NO NEW TESTS NEEDED]
