### PR TITLE
[release-1.27] Update c/image to 5.22.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/containerd v1.6.6
 	github.com/containernetworking/cni v1.1.2
 	github.com/containers/common v0.49.1
-	github.com/containers/image/v5 v5.22.0
+	github.com/containers/image/v5 v5.22.1
 	github.com/containers/ocicrypt v1.1.5
 	github.com/containers/storage v1.42.0
 	github.com/docker/distribution v2.8.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -348,8 +348,9 @@ github.com/containernetworking/plugins v1.1.1 h1:+AGfFigZ5TiQH00vhR8qPeSatj53eNG
 github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
 github.com/containers/common v0.49.1 h1:6y4/s2WwYxrv+Cox7fotOo316wuZI+iKKPUQweCYv50=
 github.com/containers/common v0.49.1/go.mod h1:ueM5hT0itKqCQvVJDs+EtjornAQtrHYxQJzP2gxeGIg=
-github.com/containers/image/v5 v5.22.0 h1:KemxPmD4D2YYOFZN2SgoTk7nBFcnwPiPW0MqjYtknSE=
 github.com/containers/image/v5 v5.22.0/go.mod h1:D8Ksv2RNB8qLJ7xe1P3rgJJOSQpahA6amv2Ax++/YO4=
+github.com/containers/image/v5 v5.22.1 h1:Oj8C/ACrNn18f8MNTqOeBOHAN51GF1rEhoVSCA/ylvI=
+github.com/containers/image/v5 v5.22.1/go.mod h1:D8Ksv2RNB8qLJ7xe1P3rgJJOSQpahA6amv2Ax++/YO4=
 github.com/containers/libtrust v0.0.0-20200511145503-9c3a6c22cd9a h1:spAGlqziZjCJL25C6F1zsQY05tfCKE9F5YwtEWWe6hU=
 github.com/containers/libtrust v0.0.0-20200511145503-9c3a6c22cd9a/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=

--- a/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/v5/docker/docker_image_dest.go
@@ -652,6 +652,7 @@ func (d *dockerImageDestination) putSignaturesToSigstoreAttachments(ctx context.
 			Digest:    "", // We will fill this in later.
 			Size:      0,
 		}, nil)
+		ociConfig.RootFS.Type = "layers"
 	} else {
 		logrus.Debugf("Fetching sigstore attachment config %s", ociManifest.Config.Digest.String())
 		// We don’t benefit from a real BlobInfoCache here because we never try to reuse/mount configs.

--- a/vendor/github.com/containers/image/v5/docker/errors.go
+++ b/vendor/github.com/containers/image/v5/docker/errors.go
@@ -54,7 +54,8 @@ func registryHTTPResponseToError(res *http.Response) error {
 		if len(response) > 50 {
 			response = response[:50] + "..."
 		}
-		err = fmt.Errorf("StatusCode: %d, %s", e.StatusCode, response)
+		// %.0w makes e visible to error.Unwrap() without including any text
+		err = fmt.Errorf("StatusCode: %d, %s%.0w", e.StatusCode, response, e)
 	}
 	return err
 }

--- a/vendor/github.com/containers/image/v5/version/version.go
+++ b/vendor/github.com/containers/image/v5/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 22
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -123,7 +123,7 @@ github.com/containers/common/pkg/timetype
 github.com/containers/common/pkg/umask
 github.com/containers/common/pkg/util
 github.com/containers/common/version
-# github.com/containers/image/v5 v5.22.0
+# github.com/containers/image/v5 v5.22.1
 ## explicit; go 1.17
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

Update for https://github.com/containers/image/pull/1695, fixing pushes of signatures to quay.io and reads with sigstore enabled from redhat.io

#### How to verify it

Manually

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Does not tag a new release.

#### Does this PR introduce a user-facing change?

```release-note
Fixes reads/writes of sigstore signatures/attachments in quay.io and registry.redhat.io
```

