### PR TITLE
[CI:DOCS] Cirrus: Fix meta task failing to find commit

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -83,9 +83,9 @@ meta_task:
         GCPJSON: ENCRYPTED[d3614d6f5cc0e66be89d4252b3365fd84f14eee0259d4eb47e25fc0bc2842c7937f5ee8c882b7e547b4c5ec4b6733b14]
         GCPNAME: ENCRYPTED[8509e6a681b859479ce6aa275bd3c4ac82de5beec6df6057925afc4cd85b7ef2e879066ae8baaa2d453b82958e434578]
         GCPPROJECT: ENCRYPTED[cc09b62d0ec6746a3df685e663ad25d9d5af95ef5fd843c96f3d0ec9d7f065dc63216b9c685c9f43a776a1d403991494]
-        CIRRUS_CLONE_DEPTH: 1  # source not used
 
-    script: '/usr/local/bin/entrypoint.sh |& ${_TIMESTAMP}'
+    clone_script: 'true'
+    script: '/usr/local/bin/entrypoint.sh'
 
 
 smoke_task:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

During the nightly cirrus-cron job on main, this error occured:

```
Using built-in Git...
Limiting clone depth to 1!
Cloning refs/heads/main...
Enumerating objects: 9246, done.
...cut...
Compressing objects: 100% (7182/7182), done.
Total 9246 (delta 1519), reused 6078 (delta 1101), pack-reused 0
HEAD is at f35369055df75553071190cfe8607a594ba0e68b.
Hard resetting to 3908816d5310ac1f7bcd4399d23d75c1da0c2678...
Failed to force reset to 3908816d5310ac1f7bcd4399d23d75c1da0c2678:
object not found!
```

However, the repository code isn't needed or used for the meta task. Fix this by running `/bin/true` as the `clone_script`.

#### How to verify it

The meta task clone log won't show any output

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

