### PR TITLE
bud: Consolidate multiple synthetic LABEL instructions

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -319,6 +319,7 @@ Set custom DNS search domains. Invalid if using **--dns-search** with **--networ
 Add a value (e.g. env=*value*) to the built image.  Can be used multiple times.
 If neither `=` nor a `*value*` are specified, but *env* is set in the current
 environment, the value from the current environment will be added to the image.
+The value of *env* can be overridden by ENV instructions in the Containerfile.
 To remove an environment variable from the built image, use the `--unsetenv`
 option.
 

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -456,6 +456,10 @@ func (b *Executor) buildStage(ctx context.Context, cleanupStages map[int]*StageE
 	ib := stage.Builder
 	node := stage.Node
 	base, err := ib.From(node)
+	if err != nil {
+		logrus.Debugf("buildStage(node.Children=%#v)", node.Children)
+		return "", nil, err
+	}
 
 	// If this is the last stage, then the image that we produce at
 	// its end should be given the desired output name.
@@ -464,9 +468,30 @@ func (b *Executor) buildStage(ctx context.Context, cleanupStages map[int]*StageE
 		output = b.output
 	}
 
-	if err != nil {
-		logrus.Debugf("buildStage(node.Children=%#v)", node.Children)
-		return "", nil, err
+	// If this stage is starting out with environment variables that were
+	// passed in via our API, we should include them in the history, since
+	// they affect RUN instructions in this stage.
+	if len(b.envs) > 0 {
+		var envLine string
+		for _, envSpec := range b.envs {
+			env := strings.SplitN(envSpec, "=", 2)
+			key := env[0]
+			if len(env) > 1 {
+				value := env[1]
+				envLine += fmt.Sprintf(" %q=%q", key, value)
+			} else {
+				value := os.Getenv(key)
+				envLine += fmt.Sprintf(" %q=%q", key, value)
+			}
+		}
+		if len(envLine) > 0 {
+			additionalNode, err := imagebuilder.ParseDockerfile(strings.NewReader("ENV" + envLine + "\n"))
+			if err != nil {
+				return "", nil, fmt.Errorf("while adding additional ENV step: %w", err)
+			}
+			// make this the first instruction in the stage after its FROM instruction
+			stage.Node.Children = append(additionalNode.Children, stage.Node.Children...)
+		}
 	}
 
 	b.stagesLock.Lock()

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1624,17 +1624,17 @@ func (s *StageExecutor) getBuildArgsResolvedForRun() string {
 	return strings.Join(envs, " ")
 }
 
-// getBuildArgs key returns set args are key which were specified during the build process
-// following function will be exclusively used by build history
+// getBuildArgs key returns the set of args which were specified during the
+// build process, formatted for inclusion in the build history
 func (s *StageExecutor) getBuildArgsKey() string {
-	var envs []string
+	var args []string
 	for key := range s.stage.Builder.Args {
 		if _, ok := s.stage.Builder.AllowedArgs[key]; ok {
-			envs = append(envs, key)
+			args = append(args, key)
 		}
 	}
-	sort.Strings(envs)
-	return strings.Join(envs, " ")
+	sort.Strings(args)
+	return strings.Join(args, " ")
 }
 
 // tagExistingImage adds names to an image already in the store
@@ -1934,25 +1934,6 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	for _, envSpec := range config.Env {
 		spec := strings.SplitN(envSpec, "=", 2)
 		s.builder.SetEnv(spec[0], spec[1])
-	}
-	for _, envSpec := range s.executor.envs {
-		env := strings.SplitN(envSpec, "=", 2)
-		if len(env) > 1 {
-			getenv := func(name string) string {
-				for _, envvar := range s.builder.Env() {
-					val := strings.SplitN(envvar, "=", 2)
-					if len(val) == 2 && val[0] == name {
-						return val[1]
-					}
-				}
-				logrus.Errorf("error expanding variable %q: no value set in image", name)
-				return name
-			}
-			env[1] = os.Expand(env[1], getenv)
-			s.builder.SetEnv(env[0], env[1])
-		} else {
-			s.builder.SetEnv(env[0], os.Getenv(env[0]))
-		}
 	}
 	for _, envSpec := range s.executor.unsetEnvs {
 		s.builder.UnsetEnv(envSpec)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5855,3 +5855,21 @@ _EOF
      expect_output --substring "65534"
   fi
 }
+
+@test "build-env-precedence" {
+  skip_if_no_runtime
+
+  _prefetch alpine
+
+  run_buildah build --no-cache --env E=F --env G=H --env I=J --env K=L -f ${BUDFILES}/env/Dockerfile.env-precedence ${BUDFILES}/env
+  expect_output --substring "a=b c=d E=F G=H"
+  expect_output --substring "a=b c=d E=E G=G"
+  expect_output --substring "w=x y=z I=J K=L"
+  expect_output --substring "w=x y=z I=I K=K"
+
+  run_buildah build --no-cache --layers --env E=F --env G=H --env I=J --env K=L -f ${BUDFILES}/env/Dockerfile.env-precedence ${BUDFILES}/env
+  expect_output --substring "a=b c=d E=F G=H"
+  expect_output --substring "a=b c=d E=E G=G"
+  expect_output --substring "w=x y=z I=J K=L"
+  expect_output --substring "w=x y=z I=I K=K"
+}

--- a/tests/bud/env/Dockerfile.env-precedence
+++ b/tests/bud/env/Dockerfile.env-precedence
@@ -1,0 +1,17 @@
+FROM alpine
+ENV a=b
+ENV c=d
+# E and G are passed in on the command-line, and we haven't overridden them yet, so the command will get the CLI values.
+RUN echo a=$a c=$c E=$E G=$G
+ENV E=E G=G
+# We just set E and G, and that will override values passed at the command line thanks to imagebuilder's handling of ENV instructions.
+RUN echo a=$a c=$c E=$E G=$G
+
+FROM 0
+ENV w=x
+ENV y=z
+# I and K are passed in on the command-line, and we haven't overridden them yet, so the command will get the CLI values.
+RUN echo w=$w y=$y I=$I K=$K
+ENV I=I K=K
+# We just set I and K, and that will override values passed at the command line thanks to imagebuilder's handling of ENV instructions.
+RUN echo w=$w y=$y I=$I K=$K

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -2997,4 +2997,10 @@ var internalTestCases = []testCase{
 		fsSkip:            []string{"(dir):created:mtime", "(dir):created:(dir):directory:mtime"},
 		dockerUseBuildKit: true,
 	},
+
+	{
+		name:              "env-precedence",
+		contextDir:        "env/precedence",
+		dockerUseBuildKit: true,
+	},
 }

--- a/tests/conformance/testdata/env/precedence/Dockerfile
+++ b/tests/conformance/testdata/env/precedence/Dockerfile
@@ -1,0 +1,6 @@
+FROM busybox
+ENV a=b
+ENV c=d
+RUN echo E=$E G=$G
+ENV E=E G=G
+RUN echo E=$E G=$G


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

We handle `--label` command line arguments by appending `LABEL` instructions to the Dockerfile contents before we parse it.  Previously, we were appending a separate line for each label-value pair.  Consolidate them for the sake of tools that arbitrarily limit the length of histories that they're willing to accept in images (boo!).

Add a similar implementation for `--env` command line arguments.  Previously, we'd set them in the initial configuration for each stage and also set them at commit-time, and that potentially overrode any values that were explicitly in the stage itself, and which would have affected its `RUN` instructions.  Remove the set-at-commit-time logic so that the history reflects what ends up in the image.

#### How to verify it

New conformance test!
New integration test!

#### Which issue(s) this PR fixes:

May help with CLOUDBLD-12739.  Incorporates https://github.com/containers/buildah/pull/4024, more or less.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
* When the `--env` command line flag conflicts with an ENV instruction in a Containerfile, the Containerfile's value is now the one which is recorded in the output image.
* Multiple `--label` command line flags now generate only one history entry in the output image.
* The `--env` command line flag now generates a history entry in the output image.
```