### PR TITLE
[CI:BUILD] Fix multiarch manifest-list build failures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -341,7 +341,6 @@ image_build_task: &image-build
         - env:
             FLAVOR: testing
         - env:
-            ARCHES: amd64,arm64,s390x
             FLAVOR: stable
     env:
         DISTRO_NV: "${FEDORA_NAME}"  # Required for repo cache extraction

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,7 +31,7 @@ env:
     PRIOR_FEDORA_NAME: "fedora-36"
     UBUNTU_NAME: "ubuntu-2204"
 
-    IMAGE_SUFFIX: "c4815821738868736"
+    IMAGE_SUFFIX: "c6300530360713216"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
@@ -341,6 +341,7 @@ image_build_task: &image-build
         - env:
             FLAVOR: testing
         - env:
+            ARCHES: amd64,arm64,s390x
             FLAVOR: stable
     env:
         DISTRO_NV: "${FEDORA_NAME}"  # Required for repo cache extraction

--- a/contrib/buildahimage/Containerfile
+++ b/contrib/buildahimage/Containerfile
@@ -22,13 +22,21 @@
 FROM registry.fedoraproject.org/fedora:latest
 ARG FLAVOR=stable
 
+# When building for multiple-architectures in parallel using emulation
+# it's really easy for one/more dnf processes to timeout or mis-count
+# the minimum download rates.  Bump both to be extremely forgiving of
+# an overworked host.
+RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
+    echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
+
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking
 # up space.
 # TODO: rpm --setcaps... needed due to Fedora (base) image builds
 #       being (maybe still?) affected by
 #       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
-RUN dnf -y update && \
+RUN dnf -y makecache && \
+    dnf -y update && \
     rpm --setcaps shadow-utils 2>/dev/null && \
     case "${FLAVOR}" in \
       stable) \


### PR DESCRIPTION
/kind other

#### What this PR does / why we need it:

Increase the timeout interval and minimum download-rate required for the dnf command when building multi-arch manifest-list images for buildah.

#### How to verify it

Test builds will complete w/o failure

#### Which issue(s) this PR fixes:

Fixes #4472

#### Special notes for your reviewer:

[Example failure](https://cirrus-ci.com/task/4702377224175616?logs=main)

#### Does this PR introduce a user-facing change?

```release-note
None
```

