### PR TITLE
[release-1.24] Explicitly ref. quay images for CI

### DIFF
--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -15,7 +15,16 @@ Conformance tests use Docker CE to build images to be compared with images built
 
 ## Run conformance tests
 
-You can run all of the tests with go test:
+First, pull base images used by various conformance tests:
+```
+bash
+docker pull alpine
+docker pull busybox
+docker pull quay.io/libpod/centos:7
+```
+
+Then you can run all of the tests with go test:
+
 ```
 go test -v -timeout=30m -tags "$(./btrfs_tag.sh) $(./btrfs_installed_tag.sh) $(./libdm_tag.sh)" ./tests/conformance
 ```

--- a/tests/conformance/testdata/Dockerfile.edgecases
+++ b/tests/conformance/testdata/Dockerfile.edgecases
@@ -1,3 +1,4 @@
+# Note: Hopefully a registries.conf alias redirects this to quay.io/libpod/busybox
 FROM busybox
 
 MAINTAINER docker <docker@docker.io>

--- a/tests/conformance/testdata/Dockerfile.reusebase
+++ b/tests/conformance/testdata/Dockerfile.reusebase
@@ -1,4 +1,4 @@
-FROM docker.io/library/centos:centos7 AS base
+FROM quay.io/libpod/centos:7 AS base
 RUN touch -t 201701261659.13 /1
 ENV LOCAL=/1
 

--- a/tests/conformance/testdata/Dockerfile.shell
+++ b/tests/conformance/testdata/Dockerfile.shell
@@ -1,3 +1,3 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 SHELL ["/bin/bash", "-xc"]
 RUN env

--- a/tests/conformance/testdata/copy/Dockerfile
+++ b/tests/conformance/testdata/copy/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY script /usr/bin
 RUN ls -al /usr/bin/script

--- a/tests/conformance/testdata/copydir/Dockerfile
+++ b/tests/conformance/testdata/copydir/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY dir /dir
 RUN ls -al /dir/file

--- a/tests/conformance/testdata/copyrename/Dockerfile
+++ b/tests/conformance/testdata/copyrename/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY file1 /usr/bin/file2
 RUN ls -al /usr/bin/file2 && ! ls -al /usr/bin/file1

--- a/tests/conformance/testdata/copysymlink/Dockerfile
+++ b/tests/conformance/testdata/copysymlink/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY file-link.tar.gz /

--- a/tests/conformance/testdata/copysymlink/Dockerfile2
+++ b/tests/conformance/testdata/copysymlink/Dockerfile2
@@ -1,7 +1,7 @@
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY file.tar.gz /
 RUN ln -s file.tar.gz file-link.tar.gz
 RUN ls -l /file-link.tar.gz
-FROM docker.io/library/centos:centos7
+FROM quay.io/libpod/centos:7
 COPY --from=0 /file-link.tar.gz /
 RUN ls -l /file-link.tar.gz

--- a/tests/test_buildah_rpm.sh
+++ b/tests/test_buildah_rpm.sh
@@ -12,7 +12,7 @@ load helpers
         skip_if_no_runtime
 
         # Build a container to use for building the binaries.
-        image=docker.io/library/centos:centos7
+        image=quay.io/libpod/centos:7
         cid=$(buildah from --pull --signature-policy ${TESTSDIR}/policy.json $image)
         root=$(buildah mount $cid)
         commit=$(git log --format=%H -n 1)


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Commit d5b77bf72ca1 updated the conformance test references from a deprecated repository.  However, by pointing at the docker-hub it inadvertantly introduce a significant possibility for flakes.  This is because anonymous docker hub access is rate-limited by IP.  We cannot predict the IP used for CI VMs & Containers, any of which could be at or close to the limit.  Fix this by pointing conformance tests explicitly at `quay.io/libpod/centos` which is excluesively for use by CI, with static images.

#### How to verify it

CI will pass

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

