### PR TITLE
Stop using ubi8

### DIFF
--- a/tests/bud/multiarch/Dockerfile.fail-multistage
+++ b/tests/bud/multiarch/Dockerfile.fail-multistage
@@ -1,18 +1,19 @@
-FROM registry.access.redhat.com/ubi8-micro
+ARG SAFEIMAGE
+FROM $SAFEIMAGE
 RUN touch -r /etc/os-release /timestamped
 RUN sleep 0
-FROM registry.access.redhat.com/ubi8-micro
+FROM $SAFEIMAGE
 COPY --from=0 /timestamped /timestamped
 RUN sleep 0
-FROM registry.access.redhat.com/ubi8-micro
+FROM $SAFEIMAGE
 COPY --from=1 /timestamped /timestamped
 RUN sleep 0
-FROM registry.access.redhat.com/ubi8-micro
+FROM $SAFEIMAGE
 COPY --from=2 /timestamped /timestamped
 RUN false
-FROM registry.access.redhat.com/ubi8-micro
+FROM $SAFEIMAGE
 COPY --from=3 /timestamped /timestamped
 RUN sleep 0
-FROM registry.access.redhat.com/ubi8-micro
+FROM $SAFEIMAGE
 COPY --from=4 /timestamped /timestamped
 RUN sleep 0

--- a/tests/bud/multiarch/Dockerfile.no-run
+++ b/tests/bud/multiarch/Dockerfile.no-run
@@ -3,5 +3,5 @@ FROM docker.io/library/alpine
 COPY Dockerfile.no-run /root/
 # A different base image that is known to be a manifest list, supporting a
 # different but partially-overlapping set of platforms.
-FROM registry.access.redhat.com/ubi8-micro
+FROM quay.io/libpod/testimage:20221018
 COPY --from=0 /root/Dockerfile.no-run /root/


### PR DESCRIPTION
First: because we have a bunch of tests that rely on the image
manifest list, and ubi8 is not under our control: we've already
seen where ubi8 gets changed without our knowledge, requiring
almost a week of scrambling to get things fixed again.

Second, the registry it lives on is unreliable.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```