### PR TITLE
Makefile: Fix install on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,8 @@ install.cni.sudo: gopath
 
 .PHONY: install
 install:
-	install -D -m0755 bin/buildah $(DESTDIR)/$(BINDIR)/buildah
+	install -d -m 755 $(DESTDIR)/$(BINDIR)
+	install -m 755 bin/buildah $(DESTDIR)/$(BINDIR)/buildah
 	$(MAKE) -C docs install
 
 .PHONY: uninstall
@@ -157,7 +158,8 @@ uninstall:
 
 .PHONY: install.completions
 install.completions:
-	install -m 644 -D contrib/completions/bash/buildah $(DESTDIR)/$(BASHINSTALLDIR)/buildah
+	install -m 755 -d $(DESTDIR)/$(BASHINSTALLDIR)
+	install -m 644 contrib/completions/bash/buildah $(DESTDIR)/$(BASHINSTALLDIR)/buildah
 
 .PHONY: install.runc
 install.runc:

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ validate: install.tools
 
 .PHONY: install.tools
 install.tools:
-	make -C tests/tools
+	$(MAKE) -C tests/tools
 
 .PHONY: runc
 runc: gopath


### PR DESCRIPTION
The '-D' option to install differs between Linux and FreeBSD. On Linux, it creates missing directories but on FreeBSD, it removes a destdir prefix from an optional 'metalog'. This makes the directory creation explicit using 'install -d'.

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It allows installing buildah into an empty DESTDIR directory. I missed this problem because on my test machines, I was typically installing to /usr/local/bin which nearly always exists. The use of '-D' also had the side effect of suppressing the following '-m0755' argument since '-D' takes an argument; install's default mode is 0755 so the file was installed with the correct mode by accident.

#### How to verify it

```
$ d=$(mktemp -d)
$ sudo gmake DESTDIR=$d install
install -d -m 755 /tmp/tmp.KewiGMuZ//usr/local/bin
install -m 755 bin/buildah /tmp/tmp.KewiGMuZ//usr/local/bin/buildah
gmake -C docs install
gmake[1]: Entering directory '/home/dfr/go/src/github.com/containers/buildah/docs'
install -d /tmp/tmp.KewiGMuZ//usr/local/share/man/man1
install -m 0644 buildah*.1 /tmp/tmp.KewiGMuZ//usr/local/share/man/man1
install -m 0644 links/buildah*.1 /tmp/tmp.KewiGMuZ//usr/local/share/man/man1
gmake[1]: Leaving directory '/home/dfr/go/src/github.com/containers/buildah/docs'
$ sudo rm -rf $d
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

