### PR TITLE
executor: apply label to only final stage via `--label`

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1965,6 +1965,17 @@ _EOF
   done
   run_buildah inspect --format '{{ index .Docker.Config.Labels "somefancylabel"}}' imagetwo
   expect_output ""
+
+  # build another multi-stage image with different label, it should use stages from cache from previous build
+  run_buildah build --layers $WITH_POLICY_JSON --label anotherfancylabel=true -t imagethree -f Dockerfile.name $BUDFILES/multi-stage-builds
+  # must use all steps from cache but should not contain label
+  for i in 2 6;do
+      expect_output --substring --from="${lines[$i]}" "Using cache"
+  done
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "somefancylabel"}}' imagetwo
+  expect_output ""
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "anotherfancylabel"}}' imagethree
+  expect_output "true"
 }
 
 @test "bud-multi-stage-builds" {


### PR DESCRIPTION
In https://github.com/containers/buildah/pull/4673 we made a change were we were applying labels to end of each stage, which is different than what we were doing before i.e applying label at the end of the each step.

However buildkit does not adds label to any stage or steps it only adds label at the end of final stage so lets do that.

Closes: https://github.com/containers/buildah/issues/4804

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
executor: apply label to only final stage
```

