### PR TITLE
Fix auth.json path (validated on Fedora 38)

### DIFF
--- a/docs/buildah-login.1.md
+++ b/docs/buildah-login.1.md
@@ -24,7 +24,7 @@ is not set, the default is /run/containers/$UID/auth.json.
 
 **--authfile**
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json. If XDG_RUNTIME_DIR is not set, the default is /run/containers/$UID/auth.json. This file is created using `buildah login`.
+Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json. If XDG_RUNTIME_DIR is not set, the default is /run/user/$UID/containers/auth.json. This file is created using `buildah login`.
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`

--- a/docs/buildah-logout.1.md
+++ b/docs/buildah-logout.1.md
@@ -26,7 +26,7 @@ Remove the cached credentials for all registries in the auth file
 
 **--authfile**
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json.  If XDG_RUNTIME_DIR is not set, the default is /run/containers/$UID/auth.json.
+Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json.  If XDG_RUNTIME_DIR is not set, the default is /run/user/$UID/containers/auth.json.
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`


### PR DESCRIPTION
Fix path of auth.json file.

Signed-off-by: Andreas Mack <andreas.mack@gmail.com>

#### What type of PR is this?

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
/kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
I search 15 minutes for the auth.json file. It seems the documentation is wrong.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

