### PR TITLE
Temporarily hard-skip bud-multiple-platform-values test

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5257,6 +5257,7 @@ _EOF
 }
 
 @test "bud-multiple-platform-values" {
+  skip "FIXME: #4396 - this test is broken, and is failing gating tests"
   outputlist=testlist
   # check if we can run a couple of 32-bit versions of an image, and if we can,
   # assume that emulation for other architectures is in place.


### PR DESCRIPTION
It is completely broken (see #4396) and is now causing failures
in Fedora gating tests:

   https://artifacts.dev.testing-farm.io/30e7b5bc-d162-4ae7-9a60-896f0186bf73/

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```