### PR TITLE
[release-1.27] Bump to Buildah v1.27.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Changelog
 
+## v1.27.3 (2022-10-20)
+
+    Update to c/image 5.22.1
+
 ## v1.27.2 (2022-09-20)
 
     build: backport the --skip-unused-stages flag.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+- Changelog for v1.27.3 (2022-10-20)
+  * Update to c/image 5.22.1
+
 - Changelog for v1.27.2 (2022-09-20)
   * build: backport the --skip-unused-stages flag.
 

--- a/define/types.go
+++ b/define/types.go
@@ -30,7 +30,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.27.2"
+	Version = "1.27.3"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
Bumpe to v1.27.3 so we can get the c/image update
into Podman v4.2 for RHEL 8.7.0.ZeroDay

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
[NO NEW TESTS NEEDED]
