### PR TITLE
[CI:BUILD] copr: buildah rpm should depend on containers-common-extra

### DIFF
--- a/buildah.spec.rpkg
+++ b/buildah.spec.rpkg
@@ -59,7 +59,7 @@ BuildRequires: btrfs-progs-devel
 %if 0%{?fedora} <= 35
 Requires: containers-common >= 4:1-39
 %else
-Requires: containers-common >= 4:1-46
+Requires: containers-common-extra
 %endif
 %if 0%{?rhel}
 BuildRequires: libseccomp-devel


### PR DESCRIPTION
containers-common now has a new `-extra` subpackage which handles dependencies common to podman and buildah and also depends on the main package `containers-common` itself.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:
Updates dependencies for fedora >= 36

#### How to verify it
check if copr installs fine along with deps

#### Which issue(s) this PR fixes:
None
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
None
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

