### PR TITLE
Add no-new-privileges flag

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -67,6 +67,8 @@ type CommonBuildOptions struct {
 	// NoHosts tells the builder not to create /etc/hosts content when running
 	// containers.
 	NoHosts bool
+	// NoNewPrivileges removes the ability for the container to gain privileges
+	NoNewPrivileges bool
 	// OmitTimestamp forces epoch 0 as created timestamp to allow for
 	// deterministic, content-addressable builds.
 	OmitTimestamp bool

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -669,7 +669,7 @@ Security Options
   "label=type:TYPE"   : Set the label type for the container
   "label=level:LEVEL" : Set the label level for the container
   "label=disable"     : Turn off label confinement for the container
-  "no-new-privileges" : Not supported
+  "no-new-privileges" : Disable container processes from gaining additional privileges
 
   "seccomp=unconfined" : Turn off seccomp confinement for the container
   "seccomp=profile.json :  White listed syscalls seccomp Json file to be used as a seccomp filter

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -222,13 +222,14 @@ func GetAdditionalBuildContext(value string) (define.AdditionalBuildContext, err
 func parseSecurityOpts(securityOpts []string, commonOpts *define.CommonBuildOptions) error {
 	for _, opt := range securityOpts {
 		if opt == "no-new-privileges" {
-			return errors.New("no-new-privileges is not supported")
+			commonOpts.NoNewPrivileges = true
+			continue
 		}
+
 		con := strings.SplitN(opt, "=", 2)
 		if len(con) != 2 {
 			return fmt.Errorf("invalid --security-opt name=value pair: %q", opt)
 		}
-
 		switch con[0] {
 		case "label":
 			commonOpts.LabelOpts = append(commonOpts.LabelOpts, con[1])
@@ -928,10 +929,11 @@ func IsolationOption(isolation string) (define.Isolation, error) {
 
 // Device parses device mapping string to a src, dest & permissions string
 // Valid values for device look like:
-//    '/dev/sdc"
-//    '/dev/sdc:/dev/xvdc"
-//    '/dev/sdc:/dev/xvdc:rwm"
-//    '/dev/sdc:rm"
+//
+//	'/dev/sdc"
+//	'/dev/sdc:/dev/xvdc"
+//	'/dev/sdc:/dev/xvdc:rwm"
+//	'/dev/sdc:rm"
 func Device(device string) (string, string, string, error) {
 	src := ""
 	dst := ""

--- a/run_linux.go
+++ b/run_linux.go
@@ -210,6 +210,8 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		return err
 	}
 
+	g.SetProcessNoNewPrivileges(b.CommonBuildOpts.NoNewPrivileges)
+
 	g.SetProcessApparmorProfile(b.CommonBuildOpts.ApparmorProfile)
 
 	// Now grab the spec from the generator.  Set the generator to nil so that future contributors

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5651,3 +5651,14 @@ _EOF
   run_buildah 1 build --network=none $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
   expect_output --substring "Network unreachable"
 }
+
+@test "build-with-no-new-privileges-test" {
+  _prefetch alpine
+  cat > ${TEST_SCRATCH_DIR}/Containerfile << _EOF
+FROM alpine
+RUN grep NoNewPrivs /proc/self/status
+_EOF
+
+  run_buildah build --security-opt no-new-privileges $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
+  expect_output --substring "NoNewPrivs:.*1"
+}


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
buildah build now supports --security-opt no-new-privileges flag.
```

