### PR TITLE
imagebuildah: build with `--all-platforms` must honor `userargs` and `headingargs` while evaluating base images

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5143,6 +5143,21 @@ _EOF
   assert "$manifests" = "amd64 arm64 ppc64le s390x" "arch list in manifest"
 }
 
+# attempts to resolve heading arg as base-image with --all-platforms
+@test "bud-multiple-platform-with-base-as-default-arg" {
+  outputlist=localhost/testlist
+  run_buildah build $WITH_POLICY_JSON \
+              --jobs=1 \
+              --all-platforms \
+              --manifest $outputlist \
+              -f $BUDFILES/all-platform/Containerfile.default-arg \
+              $BUDFILES/all-platform
+
+  run_buildah manifest inspect $outputlist
+  manifests=$(jq -r '.manifests[].platform.architecture' <<<"$output" |sort|fmt)
+  assert "$manifests" = "386 amd64 arm arm arm64 ppc64le s390x" "arch list in manifest"
+}
+
 @test "bud-multiple-platform for --all-platform with additional-build-context" {
   outputlist=localhost/testlist
   local contextdir=${TEST_SCRATCH_DIR}/bud/platform

--- a/tests/bud/all-platform/Containerfile.default-arg
+++ b/tests/bud/all-platform/Containerfile.default-arg
@@ -1,0 +1,2 @@
+ARG foo=alpine
+FROM $foo


### PR DESCRIPTION
Commit:
https://github.com/containers/buildah/commit/217b2d524c041674066f2e0d329ec2ad5a62004b was pushed to `main` accidently while it incorrectly assumes that `ENV` must be used while processing base image, however `ENV` should be only evaluated inside `RUN` instruction and not for any containerfile instruction such as `FROM <>`. This fixes change made in above commit.

Following commit ensures that imagebuildah considers `HeadingArgs` and `UserArgs` when its evaluating base image to pull all images from manifest list early when build is invoked with `--all-platforms`

Closes: https://github.com/containers/buildah/issues/4399

```release-note
build: base image honors userargs and heading args when built with --all-platforms
```

