### PR TITLE
test: use debian instead of docker.io/library/debian:testing-slim

### DIFF
--- a/tests/bud/verify-cleanup/Dockerfile
+++ b/tests/bud/verify-cleanup/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine as builder
 RUN mkdir subdir
 COPY hey .
 
-FROM docker.io/library/debian:testing-slim
+FROM debian
 RUN  --mount=type=bind,source=.,dst=/tmp,z \
      --mount=type=tmpfs,dst=/var/tmp \
     cat /tmp/hey


### PR DESCRIPTION
`debian:testing-slim` is causing issues in `podman CI` so use `debian` which is already present in `quay.io/libpod` See: https://github.com/containers/podman/pull/18579

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
test: use debian instead of docker.io/library/debian:testing-slim
```

