### PR TITLE
secret: accept `required` flag without value

### DIFF
--- a/run_common.go
+++ b/run_common.go
@@ -1653,9 +1653,12 @@ func (b *Builder) getSecretMount(tokens []string, secrets map[string]define.Secr
 				target = filepath.Join(workdir, target)
 			}
 		case "required":
-			required, err = strconv.ParseBool(kv[1])
-			if err != nil {
-				return nil, "", errInvalidSyntax
+			required = true
+			if len(kv) > 1 {
+				required, err = strconv.ParseBool(kv[1])
+				if err != nil {
+					return nil, "", errInvalidSyntax
+				}
 			}
 		case "mode":
 			mode64, err := strconv.ParseUint(kv[1], 8, 32)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5361,6 +5361,9 @@ _EOF
   _prefetch alpine
 
   run_buildah build $WITH_POLICY_JSON  -t secretnotreq -f $BUDFILES/run-mounts/Dockerfile.secret-not-required $BUDFILES/run-mounts
+  run_buildah 1 build $WITH_POLICY_JSON  -t secretnotreq -f $BUDFILES/run-mounts/Dockerfile.secret-required-false $BUDFILES/run-mounts
+  expect_output --substring "No such file or directory"
+  assert "$output" !~ "secret required but no secret with id mysecret found"
 }
 
 @test "bud with containerfile secret required" {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5368,6 +5368,10 @@ _EOF
 
   run_buildah 125 build $WITH_POLICY_JSON  -t secretreq -f $BUDFILES/run-mounts/Dockerfile.secret-required $BUDFILES/run-mounts
   expect_output --substring "secret required but no secret with id mysecret found"
+
+  # Also test secret required without value
+  run_buildah 125 build $WITH_POLICY_JSON  -t secretreq -f $BUDFILES/run-mounts/Dockerfile.secret-required-wo-value $BUDFILES/run-mounts
+  expect_output --substring "secret required but no secret with id mysecret found"
 }
 
 @test "bud with containerfile env secret" {

--- a/tests/bud/run-mounts/Dockerfile.secret-required-false
+++ b/tests/bud/run-mounts/Dockerfile.secret-required-false
@@ -1,0 +1,2 @@
+FROM alpine
+RUN --mount=type=secret,id=mysecret,required=false cat /run/secrets/mysecret

--- a/tests/bud/run-mounts/Dockerfile.secret-required-wo-value
+++ b/tests/bud/run-mounts/Dockerfile.secret-required-wo-value
@@ -1,0 +1,2 @@
+FROM alpine
+RUN --mount=type=secret,id=mysecret,required cat /run/secrets/mysecret


### PR DESCRIPTION
`Buildkit` and `docker` accepts `required` flag as `true` when provided without any value in `--mount=type=secret` so lets do same for buildah.

Example usage

```Dockerfile
FROM docker.io/nginx:1.23.3

RUN --mount=type=secret,id=nginx-crt,dst=/nginx-repo.crt,required \
    --mount=type=secret,id=nginx-key,dst=/nginx-repo.key,required \
    set -x \
    && . /etc/os-release \
    && stat /nginx-repo.crt \
    && stat /nginx-repo.key
```

Closes: https://github.com/containers/podman/issues/18438

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
secret: accept `required` flag without value
```

