### PR TITLE
[CI:BUILD] Packit: Enable Copr builds on PR and commit to main

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This script handles any custom processing of the spec file generated using the `post-upstream-clone`
+# action and gets used by the fix-spec-file action in .packit.yaml.
+
+set -eo pipefail
+
+# Get Version from define/types.go in HEAD
+VERSION=$(grep ^$'\tVersion' define/types.go | cut -d\" -f2 | sed -e 's/-/~/')
+
+# Generate source tarball from HEAD
+git archive --prefix=buildah-$VERSION/ -o buildah-$VERSION.tar.gz HEAD
+
+# RPM Spec modifications
+
+# Use the Version from define/types.go in rpm spec
+sed -i "s/^Version:.*/Version: $VERSION/" buildah.spec
+
+# Use Packit's supplied variable in the Release field in rpm spec.
+# buildah.spec is generated using `rpkg spec --outdir ./` as mentioned in the
+# `post-upstream-clone` action in .packit.yaml.
+sed -i "s/^Release:.*/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" buildah.spec
+
+# Use above generated tarball as Source in rpm spec
+sed -i "s/^Source:.*.tar.gz/Source: buildah-$VERSION.tar.gz/" buildah.spec
+
+# Use the right build dir for autosetup stage in rpm spec
+sed -i "s/^%setup.*/%autosetup -Sgit -n %{name}-$VERSION/" buildah.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,30 @@
+---
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+# Build targets can be found at:
+# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
+
+specfile_path: buildah.spec
+
+jobs:
+  - &copr
+    job: copr_build
+    trigger: pull_request
+    owner: rhcontainerbot
+    project: packit-builds
+    enable_net: true
+    srpm_build_deps:
+      - make
+      - rpkg
+    actions:
+      post-upstream-clone:
+        - "rpkg spec --outdir ./"
+      fix-spec-file:
+        - "bash .packit.sh"
+
+  - <<: *copr
+    # Run on commit to main branch
+    trigger: commit
+    branch: main
+    project: podman-next

--- a/buildah.go
+++ b/buildah.go
@@ -26,8 +26,7 @@ const (
 	// Package is the name of this package, used in help output and to
 	// identify working containers.
 	Package = define.Package
-	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
-	// too.
+	// Version for the Package.
 	Version = define.Version
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.

--- a/define/types.go
+++ b/define/types.go
@@ -28,8 +28,7 @@ const (
 	// Package is the name of this package, used in help output and to
 	// identify working containers.
 	Package = "buildah"
-	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
-	// too.
+	// Version for the Package. Also used by .packit.sh for Packit builds.
 	Version = "1.30.0-dev"
 
 	// DefaultRuntime if containers.conf fails.


### PR DESCRIPTION
This commit adds Packit configuration files which will trigger rpm builds on copr:`rhcontainerbot/packit-builds` on every PR as well as on copr:`rhcontainerbot/podman-next` on every commit to main branch.

This commit will ensure main branch is always buildable on all supported Fedora and CentOS Stream versions for aarch64 and x86_64.
TODO: enable build checks for s390x and ppc64le while ensuring they don't take too long to build.

The packit builds reuse `buildah.spec.rpkg` and are thus independent of Fedora / CentOS dist-git.

This change will remove the need for the current webhook based triggering
 of rpm builds on rhcontainerbot/podman-next after commit to main.
 That will be instead handled by the `trigger: commit` action added in this
 PR. New builds will continue to get posted to the same link so users
 don't need to change any existing copr repo configuration.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:
Checks for downstream build issues prior to merge.

#### How to verify it
There will be additional packit tasks in CI.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->


None


#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

