### PR TITLE
Use TypeBind consistently to name bind/nullfs mounts

### DIFF
--- a/define/mount_unsupported.go
+++ b/define/mount_unsupported.go
@@ -1,0 +1,17 @@
+//go:build darwin || windows
+// +build darwin windows
+
+package define
+
+const (
+	// TypeBind is the type for mounting host dir
+	TypeBind = "bind"
+
+	// TempDir is the default for storing temporary files
+	TempDir = "/var/tmp"
+)
+
+var (
+	// Mount potions for bind
+	BindOptions = []string{""}
+)

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -10,6 +10,7 @@ import (
 
 	"errors"
 
+	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/internal"
 	internalUtil "github.com/containers/buildah/internal/util"
 	"github.com/containers/common/pkg/parse"
@@ -22,8 +23,6 @@ import (
 )
 
 const (
-	// TypeBind is the type for mounting host dir
-	TypeBind = "bind"
 	// TypeTmpfs is the type for mounting tmpfs
 	TypeTmpfs = "tmpfs"
 	// TypeCache is the type for mounting a common persistent cache from host
@@ -51,7 +50,7 @@ var (
 // Caller is expected to perform unmount of any mounted images
 func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, store storage.Store, imageMountLabel string, additionalMountPoints map[string]internal.StageMountDetails) (specs.Mount, string, error) {
 	newMount := specs.Mount{
-		Type: TypeBind,
+		Type: define.TypeBind,
 	}
 
 	mountReadability := false
@@ -201,7 +200,7 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 	)
 	fromStage := ""
 	newMount := specs.Mount{
-		Type: TypeBind,
+		Type: define.TypeBind,
 	}
 	// if id is set a new subdirectory with `id` will be created under /host-temp/buildah-build-cache/id
 	id := ""
@@ -544,7 +543,7 @@ func GetVolumes(ctx *types.SystemContext, store storage.Store, volumes []string,
 // If this function succeeds, the caller must unlock the returned lockfile.Lockers if any (when??).
 func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, contextDir string) (map[string]specs.Mount, []string, []lockfile.Locker, error) {
 	// If `type` is not set default to "bind"
-	mountType := TypeBind
+	mountType := define.TypeBind
 	finalMounts := make(map[string]specs.Mount)
 	mountedImages := make([]string, 0)
 	targetLocks := make([]lockfile.Locker, 0)
@@ -575,7 +574,7 @@ func getMounts(ctx *types.SystemContext, store storage.Store, mounts []string, c
 			}
 		}
 		switch mountType {
-		case TypeBind:
+		case define.TypeBind:
 			mount, image, err := GetBindMount(ctx, tokens, contextDir, store, "", nil)
 			if err != nil {
 				return nil, mountedImages, nil, err

--- a/run_common.go
+++ b/run_common.go
@@ -1455,8 +1455,8 @@ func cleanableDestinationListFromMounts(mounts []spec.Mount) []string {
 //
 // If this function succeeds, the caller must unlock runMountArtifacts.TargetLocks (when??)
 func (b *Builder) runSetupRunMounts(mounts []string, sources runMountInfo, idMaps IDMaps) ([]spec.Mount, *runMountArtifacts, error) {
-	// If `type` is not set default to "bind"
-	mountType := internalParse.TypeBind
+	// If `type` is not set default to TypeBind
+	mountType := define.TypeBind
 	mountTargets := make([]string, 0, 10)
 	tmpFiles := make([]string, 0, len(mounts))
 	mountImages := make([]string, 0, 10)
@@ -1510,7 +1510,7 @@ func (b *Builder) runSetupRunMounts(mounts []string, sources runMountInfo, idMap
 				// Count is needed as the default destination of the ssh sock inside the container is  /run/buildkit/ssh_agent.{i}
 				sshCount++
 			}
-		case "bind":
+		case define.TypeBind:
 			mount, image, err := b.getBindMount(tokens, sources.SystemContext, sources.ContextDir, sources.StageMountPoints, idMaps)
 			if err != nil {
 				return nil, nil, err

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -357,8 +357,7 @@ func (b *Builder) runSetupVolumeMounts(mountLabel string, volumeMounts []string,
 		if len(spliti) > 2 {
 			options = strings.Split(spliti[2], ",")
 		}
-		options = append(options, "bind")
-		mount, err := parseMount("bind", spliti[0], spliti[1], options)
+		mount, err := parseMount("nullfs", spliti[0], spliti[1], options)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This allows declaring run mounts using e.g. '-mount=type=nullfs,...' on FreeBSD which makes more sense for FreeBSD users. It is also consistent with 'podman run' which requires the nullfs mount type on FreeBSD.

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This allows using the native filesystem type in run mounts rather than expecting the user to know that 'bind' is translated to 'nullfs' internally.

#### How to verify it

On a FreeBSD system:
```
buildah run --mount=type=nullfs,src=/tmp,dst=/foo <container> <cmd>
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

