### PR TITLE
[CI:DOCS] README: drop sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ buildah commit "$ctr1" "${2:-$USER/lighttpd}"
 EOF
 
 $ chmod +x lighttpd.sh
-$ sudo ./lighttpd.sh
+$ ./lighttpd.sh
 ```
 
 ## Commands


### PR DESCRIPTION
Running the script from the README does not require root privileges. The text seems to predate Buildah's rootless support.  It was brought to my attention during a presentation last week where an attendee asked whether Buildah requires root privileges after reading the README.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

```release-note
None
```

