### PR TITLE
[release-1.27] Cirrus: Add CI self-destruct condition on EOL date

### DIFF
--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -10,6 +10,17 @@ source $(dirname $0)/lib.sh
 
 req_env_vars OS_RELEASE_ID OS_RELEASE_VER GOSRC IN_PODMAN_IMAGE
 
+_EOL=20230601
+if [[ $(date +%Y%m%d) -ge $_EOL ]]; then
+    die "As of $_EOL this branch is probably
+no longer supported in RHEL 8.7/9.1, please
+confirm this with RHEL Program Management.  If so:
+It should be removed from Cirrus-Cron,
+the .cirrus.yml file removed, and
+the VM images (manually) unmarked
+'permanent=true'"
+fi
+
 msg "Disabling git repository owner-check system-wide."
 # Newer versions of git bark if repo. files are unexpectedly owned.
 # This mainly affects rootless and containerized testing.  But


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

This branch will never receive any security-backports when the associated RHEL release reaches EOL.  Add a condition to force CI to break with a helpful message, after this RHEL EOL date.

#### How to verify it

CI will run/pass now, but not after 06-01-2023

#### Which issue(s) this PR fixes:

Repeatedly checking if a release-branch needs to be supported.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

