### PR TITLE
Re-enable conformance tests

### DIFF
--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -15,14 +15,22 @@ Conformance tests use Docker CE to build images to be compared with images built
 
 ## Run conformance tests
 
-You can run all of the tests with go test:
+First, pull base images used by various conformance tests:
 ```
-go test -v -tags "$(./btrfs_tag.sh) $(./btrfs_installed_tag.sh) $(./libdm_tag.sh)" ./tests/conformance
+bash
+docker pull alpine
+docker pull busybox
+docker pull registry.centos.org/centos/centos:centos7
+```
+
+Then you can run all of the tests with go test:
+```
+go test -v -timeout=30m -tags "$(./btrfs_tag.sh) $(./btrfs_installed_tag.sh) $(./libdm_tag.sh)" ./tests/conformance
 ```
 
 If you want to run one of the test cases you can use the "-run" flag:
 ```
-go test -v -tags "$(./btrfs_tag.sh) $(./btrfs_installed_tag.sh) $(./libdm_tag.sh)" -run TestConformance/shell ./tests/conformance
+go test -v -timeout=30m -tags "$(./btrfs_tag.sh) $(./btrfs_installed_tag.sh) $(./libdm_tag.sh)" -run TestConformance/shell ./tests/conformance
 ```
 
 If you also want to build and compare on a line-by-line basis, run:


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

In conformance tests, just ignore the new `moby.buildkit.buildinfo.v1` field in the Docker format.  We also save the as-built manifest from the image we build using Docker, to make it easier to inspect along with other data.

#### How to verify it

Reenabled conformance tests!

#### Which issue(s) this PR fixes:

Fixes #4639.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
none
```