### PR TITLE
util.SortMounts(): make the returned order more stable

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -441,7 +441,14 @@ func (m byDestination) Len() int {
 }
 
 func (m byDestination) Less(i, j int) bool {
-	return m.parts(i) < m.parts(j)
+	iparts, jparts := m.parts(i), m.parts(j)
+	switch {
+	case iparts < jparts:
+		return true
+	case iparts > jparts:
+		return false
+	}
+	return filepath.Clean(m[i].Destination) < filepath.Clean(m[j].Destination)
 }
 
 func (m byDestination) Swap(i, j int) {
@@ -453,7 +460,7 @@ func (m byDestination) parts(i int) int {
 }
 
 func SortMounts(m []specs.Mount) []specs.Mount {
-	sort.Sort(byDestination(m))
+	sort.Stable(byDestination(m))
 	return m
 }
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMergeEnv(t *testing.T) {
@@ -93,45 +94,20 @@ func TestMountsSort(t *testing.T) {
 			Destination: "/aa/b/c",
 		},
 	}
-	mounts1b := []specs.Mount{
-		{
-			Source:      "/xyz",
-			Destination: "/",
-		},
-		{
-			Source:      "/a",
-			Destination: "/a",
-		},
-		{
-			Source:      "/b",
-			Destination: "/b",
-		},
-		{
-			Source:      "/a/b",
-			Destination: "/a/b",
-		},
-		{
-			Source:      "/d/e",
-			Destination: "/a/c",
-		},
-		{
-			Source:      "/a/b/c",
-			Destination: "/a/b/c",
-		},
-		{
-			Source:      "/a/bb/c",
-			Destination: "/a/bb/c",
-		},
-		{
-			Source:      "/a/b/c",
-			Destination: "/aa/b/c",
-		},
+	mounts1b := []string{
+		"/",
+		"/a",
+		"/b",
+		"/a/b",
+		"/a/c",
+		"/a/b/c",
+		"/a/bb/c",
+		"/aa/b/c",
 	}
 	sorted := SortMounts(mounts1a)
+	sortedDests := make([]string, len(mounts1a))
 	for i := range sorted {
-		if sorted[i].Destination != mounts1b[i].Destination {
-			t.Fatalf("failed sort \n%+v\n%+v", mounts1b, sorted)
-		}
+		sortedDests[i] = sorted[i].Destination
 	}
-
+	assert.Equalf(t, mounts1b, sortedDests, "sort returned results in unexpected by-destination order")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Use sort.Stable() instead of sort.Sort() to sort mounts, and have the comparison function compare the cleaned paths directly if they have the same number of components, so that there's a defined ordering between "/a" and "/b".

#### How to verify it

Updated the unit test!

#### Which issue(s) this PR fixes:

Related: #4408.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```