### PR TITLE
[release-1.27] Cirrus: tmp disable cross_build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -132,26 +132,26 @@ vendor_task:
 
 
 # Confirm cross-compile ALL architectures on a Mac OS-X VM.
-cross_build_task:
-    name: "Cross Compile"
-    alias: cross_build
-    only_if: >-
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
-        $CIRRUS_CRON != 'multiarch'
-
-    osx_instance:
-        image: 'big-sur-base'
-
-    script:
-        - brew update
-        - brew install go
-        - brew install go-md2man
-        - brew install gpgme
-        - go version
-        - make cross CGO_ENABLED=0
-
-    binary_artifacts:
-        path: ./bin/*
+#cross_build_task:
+#    name: "Cross Compile"
+#    alias: cross_build
+#    only_if: >-
+#        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
+#        $CIRRUS_CRON != 'multiarch'
+#
+#    osx_instance:
+#        image: 'big-sur-base'
+#
+#    script:
+#        - brew update
+#        - brew install go
+#        - brew install go-md2man
+#        - brew install gpgme
+#        - go version
+#        - make cross CGO_ENABLED=0
+#
+#    binary_artifacts:
+#        path: ./bin/*
 
 
 unit_task:
@@ -164,7 +164,7 @@ unit_task:
     depends_on: &smoke_vendor_cross
       - smoke
       - vendor
-      - cross_build
+      # - cross_build
 
     timeout_in: 1h
 
@@ -380,7 +380,7 @@ success_task:
       - unit
       - conformance
       - vendor
-      - cross_build
+      # - cross_build
       - integration
       - in_podman
       - image_build


### PR DESCRIPTION
Cron jobs for the release branches are failing with complaints about intel macos not being supported anymore. This commit disables osx tasks until we find out the best way to resolve these.

Ref: https://cirrus-ci.com/task/4647106766438400

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind failing-test 

#### What this PR does / why we need it:
disable cross_build because it fails

#### How to verify it

osx tests don't show up in CI

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

