### PR TITLE
Add user configuration to buildah container image

### DIFF
--- a/contrib/buildahimage/Containerfile
+++ b/contrib/buildahimage/Containerfile
@@ -84,11 +84,16 @@ RUN mkdir -p /var/lib/shared/overlay-images \
     touch /var/lib/shared/vfs-images/images.lock && \
     touch /var/lib/shared/vfs-layers/layers.lock
 
+ADD ./user-storage.conf /tmp/storage.conf
+
 # Define uid/gid ranges for our user https://github.com/containers/buildah/issues/3053
 RUN useradd build && \
     echo -e "build:1:999\nbuild:1001:64535" > /etc/subuid && \
     echo -e "build:1:999\nbuild:1001:64535" > /etc/subgid && \
     mkdir -p /home/build/.local/share/containers && \
+    mkdir -p /home/build/.config/containers && \
+    mv /tmp/storage.conf /home/build/.config/containers/storage.conf && \
+    chmod 700 /home/build/.config && \
     chown -R build:build /home/build
 
 VOLUME /var/lib/containers

--- a/contrib/buildahimage/user-storage.conf
+++ b/contrib/buildahimage/user-storage.conf
@@ -1,0 +1,11 @@
+[storage]
+driver = "overlay"
+
+[storage.options]
+additionalimagestores = [
+"/var/lib/shared",
+]
+
+[storage.options.overlay]
+mount_program = "/usr/bin/fuse-overlayfs"
+mountopt = "nodev,fsync=0"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The container has configuration for root,
this commit adds a similar configuration for the build user.

Closes: #4669

#### How to verify it

The commands displaying the configuration

``` bash
podman run --rm quay.io/containers/buildah buildah info
podman run --rm --user build quay.io/containers/buildah buildah info
```

should both contain:

``` json
"GraphDriverName": "overlay",
    "GraphOptions": [
        "overlay.imagestore=/var/lib/shared",
        "overlay.mount_program=/usr/bin/fuse-overlayfs",
        "overlay.mountopt=nodev,fsync=0"
    ]
```

#### Which issue(s) this PR fixes:

Fixes #4669

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

