### PR TITLE
manifest, push: use `source` as `destination` if not specified

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -210,7 +210,7 @@ func init() {
 			return manifestPushCmd(cmd, args, manifestPushOpts)
 		},
 		Example: `buildah manifest push mylist:v1.11 transport:imageName`,
-		Args:    cobra.MinimumNArgs(2),
+		Args:    cobra.MinimumNArgs(1),
 	}
 	manifestPushCommand.SetUsageTemplate(UsageTemplate())
 	flags = manifestPushCommand.Flags()
@@ -830,20 +830,20 @@ func manifestPushCmd(c *cobra.Command, args []string, opts pushOptions) error {
 	case 0:
 		return errors.New("At least a source list ID must be specified")
 	case 1:
-		return errors.New("Two arguments are necessary to push: source and destination")
+		listImageSpec = args[0]
+		destSpec = "docker://"+listImageSpec
 	case 2:
 		listImageSpec = args[0]
 		destSpec = args[1]
-		if listImageSpec == "" {
-			return fmt.Errorf(`invalid image name "%s"`, listImageSpec)
-		}
-		if destSpec == "" {
-			return fmt.Errorf(`invalid image name "%s"`, destSpec)
-		}
 	default:
 		return errors.New("Only two arguments are necessary to push: source and destination")
 	}
-
+	if listImageSpec == "" {
+		return fmt.Errorf(`invalid image name "%s"`, listImageSpec)
+	}
+	if destSpec == "" {
+		return fmt.Errorf(`invalid image name "%s"`, destSpec)
+	}
 	store, err := getStore(c)
 	if err != nil {
 		return err

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -199,6 +199,10 @@ load helpers
   run_buildah login --authfile ${TEST_SCRATCH_DIR}/tmp/test.auth --username testuser --password testpassword --tls-verify=false localhost:${REGISTRY_PORT}
   run_buildah push --authfile ${TEST_SCRATCH_DIR}/tmp/test.auth $WITH_POLICY_JSON --tls-verify=false busybox docker://localhost:${REGISTRY_PORT}/buildah/busybox:latest
   expect_output --substring "Copying"
+
+  run_buildah manifest create localhost:${REGISTRY_PORT}/testmanifest
+  run_buildah manifest push --authfile ${TEST_SCRATCH_DIR}/tmp/test.auth $WITH_POLICY_JSON --tls-verify=false localhost:${REGISTRY_PORT}/testmanifest
+  expect_output --substring "Writing manifest list to image destination"
 }
 
 @test "push with --quiet" {


### PR DESCRIPTION
`manifest push <source>` must work as-is if source is actually a valid path and no destination is provided, buildah must internally choose source as its destination just like `podman push`.

PR is similar to: https://github.com/containers/podman/pull/18395

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
manifest, push: use `source` as `destination` if not specified
```

