### PR TITLE
Ensure created ImageSource / ImageDestination objects are closed

### DIFF
--- a/internal/source/create.go
+++ b/internal/source/create.go
@@ -40,6 +40,7 @@ func Create(ctx context.Context, sourcePath string, options CreateOptions) error
 	if err != nil {
 		return err
 	}
+	defer ociDest.Close()
 
 	// Create and add a config.
 	config := ImageConfig{

--- a/internal/source/push.go
+++ b/internal/source/push.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
 )
@@ -25,11 +26,10 @@ type PushOptions struct {
 // Push the source image at `sourcePath` to `imageInput` at a container
 // registry.
 func Push(ctx context.Context, sourcePath string, imageInput string, options PushOptions) error {
-	ociSource, err := openOrCreateSourceImage(ctx, sourcePath)
+	srcRef, err := layout.ParseReference(sourcePath)
 	if err != nil {
 		return err
 	}
-
 	destRef, err := stringToImageReference(imageInput)
 	if err != nil {
 		return err
@@ -61,7 +61,7 @@ func Push(ctx context.Context, sourcePath string, imageInput string, options Pus
 	if !options.Quiet {
 		copyOpts.ReportWriter = os.Stderr
 	}
-	if _, err := copy.Image(ctx, policyContext, destRef, ociSource.Reference(), copyOpts); err != nil {
+	if _, err := copy.Image(ctx, policyContext, destRef, srcRef, copyOpts); err != nil {
 		return fmt.Errorf("pushing source image: %w", err)
 	}
 

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -77,6 +77,7 @@ func readManifestFromOCIPath(ctx context.Context, sourcePath string) (*specV1.Ma
 	if err != nil {
 		return nil, nil, -1, err
 	}
+	defer ociSource.Close()
 
 	return readManifestFromImageSource(ctx, ociSource)
 }


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

The `ImageSource`/`ImageDestination` API requires `.Close()` to be called to clean up resources. In some cases that matters, in others it's a matter of principle / ability to change the underlying implementation without adverse effects.

#### How to verify it

Existing CI for functionality. I guess code inspection for correctness and not missing anything

#### Which issue(s) this PR fixes:

Fixes #4894

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

