### PR TITLE
[release-1.28] copier.Put(): clear up os/syscall mode bit confusion  and bump to `v1.28.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Changelog
 
+## v1.28.1 (2022-11-19)
+
+   copier.Put(): clear up os/syscall mode bit confusion
+
 ## v1.28.0 (2022-09-30)
 
     Update vendor containers/(common,image)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+- Changelog for v1.28.1 (2022-11-19)
+  * copier.Put(): clear up os/syscall mode bit confusion
+
 - Changelog for v1.28.0 (2022-09-30)
   * Update vendor containers/(common,image)
   * [CI:DOCS] Add quay-description update reminder

--- a/define/types.go
+++ b/define/types.go
@@ -30,7 +30,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.28.0"
+	Version = "1.28.1"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4110,7 +4110,7 @@ _EOF
   run_buildah tag image-amd localhost/ubi8-minimal
   run_buildah build -f Containerfile --pull=false -q --arch=arm64 -t image-arm $WITH_POLICY_JSON ${mytmpdir}
   run_buildah inspect --format '{{ index .Docker.Config.Labels "architecture" }}' image-arm
-  expect_output --substring arm64
+  expect_output --substring aarch64
 
   run_buildah inspect --format '{{ .FromImageID }}' image-arm
   fromiid=$output

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1863,6 +1863,42 @@ var internalTestCases = []testCase{
 			if _, err = io.Copy(tw, bytes.NewReader([]byte("whatever"))); err != nil {
 				return fmt.Errorf("writing tar archive content: %w", err)
 			}
+			hdr = tar.Header{
+				Name:     "setuid-dir",
+				Uid:      0,
+				Gid:      0,
+				Typeflag: tar.TypeDir,
+				Size:     0,
+				Mode:     cISUID | 0755,
+				ModTime:  testDate,
+			}
+			if err = tw.WriteHeader(&hdr); err != nil {
+				return fmt.Errorf("error writing tar archive header: %w", err)
+			}
+			hdr = tar.Header{
+				Name:     "setgid-dir",
+				Uid:      0,
+				Gid:      0,
+				Typeflag: tar.TypeDir,
+				Size:     0,
+				Mode:     cISGID | 0755,
+				ModTime:  testDate,
+			}
+			if err = tw.WriteHeader(&hdr); err != nil {
+				return fmt.Errorf("error writing tar archive header: %w", err)
+			}
+			hdr = tar.Header{
+				Name:     "sticky-dir",
+				Uid:      0,
+				Gid:      0,
+				Typeflag: tar.TypeDir,
+				Size:     0,
+				Mode:     cISVTX | 0755,
+				ModTime:  testDate,
+			}
+			if err = tw.WriteHeader(&hdr); err != nil {
+				return fmt.Errorf("error writing tar archive header: %w", err)
+			}
 			return nil
 		},
 	},


### PR DESCRIPTION
Backport https://github.com/containers/buildah/pull/4411 for podman `v4.3.2` as discussed here: https://github.com/containers/buildah/issues/4427