### PR TITLE
 build: `--platform` must accept only arch

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -608,7 +608,7 @@ process.
 
 Set the OS/ARCH of the built image (and its base image, if your build uses one)
 to the provided value instead of using the current operating system and
-architecture of the host (for example `linux/arm`).
+architecture of the host (for example `linux/arm`, `linux/arm64`, `linux/amd64`).
 
 The `--platform` flag can be specified more than once, or given a
 comma-separated list of values as its argument.  When more than one platform is

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -510,8 +510,6 @@ func PlatformsFromOptions(c *cobra.Command) (platforms []struct{ OS, Arch, Varia
 	return platforms, nil
 }
 
-const platformSep = "/"
-
 // DefaultPlatform returns the standard platform for the current system
 func DefaultPlatform() string {
 	return platforms.DefaultString()
@@ -520,21 +518,19 @@ func DefaultPlatform() string {
 // Platform separates the platform string into os, arch and variant,
 // accepting any of $arch, $os/$arch, or $os/$arch/$variant.
 func Platform(platform string) (os, arch, variant string, err error) {
-	split := strings.Split(platform, platformSep)
-	switch len(split) {
-	case 3:
-		variant = split[2]
-		fallthrough
-	case 2:
-		arch = split[1]
-		os = split[0]
-		return
-	case 1:
-		if platform == "local" {
-			return Platform(DefaultPlatform())
-		}
+	if platform == "local" {
+		return Platform(DefaultPlatform())
 	}
-	return "", "", "", fmt.Errorf("invalid platform syntax for %q (use OS/ARCH[/VARIANT][,...])", platform)
+	if platform[len(platform)-1] == '/' || platform[0] == '/' {
+		// If --platform string has format as `some/plat/string/`
+		// or `/some/plat/string` make it `some/plat/string`
+		platform = strings.Trim(platform, "/")
+	}
+	platformSpec, err := platforms.Parse(platform)
+	if err != nil {
+		return "", "", "", fmt.Errorf("invalid platform syntax for --platform=%q: %w", platform, err)
+	}
+	return platformSpec.OS, platformSpec.Architecture, platformSpec.Variant, nil
 }
 
 func parseCreds(creds string) (string, string) {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -246,6 +246,14 @@ symlink(subdir)"
   run_buildah 1 run myctr ls -l subdir/
 }
 
+@test "build with --platform without OS" {
+  run_buildah info --format '{{.host.arch}}'
+  myarch="$output"
+
+  run_buildah build --platform $myarch $WITH_POLICY_JSON -t test -f $BUDFILES/base-with-arg/Containerfile
+  expect_output --substring "This is built for $myarch"
+}
+
 @test "build with basename resolving default arg" {
   run_buildah info --format '{{.host.arch}}'
   myarch="$output"


### PR DESCRIPTION
Make error message for `--platform` more clear.

Closes: https://github.com/containers/podman/issues/18194
Closes: https://github.com/containers/buildah/issues/4756

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
 build: `--platform` must accept only arch
```

