### PR TITLE
Simplify and fix cache volume locking

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -192,12 +192,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 	}
 	// unlock if any locked files from this RUN statement
 	for _, lockfile := range targetLocks {
-		if lockfile.Locked() {
-			lockfile.Unlock()
-		} else {
-			logrus.Warnf("Some lockfile was expected to be locked, this is unexpected")
-			continue
-		}
+		lockfile.Unlock()
 	}
 	return runerr
 }

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -172,6 +172,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 	if err != nil {
 		return err
 	}
+	defer internalParse.UnlockLockArray(targetLocks)
 	options.Mounts = mounts
 	// Run() will automatically clean them up.
 	options.ExternalImageMounts = mountedImages
@@ -189,10 +190,6 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 		}
 		conditionallyAddHistory(builder, c, "%s %s", shell, strings.Join(args, " "))
 		return builder.Save()
-	}
-	// unlock if any locked files from this RUN statement
-	for _, lockfile := range targetLocks {
-		lockfile.Unlock()
 	}
 	return runerr
 }

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -11,7 +11,6 @@ import (
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
-	"github.com/containers/storage/pkg/lockfile"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -169,7 +168,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 	if err != nil {
 		return fmt.Errorf("building system context: %w", err)
 	}
-	mounts, mountedImages, lockedTargets, err := internalParse.GetVolumes(systemContext, store, iopts.volumes, iopts.mounts, iopts.contextDir)
+	mounts, mountedImages, targetLocks, err := internalParse.GetVolumes(systemContext, store, iopts.volumes, iopts.mounts, iopts.contextDir)
 	if err != nil {
 		return err
 	}
@@ -192,28 +191,11 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 		return builder.Save()
 	}
 	// unlock if any locked files from this RUN statement
-	for _, path := range lockedTargets {
-		_, err := os.Stat(path)
-		if err != nil {
-			// Lockfile not found this might be a problem,
-			// since LockedTargets must contain list of all locked files
-			// don't break here since we need to unlock other files but
-			// log so user can take a look
-			logrus.Warnf("Lockfile %q was expected here, stat failed with %v", path, err)
-			continue
-		}
-		lockfile, err := lockfile.GetLockfile(path)
-		if err != nil {
-			// unable to get lockfile
-			// lets log error and continue
-			// unlocking other files
-			logrus.Warn(err)
-			continue
-		}
+	for _, lockfile := range targetLocks {
 		if lockfile.Locked() {
 			lockfile.Unlock()
 		} else {
-			logrus.Warnf("Lockfile %q was expected to be locked, this is unexpected", path)
+			logrus.Warnf("Some lockfile was expected to be locked, this is unexpected")
 			continue
 		}
 	}

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -187,11 +187,11 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
 }
 
 // GetCacheMount parses a single cache mount entry from the --mount flag.
