### PR TITLE
test: fix preserve rootfs with `--mount=type=bind` for podman-remote

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3844,7 +3844,7 @@ EOM
 
 @test "bud preserve rootfs for --mount=type=bind,from=" {
   _prefetch alpine
-  run_buildah build --build-arg NONCE="$(date)" --layers --quiet --pull=false $WITH_POLICY_JSON -f Dockerfile.3 $BUDFILES/cache-stages
+  run_buildah build --build-arg NONCE="$(date)" --layers --pull=false $WITH_POLICY_JSON -f Dockerfile.3 $BUDFILES/cache-stages
   expect_output --substring "Worked"
 }
 


### PR DESCRIPTION
`--quite` on `podman-remote` will output only image id suppressing the build output which is needed by the test, following commit makes test functional for `podman-remote`.

Fixes: https://github.com/containers/buildah/pull/4380#issuecomment-1293848854