### PR TITLE
Fix an overflow on retries on container name conflicts

### DIFF
--- a/new.go
+++ b/new.go
@@ -239,7 +239,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		tmpName = findUnusedContainer(tmpName, containers)
 	}
 
-	conflict := 100
+	suffixDigitsModulo := 100
 	for {
 
 		var flags map[string]interface{}
@@ -265,8 +265,8 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		if !errors.Is(err, storage.ErrDuplicateName) || options.Container != "" {
 			return nil, fmt.Errorf("creating container: %w", err)
 		}
-		tmpName = fmt.Sprintf("%s-%d", name, rand.Int()%conflict)
-		conflict = conflict * 10
+		tmpName = fmt.Sprintf("%s-%d", name, rand.Int()%suffixDigitsModulo)
+		suffixDigitsModulo = suffixDigitsModulo * 10
 	}
 	defer func() {
 		if err != nil {

--- a/new.go
+++ b/new.go
@@ -266,7 +266,9 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 			return nil, fmt.Errorf("creating container: %w", err)
 		}
 		tmpName = fmt.Sprintf("%s-%d", name, rand.Int()%suffixDigitsModulo)
-		suffixDigitsModulo = suffixDigitsModulo * 10
+		if suffixDigitsModulo < 1_000_000_000 {
+			suffixDigitsModulo *= 10
+		}
 	}
 	defer func() {
 		if err != nil {


### PR DESCRIPTION

#### What type of PR is this?

> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

Original report https://github.com/containers/buildah/issues/4679 , probably requires a deterministically-seeded RNG.

Because Go integers silently overflow, and 10 is multiple of 2, repeatedly multiplying by 2 eventually turns suffixDigitsModulo
into all-bits-zero, triggering a division by zero.

So, cap the suffix to a 9-digit one. That is very likely to be sufficient.

(But don't actually limit the number of retries. We could do that as well, for extra robustness. OTOH that would be another bit of code that we don't test...)

#### How to verify it

With a deterministic RNG, and 32-bit integers, about 30 repeated triggers of this code should trigger that overflow. I didn’t try.

#### Which issue(s) this PR fixes:

Fixes #4679 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

