### PR TITLE
chroot: fix mounting of ro bind mounts

### DIFF
--- a/chroot/run_linux.go
+++ b/chroot/run_linux.go
@@ -423,7 +423,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 				file.Close()
 			}
 		}
-		requestFlags := bindFlags
+		requestFlags := uintptr(0)
 		expectedFlags := uintptr(0)
 		for _, option := range m.Options {
 			switch option {
@@ -457,8 +457,18 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 		case "bind":
 			// Do the bind mount.
 			logrus.Debugf("bind mounting %q on %q", m.Destination, filepath.Join(spec.Root.Path, m.Destination))
-			if err := unix.Mount(m.Source, target, "", requestFlags, ""); err != nil {
+			if err := unix.Mount(m.Source, target, "", bindFlags|requestFlags, ""); err != nil {
 				return undoBinds, fmt.Errorf("bind mounting %q from host to %q in mount namespace (%q): %w", m.Source, m.Destination, target, err)
+			}
+			if (requestFlags & unix.MS_RDONLY) != 0 {
+				if err = unix.Statfs(target, &fs); err != nil {
+					return undoBinds, fmt.Errorf("checking if directory %q was bound read-only: %w", target, err)
+				}
+				// we need to make sure these flags are maintained in the REMOUNT operation
+				additionalFlags := uintptr(fs.Flags) & (unix.MS_NOEXEC | unix.MS_NOSUID | unix.MS_NODEV)
+				if err := unix.Mount("", target, "", unix.MS_REMOUNT|unix.MS_BIND|unix.MS_RDONLY|additionalFlags, ""); err != nil {
+					return undoBinds, fmt.Errorf("setting flags on the bind mount %q from host to %q in mount namespace (%q): %w", m.Source, m.Destination, target, err)
+				}
 			}
 			logrus.Debugf("bind mounted %q to %q", m.Source, target)
 		case "tmpfs":


### PR DESCRIPTION
a bind mount cannot be made RDONLY in the same mount operation as it is created.  For that we need a second operation.

Closes: https://github.com/containers/buildah/issues/4203

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

Fixes #4203

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

