### PR TITLE
[release-1.31 backport] [CI:BUILD] Packit: downstream task script needs GOPATH

### DIFF
--- a/rpm/update-spec-provides.sh
+++ b/rpm/update-spec-provides.sh
@@ -4,14 +4,26 @@
 # packaging, via the `propose-downstream` packit action.
 # The goimports don't need to be present upstream.
 
-set -eo pipefail
+set -eox pipefail
 
 PACKAGE=buildah
 # script is run from git root directory
 SPEC_FILE=rpm/$PACKAGE.spec
 
+export GOPATH=~/go
+GOPATHDIR=$GOPATH/src/github.com/containers/
+mkdir -p $GOPATHDIR
+ln -sf $(pwd) $GOPATHDIR/.
+
+# Packit sandbox doesn't allow root
+# Install golist by downloading and extracting rpm
+# We could handle this in packit `sandcastle` upstream itself
+# but that depends on golist existing in epel
+# https://github.com/packit/sandcastle/pull/186
+dnf download golist
+rpm2cpio golist-*.rpm | cpio -idmv
+
 sed -i '/Provides: bundled(golang.*/d' $SPEC_FILE
 
-GO_IMPORTS=$(golist --imported --package-path github.com/containers/$PACKAGE --skip-self | sort -u | xargs -I{} echo "Provides: bundled(golang({}))")
-
+GO_IMPORTS=$(./usr/bin/golist --imported --package-path github.com/containers/$PACKAGE --skip-self | sort -u | xargs -I{} echo "Provides: bundled(golang({}))")
 awk -v r="$GO_IMPORTS" '/^# vendored libraries/ {print; print r; next} 1' $SPEC_FILE > temp && mv temp $SPEC_FILE


### PR DESCRIPTION
[NO NEW TESTS NEEDED]


(cherry picked from commit 11cec852331f0c8c5b0ff9b83acb16f70fc442c9)

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


> /kind other

#### What this PR does / why we need it:
Fedora task fix

#### How to verify it
Wait for the next release.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

backport of https://github.com/containers/buildah/pull/4924 . Cherrypick bot failed.