### PR TITLE
Fix ident for dependabot gha block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,8 @@ updates:
     time: "10:00"
     timezone: Europe/Berlin
   open-pull-requests-limit: 10
-  
-  - package-ecosystem: github-actions
+
+- package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

This fixes a small indentation error on the dependabot config.

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

I don't believe dependabot is sending pull requests for actions because there are a couple that this project uses which are not up-to-date.

#### How to verify it

The version of the checkout action which this project currently uses is out-of-date. This project is currently using v2, but v3 is the latest. A pull request should come in from dependabot bumping the checkout action to version 3. 

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

