### PR TITLE
CI: Support testing w/ podman-next COPR packages

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -162,10 +162,11 @@ in_podman() {
     local envfile=$(mktemp -p '' in_podman_env_tmp_XXXXXXXX)
     trap "rm -f $envfile" EXIT
 
+    # TODO: This env. var. processing is fugly and fragile.  Refactor
+    # this closer to how podman CI does it using passthrough_envars()
     msg "Gathering env. vars. to pass-through into container."
     for envname in $(awk 'BEGIN{for(v in ENVIRON) print v}' | sort | \
-                     egrep "$envrx" | egrep -v "$SECRET_ENV_RE" | \
-                     egrep -v "^CIRRUS_.+(MESSAGE|TITLE)")
+                     egrep "$envrx" | egrep -v "$SECRET_ENV_RE");
     do
         envval="${!envname}"
         [[ -n $(tr -d "$xchars" <<<"$envval") ]] || continue


### PR DESCRIPTION
#### What type of PR is this?
/kind other

#### What this PR does / why we need it:

Sometimes important updates need to be made to dependent packages and
run through CI w/o waiting for package release and new CI VM image
builds.  Support this in buildah CI as in podman CI, by updating
packages during setup when the magic string is present and PR is in
draft-mode.

Note: To support containerized testing, both `CIRRUS_CHANGE_TITLE`
and `CIRRUS_PR_DRAFT` env. vars. are passed through.  For these tasks,
this will result in **TWO** updates - One for the host, and another one
in the container.

#### How to verify it

CI will pass with and without magic keyword in title.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

[CI Run when `[CI:NEXT]` was in the PR title.](https://cirrus-ci.com/build/6633729905393664)  I believe the handful of SELinux related test failures are a known issue.

#### Does this PR introduce a user-facing change?

```release-note
None
```

