### PR TITLE
[WIP] Replace all docker hub references with quay

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1247,7 +1247,7 @@ _EOF
   run_buildah inspect --format "{{.Docker.ContainerConfig.ExposedPorts}}" test2
   expect_output "map[8080/tcp:{}]"
   run_buildah inspect --format "{{index .Docker.History 2}}" test1
-  expect_output --substring "FROM docker.io/library/alpine:latest"
+  expect_output --substring "FROM quay.io/libpod/alpine:latest"
 
   run_buildah build $WITH_POLICY_JSON --layers -t test3 -f Dockerfile.2 $contextdir
   run_buildah images -a
@@ -1285,7 +1285,7 @@ _EOF
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' test
   expect_output "$fromDigest" "base digest from alpine"
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.name" }}' test
-  expect_output "docker.io/library/alpine:latest" "base name from alpine"
+  expect_output "quay.io/libpod/alpine:latest" "base name from alpine"
 
   run_buildah build $WITH_POLICY_JSON --layers -t test1 -f Dockerfile.6 $BUDFILES/use-layers
   run_buildah images -a
@@ -1383,7 +1383,7 @@ _EOF
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' ${target}
   expect_output "$fromDigest" "base digest from busybox"
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.name" }}' ${target}
-  expect_output "docker.io/library/busybox:latest" "base name from busybox"
+  expect_output "quay.io/libpod/busybox:latest" "base name from busybox"
 
   run_buildah from $WITH_POLICY_JSON ${target}
   run_buildah rmi -f ${target}
@@ -1394,7 +1394,7 @@ _EOF
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' ${target}
   expect_output "$fromDigest" "base digest from busybox"
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.name" }}' ${target}
-  expect_output "docker.io/library/busybox:latest" "base name from busybox"
+  expect_output "quay.io/libpod/busybox:latest" "base name from busybox"
 
   run_buildah from $WITH_POLICY_JSON ${target}
   run_buildah rmi -f ${target}
@@ -1405,7 +1405,7 @@ _EOF
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' ${target}
   expect_output "$fromDigest" "base digest from busybox"
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.name" }}' ${target}
-  expect_output "docker.io/library/busybox:latest" "base name from busybox"
+  expect_output "quay.io/libpod/busybox:latest" "base name from busybox"
 
   run_buildah from $WITH_POLICY_JSON ${target}
   run_buildah rmi -f ${target}
@@ -1416,7 +1416,7 @@ _EOF
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' ${target}
   expect_output "$fromDigest" "base digest from busybox"
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.name" }}' ${target}
-  expect_output "docker.io/library/busybox:latest" "base name from busybox"
+  expect_output "quay.io/libpod/busybox:latest" "base name from busybox"
 
   run_buildah from $WITH_POLICY_JSON ${target}
   run_buildah rmi -f ${target}
