### PR TITLE
[CI:DOCS] Skip subject-length validation for renovate PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: check subject line length
+      - if: contains(github.head_ref, 'renovate/') != true
+        name: check subject line length
         uses: tim-actions/commit-message-checker-with-regex@d6d9770051dd6460679d1cab1dcaa8cffc5c2bbd # v0.3.1
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Renovate opens PRs with subject-lines which can easily exceed the 72-character limit imposed (for stylistic reasons) on PRs.  However, in the context of a dependency update, the extra detail is helpful to humans.  Add a conditional in the workflow to bypass this check when it appears to be coming from a 'renovate/*' branch.

#### How to verify it

The `pr.yml` workflow will properly check/enforce a character limit on this PR.  However it bypassed the check in [my test run](https://github.com/containers/buildah/actions/runs/4188707504/jobs/7260170919) in an [actual Renovate PR](https://github.com/containers/buildah/pull/4583)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Ref: https://github.com/containers/buildah/pull/4587#issuecomment-1431992894

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```