### PR TITLE
buildah: wrap network setup errors

### DIFF
--- a/run_common.go
+++ b/run_common.go
@@ -1198,7 +1198,7 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 				defer teardown()
 			}
 			if err != nil {
-				return err
+				return fmt.Errorf("setup network: %w", err)
 			}
 
 			// only add hosts if we manage the hosts file


### PR DESCRIPTION



<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:
User may get confusing error messages were it is not clear that they are related to the network setup, wrap the error to make it more clear that some network setup failed.

#### How to verify it

#### Which issue(s) this PR fixes:


Fixes containers/podman#16809

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improve error message when network setup failed.
```

