### PR TITLE
add support for pasta(1) and slirp4netns options

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -533,6 +533,15 @@ Valid _mode_ values are:
 - **ns:**_path_: path to a network namespace to join;
 - **private**: create a new namespace for the container (default)
 - **\<network name|ID\>**: Join the network with the given name or ID, e.g. use `--network mynet` to join the network with the name mynet. Only supported for rootful users.
+- **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options, they can also be set with `network_cmd_options` in containers.conf:
+  - **allow_host_loopback=true|false**: Allow slirp4netns to reach the host loopback IP (default is 10.0.2.2 or the second IP from slirp4netns cidr subnet when changed, see the cidr option below). The default is false.
+  - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
+  - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
+  - **enable_ipv6=true|false**: Enable IPv6. Default is true. (Required for `outbound_addr6`).
+  - **outbound_addr=INTERFACE**: Specify the outbound interface slirp binds to (ipv4 traffic only).
+  - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp binds to.
+  - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp binds to (ipv6 traffic only).
+  - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp binds to.
 
 **--no-cache**
 

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -542,6 +542,43 @@ Valid _mode_ values are:
   - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp binds to.
   - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp binds to (ipv6 traffic only).
   - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp binds to.
+- **pasta[:OPTIONS,...]**: use **pasta**(1) to create a user-mode networking
+    stack. \
+    This is only supported in rootless mode. \
+    By default, IPv4 and IPv6 addresses and routes, as well as the pod interface
+    name, are copied from the host. If port forwarding isn't configured, ports
+    are forwarded dynamically as services are bound on either side (init
+    namespace or container namespace). Port forwarding preserves the original
+    source IP address. Options described in pasta(1) can be specified as
+    comma-separated arguments. \
+    In terms of pasta(1) options, **--config-net** is given by default, in
+    order to configure networking when the container is started, and
+    **--no-map-gw** is also assumed by default, to avoid direct access from
+    container to host using the gateway address. The latter can be overridden
+    by passing **--map-gw** in the pasta-specific options (despite not being an
+    actual pasta(1) option). \
+    Also, **-t none** and **-u none** are passed to disable
+    automatic port forwarding based on bound ports. Similarly, **-T none** and
+    **-U none** are given to disable the same functionality from container to
+    host. \
+    Some examples:
+    - **pasta:--map-gw**: Allow the container to directly reach the host using the
+        gateway address.
+    - **pasta:--mtu,1500**: Specify a 1500 bytes MTU for the _tap_ interface in
+        the container.
+    - **pasta:--ipv4-only,-a,10.0.2.0,-n,24,-g,10.0.2.2,--dns-forward,10.0.2.3,-m,1500,--no-ndp,--no-dhcpv6,--no-dhcp**,
+        equivalent to default slirp4netns(1) options: disable IPv6, assign
+        `10.0.2.0/24` to the `tap0` interface in the container, with gateway
+        `10.0.2.3`, enable DNS forwarder reachable at `10.0.2.3`, set MTU to 1500
+        bytes, disable NDP, DHCPv6 and DHCP support.
+    - **pasta:-I,tap0,--ipv4-only,-a,10.0.2.0,-n,24,-g,10.0.2.2,--dns-forward,10.0.2.3,--no-ndp,--no-dhcpv6,--no-dhcp**,
+        equivalent to default slirp4netns(1) options with Podman overrides: same as
+        above, but leave the MTU to 65520 bytes
+    - **pasta:-t,auto,-u,auto,-T,auto,-U,auto**: enable automatic port forwarding
+        based on observed bound ports from both host and container sides
+    - **pasta:-T,5201**: enable forwarding of TCP port 5201 from container to
+        host, using the loopback interface instead of the tap interface for improved
+        performance
 
 **--no-cache**
 

--- a/docs/buildah-from.1.md
+++ b/docs/buildah-from.1.md
@@ -300,6 +300,43 @@ Valid _mode_ values are:
   - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp binds to.
   - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp binds to (ipv6 traffic only).
   - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp binds to.
+- **pasta[:OPTIONS,...]**: use **pasta**(1) to create a user-mode networking
+    stack. \
+    This is only supported in rootless mode. \
+    By default, IPv4 and IPv6 addresses and routes, as well as the pod interface
+    name, are copied from the host. If port forwarding isn't configured, ports
+    are forwarded dynamically as services are bound on either side (init
+    namespace or container namespace). Port forwarding preserves the original
+    source IP address. Options described in pasta(1) can be specified as
+    comma-separated arguments. \
+    In terms of pasta(1) options, **--config-net** is given by default, in
+    order to configure networking when the container is started, and
+    **--no-map-gw** is also assumed by default, to avoid direct access from
+    container to host using the gateway address. The latter can be overridden
+    by passing **--map-gw** in the pasta-specific options (despite not being an
+    actual pasta(1) option). \
+    Also, **-t none** and **-u none** are passed to disable
+    automatic port forwarding based on bound ports. Similarly, **-T none** and
+    **-U none** are given to disable the same functionality from container to
+    host. \
+    Some examples:
+    - **pasta:--map-gw**: Allow the container to directly reach the host using the
+        gateway address.
+    - **pasta:--mtu,1500**: Specify a 1500 bytes MTU for the _tap_ interface in
+        the container.
+    - **pasta:--ipv4-only,-a,10.0.2.0,-n,24,-g,10.0.2.2,--dns-forward,10.0.2.3,-m,1500,--no-ndp,--no-dhcpv6,--no-dhcp**,
+        equivalent to default slirp4netns(1) options: disable IPv6, assign
+        `10.0.2.0/24` to the `tap0` interface in the container, with gateway
+        `10.0.2.3`, enable DNS forwarder reachable at `10.0.2.3`, set MTU to 1500
+        bytes, disable NDP, DHCPv6 and DHCP support.
+    - **pasta:-I,tap0,--ipv4-only,-a,10.0.2.0,-n,24,-g,10.0.2.2,--dns-forward,10.0.2.3,--no-ndp,--no-dhcpv6,--no-dhcp**,
+        equivalent to default slirp4netns(1) options with Podman overrides: same as
+        above, but leave the MTU to 65520 bytes
+    - **pasta:-t,auto,-u,auto,-T,auto,-U,auto**: enable automatic port forwarding
+        based on observed bound ports from both host and container sides
+    - **pasta:-T,5201**: enable forwarding of TCP port 5201 from container to
+        host, using the loopback interface instead of the tap interface for improved
+        performance
 
 **--os**="OS"
 

--- a/docs/buildah-from.1.md
+++ b/docs/buildah-from.1.md
@@ -279,15 +279,27 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
 A *name* for the working container
 
-**--network** *how*, **--net** *how*
+**--network**=*mode*, **--net**=*mode*
 
 Sets the configuration for network namespaces when the container is subsequently
 used for `buildah run`.
-The configured value can be "" (the empty string) or "container" to indicate
-that a new network namespace should be created, or it can be "host" to indicate
-that the network namespace in which `Buildah` itself is being run should be
-reused, or it can be the path to a network namespace which is already in use by
-another process.
+
+Valid _mode_ values are:
+
+- **none**: no networking. Invalid if using **--dns**, **--dns-opt**, or **--dns-search**;
+- **host**: use the host network stack. Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure;
+- **ns:**_path_: path to a network namespace to join;
+- **private**: create a new namespace for the container (default)
+- **\<network name|ID\>**: Join the network with the given name or ID, e.g. use `--network mynet` to join the network with the name mynet. Only supported for rootful users.
+- **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options, they can also be set with `network_cmd_options` in containers.conf:
+  - **allow_host_loopback=true|false**: Allow slirp4netns to reach the host loopback IP (default is 10.0.2.2 or the second IP from slirp4netns cidr subnet when changed, see the cidr option below). The default is false.
+  - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
+  - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
+  - **enable_ipv6=true|false**: Enable IPv6. Default is true. (Required for `outbound_addr6`).
+  - **outbound_addr=INTERFACE**: Specify the outbound interface slirp binds to (ipv4 traffic only).
+  - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp binds to.
+  - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp binds to (ipv6 traffic only).
+  - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp binds to.
 
 **--os**="OS"
 

