### PR TITLE
rootless: use default_rootless_network_cmd config

### DIFF
--- a/tests/run.bats
+++ b/tests/run.bats
@@ -726,7 +726,12 @@ function configure_and_check_user() {
 	local hostname=h-$(random_string)
 	ip=$(hostname -I | cut -f 1 -d " ")
 	run_buildah run --network pasta --hostname $hostname $cid cat /etc/hosts
-	assert "$output" =~ "$ip[[:blank:]]$hostname $cid"
+	assert "$output" =~ "$ip[[:blank:]]$hostname $cid" "--network pasta adds correct hostname"
+
+	# check with containers.conf setting
+	echo -e "[network]\ndefault_rootless_network_cmd = \"pasta\"" > ${TEST_SCRATCH_DIR}/containers.conf
+	CONTAINERS_CONF_OVERRIDE=${TEST_SCRATCH_DIR}/containers.conf run_buildah run --hostname $hostname $cid cat /etc/hosts
+	assert "$output" =~ "$ip[[:blank:]]$hostname $cid" "default_rootless_network_cmd = \"pasta\" works"
 }
 
 @test "run check /etc/resolv.conf" {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 

/kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

Use the `default_rootless_network_cmd` containers.conf options to know which rootless network program to use as default. This setting is important so distros and user can actually set a different default if they wish.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
Buildah now reads the default_rootless_network_cmd containers.conf option to get the default rootless network program.
```

