### PR TITLE
Add support for --group-add to buildah from

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -158,6 +158,10 @@ type Builder struct {
 	// NetworkInterface is the libnetwork network interface used to setup CNI or netavark networks.
 	NetworkInterface nettypes.ContainerNetwork `json:"-"`
 
+	// GroupAdd is a list of groups to add to the primary process within
+	// the container. 'keep-groups' allows container processes to use
+	// supplementary groups.
+	GroupAdd []string
 	// ID mapping options to use when running processes in the container with non-host user namespaces.
 	IDMappingOptions define.IDMappingOptions
 	// Capabilities is a list of capabilities to use when running commands in the container.
@@ -190,6 +194,7 @@ type BuilderInfo struct {
 	FromImage             string
 	FromImageID           string
 	FromImageDigest       string
+	GroupAdd              []string
 	Config                string
 	Manifest              string
 	Container             string
@@ -229,6 +234,7 @@ func GetBuildInfo(b *Builder) BuilderInfo {
 		Manifest:              string(b.Manifest),
 		Container:             b.Container,
 		ContainerID:           b.ContainerID,
+		GroupAdd:              b.GroupAdd,
 		MountPoint:            b.MountPoint,
 		ProcessLabel:          b.ProcessLabel,
 		MountLabel:            b.MountLabel,
@@ -277,6 +283,7 @@ type BuilderOptions struct {
 	// to store copies of layer blobs that we pull down, if any.  It should
 	// already exist.
 	BlobDirectory string
+	GroupAdd      []string
 	// Logger is the logrus logger to write log messages with
 	Logger *logrus.Logger `json:"-"`
 	// Mount signals to NewBuilder() that the container should be mounted

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -311,6 +311,7 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 		FromImage:             args[0],
 		Container:             iopts.name,
 		ContainerSuffix:       suffix,
+		GroupAdd:              iopts.GroupAdd,
 		PullPolicy:            pullPolicy,
 		SignaturePolicyPath:   signaturePolicy,
 		SystemContext:         systemContext,

--- a/define/build.go
+++ b/define/build.go
@@ -298,6 +298,10 @@ type BuildOptions struct {
 	// From is the image name to use to replace the value specified in the first
 	// FROM instruction in the Containerfile
 	From string
+	// GroupAdd is a list of groups to add to the primary process within
+	// the container. 'keep-groups' allows container processes to use
+	// supplementary groups.
+	GroupAdd []string
 	// Platforms is the list of parsed OS/Arch/Variant triples that we want
 	// to build the image for.  If this slice has items in it, the OS and
 	// Architecture fields above are ignored.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -352,6 +352,20 @@ environment variable.  `export BUILDAH_FORMAT=docker`
 Overrides the first `FROM` instruction within the Containerfile.  If there are multiple
 FROM instructions in a Containerfile, only the first is changed.
 
+**--group-add**=*group* | *keep-groups*
+
+Assign additional groups to the primary user running within the container
+process.
+
+- `keep-groups` is a special flag that tells Buildah to keep the supplementary
+group access.
+
+Allows container to use the user's supplementary group access. If file systems
+or devices are only accessible by the rootless user's group, this flag tells the
+OCI runtime to pass the group access into the container. Currently only
+available with the `crun` OCI runtime. Note: `keep-groups` is exclusive, other
+groups cannot be specified with this flag.
+
 **--help**, **-h**
 
 Print usage statement

--- a/docs/buildah-from.1.md
+++ b/docs/buildah-from.1.md
@@ -205,6 +205,20 @@ Recognized formats include *oci* (OCI image-spec v1.0, the default) and
 Note: You can also override the default format by setting the BUILDAH\_FORMAT
 environment variable.  `export BUILDAH_FORMAT=docker`
 
+**--group-add**=*group* | *keep-groups*
+
+Assign additional groups to the primary user running within the container
+process.
+
+- `keep-groups` is a special flag that tells Buildah to keep the supplementary
+group access.
+
+Allows container to use the user's supplementary group access. If file systems
+or devices are only accessible by the rootless user's group, this flag tells the
+OCI runtime to pass the group access into the container. Currently only
+available with the `crun` OCI runtime. Note: `keep-groups` is exclusive, other
+groups cannot be specified with this flag.
+
 **--http-proxy**
 
 By default proxy environment variables are passed into the container if set

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -109,6 +109,7 @@ type Executor struct {
 	rootfsMap               map[string]bool             // Holds the names of every stage whose rootfs is referenced in a COPY or ADD instruction.
 	blobDirectory           string
 	excludes                []string
+	groupAdd                []string
 	ignoreFile              string
 	args                    map[string]string
 	unusedArgs              map[string]struct{}
@@ -226,6 +227,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		store:                          store,
 		contextDir:                     options.ContextDirectory,
 		excludes:                       excludes,
+		groupAdd:                       options.GroupAdd,
 		ignoreFile:                     options.IgnoreFile,
 		pullPolicy:                     options.PullPolicy,
 		registry:                       options.Registry,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -726,6 +726,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 	builderOptions := buildah.BuilderOptions{
 		Args:                  ib.Args,
 		FromImage:             from,
+		GroupAdd:              s.executor.groupAdd,
 		PullPolicy:            pullPolicy,
 		ContainerSuffix:       s.executor.containerSuffix,
 		Registry:              s.executor.registry,

--- a/new.go
+++ b/new.go
@@ -301,6 +301,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		FromImage:             imageSpec,
 		FromImageID:           imageID,
 		FromImageDigest:       imageDigest,
+		GroupAdd:              options.GroupAdd,
 		Container:             name,
 		ContainerID:           container.ID,
 		ImageAnnotations:      imageAnnotations,

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -380,6 +380,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		Excludes:                excludes,
 		ForceRmIntermediateCtrs: iopts.ForceRm,
 		From:                    iopts.From,
+		GroupAdd:                iopts.GroupAdd,
 		IDMappingOptions:        idmappingOptions,
 		IIDFile:                 iopts.Iidfile,
 		IgnoreFile:              iopts.IgnoreFile,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -29,6 +29,7 @@ type LayerResults struct {
 // UserNSResults represents the results for the UserNS flags
 type UserNSResults struct {
 	UserNS            string
+	GroupAdd          []string
 	UserNSUIDMap      []string
 	UserNSGIDMap      []string
 	UserNSUIDMapUser  string
@@ -137,6 +138,7 @@ type FromAndBudResults struct {
 // GetUserNSFlags returns the common flags for usernamespace
 func GetUserNSFlags(flags *UserNSResults) pflag.FlagSet {
 	usernsFlags := pflag.FlagSet{}
+	usernsFlags.StringSliceVar(&flags.GroupAdd, "group-add", nil, "add additional groups to the primary container process. 'keep-groups' allows container processes to use supplementary groups.")
 	usernsFlags.StringVar(&flags.UserNS, "userns", "", "'container', `path` of user namespace to join, or 'host'")
 	usernsFlags.StringSliceVar(&flags.UserNSUIDMap, "userns-uid-map", []string{}, "`containerUID:hostUID:length` UID mapping to use in user namespace")
 	usernsFlags.StringSliceVar(&flags.UserNSGIDMap, "userns-gid-map", []string{}, "`containerGID:hostGID:length` GID mapping to use in user namespace")
@@ -148,6 +150,7 @@ func GetUserNSFlags(flags *UserNSResults) pflag.FlagSet {
 // GetUserNSFlagsCompletions returns the FlagCompletions for the userns flags
 func GetUserNSFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion := commonComp.FlagCompletions{}
+	flagCompletion["group-add"] = commonComp.AutocompleteNone
 	flagCompletion["userns"] = completion.AutocompleteNamespaceFlag
 	flagCompletion["userns-uid-map"] = commonComp.AutocompleteNone
 	flagCompletion["userns-gid-map"] = commonComp.AutocompleteNone

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5790,3 +5790,22 @@ _EOF
   run_buildah build --security-opt no-new-privileges $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
   expect_output --substring "NoNewPrivs:.*1"
 }
+
+@test "build --group-add" {
+  skip_if_no_runtime
+  id=$RANDOM
+
+  _prefetch alpine
+  cat > ${TEST_SCRATCH_DIR}/Containerfile << _EOF
+FROM alpine
+RUN id -G
+_EOF
+
+  run_buildah build --group-add $id $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
+  expect_output --substring "$id"
+
+  if is_rootless && has_supplemental_groups; then
+     run_buildah build --group-add keep-groups $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
+     expect_output --substring "65534"
+  fi
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -497,6 +497,13 @@ function is_rootless() {
     [ "$(id -u)" -ne 0 ]
 }
 
+#################
+#  has_supplemental_groups  #  Check that account has additional groups
+#################
+function has_supplemental_groups() {
+    [ "$(id -g)" != "$(id -G)" ]
+}
+
 #################################
 #  skip_if_rootless_environment # `mount` or its variant needs unshare
 #################################

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -245,6 +245,24 @@ function configure_and_check_user() {
 	expect_output "foo"
 }
 
+@test "run --group-add" {
+	skip_if_no_runtime
+        id=$RANDOM
+
+	_prefetch alpine
+	run_buildah from --group-add $id --quiet --pull=false $WITH_POLICY_JSON alpine
+	cid=$output
+	run_buildah run $cid id -G
+	expect_output --substring "$id"
+
+	if is_rootless && has_supplemental_groups; then
+	   run_buildah from --group-add keep-groups --quiet --pull=false $WITH_POLICY_JSON alpine
+	   cid=$output
+	   run_buildah run $cid id -G
+	   expect_output --substring "65534"
+	fi
+}
+
 @test "run --hostname" {
 	skip_if_no_runtime
 


### PR DESCRIPTION
Allow containers running under buildah to use
--group-add keep-groups, so that they can inherit
access to the users groups.

Also allow users to add supplimental groups to the container.

Fixes: https://github.com/containers/buildah/issues/4476

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Buildah build and buildah from support --group-add to add supplemental groups into containers or to leak the supplemental groups of the caller into the container.
```

