### PR TITLE
parse: filter edge-case for podman-remote

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -518,7 +518,7 @@ func DefaultPlatform() string {
 // Platform separates the platform string into os, arch and variant,
 // accepting any of $arch, $os/$arch, or $os/$arch/$variant.
 func Platform(platform string) (os, arch, variant string, err error) {
-	if platform == "local" {
+	if platform == "local" || platform == "" || platform == "/" {
 		return Platform(DefaultPlatform())
 	}
 	if platform[len(platform)-1] == '/' || platform[0] == '/' {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -252,6 +252,10 @@ symlink(subdir)"
 
   run_buildah build --platform $myarch $WITH_POLICY_JSON -t test -f $BUDFILES/base-with-arg/Containerfile
   expect_output --substring "This is built for $myarch"
+
+  ## podman-remote binding has a bug where is sends `--platform as /`
+  run_buildah build --platform "/" $WITH_POLICY_JSON -t test -f $BUDFILES/base-with-arg/Containerfile
+  expect_output --substring "This is built for $myarch"
 }
 
 @test "build with basename resolving default arg" {


### PR DESCRIPTION
podman-remote has a bug where it sends `/` when no platform is set, patch is there to make sure older clients still work if backend is updated.

Closes: https://github.com/containers/buildah/issues/4763

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
parse: filter edge-case for podman-remote
```