@@ -5210,11 +5210,11 @@ _EOF
 }
 
 @test "bud with --pull-always" {
-  _prefetch docker.io/library/alpine
+  _prefetch quay.io/libpod/alpine
   run_buildah build --pull-always $WITH_POLICY_JSON -t testpull $BUDFILES/containerfile
-  expect_output --from="${lines[1]}" "Trying to pull docker.io/library/alpine:latest..."
+  expect_output --from="${lines[1]}" "Trying to pull quay.io/libpod/alpine:latest..."
   run_buildah build --pull=always $WITH_POLICY_JSON -t testpull $BUDFILES/containerfile
-  expect_output --from="${lines[1]}" "Trying to pull docker.io/library/alpine:latest..."
+  expect_output --from="${lines[1]}" "Trying to pull quay.io/libpod/alpine:latest..."
 }
 
 @test "bud with --memory and --memory-swap" {

--- a/tests/bud/copy-archive/Containerfile
+++ b/tests/bud/copy-archive/Containerfile
@@ -1,2 +1,2 @@
-FROM docker.io/busybox
+FROM quay.io/libpod/busybox
 ADD test.tar.xz /

--- a/tests/bud/copy-from/Dockerfile3
+++ b/tests/bud/copy-from/Dockerfile3
@@ -1,4 +1,4 @@
-FROM docker.io/library/busybox AS build
+FROM quay.io/libpod/busybox AS build
 RUN rm -f /bin/paste
 USER 1001
-COPY --from=docker.io/library/busybox /bin/paste /test/
+COPY --from=quay.io/libpod/busybox /bin/paste /test/

--- a/tests/bud/copy-from/Dockerfile4
+++ b/tests/bud/copy-from/Dockerfile4
@@ -1,4 +1,4 @@
-FROM docker.io/library/busybox AS test
+FROM quay.io/libpod/busybox AS test
 RUN rm -f /bin/nl
-FROM docker.io/library/alpine AS final
-COPY --from=docker.io/library/busybox /bin/nl /test/
+FROM quay.io/libpod/alpine AS final
+COPY --from=quay.io/libpod/busybox /bin/nl /test/

--- a/tests/bud/env/Dockerfile.special-chars
+++ b/tests/bud/env/Dockerfile.special-chars
@@ -1,3 +1,3 @@
-FROM docker.io/ubuntu
+FROM quay.io/libpod/ubuntu
 ENV LIB="$(PREFIX)/lib"
 

--- a/tests/bud/multiarch/Dockerfile.no-run
+++ b/tests/bud/multiarch/Dockerfile.no-run
@@ -1,5 +1,5 @@
 # A base image that is known to be a manifest list.
-FROM docker.io/library/alpine
+FROM quay.io/libpod/alpine
 COPY Dockerfile.no-run /root/
 # A different base image that is known to be a manifest list, supporting a
 # different but partially-overlapping set of platforms.

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -20,7 +20,7 @@ First, pull base images used by various conformance tests:
 bash
 docker pull alpine
 docker pull busybox
-docker pull docker.io/library/centos:centos7
+docker pull quay.io/libpod/centos:7
 ```
 
 Then you can run all of the tests with go test:

--- a/tests/conformance/testdata/Dockerfile.edgecases
+++ b/tests/conformance/testdata/Dockerfile.edgecases
@@ -1,3 +1,4 @@
+# Note: a registries.conf alias should redirect this to quay.io/libpod/busybox
 FROM busybox
 
 MAINTAINER docker <docker@docker.io>

--- a/tests/conformance/testdata/Dockerfile.reusebase
+++ b/tests/conformance/testdata/Dockerfile.reusebase
@@ -1,4 +1,4 @@
-FROM docker.io/library/centos:centos7 AS base
+FROM quay.io/libpod/centos:7 AS base
 RUN touch -t 201701261659.13 /1
 ENV LOCAL=/1
 

--- a/tests/conformance/testdata/Dockerfile.shell
+++ b/tests/conformance/testdata/Dockerfile.shell
@@ -1,3 +1,3 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 SHELL ["/bin/bash", "-xc"]
 RUN env

--- a/tests/conformance/testdata/copy/Dockerfile
+++ b/tests/conformance/testdata/copy/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY script /usr/bin
 RUN ls -al /usr/bin/script

--- a/tests/conformance/testdata/copydir/Dockerfile
+++ b/tests/conformance/testdata/copydir/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY dir /dir
 RUN ls -al /dir/file

--- a/tests/conformance/testdata/copyrename/Dockerfile
+++ b/tests/conformance/testdata/copyrename/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY file1 /usr/bin/file2
 RUN ls -al /usr/bin/file2 && ! ls -al /usr/bin/file1

--- a/tests/conformance/testdata/copysymlink/Dockerfile
+++ b/tests/conformance/testdata/copysymlink/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY file-link.tar.gz /

--- a/tests/conformance/testdata/copysymlink/Dockerfile2
+++ b/tests/conformance/testdata/copysymlink/Dockerfile2
@@ -1,7 +1,7 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY file.tar.gz /
 RUN ln -s file.tar.gz file-link.tar.gz
 RUN ls -l /file-link.tar.gz
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY --from=0 /file-link.tar.gz /
 RUN ls -l /file-link.tar.gz

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -98,21 +98,21 @@ load helpers
   run_buildah rm $output
   run_buildah rmi alpine alpine2
 
-  run_buildah from --quiet --pull=true $WITH_POLICY_JSON docker.io/alpine
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON quay.io/libpod/alpine
   run_buildah rm $output
-  run_buildah rmi docker.io/alpine
+  run_buildah rmi quay.io/libpod/alpine
 
-  run_buildah from --quiet --pull=true $WITH_POLICY_JSON docker.io/alpine:latest
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON quay.io/libpod/alpine:latest
   run_buildah rm $output
-  run_buildah rmi docker.io/alpine:latest
+  run_buildah rmi quay.io/libpod/alpine:latest
 
-  run_buildah from --quiet --pull=true $WITH_POLICY_JSON docker.io/centos:7
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON quay.io/libpod/centos:7
   run_buildah rm $output
-  run_buildah rmi docker.io/centos:7
+  run_buildah rmi quay.io/libpod/centos:7
 
-  run_buildah from --quiet --pull=true $WITH_POLICY_JSON docker.io/centos:latest
+  run_buildah from --quiet --pull=true $WITH_POLICY_JSON quay.io/libpod/centos:latest
   run_buildah rm $output
-  run_buildah rmi docker.io/centos:latest
+  run_buildah rmi quay.io/libpod/centos:latest
 }
 
 @test "from the following transports: docker-archive, oci-archive, and dir" {
@@ -394,11 +394,11 @@ load helpers
 }
 
 @test "from --pull-always: emits 'Getting' even if image is cached" {
-  _prefetch docker.io/busybox
-  run_buildah inspect --format "{{.FromImageDigest}}" docker.io/busybox
+  _prefetch quay.io/libpod/busybox
+  run_buildah inspect --format "{{.FromImageDigest}}" quay.io/libpod/busybox
   fromDigest="$output"
-  run_buildah pull $WITH_POLICY_JSON docker.io/busybox
-  run_buildah from $WITH_POLICY_JSON --name busyboxc --pull-always docker.io/busybox
+  run_buildah pull $WITH_POLICY_JSON quay.io/libpod/busybox
+  run_buildah from $WITH_POLICY_JSON --name busyboxc --pull-always quay.io/libpod/busybox
   expect_output --substring "Getting"
   run_buildah commit $WITH_POLICY_JSON busyboxc fakename-img
   run_buildah 125 from $WITH_POLICY_JSON --pull=always fakename-img
@@ -407,14 +407,14 @@ load helpers
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.digest" }}' fakename-img
   expect_output "$fromDigest" "base digest from busybox"
   run_buildah inspect --format '{{index .ImageAnnotations "org.opencontainers.image.base.name" }}' fakename-img
-  expect_output "docker.io/library/busybox:latest" "base name from busybox"
+  expect_output "quay.io/libpod/busybox:latest" "base name from busybox"
 }
 
 @test "from --quiet: should not emit progress messages" {
   # Force a pull. Normally this would say 'Getting image ...' and other
   # progress messages. With --quiet, we should see only the container name.
   run_buildah '?' rmi busybox
-  run_buildah from $WITH_POLICY_JSON --quiet docker.io/busybox
+  run_buildah from $WITH_POLICY_JSON --quiet quay.io/libpod/busybox
   expect_output "busybox-working-container"
 }
 

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -130,9 +130,7 @@ function teardown_tests() {
 function normalize_image_name() {
     for img in "$@"; do
         if [[ "${img##*/}" == "$img" ]] ; then
-            echo -n docker.io/library/"$img"
-        elif [[ docker.io/"${img##*/}" == "$img" ]] ; then
-            echo -n docker.io/library/"${img##*/}"
+            echo -n quay.io/libpod/"$img"
         else
             echo -n "$img"
         fi

--- a/tests/pull.bats
+++ b/tests/pull.bats
@@ -29,10 +29,10 @@ load helpers
 }
 
 @test "pull-blocked" {
-  run_buildah 125 --registries-conf ${TEST_SOURCES}/registries.conf.block pull $WITH_POLICY_JSON docker.io/alpine
-  expect_output --substring "registry docker.io is blocked in"
+  run_buildah 125 --registries-conf ${TEST_SOURCES}/registries.conf.block pull $WITH_POLICY_JSON quay.io/libpod/alpine
+  expect_output --substring "registry quay.io is blocked in"
 
-  run_buildah --retry --registries-conf ${TEST_SOURCES}/registries.conf       pull $WITH_POLICY_JSON docker.io/alpine
+  run_buildah --retry --registries-conf ${TEST_SOURCES}/registries.conf       pull $WITH_POLICY_JSON quay.io/libpod/alpine
 }
 
 @test "pull-from-registry" {
@@ -61,7 +61,7 @@ load helpers
 
 @test "pull-from-docker-archive" {
   run_buildah --retry pull $WITH_POLICY_JSON alpine
-  run_buildah push $WITH_POLICY_JSON docker.io/library/alpine:latest docker-archive:${TEST_SCRATCH_DIR}/alp.tar:alpine:latest
+  run_buildah push $WITH_POLICY_JSON quay.io/libpod/alpine:latest docker-archive:${TEST_SCRATCH_DIR}/alp.tar:alpine:latest
   run_buildah rmi alpine
   run_buildah --retry pull $WITH_POLICY_JSON docker-archive:${TEST_SCRATCH_DIR}/alp.tar
   run_buildah images --format "{{.Name}}:{{.Tag}}"
@@ -72,7 +72,7 @@ load helpers
 
 @test "pull-from-oci-archive" {
   run_buildah --retry pull $WITH_POLICY_JSON alpine
-  run_buildah push $WITH_POLICY_JSON docker.io/library/alpine:latest oci-archive:${TEST_SCRATCH_DIR}/alp.tar:alpine
+  run_buildah push $WITH_POLICY_JSON quay.io/libpod/alpine:latest oci-archive:${TEST_SCRATCH_DIR}/alp.tar:alpine
   run_buildah rmi alpine
   run_buildah pull $WITH_POLICY_JSON oci-archive:${TEST_SCRATCH_DIR}/alp.tar
   run_buildah images --format "{{.Name}}:{{.Tag}}"
@@ -84,7 +84,7 @@ load helpers
 @test "pull-from-local-directory" {
   mkdir ${TEST_SCRATCH_DIR}/buildahtest
   run_buildah --retry pull $WITH_POLICY_JSON alpine
-  run_buildah push $WITH_POLICY_JSON docker.io/library/alpine:latest dir:${TEST_SCRATCH_DIR}/buildahtest
+  run_buildah push $WITH_POLICY_JSON quay.io/libpod/alpine:latest dir:${TEST_SCRATCH_DIR}/buildahtest
   run_buildah rmi alpine
   run_buildah pull --quiet $WITH_POLICY_JSON dir:${TEST_SCRATCH_DIR}/buildahtest
   imageID="$output"
@@ -101,11 +101,11 @@ load helpers
   run docker pull alpine
   echo "$output"
   assert "$status" -eq 0 "status of docker (yes, docker) pull alpine"
-  run_buildah pull $WITH_POLICY_JSON docker-daemon:docker.io/library/alpine:latest
+  run_buildah pull $WITH_POLICY_JSON docker-daemon:quay.io/libpod/alpine:latest
   run_buildah images --format "{{.Name}}:{{.Tag}}"
   expect_output --substring "alpine:latest"
   run_buildah rmi alpine
-  run_buildah 125 pull --all-tags $WITH_POLICY_JSON docker-daemon:docker.io/library/alpine:latest
+  run_buildah 125 pull --all-tags $WITH_POLICY_JSON docker-daemon:quay.io/libpod/alpine:latest
   expect_output --substring "pulling all tags is not supported for docker-daemon transport"
 }
 
@@ -150,7 +150,7 @@ load helpers
 
 @test "pull-from-oci-directory" {
   run_buildah --retry pull $WITH_POLICY_JSON alpine
-  run_buildah push $WITH_POLICY_JSON docker.io/library/alpine:latest oci:${TEST_SCRATCH_DIR}/alpine
+  run_buildah push $WITH_POLICY_JSON quay.io/libpod/alpine:latest oci:${TEST_SCRATCH_DIR}/alpine
   run_buildah rmi alpine
   run_buildah pull $WITH_POLICY_JSON oci:${TEST_SCRATCH_DIR}/alpine
   run_buildah images --format "{{.Name}}:{{.Tag}}"
@@ -160,21 +160,21 @@ load helpers
 }
 
 @test "pull-denied-by-registry-sources" {
-  export BUILD_REGISTRY_SOURCES='{"blockedRegistries": ["docker.io"]}'
+  export BUILD_REGISTRY_SOURCES='{"blockedRegistries": ["quay.io"]}'
 
   run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TEST_SOURCES}/registries.conf.hub --quiet busybox
-  expect_output --substring 'registry "docker.io" denied by policy: it is in the blocked registries list'
+  expect_output --substring 'registry "quay.io" denied by policy: it is in the blocked registries list'
 
   run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TEST_SOURCES}/registries.conf.hub --quiet busybox
-  expect_output --substring 'registry "docker.io" denied by policy: it is in the blocked registries list'
+  expect_output --substring 'registry "quay.io" denied by policy: it is in the blocked registries list'
 
   export BUILD_REGISTRY_SOURCES='{"allowedRegistries": ["some-other-registry.example.com"]}'
 
   run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TEST_SOURCES}/registries.conf.hub --quiet busybox
-  expect_output --substring 'registry "docker.io" denied by policy: not in allowed registries list'
+  expect_output --substring 'registry "quay.io" denied by policy: not in allowed registries list'
 
   run_buildah 125 pull $WITH_POLICY_JSON --registries-conf ${TEST_SOURCES}/registries.conf.hub --quiet busybox
-  expect_output --substring 'registry "docker.io" denied by policy: not in allowed registries list'
+  expect_output --substring 'registry "quay.io" denied by policy: not in allowed registries list'
 }
 
 @test "pull should fail with nonexistent authfile" {
@@ -298,7 +298,7 @@ load helpers
   # create bogus alpine image
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
-  run_buildah commit -q $cid docker.io/library/alpine
+  run_buildah commit -q $cid quay.io/libpod/alpine
   iid=$output
 
   #  If image does not exist the never will succeed, but iid should not change
@@ -310,7 +310,7 @@ load helpers
   assert "$output" != "$iid" "pulled image should have a new IID"
 
   # Recreate image
-  run_buildah commit -q $cid docker.io/library/alpine
+  run_buildah commit -q $cid quay.io/libpod/alpine
   iid=$output
 
   # Make sure missing image works

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -149,7 +149,7 @@ load helpers
   docker rmi buildah/busybox
 
   start_registry
-  run_buildah push $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword docker.io/busybox:latest docker://localhost:${REGISTRY_PORT}/buildah/busybox:latest
+  run_buildah push $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword quay.io/libpod/busybox:latest docker://localhost:${REGISTRY_PORT}/buildah/busybox:latest
   docker login localhost:${REGISTRY_PORT} --username testuser --password testpassword
   docker pull localhost:${REGISTRY_PORT}/buildah/busybox:latest
   output=$(docker images)

--- a/tests/registries.bats
+++ b/tests/registries.bats
@@ -26,7 +26,6 @@ load helpers
     run_buildah rmi -a
   }
   # Test with pairs of short and fully-qualified names that should be the same image.
-  registrypair busybox           docker.io/busybox
-  registrypair busybox           docker.io/library/busybox
+  registrypair busybox           quay.io/libpod/busybox
   registrypair fedora-minimal:32 registry.fedoraproject.org/fedora-minimal:32
 }

--- a/tests/registries.conf
+++ b/tests/registries.conf
@@ -19,8 +19,8 @@ mirror=[{location="quay.io/libpod"}]
 # 2021-03-23 these are used in buildah system tests, but not (yet?)
 # listed in the global shortnames.conf.
 [aliases]
-busybox="docker.io/library/busybox"
-ubuntu="docker.io/library/ubuntu"
-php="docker.io/library/php"
-alpine="docker.io/library/alpine"
-debian="docker.io/library/debian"
+busybox="quay.io/libpod/busybox"
+ubuntu="quay.io/libpod/ubuntu"
+php="quay.io/libpod/php"
+alpine="quay.io/libpod/alpine"
+debian="quay.io/libpod/debian"

--- a/tests/registries.conf.block
+++ b/tests/registries.conf.block
@@ -5,11 +5,11 @@
 
 # The default location for this configuration file is /etc/containers/registries.conf.
 
-# The only valid categories are: 'registries.search', 'registries.insecure', 
+# The only valid categories are: 'registries.search', 'registries.insecure',
 # and 'registries.block'.
 
 [registries.search]
-registries = ['docker.io', 'registry.fedoraproject.org', 'registry.access.redhat.com']
+registries = ['quay.io', 'registry.fedoraproject.org', 'registry.access.redhat.com']
 
 # If you need to access insecure registries, add the registry's fully-qualified name.
 # An insecure registry is one that does not have a valid SSL certificate or only does HTTP.
@@ -22,4 +22,4 @@ registries = []
 #
 # Docker only
 [registries.block]
-registries = ['docker.io', 'registry.fedoraproject.org', 'registry.access.redhat.com']
+registries = ['quay.io', 'registry.fedoraproject.org', 'registry.access.redhat.com']

--- a/tests/registries.conf.hub
+++ b/tests/registries.conf.hub
@@ -5,7 +5,7 @@
 
 # The default location for this configuration file is /etc/containers/registries.conf.
 
-# The only valid categories are: 'registries.search', 'registries.insecure', 
+# The only valid categories are: 'registries.search', 'registries.insecure',
 # and 'registries.block'.
 
 [registries.search]

--- a/tests/test_buildah_rpm.sh
+++ b/tests/test_buildah_rpm.sh
@@ -12,7 +12,7 @@ load helpers
         skip_if_no_runtime
 
         # Build a container to use for building the binaries.
-        image=docker.io/library/centos:centos7
+        image=quay.io/libpod/centos:7
         cid=$(buildah from --pull --signature-policy ${TEST_SOURCES}/policy.json $image)
         root=$(buildah mount $cid)
         commit=$(git log --format=%H -n 1)


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

***Depends on:*** https://github.com/containers/buildah/pull/4828

Previously tests relied heavily on magic present in
`tests/registries.conf`.  This is less than intuitive and potentially
surprising to test developers.  Search down and replace all test
references to docker.io images with quay.io/libpod images.

#### How to verify it

CI will pass

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

