### PR TITLE
remove unnecessary (hence misleading) rmi

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4481,7 +4481,6 @@ _EOF
   # since on podman-remote test this will remove prefetched alpine
   # and it will try to pull alpine from docker.io with
   # completely different digest (ruining our cache logic).
-  run_buildah rmi --prune
   run_buildah rmi test
 
   # ------ Test case ------ #


### PR DESCRIPTION
A recently-added test included an unnecessary "rmi --prune".
Unnecessary code causes brain fatigue in maintainers trying
to understand its purpose. Kill it.

I've confirmed that tests pass under buildah root & rootless
and podman local & remote.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```