### PR TITLE
[ci:docs] Fix buildahimage container.conf permissions regression

### DIFF
--- a/contrib/buildahimage/stable/Containerfile
+++ b/contrib/buildahimage/stable/Containerfile
@@ -30,7 +30,8 @@ RUN sed -e 's|^#mount_program|mount_program|g' \
            -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
            /usr/share/containers/storage.conf \
            > /etc/containers/storage.conf; \
-    chmod 644 /etc/containers/storage.conf
+    chmod 644 /etc/containers/storage.conf; \
+    chmod 644 /etc/containers/containers.conf
 
 RUN mkdir -p /var/lib/shared/overlay-images \
              /var/lib/shared/overlay-layers \

--- a/contrib/buildahimage/stable/Containerfile
+++ b/contrib/buildahimage/stable/Containerfile
@@ -29,8 +29,8 @@ RUN sed -e 's|^#mount_program|mount_program|g' \
            -e '/additionalimage.*/a "/var/lib/shared",' \
            -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
            /usr/share/containers/storage.conf \
-           > /etc/containers/storage.conf; \
-    chmod 644 /etc/containers/storage.conf; \
+           > /etc/containers/storage.conf && \
+    chmod 644 /etc/containers/storage.conf && \
     chmod 644 /etc/containers/containers.conf
 
 RUN mkdir -p /var/lib/shared/overlay-images \
@@ -43,9 +43,9 @@ RUN mkdir -p /var/lib/shared/overlay-images \
     touch /var/lib/shared/vfs-layers/layers.lock
 
 # Define uid/gid ranges for our user https://github.com/containers/buildah/issues/3053
-RUN echo -e "build:1:999\nbuild:1001:64535" > /etc/subuid; \
- echo -e "build:1:999\nbuild:1001:64535" > /etc/subgid; \
- mkdir -p /home/build/.local/share/containers; \
+RUN echo -e "build:1:999\nbuild:1001:64535" > /etc/subuid && \
+ echo -e "build:1:999\nbuild:1001:64535" > /etc/subgid && \
+ mkdir -p /home/build/.local/share/containers && \
  chown -R build:build /home/build
 
 VOLUME /var/lib/containers

--- a/contrib/buildahimage/testing/Containerfile
+++ b/contrib/buildahimage/testing/Containerfile
@@ -31,7 +31,8 @@ RUN sed -e 's|^#mount_program|mount_program|g' \
            -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
            /usr/share/containers/storage.conf \
            > /etc/containers/storage.conf; \
-    chmod 644 /etc/containers/storage.conf
+    chmod 644 /etc/containers/storage.conf; \
+    chmod 644 /etc/containers/containers.conf
 
 RUN mkdir -p /var/lib/shared/overlay-images \
              /var/lib/shared/overlay-layers \

--- a/contrib/buildahimage/testing/Containerfile
+++ b/contrib/buildahimage/testing/Containerfile
@@ -30,8 +30,8 @@ RUN sed -e 's|^#mount_program|mount_program|g' \
            -e '/additionalimage.*/a "/var/lib/shared",' \
            -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
            /usr/share/containers/storage.conf \
-           > /etc/containers/storage.conf; \
-    chmod 644 /etc/containers/storage.conf; \
+           > /etc/containers/storage.conf && \
+    chmod 644 /etc/containers/storage.conf && \
     chmod 644 /etc/containers/containers.conf
 
 RUN mkdir -p /var/lib/shared/overlay-images \

--- a/contrib/buildahimage/upstream/Containerfile
+++ b/contrib/buildahimage/upstream/Containerfile
@@ -43,7 +43,7 @@ RUN sed -e 's|^#mount_program|mount_program|g' \
         -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
         /usr/share/containers/storage.conf \
         > /etc/containers/storage.conf && \
-    chmod 644 /etc/containers/storage.conf; \
+    chmod 644 /etc/containers/storage.conf && \
     chmod 644 /etc/containers/containers.conf
 
 RUN mkdir -p /var/lib/shared/overlay-images \

--- a/contrib/buildahimage/upstream/Containerfile
+++ b/contrib/buildahimage/upstream/Containerfile
@@ -43,7 +43,8 @@ RUN sed -e 's|^#mount_program|mount_program|g' \
         -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
         /usr/share/containers/storage.conf \
         > /etc/containers/storage.conf && \
-    chmod 644 /etc/containers/storage.conf
+    chmod 644 /etc/containers/storage.conf; \
+    chmod 644 /etc/containers/containers.conf
 
 RUN mkdir -p /var/lib/shared/overlay-images \
              /var/lib/shared/overlay-layers \


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
When running `quay.io/buildah/stable:latest` (`quay.io/buildah/stable:v1.27.0`), buildah cannot be run as the build user due to a permissions error on `/etc/containers/containers.conf`. This appears to be a regression of the fix @rhatdan made in #2332. The regression appears to have been caused by 0b7c50023bd507dd7949e092dc52824962864a03. Since it's a trivial fix and I appreciate all the effort, I thought I'd make this as a pull request not just an issue.

#### How to verify it
1. Run `podman run --user build --security-opt label=disable --security-opt unmask=ALL --device /dev/fuse -ti quay.io/buildah/stable:v1.27.0`
2. Run `buildah`
```
WARN[0000] Error loading container config when searching for local runtime: reading system config "/etc/containers/containers.conf": decode configuration /etc/containers/containers.conf: open /etc/containers/containers.conf: permission denied
ERRO[0000] failed to setup From and Build flags: failed to get container config: reading system config "/etc/containers/containers.conf": decode configuration /etc/containers/containers.conf: open /etc/containers/containers.conf: permission denied
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:
Sorry, I didn't feel like creating a new account and setting up signatures. The code is a single line copied and pasted from a [previous commit](https://github.com/containers/buildah/commit/0b7c50023bd507dd7949e092dc52824962864a03). Feel free to remake it if my pseudonym is an issue.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

