### PR TITLE
Add smoke tests for encryption CLI helpers

### DIFF
--- a/pkg/cli/common_test.go
+++ b/pkg/cli/common_test.go
@@ -114,6 +114,21 @@ func TestLookupEnvVarReferences(t *testing.T) {
 	})
 }
 
+func TestDecryptConfig(t *testing.T) {
+	// Just a smoke test for the default path.
+	res, err := DecryptConfig(nil)
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+}
+
+func TestEncryptConfig(t *testing.T) {
+	// Just a smoke test for the default path.
+	cfg, layers, err := EncryptConfig(nil, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, cfg)
+	assert.Nil(t, layers)
+}
+
 func TestGetFormat(t *testing.T) {
 	_, err := GetFormat("bogus")
 	assert.NotNil(t, err)


### PR DESCRIPTION
#### What type of PR is this?

> /kind other

#### What this PR does / why we need it:

A non-`nil` but empty decryption configuration seems to be valid enough to trigger decryption in some configurations, per https://github.com/containers/podman/issues/18196 .

Like in Skopeo and Podman, only decrypt when the user explicitly instructs us to (e.g. not triggering decryption based on environment variables).

#### How to verify it

Manually, I guess.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
An explicit `--decryption-key` option is now mandatory to trigger image decryption, even if the environment implicitly points at usable keys.
```

