### PR TITLE
imagebuildah: only apply label on the final image instead of intermediate images

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -471,6 +471,34 @@ func (b *Executor) buildStage(ctx context.Context, cleanupStages map[int]*StageE
 	if stageIndex == len(stages)-1 {
 		output = b.output
 	}
+	// Check if any labels were passed in via the API, and add a final line
+	// to the Dockerfile that would provide the same result.
+	// Reason: Docker adds label modification as a last step which can be
+	// processed like regular steps, and if no modification is done to
+	// layers, its easier to re-use cached layers.
+	if len(b.labels) > 0 {
+		var labelLine string
+		labels := append([]string{}, b.labels...)
+		for _, labelSpec := range labels {
+			label := strings.SplitN(labelSpec, "=", 2)
+			key := label[0]
+			value := ""
+			if len(label) > 1 {
+				value = label[1]
+			}
+			// check only for an empty key since docker allows empty values
+			if key != "" {
+				labelLine += fmt.Sprintf(" %q=%q", key, value)
+			}
+		}
+		if len(labelLine) > 0 {
+			additionalNode, err := imagebuilder.ParseDockerfile(strings.NewReader("LABEL" + labelLine + "\n"))
+			if err != nil {
+				return "", nil, fmt.Errorf("while adding additional LABEL step: %w", err)
+			}
+			stage.Node.Children = append(stage.Node.Children, additionalNode.Children...)
+		}
+	}
 
 	// If this stage is starting out with environment variables that were
 	// passed in via our API, we should include them in the history, since

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -2022,14 +2022,6 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	if s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolUndefined || s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolTrue {
 		s.builder.SetLabel(buildah.BuilderIdentityAnnotation, define.Version)
 	}
-	for _, labelSpec := range s.executor.labels {
-		label := strings.SplitN(labelSpec, "=", 2)
-		if len(label) > 1 {
-			s.builder.SetLabel(label[0], label[1])
-		} else {
-			s.builder.SetLabel(label[0], "")
-		}
-	}
 	for _, annotationSpec := range s.executor.annotations {
 		annotation := strings.SplitN(annotationSpec, "=", 2)
 		if len(annotation) > 1 {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1845,14 +1845,6 @@ _EOF
   expect_output "$want_output"
 }
 
-@test "bud-from-scratch-override-version-label" {
-  want_output='map["io.buildah.version":"oldversion"]'
-  target=scratch-image
-  run_buildah build --label "io.buildah.version=oldversion" $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
-  run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' ${target}
-  expect_output "$want_output"
-}
-
 @test "bud-from-scratch-remove-identity-label" {
   target=scratch-image
   run_buildah build --identity-label=false $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch


### PR DESCRIPTION
Buildah currently applies labels to each intermediate image which is not the right thing to do since others builds uses these intermediate image and they can inherit the label even though they never had this intention.

Only apply labels to the final build i.e last instruction of last stage which will make sure that labels are only applied to final image and not to the intermediate images.

Closes: https://github.com/containers/buildah/issues/4632

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
stage_executor: only apply label on the final image instead of intermediate images
```

