### PR TITLE
[CI:BUILD] pr-should-include-tests: allow specfile, golangci

### DIFF
--- a/tests/validate/pr-should-include-tests
+++ b/tests/validate/pr-should-include-tests
@@ -12,9 +12,6 @@ fi
 if [[ "${CIRRUS_CHANGE_MESSAGE}" =~ NO.NEW.TESTS.NEEDED ]]; then
     exit 0
 fi
-if [[ "${CIRRUS_CHANGE_MESSAGE}" =~ NO.TESTS.NEEDED ]]; then
-    exit 0
-fi
 
 # HEAD should be good enough, but the CIRRUS envariable allows us to test
 head=${CIRRUS_CHANGE_IN_REPO:-HEAD}
@@ -49,6 +46,8 @@ filtered_changes=$(git diff --name-status $base $head |
                        fgrep -vx changelog.txt        |
                        fgrep -vx go.mod               |
                        fgrep -vx go.sum               |
+                       fgrep -vx buildah.spec.rpkg    |
+                       fgrep -vx .golangci.yml        |
                        egrep -v  '^[^/]+\.md$'        |
                        egrep -v  '^\.github/'         |
                        egrep -v  '^contrib/'          |


### PR DESCRIPTION
Make the pr-should-include-tests check more consistent with
podman: allow changes to buildah.spec.rpkg and .golangci.yml

Also, remove the check for "NO TESTS NEEDED". That was a
workaround for a bad design decision I initially made.
The correct wording is NO NEW TESTS NEEDED, and nobody
should ever use the phrase without NEW.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```