### PR TITLE
Go back to setting SysProcAttr.Pdeathsig for child processes

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -504,6 +504,7 @@ func setupRootlessNetwork(pid int) (teardown func(), err error) {
 	}
 
 	cmd := exec.Command(slirp4netns, "--mtu", "65520", "-r", "3", "-c", strconv.Itoa(pid), "tap0")
+	setPdeathsig(cmd)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil
 	cmd.ExtraFiles = []*os.File{rootlessSlirpSyncW}
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5983,7 +5983,7 @@ _EOF
   expect_output --substring "1000:1000 /home/http/public"
 }
 
-@test "build interruption" {
+function build_signalled {
   skip_if_no_runtime
 
   _prefetch alpine
@@ -5999,13 +5999,25 @@ _EOF
   echo cat is pid ${cat_pid}
   # kill the buildah process early
   sleep 30
-  kill -s SIGINT "${buildah_pid}"
+  kill -s ${1} "${buildah_pid}"
   # wait for output to stop getting written from anywhere
   wait "${buildah_pid}" "${cat_pid}"
   echo log:
   cat ${TEST_SCRATCH_DIR}/log
   echo checking:
   ! grep 'not fully killed' ${TEST_SCRATCH_DIR}/log
+}
+
+@test "build interrupted" {
+  build_signalled SIGINT
+}
+
+@test "build terminated" {
+  build_signalled SIGTERM
+}
+
+@test "build killed" {
+  build_signalled SIGKILL
 }
 
 @test "build-multiple-parse" {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Restore SysProcAttr.Pdeathsig values for child processes that we start, so that they get a SIGKILL when we exit for whatever reason.  Lock the calling goroutine to a native thread while that's happening, like we should always have done.

#### How to verify it

New integration tests!

#### Which issue(s) this PR fixes:

Should fix https://api.cirrus-ci.com/v1/artifact/task/5262176693256192/html/sys-podman-fedora-38-root-host-boltdb.log.html#t--00120.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```