### PR TITLE
[release-1.27] copier.Put(): clear up os/syscall mode bit confusion

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -1566,15 +1566,15 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 		return nil
 	}
 	makeDirectoryWriteable := func(directory string) error {
-		st, err := os.Lstat(directory)
-		if err != nil {
-			return fmt.Errorf("copier: put: error reading permissions of directory %q: %w", directory, err)
-		}
-		mode := st.Mode() & os.ModePerm
 		if _, ok := directoryModes[directory]; !ok {
+			st, err := os.Lstat(directory)
+			if err != nil {
+				return fmt.Errorf("copier: put: error reading permissions of directory %q: %w", directory, err)
+			}
+			mode := st.Mode()
 			directoryModes[directory] = mode
 		}
-		if err = os.Chmod(directory, 0o700); err != nil {
+		if err := os.Chmod(directory, 0o700); err != nil {
 			return fmt.Errorf("copier: put: error making directory %q writable: %w", directory, err)
 		}
 		return nil
@@ -1860,16 +1860,21 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			// set other bits that might have been reset by chown()
 			if hdr.Typeflag != tar.TypeSymlink {
 				if hdr.Mode&cISUID == cISUID {
-					mode |= syscall.S_ISUID
+					mode |= os.ModeSetuid
 				}
 				if hdr.Mode&cISGID == cISGID {
-					mode |= syscall.S_ISGID
+					mode |= os.ModeSetgid
 				}
 				if hdr.Mode&cISVTX == cISVTX {
-					mode |= syscall.S_ISVTX
+					mode |= os.ModeSticky
 				}
-				if err = syscall.Chmod(path, uint32(mode)); err != nil {
-					return fmt.Errorf("error setting additional permissions on %q to 0%o: %w", path, mode, err)
+				if hdr.Typeflag == tar.TypeDir {
+					// if/when we do the final setting of permissions on this
+					// directory, make sure to incorporate these bits, too
+					directoryModes[path] = mode
+				}
+				if err = os.Chmod(path, mode); err != nil {
+					return fmt.Errorf("copier: put: setting additional permissions on %q to 0%o: %w", path, mode, err)
 				}
 			}
 			// set xattrs, including some that might have been reset by chown()

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1872,6 +1872,42 @@ var internalTestCases = []testCase{
 			if _, err = io.Copy(tw, bytes.NewReader([]byte("whatever"))); err != nil {
 				return fmt.Errorf("error writing tar archive content: %w", err)
 			}
+			hdr = tar.Header{
+				Name:     "setuid-dir",
+				Uid:      0,
+				Gid:      0,
+				Typeflag: tar.TypeDir,
+				Size:     0,
+				Mode:     cISUID | 0755,
+				ModTime:  testDate,
+			}
+			if err = tw.WriteHeader(&hdr); err != nil {
+				return fmt.Errorf("error writing tar archive header: %w", err)
+			}
+			hdr = tar.Header{
+				Name:     "setgid-dir",
+				Uid:      0,
+				Gid:      0,
+				Typeflag: tar.TypeDir,
+				Size:     0,
+				Mode:     cISGID | 0755,
+				ModTime:  testDate,
+			}
+			if err = tw.WriteHeader(&hdr); err != nil {
+				return fmt.Errorf("error writing tar archive header: %w", err)
+			}
+			hdr = tar.Header{
+				Name:     "sticky-dir",
+				Uid:      0,
+				Gid:      0,
+				Typeflag: tar.TypeDir,
+				Size:     0,
+				Mode:     cISVTX | 0755,
+				ModTime:  testDate,
+			}
+			if err = tw.WriteHeader(&hdr); err != nil {
+				return fmt.Errorf("error writing tar archive header: %w", err)
+			}
 			return nil
 		},
 	},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When noting that a non-symlink has setuid/setgid/sticky bits, switch from using `syscall` package bits and `syscall.Chmod()` to using `os` package bits and `os.Chmod()`, and if the item's a directory, record the updated mode information in the `directoryModes` map that we'll use to reset its permissions later.

#### How to verify it

Expanded conformance test!

#### Which issue(s) this PR fixes:

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2141452.

#### Special notes for your reviewer:

Cherry-picked from #4411.

#### Does this PR introduce a user-facing change?

```release-note
None
```