### PR TITLE
Pass process environment variables by reference

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -152,7 +152,6 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 		CNIConfigDir:     iopts.CNIConfigDir,
 		AddCapabilities:  iopts.capAdd,
 		DropCapabilities: iopts.capDrop,
-		Env:              iopts.env,
 		WorkingDir:       iopts.workingDir,
 	}
 
@@ -163,6 +162,8 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 			options.Terminal = buildah.WithoutTerminal
 		}
 	}
+
+	options.Env = buildahcli.LookupEnvVarReferences(iopts.env, os.Environ())
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -512,8 +512,7 @@ func (b *Executor) buildStage(ctx context.Context, cleanupStages map[int]*StageE
 				value := env[1]
 				envLine += fmt.Sprintf(" %q=%q", key, value)
 			} else {
-				value := os.Getenv(key)
-				envLine += fmt.Sprintf(" %q=%q", key, value)
+				return "", nil, fmt.Errorf("BUG: unresolved environment variable: %q", key)
 			}
 		}
 		if len(envLine) > 0 {

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -372,7 +372,6 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		ContextDirectory:        contextDir,
 		Devices:                 iopts.Devices,
 		DropCapabilities:        iopts.CapDrop,
-		Envs:                    iopts.Envs,
 		Err:                     stderr,
 		Excludes:                excludes,
 		ForceRmIntermediateCtrs: iopts.ForceRm,
@@ -422,6 +421,9 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 	if iopts.Quiet {
 		options.ReportWriter = io.Discard
 	}
+
+	options.Envs = LookupEnvVarReferences(iopts.Envs, os.Environ())
+
 	return options, containerfiles, removeAll, nil
 }
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1633,6 +1633,12 @@ _EOF
   iid=$(cat ${TEST_SCRATCH_DIR}/output.iid)
   run_buildah inspect --format '{{.Docker.Config.Env}}' $iid
   expect_output "[]"
+
+  # Reference foo=baz from process environment
+  foo=baz run_buildah build --quiet=false --iidfile ${TEST_SCRATCH_DIR}/output.iid --env foo $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch
+  iid=$(cat ${TEST_SCRATCH_DIR}/output.iid)
+  run_buildah inspect --format '{{.Docker.Config.Env}}' $iid
+  expect_output --substring "foo=baz"
 }
 
 @test "build with custom build output and output rootfs to directory" {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -234,12 +234,19 @@ function configure_and_check_user() {
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	run_buildah config --env foo=foo $cid
+
 	# Ensure foo=foo from `buildah config`
 	run_buildah run $cid -- /bin/sh -c 'echo $foo'
 	expect_output "foo"
+
 	# Ensure foo=bar from --env override
 	run_buildah run --env foo=bar $cid -- /bin/sh -c 'echo $foo'
 	expect_output "bar"
+
+	# Reference foo=baz from process environment
+	foo=baz run_buildah run --env foo $cid -- /bin/sh -c 'echo $foo'
+	expect_output "baz"
+
 	# Ensure that the --env override did not persist
 	run_buildah run $cid -- /bin/sh -c 'echo $foo'
 	expect_output "foo"


### PR DESCRIPTION

#### What type of PR is this?

/kind api-change

#### Which issue(s) this PR fixes:

- See #4688

#### Special notes for your reviewer:

This PR contains only some of the changes discussed in #4688.

#### Does this PR introduce a user-facing change?

The first commit allows `buildah run --env` to lookup environment variables from the process environment using a rudimentary "glob" syntax.

The second commit does the same for `buildah build --env`, but alters the behavior when only a key is passed. Prior to this change, passing `--env A` when no `A` is defined in the environment sets `A=` (blank) in the container. After this change, `A` remains unset in the container.

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md

```release-note

```
-->