### PR TITLE
test: remove unneeded/expensive `COPY . .`

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -36,7 +36,7 @@ load helpers
   for var in "${checkvars[@]}"; do
     echo "ARG TARGET${var}" >>$containerfile
   done
-  echo "COPY . ." >>$containerfile
+  echo "RUN echo hi" >>$containerfile
 
   # With explicit and full --platform, there should be no warnings
   run_buildah build $WITH_POLICY_JSON --platform linux/amd64/v2 -t source -f $containerfile


### PR DESCRIPTION
Test added in https://github.com/containers/buildah/pull/4310 uses `COPY . .` which is expensive and unneeded. Also in `podman` test due to copying files directly from the currect context it hits a system/environment limit. See https://api.cirrus-ci.com/v1/artifact/task/5960273050730496/html/bud-podman-fedora-36-root-host.log.html#t--00004

Hence remove this uneeded `COPY` and instead use a `RUN echo`.

Closes: https://github.com/containers/buildah/issues/4314
