### PR TITLE
Fix requiring tests on Makefile changes

### DIFF
--- a/tests/validate/pr-should-include-tests
+++ b/tests/validate/pr-should-include-tests
@@ -42,12 +42,13 @@ fi
 filtered_changes=$(git diff --name-status $base $head |
                        awk '{print $2}'               |
                        fgrep -vx .cirrus.yml          |
-		       fgrep -vx .gitignore           |
+                       fgrep -vx .gitignore           |
                        fgrep -vx changelog.txt        |
                        fgrep -vx go.mod               |
                        fgrep -vx go.sum               |
                        fgrep -vx buildah.spec.rpkg    |
                        fgrep -vx .golangci.yml        |
+                       fgrep -vx Makefile             |
                        egrep -v  '^[^/]+\.md$'        |
                        egrep -v  '^\.github/'         |
                        egrep -v  '^contrib/'          |


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Changes to how things are built shouldn't trigger the
'pr-should-include-tests` check.

#### How to verify it

A dummy Makefile change won't trigger the check.

#### Which issue(s) this PR fixes:

[Example failure](https://cirrus-ci.com/task/4943480833703936)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

