### PR TITLE
Explicitly ref. quay images for CI

### DIFF
--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -20,7 +20,7 @@ First, pull base images used by various conformance tests:
 bash
 docker pull alpine
 docker pull busybox
-docker pull docker.io/library/centos:centos7
+docker pull quay.io/libpod/centos:7
 ```
 
 Then you can run all of the tests with go test:

--- a/tests/conformance/testdata/Dockerfile.edgecases
+++ b/tests/conformance/testdata/Dockerfile.edgecases
@@ -1,3 +1,4 @@
+# Note: a registries.conf alias should redirect this to quay.io/libpod/busybox
 FROM busybox
 
 MAINTAINER docker <docker@docker.io>

--- a/tests/conformance/testdata/Dockerfile.reusebase
+++ b/tests/conformance/testdata/Dockerfile.reusebase
@@ -1,4 +1,4 @@
-FROM docker.io/library/centos:centos7 AS base
+FROM quay.io/libpod/centos:7 AS base
 RUN touch -t 201701261659.13 /1
 ENV LOCAL=/1
 

--- a/tests/conformance/testdata/Dockerfile.shell
+++ b/tests/conformance/testdata/Dockerfile.shell
@@ -1,3 +1,3 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 SHELL ["/bin/bash", "-xc"]
 RUN env

--- a/tests/conformance/testdata/copy/Dockerfile
+++ b/tests/conformance/testdata/copy/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY script /usr/bin
 RUN ls -al /usr/bin/script

--- a/tests/conformance/testdata/copydir/Dockerfile
+++ b/tests/conformance/testdata/copydir/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY dir /dir
 RUN ls -al /dir/file

--- a/tests/conformance/testdata/copyrename/Dockerfile
+++ b/tests/conformance/testdata/copyrename/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY file1 /usr/bin/file2
 RUN ls -al /usr/bin/file2 && ! ls -al /usr/bin/file1

--- a/tests/conformance/testdata/copysymlink/Dockerfile
+++ b/tests/conformance/testdata/copysymlink/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY file-link.tar.gz /

--- a/tests/conformance/testdata/copysymlink/Dockerfile2
+++ b/tests/conformance/testdata/copysymlink/Dockerfile2
@@ -1,7 +1,7 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY file.tar.gz /
 RUN ln -s file.tar.gz file-link.tar.gz
 RUN ls -l /file-link.tar.gz
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY --from=0 /file-link.tar.gz /
 RUN ls -l /file-link.tar.gz

--- a/tests/test_buildah_rpm.sh
+++ b/tests/test_buildah_rpm.sh
@@ -12,7 +12,7 @@ load helpers
         skip_if_no_runtime
 
         # Build a container to use for building the binaries.
-        image=docker.io/library/centos:centos7
+        image=quay.io/libpod/centos:7
         cid=$(buildah from --pull --signature-policy ${TEST_SOURCES}/policy.json $image)
         root=$(buildah mount $cid)
         commit=$(git log --format=%H -n 1)


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Commit https://github.com/cevich/buildah/commit/beae5647c075353365a4cc25c81dbd6784186f16 updated the conformance test references to a
deprecated repository.  However, by pointing at the docker-hub it
inadvertantly introduce a significant possibility for flakes.  This is
because anonymous docker hub access is rate-limited by IP.  We cannot
predict the IP used for CI VMs & Containers, any of which could be at or
close to the limit.  Fix this by pointing explicitly at a
`quay.io/libpod/centos` repo. which is excluesively for use by CI, with
static images.

#### How to verify it

Conformance testing in CI will pass

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Ref: https://github.com/containers/buildah/pull/4819

#### Does this PR introduce a user-facing change?

```release-note
None
```

