### PR TITLE
executor,copy: honor default ARG value while eval stage in `COPY` stmts

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -753,6 +753,17 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 							// if following ADD or COPY needs any other
 							// stage.
 							stageName := rootfs
+							headingArgs := argsMapToSlice(stage.Builder.HeadingArgs)
+							userArgs := argsMapToSlice(stage.Builder.Args)
+							// append heading args so if --build-arg key=value is not
+							// specified but default value is set in Containerfile
+							// via `ARG key=value` so default value can be used.
+							userArgs = append(headingArgs, userArgs...)
+							baseWithArg, err := imagebuilder.ProcessWord(stageName, userArgs)
+							if err != nil {
+								return "", nil, fmt.Errorf("while replacing arg variables with values for format %q: %w", stageName, err)
+							}
+							stageName = baseWithArg
 							// If --from=<index> convert index to name
 							if index, err := strconv.Atoi(stageName); err == nil {
 								stageName = stages[index].Name

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2955,6 +2955,11 @@ _EOF
   #Verify https://github.com/containers/buildah/issues/4312
   # stage `FROM stage_${my_env}` must be resolved with default arg value and build should be successful.
   run_buildah build $WITH_POLICY_JSON -t source -f $BUDFILES/multi-stage-builds/Dockerfile.arg_in_stage
+
+  #Verify https://github.com/containers/buildah/issues/4573
+  # stage `COPY --from=stage_${my_env}` must be resolved with default arg value and build should be successful.
+  run_buildah build $WITH_POLICY_JSON -t source -f $BUDFILES/multi-stage-builds/Dockerfile.arg_in_copy
+
 }
 
 @test "bud-with-healthcheck" {

--- a/tests/bud/multi-stage-builds/Dockerfile.arg_in_copy
+++ b/tests/bud/multi-stage-builds/Dockerfile.arg_in_copy
@@ -1,0 +1,8 @@
+ARG my_env=a
+
+FROM alpine as stage_a
+RUN /bin/true
+
+FROM alpine
+ARG my_env
+COPY --from=stage_${my_env} /bin/true /bin/true_copy


### PR DESCRIPTION
COPY must honor processing any argument if any configured while evaulating `--from=` statement.

Makes below Containerfile functional without any external `--build-arg` value from CLI

```Dockerfile
ARG my_env=a

FROM alpine as stage_a
RUN /bin/true

FROM alpine
COPY --from=stage_${my_env} /bin/true true
```

Closes: https://github.com/containers/buildah/issues/4573


<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
executor,copy: honor default ARG value while eval stage in `COPY` stmts
```

