### PR TITLE
[CI:BUILD] Packit: fix pre-sync action for downstream tasks

### DIFF
--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -44,7 +44,7 @@ Summary: A command line tool used for creating OCI Images
 URL: https://%{name}.io
 # Tarball fetched from upstream
 Source: %{git0}/archive/v%{version}.tar.gz
-BuildRequires: go-md2man
+BuildRequires: %{_bindir}/go-md2man
 BuildRequires: device-mapper-devel
 BuildRequires: git-core
 BuildRequires: golang >= 1.16.6

--- a/rpm/update-spec-provides.sh
+++ b/rpm/update-spec-provides.sh
@@ -10,8 +10,16 @@ PACKAGE=buildah
 # script is run from git root directory
 SPEC_FILE=rpm/$PACKAGE.spec
 
+# Packit sandbox doesn't allow root
+# Install golist by downloading and extracting rpm
+# We could handle this in packit `sandcastle` upstream itself
+# but that depends on golist existing in epel
+# https://github.com/packit/sandcastle/pull/186
+dnf download golist
+rpm2cpio golist-*.rpm | cpio -idmv
+
 sed -i '/Provides: bundled(golang.*/d' $SPEC_FILE
 
-GO_IMPORTS=$(golist --imported --package-path github.com/containers/$PACKAGE --skip-self | sort -u | xargs -I{} echo "Provides: bundled(golang({}))")
+GO_IMPORTS=$(./usr/bin/golist --imported --package-path github.com/containers/$PACKAGE --skip-self | sort -u | xargs -I{} echo "Provides: bundled(golang({}))")
 
 awk -v r="$GO_IMPORTS" '/^# vendored libraries/ {print; print r; next} 1' $SPEC_FILE > temp && mv temp $SPEC_FILE


### PR DESCRIPTION
One of the reasons the last propose-downstream task failed for Fedora was the `golist` tool wasn't available in the Packit environment.

This commit adds golist to the environment by downloading and extracting the golist rpm.

This dependency could've been added in packit's upstream config but there were a few blockers, so it's easiest to add them in our action script.

Ref: https://github.com/containers/buildah/issues/4904

Also make go-md2man dependency in rpm/buildah.spec more generic

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:
Fixes Packit downstream task

#### How to verify it
Unfortuntaley, this can only be verified on the next release.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

Fixes #4904 

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

