### PR TITLE
Update buildah-config.1.md to include Port/Protocol

### DIFF
--- a/docs/buildah-config.1.md
+++ b/docs/buildah-config.1.md
@@ -182,12 +182,15 @@ This option is typically only meaningful when the image's OS is Windows, and is
 typically set in Windows base images, so using this option is usually
 unnecessary.
 
-**--port**, **-p** *port*
+**--port**, **-p** *port/protocol*
 
 Add a *port* to expose when running containers based on any images which
 will be built using the specified container. Can be used multiple times.
-If *port* has a trailing `-`, and is already set, then the *port* is removed from the config.
-If the port is set to "-" then all exposed ports settings are removed from the config.
+To specify whether the port listens on TCP or UDP, use "port/protocol". 
+The default is TCP if the protocol is not specified. To expose on both TCP/UDP, 
+specify the port option multiple times. If *port* has a trailing `-`, and is already set, 
+then the *port* is removed from the config. If the port is set to "-" then all exposed 
+ports settings are removed from the config.
 
 **--shell** *shell*
 
@@ -250,6 +253,8 @@ buildah config --volume /usr/myvol containerID
 buildah config --volume /usr/myvol- containerID
 
 buildah config --port 1234 --port 8080 containerID
+
+buildah config --port 514/tcp --port 514/udp containerID
 
 buildah config --env 1234=5678 containerID
 

--- a/docs/buildah-config.1.md
+++ b/docs/buildah-config.1.md
@@ -186,11 +186,11 @@ unnecessary.
 
 Add a *port* to expose when running containers based on any images which
 will be built using the specified container. Can be used multiple times.
-To specify whether the port listens on TCP or UDP, use "port/protocol". 
-The default is TCP if the protocol is not specified. To expose on both TCP/UDP, 
-specify the port option multiple times. If *port* has a trailing `-`, and is already set, 
-then the *port* is removed from the config. If the port is set to "-" then all exposed 
-ports settings are removed from the config.
+To specify whether the port listens on TCP or UDP, use "port/protocol".
+The default is TCP if the protocol is not specified. To expose the port on both TCP/UDP,
+specify the port option multiple times. If *port* has a trailing `-` and is already set,
+then the *port* is removed from the configiuration. If the port is set to "-" then all exposed
+ports settings are removed from the configuration.
 
 **--shell** *shell*
 


### PR DESCRIPTION
Protocol can be specified with --port option like --port 514/udp. Updating buildah-config documentation to include the protocol option

/kind documentation

With buildah -1.29.1-2 and higher, udp port does get exposed instead of default TCP

[root@atomic-test tmp]# buildah config --port 53/udp $container
[root@atomic-test tmp]# buildah commit --format docker $container port:latest

[root@atomic-test tmp]# podman create -it -P port:latest
56545611f432ad5557e3ef30204e835403a0f51460b108fc2cf32a27fdb06d28
[root@atomic-test tmp]# podman start 56545611f432ad5557e3ef30204e835403a0f51460b108fc2cf32a27fdb06d28
56545611f432ad5557e3ef30204e835403a0f51460b108fc2cf32a27fdb06d28
[root@atomic-test tmp]# podman port -l
53/udp -> 0.0.0.0:5714