### PR TITLE
Update to Go 1.18

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -121,7 +121,7 @@ vendor_task:
 
     # Runs within Cirrus's "community cluster"
     container:
-        image: docker.io/library/golang:1.17
+        image: docker.io/library/golang:1.18
         cpu: 1
         memory: 1
 

--- a/Makefile
+++ b/Makefile
@@ -185,11 +185,11 @@ test-unit: tests/testreport/testreport
 	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover $(RACEFLAGS) ./cmd/buildah -args --root $$tmp/root --runroot $$tmp/runroot --storage-driver vfs --signature-policy $(shell pwd)/tests/policy.json --registries-conf $(shell pwd)/tests/registries.conf
 
 vendor-in-container:
-	podman run --privileged --rm --env HOME=/root -v `pwd`:/src -w /src docker.io/library/golang:1.17 make vendor
+	podman run --privileged --rm --env HOME=/root -v `pwd`:/src -w /src docker.io/library/golang:1.18 make vendor
 
 .PHONY: vendor
 vendor:
-	GO111MODULE=on $(GO) mod tidy -compat=1.17
+	GO111MODULE=on $(GO) mod tidy
 	GO111MODULE=on $(GO) mod vendor
 	GO111MODULE=on $(GO) mod verify
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/buildah
 
-go 1.17
+go 1.18
 
 require (
 	github.com/containerd/containerd v1.7.0


### PR DESCRIPTION
#### What type of PR is this?

> /kind cleanup

#### What this PR does / why we need it:

Go 1.18 is already required in practice, see
```
grep 'func .*]('
```

This also renders the `-compat=1.17` option to `go mod tidy` unnecessary, so drop it.

The main expected benefit is that this avoid vendoring problems caused by the differences between `go mod tidy -compat=1.{16,17}`, see #4652 and #4656 .

#### How to verify it

Existing CI.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
[NO NEW TESTS NEEDED]
