### PR TITLE
[CI:DOCS] Renovate: Don't touch fragile test stuffs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,7 +57,7 @@
     "**/vendor/**",
     "**/docs/**",
     "**/examples/**",
-    "**/tests/tools/vendor/**"
+    "**/tests/**"
   ],
 
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

There's a reason we maintain a cache of test-only images in a special registry namespace: So we rarely/never need to muck with sensitive name references in the tests themselves.  Teach renovate to simply ignore updates to all test-related stuffs.

#### How to verify it

Manually, by running `podman run -it
            -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z
            docker.io/renovate/renovate:latest
            renovate-config-validator`

#### Which issue(s) this PR fixes:

Fixes: #4848

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

