### PR TITLE
build, secret: allow relative mountpoints wrt to work dir for `--mount=type=secret`

### DIFF
--- a/run_common.go
+++ b/run_common.go
@@ -1497,7 +1497,7 @@ func (b *Builder) runSetupRunMounts(mounts []string, sources runMountInfo, idMap
 		}
 		switch mountType {
 		case "secret":
-			mount, envFile, err := b.getSecretMount(tokens, sources.Secrets, idMaps)
+			mount, envFile, err := b.getSecretMount(tokens, sources.Secrets, idMaps, sources.WorkDir)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1598,7 +1598,7 @@ func (b *Builder) getTmpfsMount(tokens []string, idMaps IDMaps) (*spec.Mount, er
 	return &volumes[0], nil
 }
 
-func (b *Builder) getSecretMount(tokens []string, secrets map[string]define.Secret, idMaps IDMaps) (*spec.Mount, string, error) {
+func (b *Builder) getSecretMount(tokens []string, secrets map[string]define.Secret, idMaps IDMaps, workdir string) (*spec.Mount, string, error) {
 	errInvalidSyntax := errors.New("secret should have syntax id=id[,target=path,required=bool,mode=uint,uid=uint,gid=uint")
 	if len(tokens) == 0 {
 		return nil, "", errInvalidSyntax
@@ -1618,6 +1618,9 @@ func (b *Builder) getSecretMount(tokens []string, secrets map[string]define.Secr
 			id = kv[1]
 		case "target", "dst", "destination":
 			target = kv[1]
+			if !filepath.IsAbs(target) {
+				target = filepath.Join(workdir, target)
+			}
 		case "required":
 			required, err = strconv.ParseBool(kv[1])
 			if err != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -519,6 +519,13 @@ _EOF
   expect_output --substring "Groups:	1000"
 }
 
+@test "build-test --mount=type=secret test relative to workdir mount" {
+  local contextdir=$BUDFILES/secret-relative
+  run_buildah build $WITH_POLICY_JSON --no-cache --secret id=secret-foo,src=$contextdir/secret1.txt --secret id=secret-bar,src=$contextdir/secret2.txt -t test -f $contextdir/Dockerfile
+  expect_output --substring "secret:foo"
+  expect_output --substring "secret:bar"
+}
+
 @test "build-test --mount=type=cache test relative to workdir mount" {
   local contextdir=${TEST_SCRATCH_DIR}/bud/platform
   mkdir -p $contextdir

--- a/tests/bud/secret-relative/Dockerfile
+++ b/tests/bud/secret-relative/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+RUN mkdir test
+WORKDIR test
+RUN --mount=type=secret,id=secret-foo,dst=secret1.txt --mount=type=secret,id=secret-bar,dst=secret2.txt \
+     cat /test/secret1.txt && cat /test/secret2.txt

--- a/tests/bud/secret-relative/secret1.txt
+++ b/tests/bud/secret-relative/secret1.txt
@@ -1,0 +1,1 @@
+secret:foo

--- a/tests/bud/secret-relative/secret2.txt
+++ b/tests/bud/secret-relative/secret2.txt
@@ -1,0 +1,1 @@
+secret:bar


### PR DESCRIPTION
When working with `--mount=type=secret` allow `target`/`dst` to accept relative paths w.r.t to the configured work dir.

See detailed use-case here: https://github.com/containers/buildah/issues/4491

Closes: https://github.com/containers/buildah/issues/4491

**Steps to reproduce the issue from #4491:**

1. Create Dockerfile and Makefile:

Dockerfile:
```
FROM docker.io/ubuntu:22.04

WORKDIR /somedir

RUN --mount=type=secret,id=secret-foo,dst=secret1.txt --mount=type=secret,id=secret-bar,dst=secret2.txt \
     printf "PWD=%s\n" "$(pwd)" && ls -la && ls -la / && stat secret1.txt && stat secret2.txt && \
     cp secret1.txt /root/secret-foo.txt && \
     cp secret2.txt /root/secret-bar.txt
```

Makefile:
```
DOCKER ?= docker

.PHONY: build-container

build-container:
	rm -rf build
	mkdir build
	echo "secret:foo" >build/secret1.txt
	echo "secret:bar" >build/secret2.txt
	buildah --no-cache --secret id=secret-foo,src=build/secret1.txt --secret id=secret-bar,src=build/secret2.txt -t defanator/example:tag1 .
	podman run --rm -t -i defanator/example:tag1 cat /root/secret-foo.txt
	podman run --rm -t -i defanator/example:tag1 cat /root/secret-bar.txt
	podman rmi defanator/example:tag1
```
```
make
```


<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build, secret: allow realtive mountpoints wrt to work dir for `--mount=type=secret`
```

