### PR TITLE
At startup, log the effective capabilities for debugging

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -147,6 +147,7 @@ func before(cmd *cobra.Command) error {
 	case "", "help", "version", "mount":
 		return nil
 	}
+	debugCapabilities()
 	unshare.MaybeReexecUsingUserNamespace(false)
 	if globalFlagResults.CPUProfile != "" {
 		globalFlagResults.cpuProfileFile, err = os.Create(globalFlagResults.CPUProfile)

--- a/cmd/buildah/unshare_unsupported.go
+++ b/cmd/buildah/unshare_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package main
@@ -15,4 +16,7 @@ func init() {
 		},
 	}
 	rootCmd.AddCommand(&unshareCommand)
+}
+
+func debugCapabilities() {
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Log the set of effective capabilities at startup, to make troubleshooting permissions oddities in containers just a little easier.

#### How to verify it

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

This should be useful mainly for people who try to run buildah in a container.

#### Does this PR introduce a user-facing change?

```release-note
When run with debug-level logging enabled, the buildah binary will log the set of effective capabilities at startup.
```