-func GetCacheMount(args []string, store storage.Store, imageMountLabel string, additionalMountPoints map[string]internal.StageMountDetails) (specs.Mount, []string, error) {
+func GetCacheMount(args []string, store storage.Store, imageMountLabel string, additionalMountPoints map[string]internal.StageMountDetails) (specs.Mount, []lockfile.Locker, error) {
 	var err error
 	var mode uint64
 	var buildahLockFilesDir string
-	lockedTargets := make([]string, 0)
+	targetLocks := make([]lockfile.Locker, 0)
 	var (
 		setDest           bool
 		setShared         bool
@@ -239,59 +239,59 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 			sharing = kv[1]
 		case "bind-propagation":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
+				return newMount, targetLocks, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			newMount.Options = append(newMount.Options, kv[1])
 		case "id":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
+				return newMount, targetLocks, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			id = kv[1]
 		case "from":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
+				return newMount, targetLocks, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			fromStage = kv[1]
 		case "target", "dst", "destination":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
+				return newMount, targetLocks, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			if err := parse.ValidateVolumeCtrDir(kv[1]); err != nil {
-				return newMount, lockedTargets, err
+				return newMount, targetLocks, err
 			}
 			newMount.Destination = kv[1]
 			setDest = true
 		case "src", "source":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
+				return newMount, targetLocks, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			newMount.Source = kv[1]
 		case "mode":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
+				return newMount, targetLocks, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			mode, err = strconv.ParseUint(kv[1], 8, 32)
 			if err != nil {
-				return newMount, lockedTargets, fmt.Errorf("unable to parse cache mode: %w", err)
+				return newMount, targetLocks, fmt.Errorf("unable to parse cache mode: %w", err)
 			}
 		case "uid":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
+				return newMount, targetLocks, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			uid, err = strconv.Atoi(kv[1])
 			if err != nil {
-				return newMount, lockedTargets, fmt.Errorf("unable to parse cache uid: %w", err)
+				return newMount, targetLocks, fmt.Errorf("unable to parse cache uid: %w", err)
 			}
 		case "gid":
 			if len(kv) == 1 {
-				return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
+				return newMount, targetLocks, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
 			gid, err = strconv.Atoi(kv[1])
 			if err != nil {
-				return newMount, lockedTargets, fmt.Errorf("unable to parse cache gid: %w", err)
+				return newMount, targetLocks, fmt.Errorf("unable to parse cache gid: %w", err)
 			}
 		default:
-			return newMount, lockedTargets, fmt.Errorf("%v: %w", kv[0], errBadMntOption)
+			return newMount, targetLocks, fmt.Errorf("%v: %w", kv[0], errBadMntOption)
 		}
 	}
 
@@ -302,7 +302,7 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 	}
 
 	if !setDest {
-		return newMount, lockedTargets, errBadVolDest
+		return newMount, targetLocks, errBadVolDest
 	}
 
 	if fromStage != "" {
@@ -319,7 +319,7 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		// Cache does not supports using image so if not stage found
 		// return with error
 		if mountPoint == "" {
-			return newMount, lockedTargets, fmt.Errorf("no stage found with name %s", fromStage)
+			return newMount, targetLocks, fmt.Errorf("no stage found with name %s", fromStage)
 		}
 		// path should be /contextDir/specified path
 		newMount.Source = filepath.Join(mountPoint, filepath.Clean(string(filepath.Separator)+newMount.Source))
@@ -335,7 +335,7 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		// create cache on host if not present
 		err = os.MkdirAll(cacheParent, os.FileMode(0755))
 		if err != nil {
-			return newMount, lockedTargets, fmt.Errorf("unable to create build cache directory: %w", err)
+			return newMount, targetLocks, fmt.Errorf("unable to create build cache directory: %w", err)
 		}
 
 		if id != "" {
@@ -352,14 +352,14 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		//buildkit parity: change uid and gid if specified otheriwise keep `0`
 		err = idtools.MkdirAllAndChownNew(newMount.Source, os.FileMode(mode), idPair)
 		if err != nil {
-			return newMount, lockedTargets, fmt.Errorf("unable to change uid,gid of cache directory: %w", err)
+			return newMount, targetLocks, fmt.Errorf("unable to change uid,gid of cache directory: %w", err)
 		}
 
 		// create a subdirectory inside `cacheParent` just to store lockfiles
 		buildahLockFilesDir = filepath.Join(cacheParent, buildahLockFilesDir)
 		err = os.MkdirAll(buildahLockFilesDir, os.FileMode(0700))
 		if err != nil {
-			return newMount, lockedTargets, fmt.Errorf("unable to create build cache lockfiles directory: %w", err)
+			return newMount, targetLocks, fmt.Errorf("unable to create build cache lockfiles directory: %w", err)
 		}
 	}
 
@@ -368,17 +368,17 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		// lock parent cache
 		lockfile, err := lockfile.GetLockfile(filepath.Join(buildahLockFilesDir, BuildahCacheLockfile))
 		if err != nil {
-			return newMount, lockedTargets, fmt.Errorf("unable to acquire lock when sharing mode is locked: %w", err)
+			return newMount, targetLocks, fmt.Errorf("unable to acquire lock when sharing mode is locked: %w", err)
 		}
 		// Will be unlocked after the RUN step is executed.
 		lockfile.Lock()
-		lockedTargets = append(lockedTargets, filepath.Join(buildahLockFilesDir, BuildahCacheLockfile))
+		targetLocks = append(targetLocks, lockfile)
 	case "shared":
 		// do nothing since default is `shared`
 		break
 	default:
 		// error out for unknown values
-		return newMount, lockedTargets, fmt.Errorf("unrecognized value %q for field `sharing`: %w", sharing, err)
+		return newMount, targetLocks, fmt.Errorf("unrecognized value %q for field `sharing`: %w", sharing, err)
 	}
 
 	// buildkit parity: default sharing should be shared
@@ -396,11 +396,11 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 
 	opts, err := parse.ValidateVolumeOpts(newMount.Options)
 	if err != nil {
-		return newMount, lockedTargets, err
+		return newMount, targetLocks, err
 	}
 	newMount.Options = opts
 
-	return newMount, lockedTargets, nil
+	return newMount, targetLocks, nil
 }
 
 // ValidateVolumeMountHostDir validates the host path of buildah --volume
