### PR TITLE
[WIP] [CI:BUILD] Multiarch: Disable fedora-cisco-openh264 repo.

### DIFF
--- a/contrib/buildahimage/Containerfile
+++ b/contrib/buildahimage/Containerfile
@@ -28,7 +28,8 @@ ARG FLAVOR=stable
 # TODO: rpm --setcaps... needed due to Fedora (base) image builds
 #       being (maybe still?) affected by
 #       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
-RUN dnf -y update && \
+RUN rm -f /etc/yum.repos.d/fedora-cisco-openh264.repo && \
+    dnf -y update && \
     rpm --setcaps shadow-utils 2>/dev/null && \
     case "${FLAVOR}" in \
       stable) \


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

For whatever (unknown) reason, this repository constantly fails/times-out during multi-arch manifest-list builds.  Though it seems to behave for the same build job on `podman` and `skopeo`, it fails here.  Since H264 decoding capability is never ever needed in this context, disable it.

#### How to verify it

All of the test multi-arch build tasks in this PR will pass.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Historical example of failure: https://cirrus-ci.com/task/5713094295420928
Historical example of success (podman): https://cirrus-ci.com/task/6094242645278720

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

