### PR TITLE
[skip-ci] GHA: Reuse both cirrus rerun and check workflows

### DIFF
--- a/.github/workflows/rerun_cirrus_cron.yml
+++ b/.github/workflows/rerun_cirrus_cron.yml
@@ -1,7 +1,6 @@
 ---
 
-# See also:
-# https://github.com/containers/podman/blob/main/.github/workflows/check_cirrus_cron.yml
+# See also: https://github.com/containers/podman/blob/main/.github/workflows/rerun_cirrus_cron.yml
 
 on:
   # Note: This only applies to the default branch.
@@ -9,12 +8,12 @@ on:
     # N/B: This should correspond to a period slightly after
     # the last job finishes running.  See job defs. at:
     # https://cirrus-ci.com/settings/repository/6706677464432640
-    - cron:  '59 23 * * 1-5'
+    - cron:  '05 22 * * 1-5'
   # Debug: Allow triggering job manually in github-actions WebUI
   workflow_dispatch: {}
 
 jobs:
   # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
-  call_cron_failures:
-    uses: containers/podman/.github/workflows/check_cirrus_cron.yml@main
+  call_cron_rerun:
+    uses: containers/podman/.github/workflows/rerun_cirrus_cron.yml@main
     secrets: inherit


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

More features, less to maintain.  Everybody wins.

Depends on https://github.com/containers/podman/pull/16503

#### How to verify it

Difficult to do.  Would need to setup another repo with all the necessary secrets and push these changes to it's `main`.  Basically a PITA.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```

