### PR TITLE
bud.bats: fix expected aarch

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4238,13 +4238,13 @@ _EOF
   run_buildah tag image-amd localhost/${SAFEIMAGE_NAME}:${SAFEIMAGE_TAG}
   run_buildah build --pull=false -q --arch=arm64 -t image-arm $WITH_POLICY_JSON ${mytmpdir}
   run_buildah inspect --format '{{ .OCIv1.Architecture }}' image-arm
-  expect_output arm64
+  expect_output aarch64
 
   run_buildah inspect --format '{{ .FromImageID }}' image-arm
   fromiid=$output
 
   run_buildah inspect --format '{{ .OCIv1.Architecture  }}'  $fromiid
-  expect_output arm64
+  expect_output aarch64
 }
 
 @test "bud --file with directory" {


### PR DESCRIPTION
buildah inspect prints out arm image architecture as `aarch64` while expected architecture was set to `arm64`. This was causing gating test failures on Fedora bodhi.

Ref: https://artifacts.dev.testing-farm.io/6d9c4f78-7ec3-4911-bea0-77395b8b19f3/

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


@flouthoc @nalind @edsantiago @TomSweeneyRedHat PTAL

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


/kind failing-test 

#### What this PR does / why we need it:

Fixes a buildah inspect test for aarch64 images.

#### How to verify it

Test should pass.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

