### PR TITLE
`mount=type=cache`: seperate cache parent on host for each user

### DIFF
--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/lockfile"
+	"github.com/containers/storage/pkg/unshare"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 )
@@ -330,8 +331,8 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		// create a common cache directory, which persists on hosts within temp lifecycle
 		// add subdirectory if specified
 
-		// cache parent directory
-		cacheParent := filepath.Join(internalUtil.GetTempDir(), BuildahCacheDir)
+		// cache parent directory: creates separate cache parent for each user.
+		cacheParent := filepath.Join(internalUtil.GetTempDir(), BuildahCacheDir+"-"+strconv.Itoa(unshare.GetRootlessUID()))
 		// create cache on host if not present
 		err = os.MkdirAll(cacheParent, os.FileMode(0755))
 		if err != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5410,6 +5410,9 @@ _EOF
   run_buildah build -t testbud $WITH_POLICY_JSON -f $contextdir/Dockerfilecachewritewithoutz
   # try reading something from persistent cache in a different build
   run_buildah build -t testbud2 $WITH_POLICY_JSON -f $contextdir/Dockerfilecachereadwithoutz
+  buildah_cache_dir="$TMPDIR/buildah-cache-$UID"
+  # buildah cache parent must exist for uid specific to this invocation
+  test -d "$buildah_cache_dir"
   expect_output --substring "hello"
 }
 


### PR DESCRIPTION
`mount=type=cache` creates a common cache directory on host in temporary directory, split this cache directory for each user invocation in order to prevent overlapping of cache content when `buildah` is invoked by different users on same host.

Closes: https://github.com/containers/buildah/issues/4404
