### PR TITLE
system tests: remove unhelpful assertions

### DIFF
--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -128,7 +128,7 @@ load helpers
   run_buildah rmi containers-storage:other-new-image
   run_buildah rmi another-new-image
   run_buildah images -q
-  [ "$output" != "" ]
+  assert "$output" != "" "images -q"
   run_buildah rmi -a
   run_buildah images -q
   expect_output ""

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2064,7 +2064,7 @@ function _test_http() {
   root=$output
   test ! -s $root/vol/subvol/subvolfile
   run stat -c %f $root/vol/subvol
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status code from stat $root/vol/subvol"
   expect_output "41ed" "stat($root/vol/subvol) [0x41ed = 040755]"
 }
 
@@ -2180,12 +2180,12 @@ function _test_http() {
   run_buildah mount ${cid}
   root=$output
   run ls $root/data/log
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status from ls $root/data/log"
   expect_output --substring "test"     "ls \$root/data/log"
   expect_output --substring "blah.txt" "ls \$root/data/log"
 
   run ls -al $root
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status from ls -al $root"
   expect_output --substring "test-log -> /data/log" "ls -l \$root/data/log"
   expect_output --substring "blah -> /test-log"     "ls -l \$root/data/log"
 }
@@ -2199,11 +2199,11 @@ function _test_http() {
   run_buildah mount ${cid}
   root=$output
   run ls $root/log
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status from ls $root/log"
   expect_output --substring "test" "ls \$root/log"
 
   run ls -al $root
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status from ls -al $root"
   expect_output --substring "test-log -> ../log" "ls -l \$root/log"
   test -r $root/var/data/empty
 }
@@ -2217,20 +2217,20 @@ function _test_http() {
   run_buildah mount ${cid}
   root=$output
   run ls $root/data/log
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status from ls $root/data/log"
   expect_output --substring "bin"      "ls \$root/data/log"
   expect_output --substring "blah.txt" "ls \$root/data/log"
 
   run ls -al $root/myuser
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status from ls -al $root/myuser"
   expect_output --substring "log -> /test" "ls -al \$root/myuser"
 
   run ls -al $root/test
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status from ls -al $root/test"
   expect_output --substring "bar -> /test-log" "ls -al \$root/test"
 
   run ls -al $root/test-log
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status from ls -al $root/test-log"
   expect_output --substring "foo -> /data/log" "ls -al \$root/test-log"
 }
 
@@ -2250,11 +2250,11 @@ function _test_http() {
   run_buildah mount ${cid}
   root=$output
   run ls $root/bin
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status from ls $root/bin"
   expect_output --substring "myexe" "ls \$root/bin"
 
   run cat $root/bin/myexe
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status from cat $root/bin/myexe"
   expect_output "symlink-test" "cat \$root/bin/myexe"
 }
 
@@ -2267,7 +2267,7 @@ function _test_http() {
   run_buildah mount ${cid}
   root=$output
   run ls $root/data
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status from ls $root/data"
   expect_output --substring "myexe" "ls \$root/data"
 }
 

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -132,7 +132,7 @@ load helpers
   config="$output"
   run python3 -c 'import json, sys; config = json.load(sys.stdin); print(config["history"][len(config["history"])-1]["created_by"])' <<< "$config"
   echo "$output"
-  [ "${status}" -eq 0 ]
+  assert "$status" -eq 0 "status from python command 1"
   expect_output "untracked actions"
 
   run_buildah config --created-by "" $cid
@@ -141,7 +141,7 @@ load helpers
   config="$output"
   run python3 -c 'import json, sys; config = json.load(sys.stdin); print(config["history"][len(config["history"])-1]["created_by"])' <<< "$config"
   echo "$output"
-  [ "${status}" -eq 0 ]
+  assert "$status" -eq 0 "status from python command 2"
   expect_output "/bin/sh"
 }
 

--- a/tests/help.bats
+++ b/tests/help.bats
@@ -68,8 +68,8 @@ function check_help() {
 
     # This can happen if the output of --help changes, such as between
     # the old command parser and cobra.
-    [ $count -gt 0 ] || \
-        die "Internal error: no commands found in 'buildah help $@' list"
+    assert "$count" -gt 0 \
+           "Internal error: no commands found in 'buildah help $@' list"
 
     # Sanity check: make sure the special loops above triggered at least once.
     # (We've had situations where a typo makes the conditional never run in podman)
@@ -85,8 +85,8 @@ function check_help() {
 
     # This can happen if the output of --help changes, such as between
     # the old command parser and cobra.
-    [ $count -gt 0 ] || \
-        die "Internal error: no commands found in 'buildah help list"
+    assert "$count" -gt 0 \
+           "Internal error: no commands found in 'buildah help list"
 
 }
 

--- a/tests/images.bats
+++ b/tests/images.bats
@@ -138,7 +138,7 @@ load helpers
 
   run_buildah images --json
   run python3 -m json.tool <<< "$output"
-  [ "${status}" -eq 0 ]
+  assert "$status" -eq 0 "status from python json.tool"
 }
 
 @test "specify an existing image" {

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -81,8 +81,10 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     expect_output --substring ${IMAGE_LIST_ARM_INSTANCE_DIGEST}
     expect_output --substring ${IMAGE_LIST_PPC64LE_INSTANCE_DIGEST}
     expect_output --substring ${IMAGE_LIST_S390X_INSTANCE_DIGEST}
-    run grep ${IMAGE_LIST_ARM64_INSTANCE_DIGEST} <<< "$output"
-    [ $status -ne 0 ]
+
+    # ARM64 should now be gone
+    arm64=$(grep ${IMAGE_LIST_ARM64_INSTANCE_DIGEST} <<< "$output" || true)
+    assert "$arm64" = "" "arm64 instance digest found in manifest list"
 }
 
 @test "manifest-remove-not-found" {
@@ -108,8 +110,9 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 	    s390x) IMAGE_LIST_EXPECTED_INSTANCE_DIGEST=${IMAGE_LIST_S390X_INSTANCE_DIGEST} ;;
 	    *) skip "current arch \"$(go env GOARCH 2> /dev/null)\" not present in manifest list" ;;
     esac