--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -163,10 +163,22 @@ Current supported mount TYPES are bind, cache, secret and tmpfs. <sup>[[1]](#Foo
 
 Sets the configuration for the network namespace for the container.
 
-- **none**: no networking;
+Valid _mode_ values are:
+
+- **none**: no networking. Invalid if using **--dns**, **--dns-opt**, or **--dns-search**;
 - **host**: use the host network stack. Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure;
 - **ns:**_path_: path to a network namespace to join;
-- `private`: create a new namespace for the container (default)
+- **private**: create a new namespace for the container (default)
+- **\<network name|ID\>**: Join the network with the given name or ID, e.g. use `--network mynet` to join the network with the name mynet. Only supported for rootful users.
+- **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options, they can also be set with `network_cmd_options` in containers.conf:
+  - **allow_host_loopback=true|false**: Allow slirp4netns to reach the host loopback IP (default is 10.0.2.2 or the second IP from slirp4netns cidr subnet when changed, see the cidr option below). The default is false.
+  - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
+  - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
+  - **enable_ipv6=true|false**: Enable IPv6. Default is true. (Required for `outbound_addr6`).
+  - **outbound_addr=INTERFACE**: Specify the outbound interface slirp binds to (ipv4 traffic only).
+  - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp binds to.
+  - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp binds to (ipv6 traffic only).
+  - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp binds to.
 
 **--no-hosts**
 

--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -179,6 +179,43 @@ Valid _mode_ values are:
   - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp binds to.
   - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp binds to (ipv6 traffic only).
   - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp binds to.
+- **pasta[:OPTIONS,...]**: use **pasta**(1) to create a user-mode networking
+    stack. \
+    This is only supported in rootless mode. \
+    By default, IPv4 and IPv6 addresses and routes, as well as the pod interface
+    name, are copied from the host. If port forwarding isn't configured, ports
+    are forwarded dynamically as services are bound on either side (init
+    namespace or container namespace). Port forwarding preserves the original
+    source IP address. Options described in pasta(1) can be specified as
+    comma-separated arguments. \
+    In terms of pasta(1) options, **--config-net** is given by default, in
+    order to configure networking when the container is started, and
+    **--no-map-gw** is also assumed by default, to avoid direct access from
+    container to host using the gateway address. The latter can be overridden
+    by passing **--map-gw** in the pasta-specific options (despite not being an
+    actual pasta(1) option). \
+    Also, **-t none** and **-u none** are passed to disable
+    automatic port forwarding based on bound ports. Similarly, **-T none** and
+    **-U none** are given to disable the same functionality from container to
+    host. \
+    Some examples:
+    - **pasta:--map-gw**: Allow the container to directly reach the host using the
+        gateway address.
+    - **pasta:--mtu,1500**: Specify a 1500 bytes MTU for the _tap_ interface in
+        the container.
+    - **pasta:--ipv4-only,-a,10.0.2.0,-n,24,-g,10.0.2.2,--dns-forward,10.0.2.3,-m,1500,--no-ndp,--no-dhcpv6,--no-dhcp**,
+        equivalent to default slirp4netns(1) options: disable IPv6, assign
+        `10.0.2.0/24` to the `tap0` interface in the container, with gateway
+        `10.0.2.3`, enable DNS forwarder reachable at `10.0.2.3`, set MTU to 1500
+        bytes, disable NDP, DHCPv6 and DHCP support.
+    - **pasta:-I,tap0,--ipv4-only,-a,10.0.2.0,-n,24,-g,10.0.2.2,--dns-forward,10.0.2.3,--no-ndp,--no-dhcpv6,--no-dhcp**,
+        equivalent to default slirp4netns(1) options with Podman overrides: same as
+        above, but leave the MTU to 65520 bytes
+    - **pasta:-t,auto,-u,auto,-T,auto,-U,auto**: enable automatic port forwarding
+        based on observed bound ports from both host and container sides
+    - **pasta:-T,5201**: enable forwarding of TCP port 5201 from container to
+        host, using the loopback interface instead of the tap interface for improved
+        performance
 
 **--no-hosts**
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/containerd/containerd v1.7.2
 	github.com/containernetworking/cni v1.1.2
-	github.com/containers/common v0.53.1-0.20230620132900-ac2475afa81d
+	github.com/containers/common v0.53.1-0.20230622141517-6eebb3712106
 	github.com/containers/image/v5 v5.25.1-0.20230613183705-07ced6137083
 	github.com/containers/ocicrypt v1.1.7
 	github.com/containers/storage v1.46.2-0.20230613134951-e424b6649be3

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/containerd/containerd v1.7.2
 	github.com/containernetworking/cni v1.1.2
+	github.com/containernetworking/plugins v1.3.0
 	github.com/containers/common v0.53.1-0.20230622141517-6eebb3712106
 	github.com/containers/image/v5 v5.25.1-0.20230613183705-07ced6137083
 	github.com/containers/ocicrypt v1.1.7
@@ -51,7 +52,6 @@ require (
 	github.com/container-orchestrated-devices/container-device-interface v0.5.4 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
-	github.com/containernetworking/plugins v1.3.0 // indirect
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20230514072755-504adb8a8af1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl3
 github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q6mVDp5H1HnjM=
 github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
-github.com/containers/common v0.53.1-0.20230620132900-ac2475afa81d h1:Z+xdHWSwjW/VGdYGufKfqji+G7FQ1IdkFai0MOpqzd4=
-github.com/containers/common v0.53.1-0.20230620132900-ac2475afa81d/go.mod h1:qE1MzGl69IoK7ZNCCH51+aLVjyQtnH0LiZe0wG32Jy0=
+github.com/containers/common v0.53.1-0.20230622141517-6eebb3712106 h1:RQ+fcBCDgKHbIm8uhxeQEsoLhGLrM3WB5HXCDTe03tM=
+github.com/containers/common v0.53.1-0.20230622141517-6eebb3712106/go.mod h1:qE1MzGl69IoK7ZNCCH51+aLVjyQtnH0LiZe0wG32Jy0=
 github.com/containers/image/v5 v5.25.1-0.20230613183705-07ced6137083 h1:6Pbnll97ls6G0U3DSxaTqp7Sd8Fykc4gd7BUJm7Bpn8=
 github.com/containers/image/v5 v5.25.1-0.20230613183705-07ced6137083/go.mod h1:yRLIs3vw20kCSt3ZvRyX3cp4EIYjNUW6RX9uq2cZ8J8=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/run_common.go
+++ b/run_common.go
@@ -1131,7 +1131,7 @@ func runUsingRuntimeMain() {
 	os.Exit(1)
 }
 
-func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options RunOptions, configureNetwork bool, configureNetworks,
+func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options RunOptions, configureNetwork bool, networkString string,
 	moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName, buildContainerName, hostsFile string) (err error) {
 	// Lock the caller to a single OS-level thread.
 	runtime.LockOSThread()
@@ -1237,7 +1237,7 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 				return fmt.Errorf("parsing pid %s as a number: %w", string(pidValue), err)
 			}
 
-			teardown, netstatus, err := b.runConfigureNetwork(pid, isolation, options, configureNetworks, containerName)
+			teardown, netstatus, err := b.runConfigureNetwork(pid, isolation, options, networkString, containerName)
 			if teardown != nil {
 				defer teardown()
 			}
@@ -1247,13 +1247,7 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 
 			// only add hosts if we manage the hosts file
 			if hostsFile != "" {
-				var entries etchosts.HostEntries
-				if netstatus != nil {
-					entries = etchosts.GetNetworkHostEntries(netstatus, spec.Hostname, buildContainerName)
-				} else {
-					// we have slirp4netns, default to slirp4netns ip since this is not configurable in buildah
-					entries = etchosts.HostEntries{{IP: "10.0.2.100", Names: []string{spec.Hostname, buildContainerName}}}
-				}
+				entries := etchosts.GetNetworkHostEntries(netstatus, spec.Hostname, buildContainerName)
 				// make sure to sync this with (b *Builder) generateHosts()
 				err = etchosts.Add(hostsFile, entries)
 				if err != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6008,6 +6008,30 @@ _EOF
   assert "$output" =~ "mtu 2000" "ip addr shows mtu 2000"
 }
 
+@test "bud with --network pasta" {
+  skip_if_no_runtime
+  skip_if_chroot
+  skip_if_root_environment "pasta only works rootless"
+
+  # FIXME: unskip when we have a new pasta version with:
+  # https://archives.passt.top/passt-dev/20230623082531.25947-2-pholzing@redhat.com/
+  skip "pasta bug prevents this from working"
+
+  _prefetch alpine
+
+  # pasta by default copies the host ip
+  ip=$(hostname -I | cut -f 1 -d " ")
+
+  run_buildah bud $WITH_POLICY_JSON --network pasta $BUDFILES/network
+  assert "$output" =~ "$ip" "ip addr shows default subnet"
+
+  # check some entwork options, it accepts raw pasta(1) areguments
+  mac="9a:dd:31:ea:92:98"
+  run_buildah bud $WITH_POLICY_JSON --network pasta:--mtu,2000,--ns-mac-addr,"$mac" $BUDFILES/network
+  assert "$output" =~ "$mac" "ip addr shows custom mac address"
+  assert "$output" =~ "mtu 2000" "ip addr shows mtu 2000"
+}
+
 @test "bud WORKDIR owned by USER" {
   _prefetch alpine
   target=alpine-image

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5992,6 +5992,22 @@ _EOF
   fi
 }
 
+@test "bud with --network slirp4netns" {
+  skip_if_no_runtime
+  skip_if_in_container
+  skip_if_chroot
+
+  _prefetch alpine
+
+  run_buildah bud $WITH_POLICY_JSON --network slirp4netns $BUDFILES/network
+  # default subnet is 10.0.2.100/24
+  assert "$output" =~ "10.0.2.100/24" "ip addr shows default subnet"
+
+  run_buildah bud $WITH_POLICY_JSON --network slirp4netns:cidr=192.168.255.0/24,mtu=2000 $BUDFILES/network
+  assert "$output" =~ "192.168.255.100/24" "ip addr shows custom subnet"
+  assert "$output" =~ "mtu 2000" "ip addr shows mtu 2000"
+}
+
 @test "bud WORKDIR owned by USER" {
   _prefetch alpine
   target=alpine-image

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -673,6 +673,10 @@ function configure_and_check_user() {
 	expect_output --substring "(10.88.*|10.0.2.100)[[:blank:]]$cid"
 	assert "$output" !~ "(10.88.*|10.0.2.100)[[:blank:]]host1 $cid" "Container IP should not contain host1"
 
+	# check slirp4netns sets correct hostname with another cidr
+	run_buildah run --network slirp4netns:cidr=192.168.2.0/24 --hostname $hostname $cid cat /etc/hosts
+	expect_output --substring "192.168.2.100[[:blank:]]$hostname $cid"
+
 	run_buildah run --network=container $cid cat /etc/hosts
 	m=$(buildah mount $cid)
 	run cat $m/etc/hosts

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -711,6 +711,24 @@ function configure_and_check_user() {
 	run_buildah rm -a
 }
 
+@test "run check /etc/hosts with --network pasta" {
+	skip_if_no_runtime
+	skip_if_chroot
+	skip_if_root_environment "pasta only works rootless"
+
+	# FIXME: unskip when we have a new pasta version with:
+	# https://archives.passt.top/passt-dev/20230623082531.25947-2-pholzing@redhat.com/
+	skip "pasta bug prevents this from working"
+
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON debian
+	cid=$output
+
+	local hostname=h-$(random_string)
+	ip=$(hostname -I | cut -f 1 -d " ")
+	run_buildah run --network pasta --hostname $hostname $cid cat /etc/hosts
+	assert "$output" =~ "$ip[[:blank:]]$hostname $cid"
+}
+
 @test "run check /etc/resolv.conf" {
         skip_if_rootless_environment
 	skip_if_no_runtime

--- a/vendor/github.com/containers/common/libnetwork/pasta/pasta.go
+++ b/vendor/github.com/containers/common/libnetwork/pasta/pasta.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// pasta.go - Start pasta(1) for user-mode connectivity
+//
+// Copyright (c) 2022 Red Hat GmbH
+// Author: Stefano Brivio <sbrivio@redhat.com>
+
+// This file has been imported from the podman repository
+// (libpod/networking_pasta_linux.go), for the full history see there.
+
+package pasta
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/containers/common/libnetwork/types"
+	"github.com/containers/common/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	BinaryName = "pasta"
+)
+
+type SetupOptions struct {
+	// Config used to get pasta options and binary path via HelperBinariesDir
+	Config *config.Config
+	// Netns is the path to the container Netns
+	Netns string
+	// Ports that should be forwarded in the container
+	Ports []types.PortMapping
+	// ExtraOptions are pasta(1) cli options, these will be appended after the
+	// pasta options from containers.conf to allow some form of overwrite.
+	ExtraOptions []string
+}
+
+// Setup start the pasta process for the given netns.
+// The pasta binary is looked up in the HelperBinariesDir and $PATH.
+// Note that there is no need any special cleanup logic, the pasta process will
+// automatically exit when the netns path is deleted.
+func Setup(opts *SetupOptions) error {
+	NoTCPInitPorts := true
+	NoUDPInitPorts := true
+	NoTCPNamespacePorts := true
+	NoUDPNamespacePorts := true
+	NoMapGW := true
+
+	path, err := opts.Config.FindHelperBinary(BinaryName, true)
+	if err != nil {
+		return fmt.Errorf("could not find pasta, the network namespace can't be configured: %w", err)
+	}
+
+	cmdArgs := []string{}
+	cmdArgs = append(cmdArgs, "--config-net")
+
+	for _, i := range opts.Ports {
+		protocols := strings.Split(i.Protocol, ",")
+		for _, protocol := range protocols {
+			var addr string
+
+			if i.HostIP != "" {
+				addr = fmt.Sprintf("%s/", i.HostIP)
+			}
+
+			switch protocol {
+			case "tcp":
+				cmdArgs = append(cmdArgs, "-t")
+			case "udp":
+				cmdArgs = append(cmdArgs, "-u")
+			default:
+				return fmt.Errorf("can't forward protocol: %s", protocol)
+			}
+
+			arg := fmt.Sprintf("%s%d-%d:%d-%d", addr,
+				i.HostPort,
+				i.HostPort+i.Range-1,
+				i.ContainerPort,
+				i.ContainerPort+i.Range-1)
+			cmdArgs = append(cmdArgs, arg)
+		}
+	}
+
+	// first append options set in the config
+	cmdArgs = append(cmdArgs, opts.Config.Network.PastaOptions...)
+	// then append the ones that were set on the cli
+	cmdArgs = append(cmdArgs, opts.ExtraOptions...)
+
+	for i, opt := range cmdArgs {
+		switch opt {
+		case "-t", "--tcp-ports":
+			NoTCPInitPorts = false
+		case "-u", "--udp-ports":
+			NoUDPInitPorts = false
+		case "-T", "--tcp-ns":
+			NoTCPNamespacePorts = false
+		case "-U", "--udp-ns":
+			NoUDPNamespacePorts = false
+		case "--map-gw":
+			NoMapGW = false
+			// not an actual pasta(1) option
+			cmdArgs = append(cmdArgs[:i], cmdArgs[i+1:]...)
+		}
+	}
+
+	if NoTCPInitPorts {
+		cmdArgs = append(cmdArgs, "-t", "none")
+	}
+	if NoUDPInitPorts {
+		cmdArgs = append(cmdArgs, "-u", "none")
+	}
+	if NoTCPNamespacePorts {
+		cmdArgs = append(cmdArgs, "-T", "none")
+	}
+	if NoUDPNamespacePorts {
+		cmdArgs = append(cmdArgs, "-U", "none")
+	}
+	if NoMapGW {
+		cmdArgs = append(cmdArgs, "--no-map-gw")
+	}
+
+	cmdArgs = append(cmdArgs, "--netns", opts.Netns)
+
+	logrus.Debugf("pasta arguments: %s", strings.Join(cmdArgs, " "))
+
+	// pasta forks once ready, and quits once we delete the target namespace
+	_, err = exec.Command(path, cmdArgs...).Output()
+	if err != nil {
+		exitErr := &exec.ExitError{}
+		if errors.As(err, &exitErr) {
+			return fmt.Errorf("pasta failed with exit code %d:\n%s",
+				exitErr.ExitCode(), exitErr.Stderr)
+		}
+		return fmt.Errorf("failed to start pasta: %w", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/containers/common/libnetwork/slirp4netns/const.go
+++ b/vendor/github.com/containers/common/libnetwork/slirp4netns/const.go
@@ -1,0 +1,12 @@
+package slirp4netns
+
+const (
+	ipv6ConfDefaultAcceptDadSysctl = "/proc/sys/net/ipv6/conf/default/accept_dad"
+	BinaryName                     = "slirp4netns"
+
+	// defaultMTU the default MTU override
+	defaultMTU = 65520
+
+	// default slirp4ns subnet
+	defaultSubnet = "10.0.2.0/24"
+)

--- a/vendor/github.com/containers/common/libnetwork/slirp4netns/slirp4netns.go
+++ b/vendor/github.com/containers/common/libnetwork/slirp4netns/slirp4netns.go
@@ -1,0 +1,752 @@
+//go:build linux
+// +build linux
+
+package slirp4netns
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containers/common/libnetwork/types"
+	"github.com/containers/common/pkg/config"
+	"github.com/containers/common/pkg/rootlessport"
+	"github.com/containers/common/pkg/servicereaper"
+	"github.com/containers/common/pkg/util"
+	"github.com/sirupsen/logrus"
+)
+
+type slirpFeatures struct {
+	HasDisableHostLoopback bool
+	HasMTU                 bool
+	HasEnableSandbox       bool
+	HasEnableSeccomp       bool
+	HasCIDR                bool
+	HasOutboundAddr        bool
+	HasIPv6                bool
+}
+
+type slirp4netnsCmdArg struct {
+	Proto     string `json:"proto,omitempty"`
+	HostAddr  string `json:"host_addr"`
+	HostPort  uint16 `json:"host_port"`
+	GuestAddr string `json:"guest_addr"`
+	GuestPort uint16 `json:"guest_port"`
+}
+
+type slirp4netnsCmd struct {
+	Execute string            `json:"execute"`
+	Args    slirp4netnsCmdArg `json:"arguments"`
+}
+
+type networkOptions struct {
+	cidr                string
+	disableHostLoopback bool
+	enableIPv6          bool
+	isSlirpHostForward  bool
+	noPivotRoot         bool
+	mtu                 int
+	outboundAddr        string
+	outboundAddr6       string
+}
+
+type SetupOptions struct {
+	// Config used to get slip4netns path and other default options
+	Config *config.Config
+	// ContainerID is the ID of the container
+	ContainerID string
+	// Netns path to the netns
+	Netns string
+	// Ports the should be forwarded
+	Ports []types.PortMapping
+	// ExtraOptions for slirp4netns that were set on the cli
+	ExtraOptions []string
+	// Slirp4netnsExitPipeR pipe used to exit the slirp4netns process.
+	// This is must be the reading end, the writer must be kept open until you want the
+	// process to exit. For podman, conmon will hold the pipe open.
+	// It can be set to nil in which case we do not use the pipe exit and the caller
+	// must use the returned pid to kill the process after it is done.
+	Slirp4netnsExitPipeR *os.File
+	// RootlessPortSyncPipe pipe used to exit the rootlessport process.
+	// Same as Slirp4netnsExitPipeR, except this is only used when ports are given.
+	RootlessPortExitPipeR *os.File
+	// Pdeathsig is the signal which is send to slirp4netns process if the calling thread
+	// exits. The caller is responsible for locking the thread with runtime.LockOSThread().
+	Pdeathsig syscall.Signal
+}
+
+// SetupResult return type from Setup()
+type SetupResult struct {
+	// Pid of the created slirp4netns process
+	Pid int
+	// Subnet which is used by slirp4netns
+	Subnet *net.IPNet
+	// IPv6 whenever Ipv6 is enabled in slirp4netns
+	IPv6 bool
+}
+
+type logrusDebugWriter struct {
+	prefix string
+}
+
+func (w *logrusDebugWriter) Write(p []byte) (int, error) {
+	logrus.Debugf("%s%s", w.prefix, string(p))
+	return len(p), nil
+}
+
+func checkSlirpFlags(path string) (*slirpFeatures, error) {
+	cmd := exec.Command(path, "--help")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("slirp4netns %q: %w", out, err)
+	}
+	return &slirpFeatures{
+		HasDisableHostLoopback: strings.Contains(string(out), "--disable-host-loopback"),
+		HasMTU:                 strings.Contains(string(out), "--mtu"),
+		HasEnableSandbox:       strings.Contains(string(out), "--enable-sandbox"),
+		HasEnableSeccomp:       strings.Contains(string(out), "--enable-seccomp"),
+		HasCIDR:                strings.Contains(string(out), "--cidr"),
+		HasOutboundAddr:        strings.Contains(string(out), "--outbound-addr"),
+		HasIPv6:                strings.Contains(string(out), "--enable-ipv6"),
+	}, nil
+}
+
+func parseNetworkOptions(config *config.Config, extraOptions []string) (*networkOptions, error) {
+	options := make([]string, 0, len(config.Engine.NetworkCmdOptions)+len(extraOptions))
+	options = append(options, config.Engine.NetworkCmdOptions...)
+	options = append(options, extraOptions...)
+	opts := &networkOptions{
+		// overwrite defaults
+		disableHostLoopback: true,
+		mtu:                 defaultMTU,
+		noPivotRoot:         config.Engine.NoPivotRoot,
+		enableIPv6:          true,
+	}
+	for _, o := range options {
+		parts := strings.SplitN(o, "=", 2)
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("unknown option for slirp4netns: %q", o)
+		}
+		option, value := parts[0], parts[1]
+		switch option {
+		case "cidr":
+			ipv4, _, err := net.ParseCIDR(value)
+			if err != nil || ipv4.To4() == nil {
+				return nil, fmt.Errorf("invalid cidr %q", value)
+			}
+			opts.cidr = value
+		case "port_handler":
+			switch value {
+			case "slirp4netns":
+				opts.isSlirpHostForward = true
+			case "rootlesskit":
+				opts.isSlirpHostForward = false
+			default:
+				return nil, fmt.Errorf("unknown port_handler for slirp4netns: %q", value)
+			}
+		case "allow_host_loopback":
+			switch value {
+			case "true":
+				opts.disableHostLoopback = false
+			case "false":
+				opts.disableHostLoopback = true
+			default:
+				return nil, fmt.Errorf("invalid value of allow_host_loopback for slirp4netns: %q", value)
+			}
+		case "enable_ipv6":
+			switch value {
+			case "true":
+				opts.enableIPv6 = true
+			case "false":
+				opts.enableIPv6 = false
+			default:
+				return nil, fmt.Errorf("invalid value of enable_ipv6 for slirp4netns: %q", value)
+			}
+		case "outbound_addr":
+			ipv4 := net.ParseIP(value)
+			if ipv4 == nil || ipv4.To4() == nil {
+				_, err := net.InterfaceByName(value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid outbound_addr %q", value)
+				}
+			}
+			opts.outboundAddr = value
+		case "outbound_addr6":
+			ipv6 := net.ParseIP(value)
+			if ipv6 == nil || ipv6.To4() != nil {
+				_, err := net.InterfaceByName(value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid outbound_addr6: %q", value)
+				}
+			}
+			opts.outboundAddr6 = value
+		case "mtu":
+			var err error
+			opts.mtu, err = strconv.Atoi(value)
+			if opts.mtu < 68 || err != nil {
+				return nil, fmt.Errorf("invalid mtu %q", value)
+			}
+		default:
+			return nil, fmt.Errorf("unknown option for slirp4netns: %q", o)
+		}
+	}
+	return opts, nil
+}
+
+func createBasicSlirpCmdArgs(options *networkOptions, features *slirpFeatures) ([]string, error) {
+	cmdArgs := []string{}
+	if options.disableHostLoopback && features.HasDisableHostLoopback {
+		cmdArgs = append(cmdArgs, "--disable-host-loopback")
+	}
+	if options.mtu > -1 && features.HasMTU {
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--mtu=%d", options.mtu))
+	}
+	if !options.noPivotRoot && features.HasEnableSandbox {
+		cmdArgs = append(cmdArgs, "--enable-sandbox")
+	}
+	if features.HasEnableSeccomp {
+		cmdArgs = append(cmdArgs, "--enable-seccomp")
+	}
+
+	if options.cidr != "" {
+		if !features.HasCIDR {
+			return nil, fmt.Errorf("cidr not supported")
+		}
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--cidr=%s", options.cidr))
+	}
+
+	if options.enableIPv6 {
+		if !features.HasIPv6 {
+			return nil, fmt.Errorf("enable_ipv6 not supported")
+		}
+		cmdArgs = append(cmdArgs, "--enable-ipv6")
+	}
+
+	if options.outboundAddr != "" {
+		if !features.HasOutboundAddr {
+			return nil, fmt.Errorf("outbound_addr not supported")
+		}
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--outbound-addr=%s", options.outboundAddr))
+	}
+
+	if options.outboundAddr6 != "" {
+		if !features.HasOutboundAddr || !features.HasIPv6 {
+			return nil, fmt.Errorf("outbound_addr6 not supported")
+		}
+		if !options.enableIPv6 {
+			return nil, fmt.Errorf("enable_ipv6=true is required for outbound_addr6")
+		}
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--outbound-addr6=%s", options.outboundAddr6))
+	}
+
+	return cmdArgs, nil
+}
+
+// Setup can be called in rootful as well as in rootless.
+// Spawns the slirp4netns process and setup port forwarding if ports are given.
+func Setup(opts *SetupOptions) (*SetupResult, error) {
+	path := opts.Config.Engine.NetworkCmdPath
+	if path == "" {
+		var err error
+		path, err = opts.Config.FindHelperBinary(BinaryName, true)
+		if err != nil {
+			return nil, fmt.Errorf("could not find slirp4netns, the network namespace can't be configured: %w", err)
+		}
+	}
+
+	syncR, syncW, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open pipe: %w", err)
+	}
+	defer closeQuiet(syncR)
+	defer closeQuiet(syncW)
+
+	havePortMapping := len(opts.Ports) > 0
+	logPath := filepath.Join(opts.Config.Engine.TmpDir, fmt.Sprintf("slirp4netns-%s.log", opts.ContainerID))
+
+	netOptions, err := parseNetworkOptions(opts.Config, opts.ExtraOptions)
+	if err != nil {
+		return nil, err
+	}
+	slirpFeatures, err := checkSlirpFlags(path)
+	if err != nil {
+		return nil, fmt.Errorf("checking slirp4netns binary %s: %q: %w", path, err, err)
+	}
+	cmdArgs, err := createBasicSlirpCmdArgs(netOptions, slirpFeatures)
+	if err != nil {
+		return nil, err
+	}
+
+	// the slirp4netns arguments being passed are described as follows:
+	// from the slirp4netns documentation: https://github.com/rootless-containers/slirp4netns
+	// -c, --configure Brings up the tap interface
+	// -e, --exit-fd=FD specify the FD for terminating slirp4netns
+	// -r, --ready-fd=FD specify the FD to write to when the initialization steps are finished
+	cmdArgs = append(cmdArgs, "-c", "-r", "3")
+	if opts.Slirp4netnsExitPipeR != nil {
+		cmdArgs = append(cmdArgs, "-e", "4")
+	}
+
+	var apiSocket string
+	if havePortMapping && netOptions.isSlirpHostForward {
+		apiSocket = filepath.Join(opts.Config.Engine.TmpDir, fmt.Sprintf("%s.net", opts.ContainerID))
+		cmdArgs = append(cmdArgs, "--api-socket", apiSocket)
+	}
+
+	cmdArgs = append(cmdArgs, "--netns-type=path", opts.Netns, "tap0")
+
+	cmd := exec.Command(path, cmdArgs...)
+	logrus.Debugf("slirp4netns command: %s", strings.Join(cmd.Args, " "))
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid:   true,
+		Pdeathsig: opts.Pdeathsig,
+	}
+
+	// workaround for https://github.com/rootless-containers/slirp4netns/pull/153
+	if !netOptions.noPivotRoot && slirpFeatures.HasEnableSandbox {
+		cmd.SysProcAttr.Cloneflags = syscall.CLONE_NEWNS
+		cmd.SysProcAttr.Unshareflags = syscall.CLONE_NEWNS
+	}
+
+	// Leak one end of the pipe in slirp4netns, the other will be sent to conmon
+	cmd.ExtraFiles = append(cmd.ExtraFiles, syncW)
+	if opts.Slirp4netnsExitPipeR != nil {
+		cmd.ExtraFiles = append(cmd.ExtraFiles, opts.Slirp4netnsExitPipeR)
+	}
+
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open slirp4netns log file %s: %w", logPath, err)
+	}
+	defer logFile.Close()
+	// Unlink immediately the file so we won't need to worry about cleaning it up later.
+	// It is still accessible through the open fd logFile.
+	if err := os.Remove(logPath); err != nil {
+		return nil, fmt.Errorf("delete file %s: %w", logPath, err)
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	var slirpReadyWg, netnsReadyWg *sync.WaitGroup
+	if netOptions.enableIPv6 {
+		// use two wait groups to make sure we set the sysctl before
+		// starting slirp and reset it only after slirp is ready
+		slirpReadyWg = &sync.WaitGroup{}
+		netnsReadyWg = &sync.WaitGroup{}
+		slirpReadyWg.Add(1)
+		netnsReadyWg.Add(1)
+
+		go func() {
+			err := ns.WithNetNSPath(opts.Netns, func(_ ns.NetNS) error {
+				// Duplicate Address Detection slows the ipv6 setup down for 1-2 seconds.
+				// Since slirp4netns is run in its own namespace and not directly routed
+				// we can skip this to make the ipv6 address immediately available.
+				// We change the default to make sure the slirp tap interface gets the
+				// correct value assigned so DAD is disabled for it
+				// Also make sure to change this value back to the original after slirp4netns
+				// is ready in case users rely on this sysctl.
+				orgValue, err := os.ReadFile(ipv6ConfDefaultAcceptDadSysctl)
+				if err != nil {
+					netnsReadyWg.Done()
+					// on ipv6 disabled systems the sysctl does not exist
+					// so we should not error
+					if errors.Is(err, os.ErrNotExist) {
+						return nil
+					}
+					return err
+				}
+				err = os.WriteFile(ipv6ConfDefaultAcceptDadSysctl, []byte("0"), 0o644)
+				netnsReadyWg.Done()
+				if err != nil {
+					return err
+				}
+
+				// wait until slirp4nets is ready before resetting this value
+				slirpReadyWg.Wait()
+				return os.WriteFile(ipv6ConfDefaultAcceptDadSysctl, orgValue, 0o644)
+			})
+			if err != nil {
+				logrus.Warnf("failed to set net.ipv6.conf.default.accept_dad sysctl: %v", err)
+			}
+		}()
+
+		// wait until we set the sysctl
+		netnsReadyWg.Wait()
+	}
+
+	if err := cmd.Start(); err != nil {
+		if netOptions.enableIPv6 {
+			slirpReadyWg.Done()
+		}
+		return nil, fmt.Errorf("failed to start slirp4netns process: %w", err)
+	}
+	defer func() {
+		servicereaper.AddPID(cmd.Process.Pid)
+		if err := cmd.Process.Release(); err != nil {
+			logrus.Errorf("Unable to release command process: %q", err)
+		}
+	}()
+
+	err = waitForSync(syncR, cmd, logFile, 1*time.Second)
+	if netOptions.enableIPv6 {
+		slirpReadyWg.Done()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Set a default slirp subnet. Parsing a string with the net helper is easier than building the struct myself
+	_, slirpSubnet, _ := net.ParseCIDR(defaultSubnet)
+
+	// Set slirp4netnsSubnet addresses now that we are pretty sure the command executed
+	if netOptions.cidr != "" {
+		ipv4, ipv4network, err := net.ParseCIDR(netOptions.cidr)
+		if err != nil || ipv4.To4() == nil {
+			return nil, fmt.Errorf("invalid cidr %q", netOptions.cidr)
+		}
+		slirpSubnet = ipv4network
+	}
+
+	if havePortMapping {
+		if netOptions.isSlirpHostForward {
+			err = setupRootlessPortMappingViaSlirp(opts.Ports, cmd, apiSocket)
+		} else {
+			err = SetupRootlessPortMappingViaRLK(opts, slirpSubnet, nil)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &SetupResult{
+		Pid:    cmd.Process.Pid,
+		Subnet: slirpSubnet,
+		IPv6:   netOptions.enableIPv6,
+	}, nil
+}
+
+// Get expected slirp ipv4 address based on subnet. If subnet is null use default subnet
+// Reference: https://github.com/rootless-containers/slirp4netns/blob/master/slirp4netns.1.md#description
+func GetIP(subnet *net.IPNet) (*net.IP, error) {
+	_, slirpSubnet, _ := net.ParseCIDR(defaultSubnet)
+	if subnet != nil {
+		slirpSubnet = subnet
+	}
+	expectedIP, err := addToIP(slirpSubnet, uint32(100))
+	if err != nil {
+		return nil, fmt.Errorf("calculating expected ip for slirp4netns: %w", err)
+	}
+	return expectedIP, nil
+}
+
+// Get expected slirp Gateway ipv4 address based on subnet
+// Reference: https://github.com/rootless-containers/slirp4netns/blob/master/slirp4netns.1.md#description
+func GetGateway(subnet *net.IPNet) (*net.IP, error) {
+	_, slirpSubnet, _ := net.ParseCIDR(defaultSubnet)
+	if subnet != nil {
+		slirpSubnet = subnet
+	}
+	expectedGatewayIP, err := addToIP(slirpSubnet, uint32(2))
+	if err != nil {
+		return nil, fmt.Errorf("calculating expected gateway ip for slirp4netns: %w", err)
+	}
+	return expectedGatewayIP, nil
+}
+
+// Get expected slirp DNS ipv4 address based on subnet
+// Reference: https://github.com/rootless-containers/slirp4netns/blob/master/slirp4netns.1.md#description
+func GetDNS(subnet *net.IPNet) (*net.IP, error) {
+	_, slirpSubnet, _ := net.ParseCIDR(defaultSubnet)
+	if subnet != nil {
+		slirpSubnet = subnet
+	}
+	expectedDNSIP, err := addToIP(slirpSubnet, uint32(3))
+	if err != nil {
+		return nil, fmt.Errorf("calculating expected dns ip for slirp4netns: %w", err)
+	}
+	return expectedDNSIP, nil
+}
+
+// Helper function to calculate slirp ip address offsets
+// Adapted from: https://github.com/signalsciences/ipv4/blob/master/int.go#L12-L24
+func addToIP(subnet *net.IPNet, offset uint32) (*net.IP, error) {
+	// I have no idea why I have to do this, but if I don't ip is 0
+	ipFixed := subnet.IP.To4()
+
+	ipInteger := uint32(ipFixed[3]) | uint32(ipFixed[2])<<8 | uint32(ipFixed[1])<<16 | uint32(ipFixed[0])<<24
+	ipNewRaw := ipInteger + offset
+	// Avoid overflows
+	if ipNewRaw < ipInteger {
+		return nil, fmt.Errorf("integer overflow while calculating ip address offset, %s + %d", ipFixed, offset)
+	}
+	ipNew := net.IPv4(byte(ipNewRaw>>24), byte(ipNewRaw>>16&0xFF), byte(ipNewRaw>>8)&0xFF, byte(ipNewRaw&0xFF))
+	if !subnet.Contains(ipNew) {
+		return nil, fmt.Errorf("calculated ip address %s is not within given subnet %s", ipNew.String(), subnet.String())
+	}
+	return &ipNew, nil
+}
+
+func waitForSync(syncR *os.File, cmd *exec.Cmd, logFile io.ReadSeeker, timeout time.Duration) error {
+	prog := filepath.Base(cmd.Path)
+	if len(cmd.Args) > 0 {
+		prog = cmd.Args[0]
+	}
+	b := make([]byte, 16)
+	for {
+		if err := syncR.SetDeadline(time.Now().Add(timeout)); err != nil {
+			return fmt.Errorf("setting %s pipe timeout: %w", prog, err)
+		}
+		// FIXME: return err as soon as proc exits, without waiting for timeout
+		_, err := syncR.Read(b)
+		if err == nil {
+			break
+		}
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			// Check if the process is still running.
+			var status syscall.WaitStatus
+			pid, err := syscall.Wait4(cmd.Process.Pid, &status, syscall.WNOHANG, nil)
+			if err != nil {
+				return fmt.Errorf("failed to read %s process status: %w", prog, err)
+			}
+			if pid != cmd.Process.Pid {
+				continue
+			}
+			if status.Exited() {
+				// Seek at the beginning of the file and read all its content
+				if _, err := logFile.Seek(0, 0); err != nil {
+					logrus.Errorf("Could not seek log file: %q", err)
+				}
+				logContent, err := io.ReadAll(logFile)
+				if err != nil {
+					return fmt.Errorf("%s failed: %w", prog, err)
+				}
+				return fmt.Errorf("%s failed: %q", prog, logContent)
+			}
+			if status.Signaled() {
+				return fmt.Errorf("%s killed by signal", prog)
+			}
+			continue
+		}
+		return fmt.Errorf("failed to read from %s sync pipe: %w", prog, err)
+	}
+	return nil
+}
+
+func SetupRootlessPortMappingViaRLK(opts *SetupOptions, slirpSubnet *net.IPNet, netStatus map[string]types.StatusBlock) error {
+	syncR, syncW, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("failed to open pipe: %w", err)
+	}
+	defer closeQuiet(syncR)
+	defer closeQuiet(syncW)
+
+	logPath := filepath.Join(opts.Config.Engine.TmpDir, fmt.Sprintf("rootlessport-%s.log", opts.ContainerID))
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return fmt.Errorf("failed to open rootlessport log file %s: %w", logPath, err)
+	}
+	defer logFile.Close()
+	// Unlink immediately the file so we won't need to worry about cleaning it up later.
+	// It is still accessible through the open fd logFile.
+	if err := os.Remove(logPath); err != nil {
+		return fmt.Errorf("delete file %s: %w", logPath, err)
+	}
+
+	childIP := GetRootlessPortChildIP(slirpSubnet, netStatus)
+	cfg := rootlessport.Config{
+		Mappings:    opts.Ports,
+		NetNSPath:   opts.Netns,
+		ExitFD:      3,
+		ReadyFD:     4,
+		TmpDir:      opts.Config.Engine.TmpDir,
+		ChildIP:     childIP,
+		ContainerID: opts.ContainerID,
+		RootlessCNI: netStatus != nil,
+	}
+	cfgJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	cfgR := bytes.NewReader(cfgJSON)
+	var stdout bytes.Buffer
+	path, err := opts.Config.FindHelperBinary(rootlessport.BinaryName, false)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(path)
+	cmd.Args = []string{rootlessport.BinaryName}
+
+	// Leak one end of the pipe in rootlessport process, the other will be sent to conmon
+	cmd.ExtraFiles = append(cmd.ExtraFiles, opts.RootlessPortExitPipeR, syncW)
+	cmd.Stdin = cfgR
+	// stdout is for human-readable error, stderr is for debug log
+	cmd.Stdout = &stdout
+	cmd.Stderr = io.MultiWriter(logFile, &logrusDebugWriter{"rootlessport: "})
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start rootlessport process: %w", err)
+	}
+	defer func() {
+		servicereaper.AddPID(cmd.Process.Pid)
+		if err := cmd.Process.Release(); err != nil {
+			logrus.Errorf("Unable to release rootlessport process: %q", err)
+		}
+	}()
+	if err := waitForSync(syncR, cmd, logFile, 3*time.Second); err != nil {
+		stdoutStr := stdout.String()
+		if stdoutStr != "" {
+			// err contains full debug log and too verbose, so return stdoutStr
+			logrus.Debug(err)
+			return fmt.Errorf("rootlessport " + strings.TrimSuffix(stdoutStr, "\n"))
+		}
+		return err
+	}
+	logrus.Debug("rootlessport is ready")
+	return nil
+}
+
+func setupRootlessPortMappingViaSlirp(ports []types.PortMapping, cmd *exec.Cmd, apiSocket string) (err error) {
+	const pidWaitTimeout = 60 * time.Second
+	chWait := make(chan error)
+	go func() {
+		interval := 25 * time.Millisecond
+		for i := time.Duration(0); i < pidWaitTimeout; i += interval {
+			// Check if the process is still running.
+			var status syscall.WaitStatus
+			pid, err := syscall.Wait4(cmd.Process.Pid, &status, syscall.WNOHANG, nil)
+			if err != nil {
+				break
+			}
+			if pid != cmd.Process.Pid {
+				continue
+			}
+			if status.Exited() || status.Signaled() {
+				chWait <- fmt.Errorf("slirp4netns exited with status %d", status.ExitStatus())
+			}
+			time.Sleep(interval)
+		}
+	}()
+	defer close(chWait)
+
+	// wait that API socket file appears before trying to use it.
+	if _, err := util.WaitForFile(apiSocket, chWait, pidWaitTimeout); err != nil {
+		return fmt.Errorf("waiting for slirp4nets to create the api socket file %s: %w", apiSocket, err)
+	}
+
+	// for each port we want to add we need to open a connection to the slirp4netns control socket
+	// and send the add_hostfwd command.
+	for _, port := range ports {
+		protocols := strings.Split(port.Protocol, ",")
+		for _, protocol := range protocols {
+			hostIP := port.HostIP
+			if hostIP == "" {
+				hostIP = "0.0.0.0"
+			}
+			for i := uint16(0); i < port.Range; i++ {
+				if err := openSlirp4netnsPort(apiSocket, protocol, hostIP, port.HostPort+i, port.ContainerPort+i); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	logrus.Debug("slirp4netns port-forwarding setup via add_hostfwd is ready")
+	return nil
+}
+
+// openSlirp4netnsPort sends the slirp4netns pai quey to the given socket
+func openSlirp4netnsPort(apiSocket, proto, hostip string, hostport, guestport uint16) error {
+	conn, err := net.Dial("unix", apiSocket)
+	if err != nil {
+		return fmt.Errorf("cannot open connection to %s: %w", apiSocket, err)
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			logrus.Errorf("Unable to close slirp4netns connection: %q", err)
+		}
+	}()
+	apiCmd := slirp4netnsCmd{
+		Execute: "add_hostfwd",
+		Args: slirp4netnsCmdArg{
+			Proto:     proto,
+			HostAddr:  hostip,
+			HostPort:  hostport,
+			GuestPort: guestport,
+		},
+	}
+	// create the JSON payload and send it.  Mark the end of request shutting down writes
+	// to the socket, as requested by slirp4netns.
+	data, err := json.Marshal(&apiCmd)
+	if err != nil {
+		return fmt.Errorf("cannot marshal JSON for slirp4netns: %w", err)
+	}
+	if _, err := conn.Write([]byte(fmt.Sprintf("%s\n", data))); err != nil {
+		return fmt.Errorf("cannot write to control socket %s: %w", apiSocket, err)
+	}
+	if err := conn.(*net.UnixConn).CloseWrite(); err != nil {
+		return fmt.Errorf("cannot shutdown the socket %s: %w", apiSocket, err)
+	}
+	buf := make([]byte, 2048)
+	readLength, err := conn.Read(buf)
+	if err != nil {
+		return fmt.Errorf("cannot read from control socket %s: %w", apiSocket, err)
+	}
+	// if there is no 'error' key in the received JSON data, then the operation was
+	// successful.
+	var y map[string]interface{}
+	if err := json.Unmarshal(buf[0:readLength], &y); err != nil {
+		return fmt.Errorf("parsing error status from slirp4netns: %w", err)
+	}
+	if e, found := y["error"]; found {
+		return fmt.Errorf("from slirp4netns while setting up port redirection: %v", e)
+	}
+	return nil
+}
+
+func GetRootlessPortChildIP(slirpSubnet *net.IPNet, netStatus map[string]types.StatusBlock) string {
+	if slirpSubnet != nil {
+		slirp4netnsIP, err := GetIP(slirpSubnet)
+		if err != nil {
+			return ""
+		}
+		return slirp4netnsIP.String()
+	}
+
+	var ipv6 net.IP
+	for _, status := range netStatus {
+		for _, netInt := range status.Interfaces {
+			for _, netAddress := range netInt.Subnets {
+				ipv4 := netAddress.IPNet.IP.To4()
+				if ipv4 != nil {
+					return ipv4.String()
+				}
+				ipv6 = netAddress.IPNet.IP
+			}
+		}
+	}
+	if ipv6 != nil {
+		return ipv6.String()
+	}
+	return ""
+}
+
+// closeQuiet closes a file and logs any error. Should only be used within
+// a defer.
+func closeQuiet(f *os.File) {
+	if err := f.Close(); err != nil {
+		logrus.Errorf("Unable to close file %s: %q", f.Name(), err)
+	}
+}

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -510,6 +510,9 @@ type EngineConfig struct {
 
 	// CompressionFormat is the compression format used to compress image layers.
 	CompressionFormat string `toml:"compression_format,omitempty"`
+
+	// CompressionLevel is the compression level used to compress image layers.
+	CompressionLevel *int `toml:"compression_level,omitempty"`
 }
 
 // SetOptions contains a subset of options in a Config. It's used to indicate if

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -381,6 +381,12 @@ default_sysctls = [
 #
 #compression_format = "gzip"
 
+# The compression level to use when pushing an image.
+# Valid options depend on the compression format used.
+# For gzip, valid options are 1-9, with a default of 5.
+# For zstd, valid options are 1-20, with a default of 3.
+#
+#compression_level = 5
 
 # Cgroup management implementation used for the runtime.
 # Valid options "systemd" or "cgroupfs"

--- a/vendor/github.com/containers/common/pkg/config/containers.conf-freebsd
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf-freebsd
@@ -311,6 +311,13 @@ default_sysctls = [
 #
 #compression_format = "gzip"
 
+# The compression level to use when pushing an image.
+# Valid options depend on the compression format used.
+# For gzip, valid options are 1-9, with a default of 5.
+# For zstd, valid options are 1-20, with a default of 3.
+#
+#compression_level = 5
+
 # Environment variables to pass into conmon
 #
 #conmon_env_vars = [

--- a/vendor/github.com/containers/common/pkg/rootlessport/rootlessport_linux.go
+++ b/vendor/github.com/containers/common/pkg/rootlessport/rootlessport_linux.go
@@ -1,0 +1,27 @@
+//go:build linux
+// +build linux
+
+// Rootlessport Config type for use in podman/cmd/rootlessport.
+package rootlessport
+
+import (
+	"github.com/containers/common/libnetwork/types"
+)
+
+const (
+	// BinaryName is the binary name for the parent process.
+	BinaryName = "rootlessport"
+)
+
+// Config needs to be provided to the process via stdin as a JSON string.
+// stdin needs to be closed after the message has been written.
+type Config struct {
+	Mappings    []types.PortMapping
+	NetNSPath   string
+	ExitFD      int
+	ReadyFD     int
+	TmpDir      string
+	ChildIP     string
+	ContainerID string
+	RootlessCNI bool
+}

--- a/vendor/github.com/containers/common/pkg/servicereaper/service.go
+++ b/vendor/github.com/containers/common/pkg/servicereaper/service.go
@@ -1,0 +1,65 @@
+//go:build linux
+// +build linux
+
+package servicereaper
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+)
+
+type service struct {
+	pidMap map[int]bool
+	mutex  *sync.Mutex
+}
+
+var s = service{
+	pidMap: map[int]bool{},
+	mutex:  &sync.Mutex{},
+}
+
+func AddPID(pid int) {
+	s.mutex.Lock()
+	s.pidMap[pid] = true
+	s.mutex.Unlock()
+}
+
+func Start() {
+	// create signal channel and only wait for SIGCHLD
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, syscall.SIGCHLD)
+	// wait and reap in an  extra goroutine
+	go reaper(sigc)
+}
+
+func reaper(sigc chan os.Signal) {
+	for {
+		// block until we receive SIGCHLD
+		<-sigc
+		s.mutex.Lock()
+		for pid := range s.pidMap {
+			var status syscall.WaitStatus
+			waitpid, err := syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
+			if err != nil {
+				// do not log error for ECHILD
+				if err != syscall.ECHILD {
+					logrus.Warnf("Wait for pid %d failed: %v ", pid, err)
+				}
+				delete(s.pidMap, pid)
+				continue
+			}
+			// if pid == 0 nothing happened
+			if waitpid == 0 {
+				continue
+			}
+			if status.Exited() || status.Signaled() {
+				delete(s.pidMap, pid)
+			}
+		}
+		s.mutex.Unlock()
+	}
+}

--- a/vendor/github.com/containers/common/pkg/util/util.go
+++ b/vendor/github.com/containers/common/pkg/util/util.go
@@ -3,11 +3,16 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/containers/common/libnetwork/types"
+	"github.com/fsnotify/fsnotify"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -130,4 +135,55 @@ func FilterID(id string, filters []string) bool {
 		}
 	}
 	return false
+}
+
+// WaitForFile waits until a file has been created or the given timeout has occurred
+func WaitForFile(path string, chWait chan error, timeout time.Duration) (bool, error) {
+	var inotifyEvents chan fsnotify.Event
+	watcher, err := fsnotify.NewWatcher()
+	if err == nil {
+		if err := watcher.Add(filepath.Dir(path)); err == nil {
+			inotifyEvents = watcher.Events
+		}
+		defer func() {
+			if err := watcher.Close(); err != nil {
+				logrus.Errorf("Failed to close fsnotify watcher: %v", err)
+			}
+		}()
+	}
+
+	var timeoutChan <-chan time.Time
+
+	if timeout != 0 {
+		timeoutChan = time.After(timeout)
+	}
+
+	for {
+		select {
+		case e := <-chWait:
+			return true, e
+		case <-inotifyEvents:
+			_, err := os.Stat(path)
+			if err == nil {
+				return false, nil
+			}
+			if !os.IsNotExist(err) {
+				return false, err
+			}
+		case <-time.After(25 * time.Millisecond):
+			// Check periodically for the file existence.  It is needed
+			// if the inotify watcher could not have been created.  It is
+			// also useful when using inotify as if for any reasons we missed
+			// a notification, we won't hang the process.
+			_, err := os.Stat(path)
+			if err == nil {
+				return false, nil
+			}
+			if !os.IsNotExist(err) {
+				return false, err
+			}
+		case <-timeoutChan:
+			return false, fmt.Errorf("timed out waiting for file %s", path)
+		}
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -99,6 +99,7 @@ github.com/containers/common/libnetwork/internal/util
 github.com/containers/common/libnetwork/netavark
 github.com/containers/common/libnetwork/network
 github.com/containers/common/libnetwork/resolvconf
+github.com/containers/common/libnetwork/slirp4netns
 github.com/containers/common/libnetwork/types
 github.com/containers/common/libnetwork/util
 github.com/containers/common/pkg/apparmor
@@ -119,7 +120,9 @@ github.com/containers/common/pkg/machine
 github.com/containers/common/pkg/manifests
 github.com/containers/common/pkg/parse
 github.com/containers/common/pkg/retry
+github.com/containers/common/pkg/rootlessport
 github.com/containers/common/pkg/seccomp
+github.com/containers/common/pkg/servicereaper
 github.com/containers/common/pkg/signal
 github.com/containers/common/pkg/subscriptions
 github.com/containers/common/pkg/supplemented

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -98,6 +98,7 @@ github.com/containers/common/libnetwork/etchosts
 github.com/containers/common/libnetwork/internal/util
 github.com/containers/common/libnetwork/netavark
 github.com/containers/common/libnetwork/network
+github.com/containers/common/libnetwork/pasta
 github.com/containers/common/libnetwork/resolvconf
 github.com/containers/common/libnetwork/slirp4netns
 github.com/containers/common/libnetwork/types

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -88,7 +88,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.3.0
 ## explicit; go 1.20
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/common v0.53.1-0.20230620132900-ac2475afa81d
+# github.com/containers/common v0.53.1-0.20230622141517-6eebb3712106
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 

/kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

This uses the same code as podman for slirp4netns, this means
- ipv6 is enabled by default
- slirp4netns options are read from contianers.conf
- slirp4netns options can now be set on the cli. This required some
small rework on where we parse the network string.

Lastly I updated the --network docs, to document the new slirp4netns
mode. That included fixing up buildah-from and buildah-run pages which
were incomplete in that regard. Now we show the same for all options.

Like podman allow buildah and therefore podman build to use the network
mode pasta. The pasta integration is very simple and we do not even
need a teardown handler for that as pasta will exit on its own when the
netns path is removed.

However right now this is broken, pasta will fail to open
/proc/$pid/ns/net. I send a patch[1] to fix this upstream in pasta.
I assume this will land quickly so I like to get this in now just so we
have this included in podman v4.6. Thus the test is skipped for now.

[1] https://archives.passt.top/passt-dev/20230623082531.25947-2-pholzing@redhat.com/

#### How to verify it

#### Which issue(s) this PR fixes:

Fixes #3968

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Buidlah now supports pasta as network mode like podman.
Slirp4netns now uses the options from containers.conf and uses ipv6 by default. 
```

