### PR TITLE
imagebuildah.StageExecutor: suppress bogus "Pushing cache []:..." messages

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5632,15 +5632,13 @@ _EOF
 @test "bud-with-mount-cache-like-buildkit-verify-default-selinux-option" {
   skip_if_no_runtime
   skip_if_in_container
-  local contextdir=${TEST_SCRATCH_DIR}/buildkit-mount2
-  cp -R $BUDFILES/buildkit-mount $contextdir
   _prefetch alpine
   # try writing something to persistent cache
-  run_buildah build -t testbud $WITH_POLICY_JSON -f $contextdir/Dockerfilecachewritewithoutz
+  TMPDIR=${TEST_SCRATCH_DIR} run_buildah build -t testbud $WITH_POLICY_JSON -f $BUDFILES/buildkit-mount/Dockerfilecachewritewithoutz
   # try reading something from persistent cache in a different build
-  run_buildah build -t testbud2 $WITH_POLICY_JSON -f $contextdir/Dockerfilecachereadwithoutz
-  buildah_cache_dir="$TMPDIR/buildah-cache-$UID"
-  # buildah cache parent must exist for uid specific to this invocation
+  TMPDIR=${TEST_SCRATCH_DIR} run_buildah build -t testbud2 $WITH_POLICY_JSON -f $BUDFILES/buildkit-mount/Dockerfilecachereadwithoutz
+  buildah_cache_dir="${TEST_SCRATCH_DIR}/buildah-cache-$UID"
+  # buildah cache parent must have been created for our uid specific to this test
   test -d "$buildah_cache_dir"
   expect_output --substring "hello"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When we changed the cache-from and cache-to options to take slices of name values instead of single values, we didn't update logic that checked if a value was set to handle cases where we had a non-nil slice with no elements in it.

#### How to verify it

It's a cosmetic change, so I expect our existing tests should be enough.  I fixed a different bug in a test that was failing on my system.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah build` should no longer produce spurious "Pushing cache []:..." messages while building images.
```