### PR TITLE
CI: fix test broken by renovatebot

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3085,7 +3085,8 @@ _EOF
 }
 
 @test "bud with copy-from in Dockerfile no prior FROM" {
-  _prefetch busybox quay.io/libpod/testimage:20210610
+  want_tag=20221018
+  _prefetch busybox quay.io/libpod/testimage:$want_tag
   target=no-prior-from
   run_buildah build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/copy-from/Dockerfile $BUDFILES/copy-from
 
@@ -3096,7 +3097,7 @@ _EOF
 
   newfile="/home/busyboxpodman/copied-testimage-id"
   test -e $mnt/$newfile
-  expect_output --from="$(< $mnt/$newfile)" "20210610" "Contents of $newfile"
+  expect_output --from="$(< $mnt/$newfile)" "$want_tag" "Contents of $newfile"
 }
 
 @test "bud with copy-from with bad from flag in Dockerfile with --layers" {

--- a/tests/bud/copy-from/Dockerfile
+++ b/tests/bud/copy-from/Dockerfile
@@ -1,2 +1,4 @@
 FROM busybox
+# DO NOT TOUCH THIS UNLESS YOU KNOW WHAT YOU'RE DOING!
+# renovatebot seems to want to clobber the image tag below. DO NOT LET IT DO SO.
 COPY --from=quay.io/libpod/testimage:20221018 /home/podman/testimage-id /home/busyboxpodman/copied-testimage-id


### PR DESCRIPTION
Fixes the damage done by #4737. Renovatebot did something stupid,
and CI broke. Fix, refactor, and add a comment to warn against
this happening again.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```