### PR TITLE
Add --label2annotation flag

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -244,6 +244,8 @@ type BuildOptions struct {
 	Squash bool
 	// Labels metadata for an image
 	Labels []string
+	// LabelsToAnnotations tells Buildah to save labels as annotations in OCI Images
+	LabelsToAnnotations bool
 	// Annotation metadata for an image
 	Annotations []string
 	// OnBuild commands to be run by images based on this image

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -476,6 +476,10 @@ If the specified capabilities are not in the default set, container engines
 should print an error message and will run the container with the default
 capabilities.
 
+**--label2annotation** *bool-value*
+
+Labels defined in the Containerfile are saved annotations in OCI Images. These labels will not be added as labels to the image. This options is not supported for --format=docker. (Default is `false`).
+
 **--layers** *bool-value*
 
 Cache intermediate images during the build process (Default is `false`).

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -100,6 +100,7 @@ type Executor struct {
 	iidfile                 string
 	squash                  bool
 	labels                  []string
+	labelsToAnnotations     bool
 	annotations             []string
 	layers                  bool
 	noHosts                 bool
@@ -263,6 +264,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		iidfile:                        options.IIDFile,
 		squash:                         options.Squash,
 		labels:                         append([]string{}, options.Labels...),
+		labelsToAnnotations:            options.LabelsToAnnotations,
 		annotations:                    append([]string{}, options.Annotations...),
 		layers:                         options.Layers,
 		noHosts:                        options.CommonBuildOpts.NoHosts,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -740,34 +740,34 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 
 	builderOptions := buildah.BuilderOptions{
 		Args:                  ib.Args,
+		BlobDirectory:         s.executor.blobDirectory,
+		CNIConfigDir:          s.executor.cniConfigDir,
+		CNIPluginPath:         s.executor.cniPluginPath,
+		Capabilities:          s.executor.capabilities,
+		CommonBuildOpts:       s.executor.commonBuildOptions,
+		ConfigureNetwork:      s.executor.configureNetwork,
+		ContainerSuffix:       s.executor.containerSuffix,
+		DefaultMountsFilePath: s.executor.defaultMountsFilePath,
+		Devices:               s.executor.devices,
+		Format:                s.executor.outputFormat,
 		FromImage:             from,
 		GroupAdd:              s.executor.groupAdd,
-		PullPolicy:            pullPolicy,
-		ContainerSuffix:       s.executor.containerSuffix,
-		Registry:              s.executor.registry,
-		BlobDirectory:         s.executor.blobDirectory,
-		SignaturePolicyPath:   s.executor.signaturePolicyPath,
-		ReportWriter:          s.executor.reportWriter,
-		SystemContext:         builderSystemContext,
-		Isolation:             s.executor.isolation,
-		NamespaceOptions:      s.executor.namespaceOptions,
-		ConfigureNetwork:      s.executor.configureNetwork,
-		CNIPluginPath:         s.executor.cniPluginPath,
-		CNIConfigDir:          s.executor.cniConfigDir,
-		NetworkInterface:      s.executor.networkInterface,
 		IDMappingOptions:      s.executor.idmappingOptions,
-		CommonBuildOpts:       s.executor.commonBuildOptions,
-		DefaultMountsFilePath: s.executor.defaultMountsFilePath,
-		Format:                s.executor.outputFormat,
-		Capabilities:          s.executor.capabilities,
-		Devices:               s.executor.devices,
-		MaxPullRetries:        s.executor.maxPullPushRetries,
-		PullRetryDelay:        s.executor.retryPullPushDelay,
-		OciDecryptConfig:      s.executor.ociDecryptConfig,
+		Isolation:             s.executor.isolation,
 		Logger:                s.executor.logger,
-		ProcessLabel:          s.executor.processLabel,
+		MaxPullRetries:        s.executor.maxPullPushRetries,
 		MountLabel:            s.executor.mountLabel,
+		NamespaceOptions:      s.executor.namespaceOptions,
+		NetworkInterface:      s.executor.networkInterface,
+		OciDecryptConfig:      s.executor.ociDecryptConfig,
 		PreserveBaseImageAnns: preserveBaseImageAnnotations,
+		ProcessLabel:          s.executor.processLabel,
+		PullPolicy:            pullPolicy,
+		PullRetryDelay:        s.executor.retryPullPushDelay,
+		Registry:              s.executor.registry,
+		ReportWriter:          s.executor.reportWriter,
+		SignaturePolicyPath:   s.executor.signaturePolicyPath,
+		SystemContext:         builderSystemContext,
 	}
 
 	builder, err = buildah.NewBuilder(ctx, s.executor.store, builderOptions)
@@ -2017,7 +2017,11 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	s.builder.ClearLabels()
 
 	for k, v := range config.Labels {
-		s.builder.SetLabel(k, v)
+		if s.executor.labelsToAnnotations {
+			s.builder.SetAnnotation(k, v)
+		} else {
+			s.builder.SetLabel(k, v)
+		}
 	}
 	if s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolUndefined || s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolTrue {
 		s.builder.SetLabel(buildah.BuilderIdentityAnnotation, define.Version)

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -138,10 +138,15 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 	if err != nil {
 		return options, nil, nil, err
 	}
+	if iopts.LabelsToAnnotations && format == define.Dockerv2ImageManifest {
+		return options, nil, nil, fmt.Errorf("annotations not supported in %q format", iopts.Format)
+	}
+
 	layers := UseLayers()
 	if c.Flag("layers").Changed {
 		layers = iopts.Layers
 	}
+
 	contextDir := ""
 	cliArgs := inputArgs
 
@@ -383,6 +388,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		Isolation:               isolation,
 		Jobs:                    &iopts.Jobs,
 		Labels:                  iopts.Label,
+		LabelsToAnnotations:     iopts.LabelsToAnnotations,
 		Layers:                  layers,
 		LogFile:                 iopts.Logfile,
 		LogRusage:               iopts.LogRusage,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -72,6 +72,7 @@ type BudResults struct {
 	From                string
 	Iidfile             string
 	Label               []string
+	LabelsToAnnotations bool
 	Logfile             string
 	LogSplitByPlatform  bool
 	Manifest            string
@@ -226,6 +227,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.Iidfile, "iidfile", "", "`file` to write the image ID to")
 	fs.IntVar(&flags.Jobs, "jobs", 1, "how many stages to run in parallel")
 	fs.StringArrayVar(&flags.Label, "label", []string{}, "set metadata for an image (default [])")
+	fs.BoolVar(&flags.LabelsToAnnotations, "label2annotation", false, "save labels as annotations when defined in Containerfile")
 	fs.StringVar(&flags.Logfile, "logfile", "", "log to `file` instead of stdout/stderr")
 	fs.BoolVar(&flags.LogSplitByPlatform, "logsplit", false, "split logfile to different files for each platform")
 	fs.Int("loglevel", 0, "NO LONGER USED, flag ignored, and hidden")

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6168,3 +6168,19 @@ _EOF
     false
   fi
 }
+
+@test "bud with --label2annotation flag" {
+  run_buildah build -t test -f $BUDFILES/containerfile/Containerfile .
+  run_buildah inspect --format '{{ .OCIv1.Config.Labels }}' test
+  expect_output --substring "foo:bar"
+
+  run_buildah 125 build --format docker --label2annotation -t test -f $BUDFILES/containerfile/Containerfile .
+  expect_output 'Error: annotations not supported in "docker" format'
+
+  run_buildah build --label2annotation -t test -f $BUDFILES/containerfile/Containerfile .
+  run_buildah inspect --format '{{index .ImageAnnotations "foo" }}' test
+  expect_output --substring "bar"
+  run_buildah inspect --format '{{ .OCIv1.Config.Labels }}' test
+  assert "$output" !~ "foo" \
+         "oci format should not have Containerfile labels"
+}

--- a/tests/bud/containerfile/Containerfile
+++ b/tests/bud/containerfile/Containerfile
@@ -1,2 +1,3 @@
 # This is for testing Containerfile with Buildah
 FROM alpine
+LABEL foo=bar


### PR DESCRIPTION
Containerfile and Dockerfile have not way to describe Annotations.

--ltoa flat tells buildah to convert all Labels specified in the Containerfile to Annotations when generating OCI Image format.

Fixes: https://github.com/containers/buildah/issues/4351

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
buildah build supports --ltoa flag to convert Label references within the Containerfile to Annotations in the final OCI Image.
```

