### PR TITLE
copier: retain symlink target w/ follow-link

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -1532,7 +1532,17 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 					}
 				}
 
-				if err := copierHandlerGetOne(info, "", name, item, req.GetOptions, tw, hardlinkChecker, idMappings); err != nil {
+				// If following link, pass symlink target for
+				// the link to be generated at the destination
+				var symlinkTarget string
+				if req.GetOptions.NoDerefSymlinks && info.Mode()&os.ModeType == os.ModeSymlink {
+					symlinkTarget, err = os.Readlink(item)
+					if err != nil {
+						return err
+					}
+				}
+
+				if err := copierHandlerGetOne(info, symlinkTarget, name, item, req.GetOptions, tw, hardlinkChecker, idMappings); err != nil {
 					if req.GetOptions.IgnoreUnreadable && errorIsPermission(err) {
 						continue
 					}

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -2438,3 +2438,90 @@ func TestSortedExtendedGlob(t *testing.T) {
 	require.NoError(t, err, "globbing")
 	require.ElementsMatch(t, expect, matched, "sorted globbing")
 }
+
+func TestGetNoDerefSymlink(t *testing.T) {
+	couldChroot := canChroot
+	canChroot = false
+	testGetNoDerefSymlink(t)
+	canChroot = couldChroot
+}
+
+func testGetNoDerefSymlink(t *testing.T) {
+	var testArchives = []struct {
+		name     string
+		rootOnly bool
+		headers  []tar.Header
+		contents map[string][]byte
+	}{
+		{
+			name:     "regular",
+			rootOnly: false,
+			headers: []tar.Header{
+				{Name: "link-b", Typeflag: tar.TypeSymlink, Linkname: "../file-doesnt-exist", Size: 23, Mode: 0777, ModTime: testDate},
+			},
+			contents: map[string][]byte{
+				"archive-a": testArchiveSlice,
+			},
+		},
+	}
+
+	topdir := "."
+	for _, testArchive := range testArchives {
+		if uid != 0 && testArchive.rootOnly {
+			t.Logf("test archive %q can only be tested with root privileges, skipping", testArchive.name)
+			continue
+		}
+
+		dir, err := makeContextFromArchive(t, makeArchive(testArchive.headers, testArchive.contents), topdir)
+		require.NoErrorf(t, err, "error creating context from archive %q", testArchive.name)
+
+		root := dir
+
+		for _, noDerefSymlinks := range []bool{true, false} {
+			for _, testItem := range testArchive.headers {
+				name := filepath.FromSlash(testItem.Name)
+				name = filepath.Join(root, topdir, name)
+				if !t.Failed() && testItem.Typeflag == tar.TypeSymlink {
+					t.Run(fmt.Sprintf("noDerefSymlinks=%t,name=%s", noDerefSymlinks, name), func(t *testing.T) {
+						var getErr error
+						var wg sync.WaitGroup
+						getOptions := GetOptions{}
+						getOptions.NoDerefSymlinks = noDerefSymlinks
+						pipeReader, pipeWriter := io.Pipe()
+						wg.Add(1)
+						go func() {
+							getErr = Get(root, topdir, getOptions, []string{name}, pipeWriter)
+							pipeWriter.Close()
+							wg.Done()
+						}()
+						tr := tar.NewReader(pipeReader)
+						hdr, err := tr.Next()
+						actualContents := []string{}
+						for err == nil {
+							actualContents = append(actualContents, filepath.FromSlash(hdr.Linkname))
+							hdr, err = tr.Next()
+						}
+						wg.Wait()
+						pipeReader.Close()
+						assert.Equal(t, io.EOF.Error(), err.Error(), "expected EOF at end of archive, got %q", err.Error())
+
+						// We stat the target(name) and then assert the err
+						// If we're following links (noDerefSymlinks: false)
+						// we expect an error because copier would create
+						// a link with a target which is non-existent (../file-b).
+						// https://github.com/containers/podman/issues/16585
+						//
+						// But if we're not following links, copier would
+						// create the link by following the target as per
+						// docker's behaviour when not following links.
+						if !noDerefSymlinks {
+							assert.ErrorContains(t, getErr, fmt.Sprintf("copier: get: lstat %q", name))
+						} else {
+							assert.NoErrorf(t, getErr, "unexpected error from Get(%q): %v", name, getErr)
+						}
+					})
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
Adds support for _not_ following link with `podman cp` by default in order to conform to docker's behavior.

#### How to verify it

#### Which issue(s) this PR fixes:
This PR is in conjunction with https://github.com/containers/podman/pull/18020 which closes https://github.com/containers/podman/issues/16585