### PR TITLE
contrib/buildahimage: set config correctly for rootless `build` user

### DIFF
--- a/contrib/buildahimage/Containerfile
+++ b/contrib/buildahimage/Containerfile
@@ -89,7 +89,17 @@ RUN useradd build && \
     echo -e "build:1:999\nbuild:1001:64535" > /etc/subuid && \
     echo -e "build:1:999\nbuild:1001:64535" > /etc/subgid && \
     mkdir -p /home/build/.local/share/containers && \
+    mkdir -p /home/build/.config/containers && \
     chown -R build:build /home/build
+# See:  https://github.com/containers/buildah/issues/4669
+# Copy & modify the config for the `build` user and remove the global
+# `runroot` and `graphroot` which current `build` user cannot access,
+# in such case storage will choose a runroot in `/var/tmp`.
+RUN sed -e 's|^#mount_program|mount_program|g' \
+        -e 's|^graphroot|#graphroot|g' \
+        -e 's|^runroot|#runroot|g' \
+        /etc/containers/storage.conf \
+        > /home/build/.config/containers/storage.conf
 
 VOLUME /var/lib/containers
 VOLUME /home/build/.local/share/containers


### PR DESCRIPTION
For image published at `quay.io/containers/buildah` buildah should correctly use `fuseoverlay` for rootless `build` user `fuse-overlayfs`.

Closes: https://github.com/containers/buildah/issues/4669

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
contrib/buildahimage: set config correctly for rootless `build` user
```

