### PR TITLE
sshagent: use `ExtendedAgent` instead of `Agent`

### DIFF
--- a/pkg/sshagent/sshagent.go
+++ b/pkg/sshagent/sshagent.go
@@ -164,7 +164,7 @@ func (a *AgentServer) ServePath() string {
 // readOnlyAgent implemetnts the agent.Agent interface
 // readOnlyAgent allows reads only to prevent keys from being added from the build to the forwarded ssh agent on the host
 type readOnlyAgent struct {
-	agent.Agent
+	agent.ExtendedAgent
 }
 
 func (a *readOnlyAgent) Add(_ agent.AddedKey) error {
@@ -181,6 +181,10 @@ func (a *readOnlyAgent) RemoveAll() error {
 
 func (a *readOnlyAgent) Lock(_ []byte) error {
 	return errors.New("locking agent not allowed by buildah")
+}
+
+func (a *readOnlyAgent) Extension(_ string, _ []byte) ([]byte, error) {
+	return nil, errors.New("extensions not allowed by buildah")
 }
 
 // Source is what the forwarded agent's source is


### PR DESCRIPTION
It seems ExtendedAgent supports signing with flags instead of ignoring it. This commit mimics how the ExtendedAgent is configured in Buildkit : https://github.com/moby/buildkit/blob/master/session/sshforward/sshprovider/agentprovider.go#L221

[NO NEW TESTS NEEDED]
This needs to configure github account with ssh-agent in CI ( which is difficult to add in CI )  but patch manually verified here: https://github.com/containers/buildah/issues/4636#issuecomment-1451447050
Closes: https://github.com/containers/buildah/issues/4636

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
sshagent: use `ExtendedAgent` instead of `Agent`
```