+
     run grep ${IMAGE_LIST_EXPECTED_INSTANCE_DIGEST##sha256} ${TEST_SCRATCH_DIR}/pushed/manifest.json
-    [ $status -eq 0 ]
+    assert "$status" -eq 0 "status code of grep for expected instance digest"
 }
 
 @test "manifest-push-all" {

--- a/tests/overlay.bats
+++ b/tests/overlay.bats
@@ -28,7 +28,7 @@ load helpers
 
   # This should fail
   run ls ${TEST_SCRATCH_DIR}/lower/bar
-  [ "$status" -ne 0 ]
+  assert "$status" -ne 0 "status of ls ${TEST_SCRATCH_DIR}/lower/bar"
 }
 
 @test "overlay source permissions and owners" {
@@ -58,7 +58,7 @@ load helpers
 
   # This should fail since /tmp/test was an overlay, not a bind mount
   run ls ${TEST_SCRATCH_DIR}/lower/bar
-  [ "$status" -ne 0 ]
+  assert "$status" -ne 0 "status of ls ${TEST_SCRATCH_DIR}/lower/bar"
 }
 
 @test "overlay path contains colon" {
@@ -92,5 +92,5 @@ load helpers
 
   # This should fail
   run ls ${TEST_SCRATCH_DIR}/a:lower/bar
-  [ "$status" -ne 0 ]
+  assert "$status" -ne 0 "status of ls ${TEST_SCRATCH_DIR}/a:lower/bar"
 }

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -13,7 +13,7 @@ load helpers
   # force a failed pull and look at the error message which *must* include the
   # the resolved image name (localhost/image:latest).
   run_buildah 125 pull --policy=always image
-  [[ "$output" == *"initializing source docker://localhost/image:latest"* ]]
+  assert "$output" =~ "initializing source docker://localhost/image:latest"
   run_buildah rmi localhost/image ${iid}
 }
 
@@ -56,7 +56,7 @@ load helpers
   run_buildah --retry pull --registries-conf ${TEST_SOURCES}/registries.conf $WITH_POLICY_JSON alpine@sha256:e9a2035f9d0d7cee1cdd445f5bfa0c5c646455ee26f14565dce23cf2d2de7570
   run_buildah 125 pull --registries-conf ${TEST_SOURCES}/registries.conf $WITH_POLICY_JSON fakeimage/fortest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
-  [[ ! "$output" =~ "fakeimage/fortest" ]]
+  assert "$output" !~ "fakeimage/fortest" "fakeimage/fortest found in buildah images"
 }
 
 @test "pull-from-docker-archive" {
@@ -100,7 +100,7 @@ load helpers
 
   run docker pull alpine
   echo "$output"
-  [ "$status" -eq 0 ]
+  assert "$status" -eq 0 "status of docker (yes, docker) pull alpine"
   run_buildah pull $WITH_POLICY_JSON docker-daemon:docker.io/library/alpine:latest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine:latest"

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -31,7 +31,7 @@ load helpers
   cid3=$output
   run_buildah 125 rmi alpine busybox
   run_buildah images -q
-  [ "$output" != "" ]
+  assert "$output" != "" "images -q"
 
   run_buildah rmi -f alpine busybox
   run_buildah images -q
@@ -66,7 +66,7 @@ load helpers
   cid3=$output
   run_buildah 125 rmi --all
   run_buildah images -q
-  [ "$output" != "" ]
+  assert "$output" != "" "images -q"
 
   run_buildah rmi --all --force
   run_buildah images -q

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -814,7 +814,7 @@ _EOF
 		found_runtime=y
 		run_buildah '?' run --runtime=runc --runtime-flag=debug $cid true
 		if [ "$status" -eq 0 ]; then
-			[ -n "$output" ]
+			assert "$output" != "" "Output from running 'true' with --runtime-flag=debug"
 		else
 			# runc fully supports cgroup v2 (unified mode) since v1.0.0-rc93.
 			# older runc doesn't work on cgroup v2.
@@ -825,7 +825,7 @@ _EOF
 	if [ -n "$(command -v crun)" ]; then
 		found_runtime=y
 		run_buildah run --runtime=crun --runtime-flag=debug $cid true
-		[ -n "$output" ]
+		assert "$output" != "" "Output from running 'true' with --runtime-flag=debug"
 	fi
 
 	if [ -z "${found_runtime}" ]; then

--- a/tests/selinux.bats
+++ b/tests/selinux.bats
@@ -16,7 +16,7 @@ load helpers
   run_buildah from --quiet --quiet $WITH_POLICY_JSON $image
   cid=$output
   run_buildah run $cid sh -c 'tr \\0 \\n < /proc/self/attr/current'
-  [ "$output" != "" ]
+  assert "$output" != "" "/proc/self/attr/current cannot be empty"
   firstlabel="$output"
 
   # Ensure that we label the same container consistently across multiple "run" instructions.


### PR DESCRIPTION
Regular primitive bats uses assertions like '[ $foo = something ]'.
These are worthless for debugging: when they fail, all you know
is that foo is not "something" but you don't know what foo _is_.

Find and replace those assertions with 'assert', which is
more informative. Instances found via:

   $ ack '^ *\[' tests/*.bats

There are many matches for 'test' (instead of '[') but those
mostly look like file-existence ones, which are less evil
than string-check tests. I'm leaving those be for now.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```