@@ -488,18 +488,18 @@ func Volume(volume string) (specs.Mount, error) {
 }
 
 // GetVolumes gets the volumes from --volume and --mount
-func GetVolumes(ctx *types.SystemContext, store storage.Store, volumes []string, mounts []string, contextDir string) ([]specs.Mount, []string, []string, error) {
-	unifiedMounts, mountedImages, lockedTargets, err := getMounts(ctx, store, mounts, contextDir)
+func GetVolumes(ctx *types.SystemContext, store storage.Store, volumes []string, mounts []string, contextDir string) ([]specs.Mount, []string, []lockfile.Locker, error) {
+	unifiedMounts, mountedImages, targetLocks, err := getMounts(ctx, store, mounts, contextDir)
 	if err != nil {
-		return nil, mountedImages, lockedTargets, err
+		return nil, mountedImages, targetLocks, err
 	}
 	volumeMounts, err := getVolumeMounts(volumes)
 	if err != nil {
-		return nil, mountedImages, lockedTargets, err
+		return nil, mountedImages, targetLocks, err
 	}
 	for dest, mount := range volumeMounts {
 		if _, ok := unifiedMounts[dest]; ok {
-			return nil, mountedImages, lockedTargets, fmt.Errorf("%v: %w", dest, errDuplicateDest)
+			return nil, mountedImages, targetLocks, fmt.Errorf("%v: %w", dest, errDuplicateDest)
 		}
 		unifiedMounts[dest] = mount
 	}
@@ -508,19 +508,19 @@ func GetVolumes(ctx *types.SystemContext, store storage.Store, volumes []string,
 	for _, mount := range unifiedMounts {
 		finalMounts = append(finalMounts, mount)
 	}
-	return finalMounts, mountedImages, lockedTargets, nil
+	return finalMounts, mountedImages, targetLocks, nil
 }
 
 // getMounts takes user-provided input from the --mount flag and creates OCI
 // spec mounts.
 // buildah run --mount type=bind,src=/etc/resolv.conf,target=/etc/resolv.conf ...
 // buildah run --mount type=tmpfs,target=/dev/shm ...
-func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, contextDir string) (map[string]specs.Mount, []string, []string, error) {
+func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, contextDir string) (map[string]specs.Mount, []string, []lockfile.Locker, error) {
 	// If `type` is not set default to "bind"
 	mountType := TypeBind
 	finalMounts := make(map[string]specs.Mount)
 	mountedImages := make([]string, 0)
-	lockedTargets := make([]string, 0)
+	targetLocks := make([]lockfile.Locker, 0)
 
 	errInvalidSyntax := errors.New("incorrect mount format: should be --mount type=<bind|tmpfs>,[src=<host-dir>,]target=<ctr-dir>[,options]")
 
@@ -530,13 +530,13 @@ func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, c
 	for _, mount := range mounts {
 		tokens := strings.Split(mount, ",")
 		if len(tokens) < 2 {
-			return nil, mountedImages, lockedTargets, fmt.Errorf("%q: %w", mount, errInvalidSyntax)
+			return nil, mountedImages, targetLocks, fmt.Errorf("%q: %w", mount, errInvalidSyntax)
 		}
 		for _, field := range tokens {
 			if strings.HasPrefix(field, "type=") {
 				kv := strings.Split(field, "=")
 				if len(kv) != 2 {
-					return nil, mountedImages, lockedTargets, fmt.Errorf("%q: %w", mount, errInvalidSyntax)
+					return nil, mountedImages, targetLocks, fmt.Errorf("%q: %w", mount, errInvalidSyntax)
 				}
 				mountType = kv[1]
 			}
@@ -545,38 +545,38 @@ func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, c
 		case TypeBind:
 			mount, image, err := GetBindMount(ctx, tokens, contextDir, store, "", nil)
 			if err != nil {
-				return nil, mountedImages, lockedTargets, err
+				return nil, mountedImages, targetLocks, err
 			}
 			if _, ok := finalMounts[mount.Destination]; ok {
-				return nil, mountedImages, lockedTargets, fmt.Errorf("%v: %w", mount.Destination, errDuplicateDest)
+				return nil, mountedImages, targetLocks, fmt.Errorf("%v: %w", mount.Destination, errDuplicateDest)
 			}
 			finalMounts[mount.Destination] = mount
 			mountedImages = append(mountedImages, image)
 		case TypeCache:
-			mount, lockedPaths, err := GetCacheMount(tokens, store, "", nil)
-			lockedTargets = lockedPaths
+			mount, tl, err := GetCacheMount(tokens, store, "", nil)
+			targetLocks = tl
 			if err != nil {
-				return nil, mountedImages, lockedTargets, err
+				return nil, mountedImages, targetLocks, err
 			}
 			if _, ok := finalMounts[mount.Destination]; ok {
-				return nil, mountedImages, lockedTargets, fmt.Errorf("%v: %w", mount.Destination, errDuplicateDest)
+				return nil, mountedImages, targetLocks, fmt.Errorf("%v: %w", mount.Destination, errDuplicateDest)
 			}
 			finalMounts[mount.Destination] = mount
 		case TypeTmpfs:
 			mount, err := GetTmpfsMount(tokens)
 			if err != nil {
-				return nil, mountedImages, lockedTargets, err
+				return nil, mountedImages, targetLocks, err
 			}
 			if _, ok := finalMounts[mount.Destination]; ok {
-				return nil, mountedImages, lockedTargets, fmt.Errorf("%v: %w", mount.Destination, errDuplicateDest)
+				return nil, mountedImages, targetLocks, fmt.Errorf("%v: %w", mount.Destination, errDuplicateDest)
 			}
 			finalMounts[mount.Destination] = mount
 		default:
-			return nil, mountedImages, lockedTargets, fmt.Errorf("invalid filesystem type %q", mountType)
+			return nil, mountedImages, targetLocks, fmt.Errorf("invalid filesystem type %q", mountType)
 		}
 	}
 
-	return finalMounts, mountedImages, lockedTargets, nil
+	return finalMounts, mountedImages, targetLocks, nil
 }
 
 // GetTmpfsMount parses a single tmpfs mount entry from the --mount flag

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -554,7 +554,7 @@ func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, c
 			mountedImages = append(mountedImages, image)
 		case TypeCache:
 			mount, tl, err := GetCacheMount(tokens, store, "", nil)
-			targetLocks = tl
+			targetLocks = append(targetLocks, tl...)
 			if err != nil {
 				return nil, mountedImages, targetLocks, err
 			}

--- a/run.go
+++ b/run.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/buildah/internal"
 	"github.com/containers/buildah/pkg/sshagent"
 	"github.com/containers/image/v5/types"
+	"github.com/containers/storage/pkg/lockfile"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -176,8 +177,8 @@ type runMountArtifacts struct {
 	Agents []*sshagent.AgentServer
 	// SSHAuthSock is the path to the ssh auth sock inside the container
 	SSHAuthSock string
-	// LockedTargets to be unlocked if there are any.
-	LockedTargets []string
+	// TargetLocks to be unlocked if there are any.
+	TargetLocks []lockfile.Locker
 }
 
 // RunMountInfo are the available run mounts for this run

--- a/run_common.go
+++ b/run_common.go
@@ -1454,7 +1454,7 @@ func (b *Builder) runSetupRunMounts(mounts []string, sources runMountInfo, idMap
 	agents := make([]*sshagent.AgentServer, 0, len(mounts))
 	sshCount := 0
 	defaultSSHSock := ""
-	lockedTargets := []string{}
+	targetLocks := []lockfile.Locker{}
 	for _, mount := range mounts {
 		tokens := strings.Split(mount, ",")
 		for _, field := range tokens {
@@ -1513,13 +1513,13 @@ func (b *Builder) runSetupRunMounts(mounts []string, sources runMountInfo, idMap
 			finalMounts = append(finalMounts, *mount)
 			mountTargets = append(mountTargets, mount.Destination)
 		case "cache":
-			mount, lockedPaths, err := b.getCacheMount(tokens, sources.StageMountPoints, idMaps)
+			mount, tl, err := b.getCacheMount(tokens, sources.StageMountPoints, idMaps)
 			if err != nil {
 				return nil, nil, err
 			}
 			finalMounts = append(finalMounts, *mount)
 			mountTargets = append(mountTargets, mount.Destination)
-			lockedTargets = append(lockedTargets, lockedPaths...)
+			targetLocks = append(targetLocks, tl...)
 		default:
 			return nil, nil, fmt.Errorf("invalid mount type %q", mountType)
 		}
@@ -1530,7 +1530,7 @@ func (b *Builder) runSetupRunMounts(mounts []string, sources runMountInfo, idMap
 		Agents:          agents,
 		MountedImages:   mountImages,
 		SSHAuthSock:     defaultSSHSock,
-		LockedTargets:   lockedTargets,
+		TargetLocks:     targetLocks,
 	}
 	return finalMounts, artifacts, nil
 }
@@ -1862,28 +1862,11 @@ func (b *Builder) cleanupRunMounts(context *imageTypes.SystemContext, mountpoint
 		}
 	}
 	// unlock if any locked files from this RUN statement
-	for _, path := range artifacts.LockedTargets {
-		_, err := os.Stat(path)
-		if err != nil {
-			// Lockfile not found this might be a problem,
-			// since LockedTargets must contain list of all locked files
-			// don't break here since we need to unlock other files but
-			// log so user can take a look
-			logrus.Warnf("Lockfile %q was expected here, stat failed with %v", path, err)
-			continue
-		}
-		lockfile, err := lockfile.GetLockfile(path)
-		if err != nil {
-			// unable to get lockfile
-			// lets log error and continue
-			// unlocking other files
-			logrus.Warn(err)
-			continue
-		}
+	for _, lockfile := range artifacts.TargetLocks {
 		if lockfile.Locked() {
 			lockfile.Unlock()
 		} else {
-			logrus.Warnf("Lockfile %q was expected to be locked, this is unexpected", path)
+			logrus.Warnf("Some lockfile %q was expected to be locked, this is unexpected", path)
 			continue
 		}
 	}

--- a/run_common.go
+++ b/run_common.go
@@ -1863,12 +1863,7 @@ func (b *Builder) cleanupRunMounts(context *imageTypes.SystemContext, mountpoint
 	}
 	// unlock if any locked files from this RUN statement
 	for _, lockfile := range artifacts.TargetLocks {
-		if lockfile.Locked() {
-			lockfile.Unlock()
-		} else {
-			logrus.Warnf("Some lockfile %q was expected to be locked, this is unexpected", path)
-			continue
-		}
+		lockfile.Unlock()
 	}
 	return prevErr
 }

--- a/run_common.go
+++ b/run_common.go
@@ -1519,7 +1519,9 @@ func (b *Builder) runSetupRunMounts(mounts []string, sources runMountInfo, idMap
 			}
 			finalMounts = append(finalMounts, *mount)
 			mountTargets = append(mountTargets, mount.Destination)
-			targetLocks = append(targetLocks, tl...)
+			if tl != nil {
+				targetLocks = append(targetLocks, tl)
+			}
 		default:
 			return nil, nil, fmt.Errorf("invalid mount type %q", mountType)
 		}

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -25,6 +25,7 @@ import (
 	nettypes "github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/lockfile"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/docker/go-units"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -308,7 +309,7 @@ func setupSpecialMountSpecChanges(spec *spec.Spec, shmSize string) ([]specs.Moun
 	return spec.Mounts, nil
 }
 
-func (b *Builder) getCacheMount(tokens []string, stageMountPoints map[string]internal.StageMountDetails, idMaps IDMaps) (*spec.Mount, []string, error) {
+func (b *Builder) getCacheMount(tokens []string, stageMountPoints map[string]internal.StageMountDetails, idMaps IDMaps) (*spec.Mount, []lockfile.Locker, error) {
 	return nil, nil, errors.New("cache mounts not supported on freebsd")
 }
 

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -309,6 +309,7 @@ func setupSpecialMountSpecChanges(spec *spec.Spec, shmSize string) ([]specs.Moun
 	return spec.Mounts, nil
 }
 
+// If this function succeeds and returns a non-nil lockfile.Locker, the caller must unlock it (when??).
 func (b *Builder) getCacheMount(tokens []string, stageMountPoints map[string]internal.StageMountDetails, idMaps IDMaps) (*spec.Mount, lockfile.Locker, error) {
 	return nil, nil, errors.New("cache mounts not supported on freebsd")
 }

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -309,7 +309,7 @@ func setupSpecialMountSpecChanges(spec *spec.Spec, shmSize string) ([]specs.Moun
 	return spec.Mounts, nil
 }
 
-func (b *Builder) getCacheMount(tokens []string, stageMountPoints map[string]internal.StageMountDetails, idMaps IDMaps) (*spec.Mount, []lockfile.Locker, error) {
+func (b *Builder) getCacheMount(tokens []string, stageMountPoints map[string]internal.StageMountDetails, idMaps IDMaps) (*spec.Mount, lockfile.Locker, error) {
 	return nil, nil, errors.New("cache mounts not supported on freebsd")
 }
 

--- a/run_linux.go
+++ b/run_linux.go
@@ -34,6 +34,7 @@ import (
 	hooksExec "github.com/containers/common/pkg/hooks/exec"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/ioutils"
+	"github.com/containers/storage/pkg/lockfile"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/docker/go-units"
@@ -1196,18 +1197,18 @@ func checkIdsGreaterThan5(ids []spec.LinuxIDMapping) bool {
 	return false
 }
 
-func (b *Builder) getCacheMount(tokens []string, stageMountPoints map[string]internal.StageMountDetails, idMaps IDMaps) (*spec.Mount, []string, error) {
+func (b *Builder) getCacheMount(tokens []string, stageMountPoints map[string]internal.StageMountDetails, idMaps IDMaps) (*spec.Mount, []lockfile.Locker, error) {
 	var optionMounts []specs.Mount
-	mount, lockedTargets, err := internalParse.GetCacheMount(tokens, b.store, b.MountLabel, stageMountPoints)
+	mount, targetLocks, err := internalParse.GetCacheMount(tokens, b.store, b.MountLabel, stageMountPoints)
 	if err != nil {
-		return nil, lockedTargets, err
+		return nil, targetLocks, err
 	}
 	optionMounts = append(optionMounts, mount)
 	volumes, err := b.runSetupVolumeMounts(b.MountLabel, nil, optionMounts, idMaps)
 	if err != nil {
-		return nil, lockedTargets, err
+		return nil, targetLocks, err
 	}
-	return &volumes[0], lockedTargets, nil
+	return &volumes[0], targetLocks, nil
 }
 
 // setPdeathsig sets a parent-death signal for the process

--- a/run_linux.go
+++ b/run_linux.go
@@ -1197,18 +1197,19 @@ func checkIdsGreaterThan5(ids []spec.LinuxIDMapping) bool {
 	return false
 }
 
-func (b *Builder) getCacheMount(tokens []string, stageMountPoints map[string]internal.StageMountDetails, idMaps IDMaps) (*spec.Mount, []lockfile.Locker, error) {
+// The caller should eventually unlock returned lockfile.Locker, if it is non-nil, even if this function fails.
+func (b *Builder) getCacheMount(tokens []string, stageMountPoints map[string]internal.StageMountDetails, idMaps IDMaps) (*spec.Mount, lockfile.Locker, error) {
 	var optionMounts []specs.Mount
-	mount, targetLocks, err := internalParse.GetCacheMount(tokens, b.store, b.MountLabel, stageMountPoints)
+	mount, targetLock, err := internalParse.GetCacheMount(tokens, b.store, b.MountLabel, stageMountPoints)
 	if err != nil {
-		return nil, targetLocks, err
+		return nil, targetLock, err
 	}
 	optionMounts = append(optionMounts, mount)
 	volumes, err := b.runSetupVolumeMounts(b.MountLabel, nil, optionMounts, idMaps)
 	if err != nil {
-		return nil, targetLocks, err
+		return nil, targetLock, err
 	}
-	return &volumes[0], targetLocks, nil
+	return &volumes[0], targetLock, nil
 }
 
 // setPdeathsig sets a parent-death signal for the process


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

- Simplify the handling of “target locks” used for cache volumes with `sharing=locked` (an undocumented feature AFAICS): Pass around lock objects instead of files, completely eliminating various error paths
- Ensure that the locks are unlocked on error paths throughout the call stack.
- (This also eliminates reliance on `Lockfile.Locked`, which is going away in https://github.com/containers/storage/pull/1399 ).

#### How to verify it

Existing tests? I didn’t even try running the code.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Cc: @flouthoc who added the feature in #3820.

#### Does this PR introduce a user-facing change?

```release-note
None
```

