### PR TITLE
[CI:DOCS] Update debian/ubuntu build instructions

### DIFF
--- a/install.md
+++ b/install.md
@@ -246,42 +246,24 @@ On openSUSE Tumbleweed, install go via `zypper in go`, then run this command:
 The build steps for Buildah on SUSE / openSUSE are the same as for Fedora, above.
 
 
-### Ubuntu
+### Ubuntu/Debian
 
-In Ubuntu jammy you can use these commands:
+In Ubuntu 22.10 (Karmic) or Debian 12 (Bookworm) you can use these commands:
 
 ```
   sudo apt-get -y -qq update
-  sudo apt-get -y install bats btrfs-progs git libapparmor-dev libglib2.0-dev libgpgme11-dev libseccomp-dev libselinux1-dev skopeo go-md2man make
-  sudo apt-get -y install golang-1.18
+  sudo apt-get -y install bats btrfs-progs git go-md2man golang libapparmor-dev libglib2.0-dev libgpgme11-dev libseccomp-dev libselinux1-dev make skopeo
 ```
-Then to install Buildah on Ubuntu follow the steps in this example:
+
+Then to install Buildah follow the steps in this example:
 
 ```
-  mkdir ~/buildah
-  cd ~/buildah
-  export GOPATH=`pwd`
-  git clone https://github.com/containers/buildah ./src/github.com/containers/buildah
-  cd ./src/github.com/containers/buildah
-  PATH=/usr/lib/go-1.18/bin:$PATH make runc all SECURITYTAGS="apparmor seccomp"
+  git clone https://github.com/containers/buildah
+  cd buildah
+  make runc all SECURITYTAGS="apparmor seccomp"
   sudo make install install.runc
   buildah --help
 ```
-
-### Debian
-
-To install the required dependencies, you can use those commands, tested under Debian GNU/Linux amd64 9.3 (stretch):
-
-```
-gpg --recv-keys 0x018BA5AD9DF57A4448F0E6CF8BECF1637AD8C79D
-sudo gpg --export 0x018BA5AD9DF57A4448F0E6CF8BECF1637AD8C79D >> /usr/share/keyrings/projectatomic-ppa.gpg
-sudo echo 'deb [signed-by=/usr/share/keyrings/projectatomic-ppa.gpg] http://ppa.launchpad.net/projectatomic/ppa/ubuntu zesty main' > /etc/apt/sources.list.d/projectatomic-ppa.list
-sudo apt update
-sudo apt -y install -t stretch-backports golang
-sudo apt -y install bats btrfs-tools git libapparmor-dev libglib2.0-dev libgpgme11-dev libseccomp-dev libselinux1-dev skopeo-containers go-md2man
-```
-
-The build steps on Debian are otherwise the same as Ubuntu, above.
 
 ## Vendoring - Dependency Management
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Modern versions of Debian set the default gpg keyserver to `keys.openpgp.org`, but this keyserver strips userIDs that do not contain a (verified) email address. The PPA signing key mentioned in the user documentation has no verified (or verifiable) userIDs, so `keys.openpgp.org` serves it with no userIDs at all, and the result is not usable by gpg.

To fix, use a keyserver that serves all userIDs.

#### How to verify it

Go to a fresh Debian machine, and incant:

`gpg --recv-keys 0x018BA5AD9DF57A4448F0E6CF8BECF1637AD8C79D`

This will fail with the following error:

`gpg: key 8BECF1637AD8C79D: no user ID`

Now try:

`gpg --keyserver keyserver.ubuntu.com --recv-keys 0x018BA5AD9DF57A4448F0E6CF8BECF1637AD8C79D`

This will succeed.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
