### PR TITLE
docs: specify order preference for FROM when using multiple `containerfiles`

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -328,7 +328,7 @@ option.
 Specifies a Containerfile which contains instructions for building the image,
 either a local file or an **http** or **https** URL.  If more than one
 Containerfile is specified, *FROM* instructions will only be accepted from the
-first specified file.
+last specified file.
 
 If a local file is specified as the Containerfile and it does not exist, the
 context directory will be prepended to the local file value.


### PR DESCRIPTION
When multiple files are specified buildah considers `FROM` instruction from the last file specified and so does `buildkit` and `docker` so lets specify that in docs.

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]

Closes: https://github.com/containers/buildah/issues/4544
