### PR TITLE
Fix RUN --mount=type=bind,from=<stage> not triggering preservation of <stage> rootfs

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -757,6 +757,8 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 										// add base to current stage's dependency tree
 										// but also confirm if this is not in additional context.
 										if _, ok := b.additionalBuildContexts[mountFrom]; !ok {
+											// Treat from as a rootfs we need to preserve
+											b.rootfsMap[mountFrom] = true
 											if _, ok := dependencyMap[mountFrom]; ok {
 												// update current stage's dependency info
 												currentStageInfo := dependencyMap[stage.Name]

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3842,6 +3842,12 @@ EOM
   run_buildah rm -a
 }
 
+@test "bud preserve rootfs for --mount=type=bind,from=" {
+  _prefetch alpine
+  run_buildah build --build-arg NONCE="$(date)" --layers --quiet --pull=false $WITH_POLICY_JSON -f Dockerfile.3 $BUDFILES/cache-stages
+  expect_output --substring "Worked"
+}
+
 @test "bud timestamp" {
   _prefetch alpine
   timestamp=40

--- a/tests/bud/cache-stages/Dockerfile.3
+++ b/tests/bud/cache-stages/Dockerfile.3
@@ -1,0 +1,25 @@
+FROM alpine AS common
+
+RUN echo "common" > /common.txt
+
+FROM common AS buildA
+RUN echo "foo" > /foo.txt
+
+FROM common AS buildB
+# This is contrived to force a cached layer without having to build twice
+# Ordinarily you wouldn't have duplicate stages
+RUN echo "foo" > /foo.txt
+
+FROM alpine
+
+ARG NONCE
+
+RUN --mount=type=bind,from=buildA,target=/buildA \
+    --mount=type=bind,from=buildB,target=/buildB \
+    set -ex; \
+    cat /buildA/common.txt; \
+    cat /buildA/foo.txt; \
+    cat /buildB/common.txt; \
+    cat /buildB/foo.txt; \
+    echo "Worked"; \
+    : ;


### PR DESCRIPTION
The lack of the preservation was probably an oversight when --mount was added for RUN.

I added a test that fails without the modification and succeeds with.

Fixes #4375

Signed-off-by: Marcus Watkins <mwatkins@mitre.org>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind bug

#### What this PR does / why we need it:

Fixes #4375 

#### How to verify it

Run new test with and without change

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

Fixes #4375

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

