### PR TITLE
[CI:BUILD] RPM: Fix ELN builds

### DIFF
--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -44,7 +44,7 @@ Summary: A command line tool used for creating OCI Images
 URL: https://%{name}.io
 # Tarball fetched from upstream
 Source: %{git0}/archive/v%{version}.tar.gz
-BuildRequires: go-md2man
+BuildRequires: %{_bindir}/go-md2man
 BuildRequires: device-mapper-devel
 BuildRequires: git-core
 BuildRequires: golang >= 1.16.6


### PR DESCRIPTION
ELN builds have been failing because `/usr/bin/go-md2man` isn't available via the `go-md2man` package on ELN.
https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/6119506/

This commit changes the dependency to the go-md2man binary path so it should work on all build envs.

Successful build with the change:
https://koji.fedoraproject.org/koji/taskinfo?taskID=102707004

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


/kind other

#### What this PR does / why we need it:

Fixes Fedora ELN build

#### How to verify it

See links mentioned in commit message

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

