### PR TITLE
tests: change the runtime-flag test for crun

### DIFF
--- a/tests/run.bats
+++ b/tests/run.bats
@@ -824,8 +824,10 @@ _EOF
 
 	if [ -n "$(command -v crun)" ]; then
 		found_runtime=y
-		run_buildah run --runtime=crun --runtime-flag=debug $cid true
-		assert "$output" != "" "Output from running 'true' with --runtime-flag=debug"
+		run_buildah run --runtime=crun --runtime-flag=log=${TEST_SCRATCH_DIR}/oci-log $cid true
+		if test \! -e ${TEST_SCRATCH_DIR}/oci-log; then
+			die "the expected file ${TEST_SCRATCH_DIR}/oci-log was not created"
+		fi
 	fi
 
 	if [ -z "${found_runtime}" ]; then


### PR DESCRIPTION
crun might not print any debugging message, so change the runtime-flag test to use --log=log-file and test it was created.

Closes: https://github.com/containers/buildah/issues/4503

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
/kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #4503
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

