### PR TITLE
docs/tutorials/04: add defaults for Run()

### DIFF
--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/internal"
 	"github.com/containers/buildah/pkg/jail"
+	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
 	"github.com/containers/common/libnetwork/resolvconf"
 	nettypes "github.com/containers/common/libnetwork/types"
@@ -98,7 +99,13 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	if isolation == IsolationDefault {
 		isolation = b.Isolation
 		if isolation == IsolationDefault {
-			isolation = IsolationOCI
+			isolation, err = parse.IsolationOption("")
+			if err != nil {
+				logrus.Debugf("got %v while trying to determine default isolation, guessing OCI", err)
+				isolation = IsolationOCI
+			} else if isolation == IsolationDefault {
+				isolation = IsolationOCI
+			}
 		}
 	}
 	if err := checkAndOverrideIsolationOptions(isolation, &options); err != nil {

--- a/run_linux.go
+++ b/run_linux.go
@@ -96,7 +96,13 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	if isolation == define.IsolationDefault {
 		isolation = b.Isolation
 		if isolation == define.IsolationDefault {
-			isolation = define.IsolationOCI
+			isolation, err = parse.IsolationOption("")
+			if err != nil {
+				logrus.Debugf("got %v while trying to determine default isolation, guessing OCI", err)
+				isolation = IsolationOCI
+			} else if isolation == IsolationDefault {
+				isolation = IsolationOCI
+			}
 		}
 	}
 	if err := checkAndOverrideIsolationOptions(isolation, &options); err != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5524,8 +5524,7 @@ _EOF
 @test "bud-with-mount-like-buildkit" {
   skip_if_no_runtime
   skip_if_in_container
-  local contextdir=${TEST_SCRATCH_DIR}/buildkit-mount
-  cp -R $BUDFILES/buildkit-mount $contextdir
+  local contextdir=$BUDFILES/buildkit-mount
   run_buildah build -t testbud $WITH_POLICY_JSON -f $contextdir/Dockerfile $contextdir/
   expect_output --substring "hello"
   run_buildah rmi -f testbud


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

In the tutorial, switch to calling `DefaultStoreOptionsAutoDetectUID()` instead of `DefaultStoreOptions()`, which should figure things out better.

In the tutorial, add an example of using Run(), where for API backward compatibility reasons, we can't tell the difference between "grant no capabilties by default" and "grant the default set of capabilities by default".

The default isolation can be set automatically, so start doing that at run-time, but have the tutorial look it up anyway because the tutorial on the web will be newer than our current release for at least a while.

#### How to verify it

Mostly docs.  ~The default is buried so deep that I don't think the CLI even hits the changed logic.~  It turns out that the conformance and integration tests cover this code path better than I thought they did.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

One day, when we're ready to intentionally break API, we should change `BuilderOptions.Capabilities` into a pointer to a slice, so that `nil` can indicate that we should use the defaults from the configuration.

#### Does this PR introduce a user-facing change?

```release-note
None
```