### PR TITLE
Ignore the base image's base image annotations

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -350,6 +350,12 @@ type BuilderOptions struct {
 	ProcessLabel string
 	// MountLabel is the SELinux mount label associated with the container
 	MountLabel string
+	// PreserveBaseImageAnn[otation]s indicates that we should preserve base
+	// image information that was present in our base image, instead of
+	// overwriting them with information about the base image itself.  This
+	// is mainly useful as an internal implementation detail of multistage
+	// builds, and does not need to be set by most callers.
+	PreserveBaseImageAnns bool
 }
 
 // ImportOptions are used to initialize a Builder from an existing container

--- a/config.go
+++ b/config.go
@@ -92,13 +92,7 @@ func (b *Builder) initConfig(ctx context.Context, img types.Image, sys *types.Sy
 				return fmt.Errorf("parsing OCI manifest %q: %w", string(b.Manifest), err)
 			}
 			for k, v := range v1Manifest.Annotations {
-				// NOTE: do not override annotations that are
-				// already set. Otherwise, we may erase
-				// annotations such as the digest of the base
-				// image.
-				if value := b.ImageAnnotations[k]; value == "" {
-					b.ImageAnnotations[k] = v
-				}
+				b.ImageAnnotations[k] = v
 			}
 		}
 	}

--- a/tests/bud/multi-stage-builds/Dockerfile.reused2
+++ b/tests/bud/multi-stage-builds/Dockerfile.reused2
@@ -1,0 +1,6 @@
+FROM busybox as base
+RUN pwd
+FROM base
+RUN pwd
+FROM base
+RUN pwd


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In a multi-stage build, when initializing a stage whose base is the result of a previous stage, don't reset the AnnotationBaseImageName and AnnotationBaseImageDigest annotations to point to that base image, since the values in the stage's base image are already correct.

#### How to verify it

Extended conformance test!

#### Which issue(s) this PR fixes:

I think this is HACBS-1818.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
OCI images produced using multi-stage builds, where the final stage is based on an earlier stage, will no longer include an "org.opencontainers.image.base.name" annotation for the base of that earlier stage combined with an "org.opencontainers.image.base.digest" annotation which corresponds to the image produced by that earlier stage, which are two different images.
```