### PR TITLE
pkg/overlay: add limited support for FreeBSD

### DIFF
--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"errors"
 
@@ -144,74 +143,6 @@ func mountWithMountProgram(mountProgram, overlayOptions, mergeDir string) error 
 		return fmt.Errorf("exec %s: %w", mountProgram, err)
 	}
 	return nil
-}
-
-// MountWithOptions creates a subdir of the contentDir based on the source directory
-// from the source system.  It then mounts up the source directory on to the
-// generated mount point and returns the mount point to the caller.
-// But allows api to set custom workdir, upperdir and other overlay options
-// Following API is being used by podman at the moment
-func MountWithOptions(contentDir, source, dest string, opts *Options) (mount specs.Mount, Err error) {
-	mergeDir := filepath.Join(contentDir, "merge")
-
-	// Create overlay mount options for rw/ro.
-	var overlayOptions string
-	if opts.ReadOnly {
-		// Read-only overlay mounts require two lower layer.
-		lowerTwo := filepath.Join(contentDir, "lower")
-		if err := os.Mkdir(lowerTwo, 0755); err != nil {
-			return mount, err
-		}
-		overlayOptions = fmt.Sprintf("lowerdir=%s:%s,private", escapeColon(source), lowerTwo)
-	} else {
-		// Read-write overlay mounts want a lower, upper and a work layer.
-		workDir := filepath.Join(contentDir, "work")
-		upperDir := filepath.Join(contentDir, "upper")
-
-		if opts.WorkDirOptionFragment != "" && opts.UpperDirOptionFragment != "" {
-			workDir = opts.WorkDirOptionFragment
-			upperDir = opts.UpperDirOptionFragment
-		}
-
-		st, err := os.Stat(source)
-		if err != nil {
-			return mount, err
-		}
-		if err := os.Chmod(upperDir, st.Mode()); err != nil {
-			return mount, err
-		}
-		if stat, ok := st.Sys().(*syscall.Stat_t); ok {
-			if err := os.Chown(upperDir, int(stat.Uid), int(stat.Gid)); err != nil {
-				return mount, err
-			}
-		}
-		overlayOptions = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,private", escapeColon(source), upperDir, workDir)
-	}
-
-	mountProgram := findMountProgram(opts.GraphOpts)
-	if mountProgram != "" {
-		if err := mountWithMountProgram(mountProgram, overlayOptions, mergeDir); err != nil {
-			return mount, err
-		}
-
-		mount.Source = mergeDir
-		mount.Destination = dest
-		mount.Type = "bind"
-		mount.Options = []string{"bind", "slave"}
-		return mount, nil
-	}
-
-	if unshare.IsRootless() {
-		/* If a mount_program is not specified, fallback to try mounting native overlay.  */
-		overlayOptions = fmt.Sprintf("%s,userxattr", overlayOptions)
-	}
-
-	mount.Source = mergeDir
-	mount.Destination = dest
-	mount.Type = "overlay"
-	mount.Options = strings.Split(overlayOptions, ",")
-
-	return mount, nil
 }
 
 // Convert ":" to "\:", the path which will be overlay mounted need to be escaped

