### PR TITLE
Flake 3710 has been closed. Reenable the test.

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5323,12 +5323,8 @@ _EOF
 
 @test "bud-multiple-platform-no-run" {
   outputlist=localhost/testlist
-  # Note: [This is a bug] jobs=1 is intentionally set here since --jobs=0 sets
-  # concurrency to maximum which uncovers all sorts of race condition causing
-  # flakes in CI. Please put this back to --jobs=0 when https://github.com/containers/buildah/issues/3710
-  # is resolved.
   run_buildah build $WITH_POLICY_JSON \
-              --jobs=1 \
+              --jobs=0 \
               --all-platforms \
               --manifest $outputlist \
               --build-arg SAFEIMAGE=$SAFEIMAGE \


### PR DESCRIPTION
(No, I don't expect the issue to be fixed, but sometimes we need
incentives in order to pay attention to flakes)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```