### PR TITLE
Add a warning to `build --secret` docs

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -698,6 +698,8 @@ To later use the secret, use the --mount flag in a `RUN` instruction within a `C
 
 `RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret`
 
+Note: Changing the contents of secret files will not trigger a rebuild of layers that use said secrets.
+
 **--security-opt**=[]
 
 Security Options


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Add a warning about potentially confusing behavior of `--secret` flag.
Not sure how to correctly word it and if it is event a good place for said warning, but oh well.

#### How to verify it

#### Which issue(s) this PR fixes:

Fixes #4822

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
