### PR TITLE
docs/Makefile: don't show sed invocations

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,7 +15,7 @@ docs: $(patsubst %.md,%,$(wildcard *.md))
 ### sed is used to filter http/s links as well as relative links
 ### replaces "\" at the end of a line with two spaces
 ### this ensures that manpages are rendered correctly
-	$(SED) -e 's/\((buildah[^)]*\.md\(#.*\)\?)\)//g' \
+	@$(SED) -e 's/\((buildah[^)]*\.md\(#.*\)\?)\)//g' \
 	 -e 's/\[\(buildah[^]]*\)\]/\1/g' \
 	 -e 's/\[\([^]]*\)](http[^)]\+)/\1/g' \
 	 -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g' \


### PR DESCRIPTION
When running `make`, about 99% of the output looks like this:
```
sed -e 's/\((buildah[^)]*\.md\(#.*\)\?)\)//g' \
 -e 's/\[\(buildah[^]]*\)\]/\1/g' \
 -e 's/\[\([^]]*\)](http[^)]\+)/\1/g' \
 -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g' \
 -e 's/\\$/  /g' buildah-unshare.1.md  | \
../tests/tools/build/go-md2man -in /dev/stdin -out  buildah-unshare.1
sed -e 's/\((buildah[^)]*\.md\(#.*\)\?)\)//g' \
 -e 's/\[\(buildah[^]]*\)\]/\1/g' \
 -e 's/\[\([^]]*\)](http[^)]\+)/\1/g' \
 -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g' \
 -e 's/\\$/  /g' buildah-version.1.md  | \
../tests/tools/build/go-md2man -in /dev/stdin -out  buildah-version.1
```
As much as I love sed, this is not what I would want to stare at in CI logs etc.

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

