### PR TITLE
stage_executor: while mounting stages make sure freshly built stage is used

### DIFF
--- a/internal/types.go
+++ b/internal/types.go
@@ -12,6 +12,7 @@ const (
 // StageExecutor has ability to mount stages/images in current context and
 // automatically clean them up.
 type StageMountDetails struct {
+	DidExecute bool   // tells if the stage which is being mounted was freshly executed or was part of older cache
 	IsStage    bool   // tells if mountpoint returned from stage executor is stage or image
 	MountPoint string // mountpoint of stage/image
 }


### PR DESCRIPTION
When using `--mount=` in RUN instruction and source is a stage make sure
that freshly built stage is used if the stage selected in source was
just rebuilt.

Closes: https://github.com/containers/buildah/issues/4522

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
stage_executor: while mounting stages make sure freshly built stage is used
```

