### PR TITLE
CI:BUILD] RPM: define gobuild macro for rhel/centos stream

### DIFF
--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -7,9 +7,12 @@
 %global debug_package   %{nil}
 %endif
 
-%if %{defined rhel} && 0%{?rhel} == 8
-# RHEL 8's default %%gobuild macro doesn't account for the BUILDTAGS variable, so we
-# set it separately here and do not depend on RHEL 8's go-srpm-macros package.
+# RHEL's default %%gobuild macro doesn't account for the BUILDTAGS variable, so we
+# set it separately here and do not depend on RHEL's go-[s]rpm-macros package
+# until that's fixed.
+# c9s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227328
+# c8s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227331
+%if %{defined rhel}
 %define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback libtrust_openssl ${BUILDTAGS:-}" -ldflags "-linkmode=external -compressdwarf=false ${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags'" -a -v -x %{?**};
 %endif
 


### PR DESCRIPTION
The current gobuild macro doesn't account for build tags on both c9s and c8s. This is currently causing copr build failures for c9s.

Ref: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/6220412/

This commit will define gobuild for all those envs until gobuild is fixed by default.

Refs:
c9s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227328
c8s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227331

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


/kind failing-test 

#### What this PR does / why we need it:
Fixes packit tasks

#### How to verify it

packit tasks will be green

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

