### PR TITLE
[CI:DOCS] Renovate: Ensure test/tools/go.mod is managed

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,7 +53,11 @@
   // Don't leave dep. update. PRs "hanging", assign them to people.
   "assignees": ["containers/buildah-maintainers"],
 
-  /*************************************************
-   ***** Golang-specific configuration options *****
-   *************************************************/
+  "ignorePaths": [
+    "**/vendor/**",
+    "**/docs/**",
+    "**/examples/**",
+    "**/tests/tools/vendor/**"
+  ],
+
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

The default list of ignore paths means `test/tools/go.mod` is not managed by renovate:

```
  "ignorePaths": [
    "**/node_modules/**",
    "**/bower_components/**",
    "**/vendor/**",
    "**/examples/**",
    "**/__tests__/**",
    "**/test/**",
    "**/tests/**",
    "**/__fixtures__/**"
  ]
```

Override this configuration so that `test/tools/go.mod` is managed.

#### How to verify it

```
podman run -it \
            -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z \
            docker.io/renovate/renovate:latest \
            renovate-config-validator
```

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Ref: https://github.com/containers/podman/issues/18139#issuecomment-1503487244

#### Does this PR introduce a user-facing change?

```release-note
None
```

