### PR TITLE
Don't set allow.mount in the vnet jail on Freebsd

### DIFF
--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -253,10 +253,6 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		jconf.Set("devfs_ruleset", 4)
 		jconf.Set("allow.raw_sockets", true)
 		jconf.Set("allow.chflags", true)
-		jconf.Set("allow.mount", true)
-		jconf.Set("allow.mount.devfs", true)
-		jconf.Set("allow.mount.nullfs", true)
-		jconf.Set("allow.mount.fdescfs", true)
 		jconf.Set("securelevel", -1)
 		netjail, err := jail.Create(jconf)
 		if err != nil {


### PR DESCRIPTION
This was needed early in development but is no longer necessary since the OCI runtime handles container mounts in the host namespace. Something like it could be used with some other options to allow nested containers but that is not high on the priority list.

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It simplifies installation on FreeBSD. Some of these flags require the filesystem kernel module(s) to be loaded first. The kernel can automatically load filesystem modules when mounting into the container but the vnet jail setup happens before that.

#### How to verify it

On a host which does *not* have fdescfs.ko loaded, try this:

```
c=$(sudo buildah from quay.io/dougrabson/freebsd-minimal:13)
sudo buildah run $c sh
```

Without this PR, the run fails with EINVAL but with these changes, fdescfs.ko is loaded and the container starts.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```

