### PR TITLE
[CI:BUILD] Packit: add fedora-eln targets and build docs with vendored go-md2man

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,6 +16,8 @@ jobs:
     targets:
       - fedora-all-x86_64
       - fedora-all-aarch64
+      - fedora-eln-x86_64
+      - fedora-eln-aarch64
       - centos-stream+epel-next-8-x86_64
       - centos-stream+epel-next-8-aarch64
       - centos-stream+epel-next-9-x86_64

--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -47,7 +47,6 @@ Summary: A command line tool used for creating OCI Images
 URL: https://%{name}.io
 # Tarball fetched from upstream
 Source: %{git0}/archive/v%{version}.tar.gz
-BuildRequires: %{_bindir}/go-md2man
 BuildRequires: device-mapper-devel
 BuildRequires: git-core
 BuildRequires: golang >= 1.16.6
@@ -129,18 +128,18 @@ export BUILDTAGS+=' btrfs_noversion exclude_graphdriver_btrfs'
 %gobuild -o bin/imgtype ./tests/imgtype
 %gobuild -o bin/copy ./tests/copy
 %gobuild -o bin/tutorial ./tests/tutorial
-GOMD2MAN=go-md2man %{__make} -C docs
+%{__make} docs
 
 %install
-export GOPATH=$(pwd)/_build:$(pwd)
 make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
-make DESTDIR=%{buildroot} PREFIX=%{_prefix} -C docs install
 
 install -d -p %{buildroot}/%{_datadir}/%{name}/test/system
 cp -pav tests/. %{buildroot}/%{_datadir}/%{name}/test/system
 cp bin/imgtype %{buildroot}/%{_bindir}/%{name}-imgtype
 cp bin/copy    %{buildroot}/%{_bindir}/%{name}-copy
 cp bin/tutorial %{buildroot}/%{_bindir}/%{name}-tutorial
+
+rm %{buildroot}%{_datadir}/%{name}/test/system/tools/build/*
 
 #define license tag if not already defined
 %{!?_licensedir:%global license %doc}


### PR DESCRIPTION
`fedora-all` doesn't include eln targets. We need to add them explicitly.

This PR also gets rid of `go-md2man` as an rpm dependency and directly builds docs from the vendored go-md2man. This enables easy building on rhel8 and eln.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


/kind other

#### What this PR does / why we need it:

Packit tests on ELN

#### How to verify it

Tasks for ELN will be created in the CI task list.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

