### PR TITLE
build: accept arguments from file with --build-arg-file

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -68,6 +68,18 @@ resulting image's configuration.
 Please refer to the [BUILD TIME VARIABLES](#build-time-variables) section for the
 list of variables that can be overridden within the Containerfile at run time.
 
+**--build-arg-file** *path*
+
+Specifies a file of lines of build arguments of the form arg=value. Suggested file suffix is .Containerargs.
+
+Comment lines beginning with # are ignored along with blank lines. All others should be of the arg=value format passed to --build-arg.
+
+If several --build-arg-file and/or --build-arg arguments are provided, build argumentss will be merged across all provided files and command line arguments.
+
+Files will be read before command line args.
+
+When a given argument name is specified several times, the last instance is the one that is passed to the resulting builds. This means --build-arg values always override those in a --build-arg-file
+
 **--build-context** *name=value*
 
 Specify an additional build context using its short name and its location. Additional

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -76,7 +76,7 @@ Comment lines beginning with `#` are ignored, along with blank lines. All others
 
 If several arguments are provided via the `--build-arg-file` and `--build-arg` options, the build arguments will be merged across all of the provided files and command line arguments.
 
-Any file provided in a `--build-file-arg` option will be read before the arguments supplied via the `--build-arg` option.
+Any file provided in a `--build-arg-file` option will be read before the arguments supplied via the `--build-arg` option.
 
 When a given argument name is specified several times, the last instance is the one that is passed to the resulting builds. This means `--build-arg` values always override those in a `--build-arg-file`.
 

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -70,15 +70,15 @@ list of variables that can be overridden within the Containerfile at run time.
 
 **--build-arg-file** *path*
 
-Specifies a file of lines of build arguments of the form arg=value. Suggested file suffix is .Containerargs.
+Specifies a file containing lines of build arguments of the form arg=value. The suggested file name is argfile.conf.
 
-Comment lines beginning with # are ignored along with blank lines. All others should be of the arg=value format passed to --build-arg.
+Comment lines beginning with `#` are ignored, along with blank lines. All others should be of the `arg=value` format passed to `--build-arg`.
 
-If several --build-arg-file and/or --build-arg arguments are provided, build argumentss will be merged across all provided files and command line arguments.
+If several arguments are provided via the `--build-arg-file` and `--build-arg` options, the build arguments will be merged across all of the provided files and command line arguments.
 
-Files will be read before command line args.
+Any file provided in a `--build-file-arg` option will be read before the arguments supplied via the `--build-arg` option.
 
-When a given argument name is specified several times, the last instance is the one that is passed to the resulting builds. This means --build-arg values always override those in a --build-arg-file
+When a given argument name is specified several times, the last instance is the one that is passed to the resulting builds. This means `--build-arg` values always override those in a `--build-arg-file`.
 
 **--build-context** *name=value*
 

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -205,7 +205,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.Authfile, "authfile", "", "path of the authentication file.")
 	fs.StringArrayVar(&flags.OCIHooksDir, "hooks-dir", []string{}, "set the OCI hooks directory path (may be set multiple times)")
 	fs.StringArrayVar(&flags.BuildArg, "build-arg", []string{}, "`argument=value` to supply to the builder")
-	fs.StringArrayVar(&flags.BuildArgFile, "build-arg-file", []string{}, "`file.Containerargs` containing lines of argument=value to supply to the builder")
+	fs.StringArrayVar(&flags.BuildArgFile, "build-arg-file", []string{}, "`argfile.conf` containing lines of argument=value to supply to the builder")
 	fs.StringArrayVar(&flags.BuildContext, "build-context", []string{}, "`argument=value` to supply additional build context to the builder")
 	fs.StringArrayVar(&flags.CacheFrom, "cache-from", []string{}, "remote repository list to utilise as potential cache source.")
 	fs.StringArrayVar(&flags.CacheTo, "cache-to", []string{}, "remote repository list to utilise as potential cache destination.")

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -53,6 +53,7 @@ type BudResults struct {
 	Annotation          []string
 	Authfile            string
 	BuildArg            []string
+	BuildArgFile        []string
 	BuildContext        []string
 	CacheFrom           []string
 	CacheTo             []string
@@ -204,6 +205,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.Authfile, "authfile", "", "path of the authentication file.")
 	fs.StringArrayVar(&flags.OCIHooksDir, "hooks-dir", []string{}, "set the OCI hooks directory path (may be set multiple times)")
 	fs.StringArrayVar(&flags.BuildArg, "build-arg", []string{}, "`argument=value` to supply to the builder")
