### PR TITLE
run_linux: Update heuristic for mounting /sys

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -1104,8 +1104,8 @@ func setupSpecialMountSpecChanges(spec *spec.Spec, shmSize string) ([]specs.Moun
 	}
 
 	addCgroup := true
-	// mount sys when root and no userns or when both netns and userns are private
-	canMountSys := (!isRootless && !isNewUserns) || (isNetns && isNewUserns)
+	// mount sys when root and no userns or when a new netns is created
+	canMountSys := (!isRootless && !isNewUserns) || isNetns
 	if !canMountSys {
 		addCgroup = false
 		sys := "/sys"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -761,6 +761,16 @@ $output"
         expect_output --substring "cannot set --network other than host with --isolation chroot"
 }
 
+@test "run --network=private must mount a fresh /sys" {
+	skip_if_no_runtime
+
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
+	cid=$output
+        # verify there is no /sys/kernel/security in the container, that would mean /sys
+        # was bind mounted from the host.
+	run_buildah 1 run --network=private $cid grep /sys/kernel/security /proc/self/mountinfo
+}
+
 @test "run --network should override build --network" {
 	skip_if_no_runtime
 


### PR DESCRIPTION
change the heuristic to mount a fresh sysfs every time a new network namespace is created.  This modification ensures the creation of the sysfs when the network namespace is created, which is better than sharing the one from the host.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2164524

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

/kind bug

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
A fresh sysfs is mounted when the netns is private
```

