### PR TITLE
[release-1.24] remove registry.centos.org

### DIFF
--- a/install.md
+++ b/install.md
@@ -376,7 +376,7 @@ cat /etc/containers/registries.conf
 # and 'registries.block'.
 
 [registries.search]
-registries = ['docker.io', 'registry.fedoraproject.org', 'quay.io', 'registry.access.redhat.com', 'registry.centos.org']
+registries = ['docker.io', 'registry.fedoraproject.org', 'quay.io', 'registry.access.redhat.com']
 
 # If you need to access insecure registries, add the registry's fully-qualified name.
 # An insecure registry is one that does not have a valid SSL certificate or only does HTTP.

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -17,7 +17,7 @@ Conformance tests use Docker CE to build images to be compared with images built
 
 You can run all of the tests with go test:
 ```
-go test -v -tags "$(./btrfs_tag.sh) $(./btrfs_installed_tag.sh) $(./libdm_tag.sh)" ./tests/conformance
+go test -v -timeout=30m -tags "$(./btrfs_tag.sh) $(./btrfs_installed_tag.sh) $(./libdm_tag.sh)" ./tests/conformance
 ```
 
 If you want to run one of the test cases you can use the "-run" flag:

--- a/tests/conformance/testdata/Dockerfile.reusebase
+++ b/tests/conformance/testdata/Dockerfile.reusebase
@@ -1,4 +1,4 @@
-FROM registry.centos.org/centos/centos:centos7 AS base
+FROM docker.io/library/centos:centos7 AS base
 RUN touch -t 201701261659.13 /1
 ENV LOCAL=/1
 

--- a/tests/conformance/testdata/Dockerfile.shell
+++ b/tests/conformance/testdata/Dockerfile.shell
@@ -1,3 +1,3 @@
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 SHELL ["/bin/bash", "-xc"]
 RUN env

--- a/tests/conformance/testdata/copy/Dockerfile
+++ b/tests/conformance/testdata/copy/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 COPY script /usr/bin
 RUN ls -al /usr/bin/script

--- a/tests/conformance/testdata/copydir/Dockerfile
+++ b/tests/conformance/testdata/copydir/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 COPY dir /dir
 RUN ls -al /dir/file

--- a/tests/conformance/testdata/copyrename/Dockerfile
+++ b/tests/conformance/testdata/copyrename/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 COPY file1 /usr/bin/file2
 RUN ls -al /usr/bin/file2 && ! ls -al /usr/bin/file1

--- a/tests/conformance/testdata/copysymlink/Dockerfile
+++ b/tests/conformance/testdata/copysymlink/Dockerfile
@@ -1,2 +1,2 @@
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 COPY file-link.tar.gz /

--- a/tests/conformance/testdata/copysymlink/Dockerfile2
+++ b/tests/conformance/testdata/copysymlink/Dockerfile2
@@ -1,7 +1,7 @@
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 COPY file.tar.gz /
 RUN ln -s file.tar.gz file-link.tar.gz
 RUN ls -l /file-link.tar.gz
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 COPY --from=0 /file-link.tar.gz /
 RUN ls -l /file-link.tar.gz

--- a/tests/test_buildah_rpm.sh
+++ b/tests/test_buildah_rpm.sh
@@ -12,7 +12,7 @@ load helpers
         skip_if_no_runtime
 
         # Build a container to use for building the binaries.
-        image=registry.centos.org/centos/centos:centos7
+        image=docker.io/library/centos:centos7
         cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image)
         root=$(buildah mount $cid)
         commit=$(git log --format=%H -n 1)


### PR DESCRIPTION
registry.centos.org is now decommissioned

Ref: https://lists.centos.org/pipermail/centos-devel/2023-May/142956.html

Cherry-pick of #4825, which is in turn a cherry-pick of #4819. One minor conflict

Signed-off-by: Aditya R <arajan@redhat.com>
Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
None
```

