### PR TITLE
[release-1.28] Define and use a safe, reliable test image and bump to `v1.28.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Changelog
 
+## v1.28.2 (2022-11-23)
+
+   Define and use a safe, reliable test image
+   Stop using ubi8
+
 ## v1.28.1 (2022-11-19)
 
    copier.Put(): clear up os/syscall mode bit confusion

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+- Changelog for v1.28.2 (2022-11-23)
+  * Define and use a safe, reliable test image
+  * Stop using ubi8
+
 - Changelog for v1.28.1 (2022-11-19)
   * copier.Put(): clear up os/syscall mode bit confusion
 

--- a/define/types.go
+++ b/define/types.go
@@ -30,7 +30,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.28.1"
+	Version = "1.28.2"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4878,9 +4878,9 @@ _EOF
 @test "bud-multiple-platform-failure" {
   # check if we can run a couple of 32-bit versions of an image, and if we can,
   # assume that emulation for other architectures is in place.
-  os=`go env GOOS`
-  if test "$os" != linux ; then
-    skip "test Dockerfile is ubi, we can't run it"
+  os=$(go env GOOS)
+  if [[ "$os" != linux ]]; then
+    skip "GOOS is '$os'; this test can only run on linux"
   fi
   run_buildah from $WITH_POLICY_JSON --name try-386 --platform=$os/386 alpine
   run_buildah '?' run try-386 true
@@ -4893,7 +4893,13 @@ _EOF
     skip "unable to run arm container, assuming emulation is not available"
   fi
   outputlist=localhost/testlist
-  run_buildah 125 build $WITH_POLICY_JSON --jobs=0 --platform=linux/arm64,linux/amd64 --manifest $outputlist -f $BUDFILES/multiarch/Dockerfile.fail-multistage $BUDFILES/multiarch
+  run_buildah 1 build $WITH_POLICY_JSON \
+              --jobs=0 \
+              --platform=linux/arm64,linux/amd64 \
+              --manifest $outputlist \
+              --build-arg SAFEIMAGE=$SAFEIMAGE \
+              -f $BUDFILES/multiarch/Dockerfile.fail-multistage \
+              $BUDFILES/multiarch
   expect_output --substring 'building at STEP "RUN false"'
 }
 
@@ -4903,31 +4909,41 @@ _EOF
   # concurrency to maximum which uncovers all sorts of race condition causing
   # flakes in CI. Please put this back to --jobs=0 when https://github.com/containers/buildah/issues/3710
   # is resolved.
-  run_buildah build $WITH_POLICY_JSON --jobs=1 --all-platforms --manifest $outputlist -f $BUDFILES/multiarch/Dockerfile.no-run $BUDFILES/multiarch
+  run_buildah build $WITH_POLICY_JSON \
+              --jobs=1 \
+              --all-platforms \
+              --manifest $outputlist \
+              --build-arg SAFEIMAGE=$SAFEIMAGE \
+              -f $BUDFILES/multiarch/Dockerfile.no-run \
+              $BUDFILES/multiarch
+
   run_buildah manifest inspect $outputlist
-  echo "$output"
-  run jq '.manifests | length' <<< "$output"
-  echo "$output"
-  assert "$output" -gt 1 "length(.manifests)"
+  manifests=$(jq -r '.manifests[].platform.architecture' <<<"$output" |sort|fmt)
+  assert "$manifests" = "amd64 arm64 ppc64le s390x" "arch list in manifest"
 }
 
 @test "bud-multiple-platform for --all-platform with additional-build-context" {
   outputlist=localhost/testlist
-  mkdir -p ${TEST_SCRATCH_DIR}/bud/platform
+  local contextdir=${TEST_SCRATCH_DIR}/bud/platform
+  mkdir -p $contextdir
 
-cat > ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile1 << _EOF
+cat > $contextdir/Dockerfile1 << _EOF
 FROM busybox
 _EOF
 
-  # Pulled images must be ubi since we configured --build-context busybox=docker://registry.access.redhat.com/ubi8-micro
-  run_buildah build $WITH_POLICY_JSON --all-platforms --build-context busybox=docker://registry.access.redhat.com/ubi8-micro --manifest $outputlist -f ${TEST_SCRATCH_DIR}/bud/platform/Dockerfile1
-  # must contain pulling logs for ubi8 instead of busybox
-  expect_output --substring "ubi8"
+  # Pulled images must be $SAFEIMAGE since we configured --build-context
+  run_buildah build $WITH_POLICY_JSON --all-platforms --build-context busybox=docker://$SAFEIMAGE --manifest $outputlist -f $contextdir/Dockerfile1
+  # must contain pulling logs for $SAFEIMAGE instead of busybox
+  expect_output --substring "STEP 1/1: FROM $SAFEIMAGE"
+  assert "$output" =~ "\[linux/s390x\] COMMIT"
+  assert "$output" =~ "\[linux/ppc64le\] COMMIT"
+  assert "$output" !~ "busybox"
+
+  # Confirm the manifests and their architectures. It is not possible for
+  # this to change, unless we bump $SAFEIMAGE to a new versioned tag.
   run_buildah manifest inspect $outputlist
-  echo "$output"
-  run jq '.manifests | length' <<< "$output"
-  # should be equal to 4 which is equivalent to images in registry.access.redhat.com/ubi8-micro
-  assert "$output" -eq 4 "length(manifests)"
+  manifests=$(jq -r '.manifests[].platform.architecture' <<<"$output" |sort|fmt)
+  assert "$manifests" = "amd64 arm64 ppc64le s390x" "arch list in manifest"
 }
 
 # * Performs multi-stage build with label1=value1 and verifies

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4099,24 +4099,24 @@ _EOF
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir
   mkdir -p ${mytmpdir}
 cat > $mytmpdir/Containerfile << _EOF
-FROM registry.access.redhat.com/ubi8-minimal
+FROM $SAFEIMAGE
 _EOF
-  run_buildah build -f Containerfile --pull=false -q --arch=amd64 -t image-amd $WITH_POLICY_JSON ${mytmpdir}
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "architecture" }}' image-amd
-  expect_output --substring x86_64
+  run_buildah build --pull=false -q --arch=amd64 -t image-amd $WITH_POLICY_JSON ${mytmpdir}
+  run_buildah inspect --format '{{ .OCIv1.Architecture }}' image-amd
+  expect_output amd64
 
-  # Tag the image to localhost/ubi8-minimal to make sure that the image gets
+  # Tag the image to localhost/safeimage to make sure that the image gets
   # pulled since the local one does not match the requested architecture.
-  run_buildah tag image-amd localhost/ubi8-minimal
-  run_buildah build -f Containerfile --pull=false -q --arch=arm64 -t image-arm $WITH_POLICY_JSON ${mytmpdir}
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "architecture" }}' image-arm
-  expect_output --substring aarch64
+  run_buildah tag image-amd localhost/${SAFEIMAGE_NAME}:${SAFEIMAGE_TAG}
+  run_buildah build --pull=false -q --arch=arm64 -t image-arm $WITH_POLICY_JSON ${mytmpdir}
+  run_buildah inspect --format '{{ .OCIv1.Architecture }}' image-arm
+  expect_output arm64
 
   run_buildah inspect --format '{{ .FromImageID }}' image-arm
   fromiid=$output
 
-  run_buildah inspect --format '{{ index .OCIv1.Architecture  }}'  $fromiid
-  expect_output --substring arm64
+  run_buildah inspect --format '{{ .OCIv1.Architecture  }}'  $fromiid
+  expect_output arm64
 }
 
 @test "bud --file with directory" {

--- a/tests/bud/multiarch/Dockerfile.fail-multistage
+++ b/tests/bud/multiarch/Dockerfile.fail-multistage
@@ -1,18 +1,19 @@
-FROM registry.access.redhat.com/ubi8-micro
+ARG SAFEIMAGE
+FROM $SAFEIMAGE
 RUN touch -r /etc/os-release /timestamped
 RUN sleep 0
-FROM registry.access.redhat.com/ubi8-micro
+FROM $SAFEIMAGE
 COPY --from=0 /timestamped /timestamped
 RUN sleep 0
-FROM registry.access.redhat.com/ubi8-micro
+FROM $SAFEIMAGE
 COPY --from=1 /timestamped /timestamped
 RUN sleep 0
-FROM registry.access.redhat.com/ubi8-micro
+FROM $SAFEIMAGE
 COPY --from=2 /timestamped /timestamped
 RUN false
-FROM registry.access.redhat.com/ubi8-micro
+FROM $SAFEIMAGE
 COPY --from=3 /timestamped /timestamped
 RUN sleep 0
-FROM registry.access.redhat.com/ubi8-micro
+FROM $SAFEIMAGE
 COPY --from=4 /timestamped /timestamped
 RUN sleep 0

--- a/tests/bud/multiarch/Dockerfile.no-run
+++ b/tests/bud/multiarch/Dockerfile.no-run
@@ -3,5 +3,5 @@ FROM docker.io/library/alpine
 COPY Dockerfile.no-run /root/
 # A different base image that is known to be a manifest list, supporting a
 # different but partially-overlapping set of platforms.
-FROM registry.access.redhat.com/ubi8-micro
+FROM quay.io/libpod/testimage:20221018
 COPY --from=0 /root/Dockerfile.no-run /root/

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -13,6 +13,13 @@ OCI=$(${BUILDAH_BINARY} info --format '{{.host.OCIRuntime}}' || command -v runc 
 # Default timeout for a buildah command.
 BUILDAH_TIMEOUT=${BUILDAH_TIMEOUT:-300}
 
+# Safe reliable unchanging test image
+SAFEIMAGE_REGISTRY=${SAFEIMAGE_REGISTRY:-quay.io}
+SAFEIMAGE_USER=${SAFEIMAGE_USER:-libpod}
+SAFEIMAGE_NAME=${SAFEIMAGE_NAME:-testimage}
+SAFEIMAGE_TAG=${SAFEIMAGE_TAG:-20221018}
+SAFEIMAGE="${SAFEIMAGE:-$SAFEIMAGE_REGISTRY/$SAFEIMAGE_USER/$SAFEIMAGE_NAME:$SAFEIMAGE_TAG}"
+
 # Shortcut for directory containing Containerfiles for bud.bats
 BUDFILES=${TEST_SOURCES}/bud
 


### PR DESCRIPTION
I thought older `buildah` and `podman` `v4.3` branch does not accounts for `SAFEIMAGE` hence I created a simpler retrofit commit here https://github.com/containers/buildah/pull/4428 ( **I was wrong** ) and it looks like podman's old branch were already expecting https://github.com/containers/buildah/pull/4377.

A note from @edsantiago  in podman's `v4.3` branch https://github.com/containers/podman/commit/52a6516f96d2f99db6136d87e444675c051f4b48 clearly mentions that https://github.com/containers/buildah/pull/4377 had to be backported.

Since I missed backporting it before so doing it now and cutting a release.

PR which will use this release: https://github.com/containers/podman/pull/16588