### PR TITLE
sshagent: `LockOSThread` before setting `SocketLabel`

### DIFF
--- a/pkg/sshagent/sshagent.go
+++ b/pkg/sshagent/sshagent.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
@@ -68,6 +69,13 @@ func newAgentServerSocket(socketPath string) (*AgentServer, error) {
 
 // Serve starts the SSH agent on the host and returns the path of the socket where the agent is serving
 func (a *AgentServer) Serve(processLabel string) (string, error) {
+	// Calls to `selinux.SetSocketLabel` should be wrapped in
+	// runtime.LockOSThread()/runtime.UnlockOSThread() until
+	// the the socket is created to guarantee another goroutine
+	// does not migrate to the current thread before execution
+	// is complete.
+	// Ref: https://github.com/opencontainers/selinux/blob/main/go-selinux/selinux.go#L158
+	runtime.LockOSThread()
 	err := selinux.SetSocketLabel(processLabel)
 	if err != nil {
 		return "", err
@@ -83,7 +91,12 @@ func (a *AgentServer) Serve(processLabel string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// Reset socket label.
 	err = selinux.SetSocketLabel("")
+	// Unlock the thread only if the process label could be restored
+	// successfully.  Otherwise leave the thread locked and the Go runtime
+	// will terminate it once it returns to the threads pool.
+	runtime.UnlockOSThread()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
As per the library instruction `sshagent` must acquire `LockOSThread` before setting and resetting the SocketLabel to ensure that the thread is locked before following invocation completes setting and reseting the socket label.

Reference: https://pkg.go.dev/github.com/opencontainers/selinux/go-selinux#SetSocketLabel 
Closes: https://github.com/containers/buildah/issues/4245

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]
Existing tests must pass

