### PR TITLE
Proof of concept: nightly dependency treadmill

### DIFF
--- a/contrib/cirrus/build.sh
+++ b/contrib/cirrus/build.sh
@@ -15,6 +15,27 @@ if [[ "$IN_PODMAN" == "true" ]]
 then
     in_podman --rm $IN_PODMAN_NAME $0
 else
+    # Nightly dependency-bump job: fetch latest versions of the
+    # Big Three dependencies, and run full CI test suite. Notification
+    # email will go out to monitor-list upon failure.
+    if [[ "$CIRRUS_CRON" = "treadmill" ]]; then
+        for pkg in common image/v5 storage; do
+            echo "go mod edit --require containers/$pkg@main"
+            go mod edit --require github.com/containers/$pkg@main
+            make vendor
+        done
+        git add vendor
+        # Show what changed.
+        echo "git diff go.mod, then git diff --stat:"
+        git diff go.mod
+        git diff --stat
+        env GIT_AUTHOR_NAME='No B. Dee'               \
+            GIT_AUTHOR_EMAIL='nobody@example.com'     \
+            GIT_COMMITTER_NAME='No B. Dee'            \
+            GIT_COMMITTER_EMAIL='nobody@example.com'  \
+            git commit -asm"Bump containers/common,image,storage"
+    fi
+
     echo "Compiling buildah (\$GOSRC=$GOSRC)"
     showrun make clean all
 


### PR DESCRIPTION
As discussed in f2f: this is the cleanest, simplest mechanism
I can think of to auto-test the Big Three dependencies: simply
run go mod edit immediately after git checkout, then run the
entire CI test suite.

If this approach works, we can set up a new CIRRUS_CRON=treadmill job.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```