+	fs.StringArrayVar(&flags.BuildArgFile, "build-arg-file", []string{}, "`file.Containerargs` containing lines of argument=value to supply to the builder")
 	fs.StringArrayVar(&flags.BuildContext, "build-context", []string{}, "`argument=value` to supply additional build context to the builder")
 	fs.StringArrayVar(&flags.CacheFrom, "cache-from", []string{}, "remote repository list to utilise as potential cache source.")
 	fs.StringArrayVar(&flags.CacheTo, "cache-to", []string{}, "remote repository list to utilise as potential cache destination.")
@@ -285,6 +287,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["arch"] = commonComp.AutocompleteNone
 	flagCompletion["authfile"] = commonComp.AutocompleteDefault
 	flagCompletion["build-arg"] = commonComp.AutocompleteNone
+	flagCompletion["build-arg-file"] = commonComp.AutocompleteDefault
 	flagCompletion["build-context"] = commonComp.AutocompleteNone
 	flagCompletion["cache-from"] = commonComp.AutocompleteNone
 	flagCompletion["cache-to"] = commonComp.AutocompleteNone

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -250,6 +250,34 @@ symlink(subdir)"
   expect_output --substring "This is built for second"
 }
 
+@test "build with basename resolving user arg from file" {
+  run_buildah build \
+	--build-arg-file $BUDFILES/base-with-arg/first.args \
+	$WITH_POLICY_JSON -t test -f $BUDFILES/base-with-arg/Containerfile2
+  expect_output --substring "This is built for first"
+
+  run_buildah build \
+	--build-arg-file $BUDFILES/base-with-arg/second.args \
+	$WITH_POLICY_JSON -t test -f $BUDFILES/base-with-arg/Containerfile2
+  expect_output --substring "This is built for second"
+}
+
+@test "build with basename resolving user arg from latest file in arg list" {
+  run_buildah build \
+	--build-arg-file $BUDFILES/base-with-arg/second.args \
+	--build-arg-file $BUDFILES/base-with-arg/first.args \
+	$WITH_POLICY_JSON -t test -f $BUDFILES/base-with-arg/Containerfile2
+  expect_output --substring "This is built for first"
+}
+
+@test "build with basename resolving user arg from in arg list" {
+  run_buildah build \
+	--build-arg-file $BUDFILES/base-with-arg/second.args \
+	--build-arg CUSTOM_TARGET=first \
+	$WITH_POLICY_JSON -t test -f $BUDFILES/base-with-arg/Containerfile2
+  expect_output --substring "This is built for first"
+}
+
 # Following test should fail since we are trying to use build-arg which
 # was not declared. Honors discussion here: https://github.com/containers/buildah/pull/4061/commits/1237c04d6ae0ee1f027a1f02bf3ab5c57ac7d9b6#r906188374
 @test "build with basename resolving user arg - should fail" {

--- a/tests/bud/base-with-arg/first.args
+++ b/tests/bud/base-with-arg/first.args
@@ -1,0 +1,1 @@
+CUSTOM_TARGET=first

--- a/tests/bud/base-with-arg/second.args
+++ b/tests/bud/base-with-arg/second.args
@@ -1,0 +1,1 @@
+CUSTOM_TARGET=second


### PR DESCRIPTION
#### What type of PR is this?

> /kind feature

#### What this PR does / why we need it:

Allows codifying build arguments into a structured file, perhaps one named ~file.Containerargs~ `argfile.conf`

The build arg file also accepts comments starting #, so automated tooling or CI/CD workflows can monitor arguments like versions to ensure they are up-to-date.

#### How to verify it

This was the example I was testing with:

```
# Containerfile
ARG ALPINE_VERSION
FROM alpine:${ALPINE_VERSION}
```

```
# argfile.conf
# container-version: alpine
ALPINE_VERSION=3.17
```

`buildah build --build-arg-file argfile.conf -f Containerfile`

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
--build-arg-file your-args.Containerargs allows specifying --build-args from a file instead of inline in the build command
```

