### PR TITLE
lint: reenable staticcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,5 +9,6 @@ run:
 linters:
   enable:
     - revive
+    - staticcheck
     - unconvert
     - unparam


### PR DESCRIPTION
It was disabled in #2625 ("Use same linters as podman"), but
unfortunately with no explanation.

That PR removed a lot more linters. Someone should probably
go through, reevaluate & reenable.

[ Reference: #4880 ]

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```