### PR TITLE
[release-1.24] add: fail on bad `HTTP` response instead of writing to container for `URL` sources

### DIFF
--- a/add.go
+++ b/add.go
@@ -88,6 +88,11 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 		return err
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("invalid response status %d", response.StatusCode)
+	}
+
 	// Figure out what to name the new content.
 	name := renameTarget
 	if name == "" {

--- a/define/types.go
+++ b/define/types.go
@@ -183,6 +183,9 @@ func downloadToDirectory(url, dir string) error {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("invalid response status %d", resp.StatusCode)
+	}
 	if resp.ContentLength == 0 {
 		return errors.Errorf("no contents in %q", url)
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -19,6 +19,18 @@ load helpers
   expect_output --substring "options use-vc"
 }
 
+@test "build with add resolving to invalid HTTP status code" {
+  mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+
+  cat > ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile << _EOF
+FROM alpine
+ADD https://google.com/test /
+_EOF
+
+  run_buildah 125 build $WITH_POLICY_JSON -t source -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile
+  expect_output --substring "invalid response status"
+}
+
 @test "bud with .dockerignore #1" {
   _prefetch alpine busybox
   run_buildah 125 build -t testbud --signature-policy ${TESTSDIR}/policy.json -f ${TESTSDIR}/bud/dockerignore/Dockerfile ${TESTSDIR}/bud/dockerignore


### PR DESCRIPTION
Adding sources from URL using `ADD` instruction adds reponse to build
container even if it receives bad HTTP response, following behaviour is
not in parity with `docker` or `buildkit` and is causing issues with OpenShift
Container Platform see BZ for details.

Following commit ensures that `ADD` where source is external URL fails
on build step if we get bad HTTP response.

Example: Following containerfile should fail while building

```Dockerfile
FROM registry.fedoraproject.org/fedora:36
ADD https://mirror.init7.net/fedora/fedora/linux/releases/36/Server/x86_64/iso/Fedora-Server-netinst-x86_64-36-1.5.foo /
```

**Fixes: BZ#2102140**
Backport of: https://github.com/containers/buildah/pull/4086