### PR TITLE
[release-1.24] [CI:BUILD] Cirrus: Migrate OSX task to M1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -125,9 +125,9 @@ cross_build_task:
     only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     osx_instance:
-        image: 'big-sur-base'
+        image: ghcr.io/cirruslabs/macos-ventura-base:latest
     env:
-        PATH: "/usr/local/opt/go@1.18/bin:$PATH"
+        PATH: "/usr/local/opt/go@1.18/bin:/opt/homebrew/opt/go@1.18/bin:$PATH"
     script:
         - brew update
         - brew install go@1.18


### PR DESCRIPTION
Migrate our OSX build to a M1 instance, since Cirrus is sunsetting Intel-based macOS instances.

Signed-off-by: Ashley Cui <acui@redhat.com>
(cherry picked from commit 498b45770ff9d238f95d772efa2a1fd16d941077)
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind failing-test 

#### What this PR does / why we need it:
Fixes osx tests in cron run

#### How to verify it

Check the next cron run

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

