### PR TITLE
remote-cache: support multiple sources and destination for `--cache-to` and `--cache-from`

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -141,10 +141,10 @@ type BuildOptions struct {
 	TransientMounts []string
 	// CacheFrom specifies any remote repository which can be treated as
 	// potential cache source.
-	CacheFrom reference.Named
+	CacheFrom []reference.Named
 	// CacheTo specifies any remote repository which can be treated as
 	// potential cache destination.
-	CacheTo reference.Named
+	CacheTo []reference.Named
 	// CacheTTL specifies duration, if specified using `--cache-ttl` then
 	// cache intermediate images under this duration will be considered as
 	// valid cache sources and images outside this duration will be ignored.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -96,12 +96,12 @@ The value of `[name]` is matched with the following priority order:
 
 **--cache-from**
 
-Repository to utilize as a potential cache source. When specified, Buildah will try to look for
-cache images in the specified repository and will attempt to pull cache images instead of actually
+Repository to utilize as a potential list of cache sources. When specified, Buildah will try to look for
+cache images in the specified repositories and will attempt to pull cache images instead of actually
 executing the build steps locally. Buildah will only attempt to pull previously cached images if they
 are considered as valid cache hits.
 
-Use the `--cache-to` option to populate a remote repository with cache content.
+Use the `--cache-to` option to populate a remote repository or repositories with cache content.
 
 Example
 
@@ -114,8 +114,8 @@ Note: `--cache-from` option is ignored unless `--layers` is specified.
 
 **--cache-to**
 
-Set this flag to specify a remote repository that will be used to store cache images. Buildah will attempt to
-push newly built cache image to the remote repository.
+Set this flag to specify list of remote repositories that will be used to store cache images. Buildah will attempt to
+push newly built cache image to the remote repositories.
 
 Note: Use the `--cache-from` option in order to use cache content in a remote repository.
 

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -58,8 +58,8 @@ var builtinAllowedBuildArgs = map[string]bool{
 // interface.  It coordinates the entire build by using one or more
 // StageExecutors to handle each stage of the build.
 type Executor struct {
-	cacheFrom                      reference.Named
-	cacheTo                        reference.Named
+	cacheFrom                      []reference.Named
+	cacheTo                        []reference.Named
 	cacheTTL                       time.Duration
 	containerSuffix                string
 	logger                         *logrus.Logger

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -301,18 +301,18 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 			iopts.Quiet = true
 		}
 	}
-	var cacheTo reference.Named
-	var cacheFrom reference.Named
+	var cacheTo []reference.Named
+	var cacheFrom []reference.Named
 	cacheTo = nil
 	cacheFrom = nil
 	if c.Flag("cache-to").Changed {
-		cacheTo, err = parse.RepoNameToNamedReference(iopts.CacheTo)
+		cacheTo, err = parse.RepoNamesToNamedReferences(iopts.CacheTo)
 		if err != nil {
 			return options, nil, nil, fmt.Errorf("unable to parse value provided `%s` to --cache-to: %w", iopts.CacheTo, err)
 		}
 	}
 	if c.Flag("cache-from").Changed {
-		cacheFrom, err = parse.RepoNameToNamedReference(iopts.CacheFrom)
+		cacheFrom, err = parse.RepoNamesToNamedReferences(iopts.CacheFrom)
 		if err != nil {
 			return options, nil, nil, fmt.Errorf("unable to parse value provided `%s` to --cache-from: %w", iopts.CacheTo, err)
 		}

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -53,8 +53,8 @@ type BudResults struct {
 	Authfile            string
 	BuildArg            []string
 	BuildContext        []string
-	CacheFrom           string
-	CacheTo             string
+	CacheFrom           []string
+	CacheTo             []string
 	CacheTTL            string
 	CertDir             string
 	Compress            bool
@@ -202,8 +202,8 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringArrayVar(&flags.OCIHooksDir, "hooks-dir", []string{}, "set the OCI hooks directory path (may be set multiple times)")
 	fs.StringArrayVar(&flags.BuildArg, "build-arg", []string{}, "`argument=value` to supply to the builder")
 	fs.StringArrayVar(&flags.BuildContext, "build-context", []string{}, "`argument=value` to supply additional build context to the builder")
-	fs.StringVar(&flags.CacheFrom, "cache-from", "", "remote repository to utilise as potential cache source.")
-	fs.StringVar(&flags.CacheTo, "cache-to", "", "remote repository to utilise as potential cache destination.")
+	fs.StringArrayVar(&flags.CacheFrom, "cache-from", []string{}, "remote repository list to utilise as potential cache source.")
+	fs.StringArrayVar(&flags.CacheTo, "cache-to", []string{}, "remote repository list to utilise as potential cache destination.")
 	fs.StringVar(&flags.CacheTTL, "cache-ttl", "", "only consider cache images under specified duration.")
 	fs.StringVar(&flags.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	fs.BoolVar(&flags.Compress, "compress", false, "this is a legacy option, which has no effect on the image")

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -50,16 +50,20 @@ const (
 	BuildahCacheDir = "buildah-cache"
 )
 
-// RepoNameToNamedReference parse the raw string to Named reference
-func RepoNameToNamedReference(dest string) (reference.Named, error) {
-	named, err := reference.ParseNormalizedNamed(dest)
-	if err != nil {
-		return nil, fmt.Errorf("invalid repo %q: must contain registry and repository: %w", dest, err)
+// RepoNamesToNamedReferences parse the raw string to Named reference
+func RepoNamesToNamedReferences(destList []string) ([]reference.Named, error) {
+	var result []reference.Named
+	for _, dest := range destList {
+		named, err := reference.ParseNormalizedNamed(dest)
+		if err != nil {
+			return nil, fmt.Errorf("invalid repo %q: must contain registry and repository: %w", dest, err)
+		}
+		if !reference.IsNameOnly(named) {
+			return nil, fmt.Errorf("repository must contain neither a tag nor digest: %v", named)
+		}
+		result = append(result, named)
 	}
-	if !reference.IsNameOnly(named) {
-		return nil, fmt.Errorf("repository must contain neither a tag nor digest: %v", named)
-	}
-	return named, nil
+	return result, nil
 }
 
 // CommonBuildOptions parses the build options from the bud cli

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4346,6 +4346,120 @@ _EOF
   expect_output --substring "Setting --no-cache=true"
 }
 
+@test "build test pushing and pulling from multiple remote cache sources" {
+  _prefetch alpine
+  mytmpdir=${TEST_SCRATCH_DIR}/my-dir
+  mkdir -p ${mytmpdir}
+  echo something > ${mytmpdir}/somefile
+  cat > $mytmpdir/Containerfile << _EOF
+FROM alpine
+RUN echo hello
+RUN echo world
+RUN touch hello
+ADD somefile somefile
+
+FROM alpine
+RUN echo hello
+COPY --from=0 hello hello
+_EOF
+
+  start_registry
+  run_buildah login --tls-verify=false --authfile ${TEST_SCRATCH_DIR}/test.auth --username testuser --password testpassword localhost:${REGISTRY_PORT}
+
+  # ------ Test case ------ #
+  # prepare expected output beforehand
+  # must push cache twice i.e for first step and second step
+  run printf "STEP 2/5: RUN echo hello\nhello\n--> Pushing cache"
+  step1=$output
+  run printf "STEP 3/5: RUN echo world\nworld\n--> Pushing cache"
+  step2=$output
+  run printf "STEP 4/5: RUN touch hello\n--> Pushing cache"
+  step3=$output
+  run printf "STEP 5/5: ADD somefile somefile\n--> Pushing cache"
+  step4=$output
+  # First run step in second stage should not be pushed since its already pushed
+  run printf "STEP 2/3: RUN echo hello\n--> Using cache"
+  step5=$output
+  # Last step is `COPY --from=0 hello hello' so it must be committed and pushed
+  # actual output is `[2/2] STEP 3/3: COPY --from=0 hello hello\n[2/2] COMMIT test\n-->Pushing cache`
+  # but lets match smaller suffix
+  run printf "COMMIT test\n--> Pushing cache"
+  step6=$output
+
+  # actually run build
+  run_buildah build $WITH_POLICY_JSON --tls-verify=false --authfile ${TEST_SCRATCH_DIR}/test.auth --layers --cache-to localhost:${REGISTRY_PORT}/temp2 --cache-to localhost:${REGISTRY_PORT}/temp -t test -f ${mytmpdir}/Containerfile ${mytmpdir}
+  expect_output --substring "$step1"
+  expect_output --substring "$step2"
+  expect_output --substring "$step3"
+  expect_output --substring "$step4"
+  expect_output --substring "$step5"
+  expect_output --substring "$step6"
+
+  # clean all cache and intermediate images
+  # to make sure that we are only using cache
+  # from remote repo and not the local storage.
+  run_buildah rmi --all -f
+
+  # ------ Test case ------ #
+  # expect cache to be pushed on remote stream
+  # now a build on clean slate must pull cache
+  # from remote instead of actually computing the
+  # run steps
+  run printf "STEP 2/5: RUN echo hello\n--> Cache pulled from remote"
+  step1=$output
+  run printf "STEP 3/5: RUN echo world\n--> Cache pulled from remote"
+  step2=$output
+  run printf "STEP 4/5: RUN touch hello\n--> Cache pulled from remote"
+  step3=$output
+  run printf "STEP 5/5: ADD somefile somefile\n--> Cache pulled from remote"
+  step4=$output
+  # First run step in second stage should not be pulled since its already pulled
+  run printf "STEP 2/3: RUN echo hello\n--> Using cache"
+  step5=$output
+  run printf "COPY --from=0 hello hello\n--> Cache pulled from remote"
+  step6=$output
+  run_buildah build $WITH_POLICY_JSON --tls-verify=false --authfile ${TEST_SCRATCH_DIR}/test.auth --layers --cache-from localhost:${REGISTRY_PORT}/temp -t test -f ${mytmpdir}/Containerfile ${mytmpdir}
+  expect_output --substring "$step1"
+  expect_output --substring "$step2"
+  expect_output --substring "$step3"
+  expect_output --substring "$step4"
+  expect_output --substring "$step5"
+  expect_output --substring "$step6"
+
+  ##### Test when cache source is: localhost:${REGISTRY_PORT}/temp2
+
+  # clean all cache and intermediate images
+  # to make sure that we are only using cache
+  # from remote repo and not the local storage.
+  run_buildah rmi --all -f
+
+  # ------ Test case ------ #
+  # expect cache to be pushed on remote stream
+  # now a build on clean slate must pull cache
+  # from remote instead of actually computing the
+  # run steps
+  run printf "STEP 2/5: RUN echo hello\n--> Cache pulled from remote"
+  step1=$output
+  run printf "STEP 3/5: RUN echo world\n--> Cache pulled from remote"
+  step2=$output
+  run printf "STEP 4/5: RUN touch hello\n--> Cache pulled from remote"
+  step3=$output
+  run printf "STEP 5/5: ADD somefile somefile\n--> Cache pulled from remote"
+  step4=$output
+  # First run step in second stage should not be pulled since its already pulled
+  run printf "STEP 2/3: RUN echo hello\n--> Using cache"
+  step5=$output
+  run printf "COPY --from=0 hello hello\n--> Cache pulled from remote"
+  step6=$output
+  run_buildah build $WITH_POLICY_JSON --tls-verify=false --authfile ${TEST_SCRATCH_DIR}/test.auth --layers --cache-from localhost:${REGISTRY_PORT}/temp2 -t test -f ${mytmpdir}/Containerfile ${mytmpdir}
+  expect_output --substring "$step1"
+  expect_output --substring "$step2"
+  expect_output --substring "$step3"
+  expect_output --substring "$step4"
+  expect_output --substring "$step5"
+  expect_output --substring "$step6"
+}
+
 @test "build test pushing and pulling from remote cache sources" {
   _prefetch alpine
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir


### PR DESCRIPTION
Buildah must support multiple sources for remote cache when using `--cache-to` and `--cache-from` so users can distribute and collect cache from various sources.

We also need for compat with buildkit api which in past broke `podman` compat build API see: https://github.com/containers/podman/pull/16380

More discussion here: https://github.com/containers/podman/pull/16380

```release-note
remote-cache: support multiple sources and destination for `--cache-to` and `--cache-from`
```