--- a/pkg/overlay/overlay_freebsd.go
+++ b/pkg/overlay/overlay_freebsd.go
@@ -1,0 +1,31 @@
+package overlay
+
+import (
+	//"fmt"
+	//"os"
+	//"path/filepath"
+	//"strings"
+	//"syscall"
+	"errors"
+
+	//"github.com/containers/storage/pkg/unshare"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// MountWithOptions creates a subdir of the contentDir based on the source directory
+// from the source system.  It then mounts up the source directory on to the
+// generated mount point and returns the mount point to the caller.
+// But allows api to set custom workdir, upperdir and other overlay options
+// Following API is being used by podman at the moment
+func MountWithOptions(contentDir, source, dest string, opts *Options) (mount specs.Mount, Err error) {
+	if opts.ReadOnly {
+		// Read-only overlay mounts can be simulated with nullfs
+		mount.Source = source
+		mount.Destination = dest
+		mount.Type = "nullfs"
+		mount.Options = []string{"ro"}
+		return mount, nil
+	} else {
+		return mount, errors.New("read/write overlay mounts not supported on freebsd")
+	}
+}

--- a/pkg/overlay/overlay_linux.go
+++ b/pkg/overlay/overlay_linux.go
@@ -1,0 +1,80 @@
+package overlay
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/containers/storage/pkg/unshare"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// MountWithOptions creates a subdir of the contentDir based on the source directory
+// from the source system.  It then mounts up the source directory on to the
+// generated mount point and returns the mount point to the caller.
+// But allows api to set custom workdir, upperdir and other overlay options
+// Following API is being used by podman at the moment
+func MountWithOptions(contentDir, source, dest string, opts *Options) (mount specs.Mount, Err error) {
+	mergeDir := filepath.Join(contentDir, "merge")
+
+	// Create overlay mount options for rw/ro.
+	var overlayOptions string
+	if opts.ReadOnly {
+		// Read-only overlay mounts require two lower layer.
+		lowerTwo := filepath.Join(contentDir, "lower")
+		if err := os.Mkdir(lowerTwo, 0755); err != nil {
+			return mount, err
+		}
+		overlayOptions = fmt.Sprintf("lowerdir=%s:%s,private", escapeColon(source), lowerTwo)
+	} else {
+		// Read-write overlay mounts want a lower, upper and a work layer.
+		workDir := filepath.Join(contentDir, "work")
+		upperDir := filepath.Join(contentDir, "upper")
+
+		if opts.WorkDirOptionFragment != "" && opts.UpperDirOptionFragment != "" {
+			workDir = opts.WorkDirOptionFragment
+			upperDir = opts.UpperDirOptionFragment
+		}
+
+		st, err := os.Stat(source)
+		if err != nil {
+			return mount, err
+		}
+		if err := os.Chmod(upperDir, st.Mode()); err != nil {
+			return mount, err
+		}
+		if stat, ok := st.Sys().(*syscall.Stat_t); ok {
+			if err := os.Chown(upperDir, int(stat.Uid), int(stat.Gid)); err != nil {
+				return mount, err
+			}
+		}
+		overlayOptions = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,private", escapeColon(source), upperDir, workDir)
+	}
+
+	mountProgram := findMountProgram(opts.GraphOpts)
+	if mountProgram != "" {
+		if err := mountWithMountProgram(mountProgram, overlayOptions, mergeDir); err != nil {
+			return mount, err
+		}
+
+		mount.Source = mergeDir
+		mount.Destination = dest
+		mount.Type = "bind"
+		mount.Options = []string{"bind", "slave"}
+		return mount, nil
+	}
+
+	if unshare.IsRootless() {
+		/* If a mount_program is not specified, fallback to try mounting native overlay.  */
+		overlayOptions = fmt.Sprintf("%s,userxattr", overlayOptions)
+	}
+
+	mount.Source = mergeDir
+	mount.Destination = dest
+	mount.Type = "overlay"
+	mount.Options = strings.Split(overlayOptions, ",")
+
+	return mount, nil
+}

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/internal"
 	"github.com/containers/buildah/pkg/jail"
+	"github.com/containers/buildah/pkg/overlay"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
 	"github.com/containers/common/libnetwork/resolvconf"
@@ -322,13 +323,22 @@ func (b *Builder) runSetupVolumeMounts(mountLabel string, volumeMounts []string,
 	}
 
 	parseMount := func(mountType, host, container string, options []string) (specs.Mount, error) {
-		var foundrw, foundro bool
+		var foundrw, foundro, foundO bool
+		var upperDir string
 		for _, opt := range options {
 			switch opt {
 			case "rw":
 				foundrw = true
 			case "ro":
 				foundro = true
+			case "O":
+				foundO = true
+			}
+			if strings.HasPrefix(opt, "upperdir") {
+				splitOpt := strings.SplitN(opt, "=", 2)
+				if len(splitOpt) > 1 {
+					upperDir = splitOpt[1]
+				}
 			}
 		}
 		if !foundrw && !foundro {
@@ -336,6 +346,30 @@ func (b *Builder) runSetupVolumeMounts(mountLabel string, volumeMounts []string,
 		}
 		if mountType == "bind" || mountType == "rbind" {
 			mountType = "nullfs"
+		}
+		if foundO {
+			containerDir, err := b.store.ContainerDirectory(b.ContainerID)
+			if err != nil {
+				return specs.Mount{}, err
+			}
+
+			contentDir, err := overlay.TempDir(containerDir, idMaps.rootUID, idMaps.rootGID)
+			if err != nil {
+				return specs.Mount{}, fmt.Errorf("failed to create TempDir in the %s directory: %w", containerDir, err)
+			}
+
+			overlayOpts := overlay.Options{
+				RootUID:                idMaps.rootUID,
+				RootGID:                idMaps.rootGID,
+				UpperDirOptionFragment: upperDir,
+				GraphOpts:              b.store.GraphOptions(),
+			}
+
+			overlayMount, err := overlay.MountWithOptions(contentDir, host, container, &overlayOpts)
+			if err == nil {
+				b.TempVolumes[contentDir] = true
+			}
+			return overlayMount, err
 		}
 		return specs.Mount{
 			Destination: container,


### PR DESCRIPTION
Note: in theory, we could support read/write overlays on FreeBSD using a combination of unionfs and nullfs but this would take two mounts and the API only lets us return a single mount from MountWithOptions. Read only mounts can be done with just nullfs and this is enough to support read only image mounts in podman.

#### What type of PR is this?

/kind feature

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```

