### PR TITLE
executor: honor default `ARG` values while evaluating base image name.

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -690,7 +690,12 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 									base = child.Next.Value
 								}
 							}
+							headingArgs := argsMapToSlice(stage.Builder.HeadingArgs)
 							userArgs := argsMapToSlice(stage.Builder.Args)
+							// append heading args so if --build-arg key=value is not
+							// specified but default value is set in Containerfile
+							// via `ARG key=value` so default value can be used.
+							userArgs = append(headingArgs, userArgs...)
 							baseWithArg, err := imagebuilder.ProcessWord(base, userArgs)
 							if err != nil {
 								return "", nil, fmt.Errorf("while replacing arg variables with values for format %q: %w", base, err)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2810,6 +2810,10 @@ _EOF
   _prefetch busybox:musl
   target=leading-args
   run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg=VERSION=musl -f $BUDFILES/leading-args/Dockerfile $BUDFILES/leading-args
+
+  #Verify https://github.com/containers/buildah/issues/4312
+  # stage `FROM stage_${my_env}` must be resolved with default arg value and build should be successful.
+  run_buildah build $WITH_POLICY_JSON -t source -f $BUDFILES/multi-stage-builds/Dockerfile.arg_in_stage
 }
 
 @test "bud-with-healthcheck" {

--- a/tests/bud/multi-stage-builds/Dockerfile.arg_in_stage
+++ b/tests/bud/multi-stage-builds/Dockerfile.arg_in_stage
@@ -1,0 +1,7 @@
+ARG my_env=a
+
+FROM alpine as stage_a
+RUN /bin/true
+
+FROM stage_${my_env} as stage_b
+RUN /bin/true


### PR DESCRIPTION
While PR https://github.com/containers/buildah/pull/3947 added support for evaluating `--build-args` in base image names for a multi-stage,single-stage builds but it missed processing default value if any. So for scenarios where `ARG` already has a default value in Containerfile via `ARG key=value` but was not specified with `--build-arg key=value` the processing ignored the default value. Following commit just adds support for that.

Makes below Containerfile functional without any external `--build-arg` value from CLI

```Dockerfile
ARG my_env=a

FROM alpine as stage_a
RUN /bin/true

FROM stage_${my_env} as stage_b
RUN /bin/true
```

Closes: https://github.com/containers/buildah/issues/4312

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
multi-stage,executor: honor default `ARG` values while evaluating base image name.
```

