### PR TITLE
login: support interspersed args for password from `stdin`

### DIFF
--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -70,7 +70,6 @@ func init() {
 }
 
 func buildCmd(c *cobra.Command, inputArgs []string, iopts buildahcli.BuildOptions) error {
-
 	if c.Flag("logfile").Changed {
 		logfile, err := os.OpenFile(iopts.Logfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 		if err != nil {

--- a/cmd/buildah/login.go
+++ b/cmd/buildah/login.go
@@ -39,10 +39,11 @@ func init() {
 	loginCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := loginCommand.Flags()
-	flags.SetInterspersed(false)
 	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
 	flags.BoolVar(&opts.getLogin, "get-login", true, "return the current login user for the registry")
 	flags.AddFlagSet(auth.GetLoginFlags(&opts.loginOpts))
+	opts.loginOpts.Stdin = os.Stdin
+	opts.loginOpts.Stdout = os.Stdout
 	rootCmd.AddCommand(loginCommand)
 }
 

--- a/tests/authenticate.bats
+++ b/tests/authenticate.bats
@@ -10,6 +10,12 @@ load helpers
   run_buildah 0 logout localhost:$REGISTRY_PORT
 }
 
+@test "authenticate: with stdin" {
+  start_registry testuserfoo testpassword
+  run_buildah 0 login localhost:$REGISTRY_PORT --cert-dir $REGISTRY_DIR --username testuserfoo --password-stdin <<< testpassword
+  run_buildah 0 logout localhost:$REGISTRY_PORT
+}
+
 @test "authenticate: login/logout should succeed with XDG_RUNTIME_DIR unset" {
   unset XDG_RUNTIME_DIR
 


### PR DESCRIPTION
Buildah must support accepting password from stdin agnostic of order like `podman`

Example with buildah which should work

```console
$ cat password.txt | buildah login docker.io -u user --password-stdin
Error: too many arguments, login takes only 1 argument
```

Example with podman which already works
```console
$ cat password.txt | buildah login -u user --password-stdin docker.io
Login Succeeded
```

Closes: https://github.com/containers/buildah/issues/4557

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
login: support interspersed args for password from `stdin`
```

