### PR TITLE
userns: add arbitrary steps/stage to `--userns=auto` test

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -379,6 +379,12 @@ _EOF
   cat > $contextdir/Dockerfile << _EOF
 FROM alpine
 RUN cat /proc/self/uid_map
+RUN echo hello
+
+FROM alpine
+COPY --from=0 /tmp /tmp
+RUN cat /proc/self/uid_map
+RUN ls -a
 _EOF
 
   run_buildah build --userns=auto $WITH_POLICY_JSON -t source -f $contextdir/Dockerfile


### PR DESCRIPTION
Support for build with `--userns=auto` was added here https://github.com/containers/buildah/pull/4064 but it never tested a build where multiple ephemeral containers were used. So just add arbitrary steps and stages to the exisitng `--userns=auto` test to make sure build still works fine.
