### PR TITLE
imagebuildah: set len(short_image_id) to 12

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1006,8 +1006,8 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		}
 	}
 	logImageID := func(imgID string) {
-		if len(imgID) > 11 {
-			imgID = imgID[0:11]
+		if len(imgID) > 12 {
+			imgID = imgID[:12]
 		}
 		if s.executor.iidfile == "" {
 			fmt.Fprintf(s.executor.out, "--> %s\n", imgID)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6004,3 +6004,11 @@ _EOF
   expect_output --substring "w=x y=z I=J K=L"
   expect_output --substring "w=x y=z I=I K=K"
 }
+
+@test "build prints 12-digit hash" {
+  run_buildah build -t test -f $BUDFILES/containerfile/Containerfile .
+  regex='--> [0-9a-zA-Z]{12}'
+  if ! [[ $output =~ $regex ]]; then
+    false
+  fi
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Buildah bud prints a 11-digit hash during build unlike docker, which dumps a [12-digit hash.](https://github.com/moby/moby/blob/889427b334614c3aa89e7e0f7535e44bf4ce87b1/pkg/stringid/stringid.go#L14) Further looking at the relevant [commit](https://github.com/containers/buildah/commit/bb03eb3f92a7790bb26e9bad1c544107eeab4b3f), this looks like a typo since the commit clearly intends to dump the 12-digit hash aiming for parity with docker.

```
$ ./bin/buildah bud -t test -f /tmp/tmp.6WrKR1Ehxm/Dockerfile .
STEP 1/1: FROM alpine
COMMIT test
--> b2aa39c304c2  <<===
Successfully tagged localhost/test:latest
Successfully tagged docker.io/library/alpine:latest
b2aa39c304c27b96c1fef0c06bee651ac9241d49c4fe34381cab8453f9a89c7d
```

Refers https://github.com/containers/podman/issues/5012 & https://github.com/containers/buildah/pull/2124

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
buildah bud prints a 12-digit image identifier instead of an 11-digit one
```

Signed-off-by: danishprakash <danish.prakash@suse.com>