### PR TITLE
[release-1.26] copier.Put(): clear up os/syscall mode bit confusion

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3520,13 +3520,13 @@ _EOF
   # pulled since the local one does not match the requested architecture.
   run_buildah tag image-amd localhost/ubi8-minimal
   run_buildah build -f Containerfile --pull=false -q --arch=arm64 -t image-arm $WITH_POLICY_JSON ${mytmpdir}
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "architecture" }}' image-arm
+  run_buildah inspect --format '{{ .OCIv1.Architecture }}' image-arm
   expect_output --substring arm64
 
   run_buildah inspect --format '{{ .FromImageID }}' image-arm
   fromiid=$output
 
-  run_buildah inspect --format '{{ index .OCIv1.Architecture  }}'  $fromiid
+  run_buildah inspect --format '{{ .OCIv1.Architecture  }}'  $fromiid
   expect_output --substring arm64
 }
 

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1872,6 +1872,42 @@ var internalTestCases = []testCase{
 			if _, err = io.Copy(tw, bytes.NewReader([]byte("whatever"))); err != nil {
 				return errors.Wrapf(err, "error writing tar archive content")
 			}
+			hdr = tar.Header{
+				Name:     "setuid-dir",
+				Uid:      0,
+				Gid:      0,
+				Typeflag: tar.TypeDir,
+				Size:     0,
+				Mode:     cISUID | 0755,
+				ModTime:  testDate,
+			}
+			if err = tw.WriteHeader(&hdr); err != nil {
+				return fmt.Errorf("error writing tar archive header: %w", err)
+			}
+			hdr = tar.Header{
+				Name:     "setgid-dir",
+				Uid:      0,
+				Gid:      0,
+				Typeflag: tar.TypeDir,
+				Size:     0,
+				Mode:     cISGID | 0755,
+				ModTime:  testDate,
+			}
+			if err = tw.WriteHeader(&hdr); err != nil {
+				return fmt.Errorf("error writing tar archive header: %w", err)
+			}
+			hdr = tar.Header{
+				Name:     "sticky-dir",
+				Uid:      0,
+				Gid:      0,
+				Typeflag: tar.TypeDir,
+				Size:     0,
+				Mode:     cISVTX | 0755,
+				ModTime:  testDate,
+			}
+			if err = tw.WriteHeader(&hdr); err != nil {
+				return fmt.Errorf("error writing tar archive header: %w", err)
+			}
 			return nil
 		},
 	},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When noting that a non-symlink has setuid/setgid/sticky bits, switch from using `syscall` package bits and `syscall.Chmod()` to using `os` package bits and `os.Chmod()`, and if the item's a directory, record the updated mode information in the `directoryModes` map that we'll use to reset its permissions later.

#### How to verify it

Expanded conformance test!

#### Which issue(s) this PR fixes:

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2141452.

#### Special notes for your reviewer:

Cherry-picked from #4411.

#### Does this PR introduce a user-facing change?

```release-note
None
```