### PR TITLE
[WIP] Migrate cross-compile task to github-actions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -132,29 +132,6 @@ vendor_task:
         - './hack/tree_status.sh'
 
 
-# Confirm cross-compile ALL architectures on a Mac OS-X VM.
-cross_build_task:
-    name: "Cross Compile"
-    alias: cross_build
-    only_if: >-
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
-        $CIRRUS_CRON != 'multiarch'
-
-    osx_instance:
-        image: ghcr.io/cirruslabs/macos-ventura-base:latest
-
-    script:
-        - brew update
-        - brew install go
-        - brew install go-md2man
-        - brew install gpgme
-        - go version
-        - make cross CGO_ENABLED=0
-
-    binary_artifacts:
-        path: ./bin/*
-
-
 unit_task:
     name: 'Unit tests w/ $STORAGE_DRIVER'
     alias: unit
@@ -165,7 +142,6 @@ unit_task:
     depends_on: &smoke_vendor_cross
       - smoke
       - vendor
-      - cross_build
 
     timeout_in: 1h
 
@@ -381,7 +357,6 @@ success_task:
       - unit
       - conformance
       - vendor
-      - cross_build
       - integration
       - in_podman
       - image_build

--- a/.github/workflows/test_macos_build.yml
+++ b/.github/workflows/test_macos_build.yml
@@ -1,0 +1,64 @@
+---
+
+name: Test MacOS Build
+
+on: [push, pull_request]
+
+jobs:
+  # Workflows only record minimal details about the event which triggered them.
+  trigger_event_debug:
+    name: Archive workflow trigger event details
+    runs-on: ubuntu-latest
+    steps:
+      - name: Archive workflow trigger event details
+        uses: actions/upload-artifact@v3
+        with:
+          name: workflow_trigger_event
+          path: ${{ github.event_path }}
+  process_pr_description:
+    name: Process PR Description
+    runs-on: ubuntu-latest
+    outputs:
+      ci_docs: ${{ steps.ci_docs_check.outputs.present }}
+    steps:
+      - name: "Check for '[CI:DOCS]'"
+        id: ci_docs_check
+        env:
+          # DANGER: Command-injection risk, bounce value through env. var.
+          PR_DESC: "${{ github.event.pull_request.title }}"
+        run: |
+          if [[ "$PR_DESC" =~ CI:DOCS ]]; then
+            # GHA provides no indication of output values, assist human debuggers.
+            echo "::warning::Skipping job due to [CI:DOCS] in PR description"
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+  test_macos_build:
+    name: Test MacOS Build
+    runs-on: macos-latest
+    needs: process_pr_description
+    if: ${{ needs.process_pr_description.outputs.ci_docs == 'false' }}
+    steps:
+      # Side-effect: Checkout action alters the execution environment.
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      # Workflows do not save any record of their environment.  Assist future
+      # human debuggers by logging all values.  DANGER: Some values may be
+      # sensitive.  The github-runner will mask them _only_ on output, not any
+      # files/artifacts they may wind up in.
+      - name: Debug workflow trigger and environment
+        run: printenv | sort
+      - name: Test MacOS Build
+        run: |
+          brew update
+          brew install --overwrite go
+          brew install go-md2man
+          brew install gpgme
+          go version
+          make cross CGO_ENABLED=0
+      - name: Archive compiled binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: binary
+          path: "./bin/*"


### PR DESCRIPTION
#### What type of PR is this?
/kind other

#### What this PR does / why we need it:

As of Sept. 1st 2023 Cirrus-CI will start charging for hosted compute time.  At the time of this commit, according to the containers-org billing page, github provides 200 "free" minutes per month of MacOS time.  However, the same page shows 0 minutes used across-the-board, so perhaps they're not counting minutes at all.

**Note**: This new workflow will...
* Run _much_ slower in GHA (~25-30m) vs Cirrus-CI (~5-7m)
* Execute for all PRs and merges w/o regard to the branch (Cirrus-CI only acted upon the 
  branch copy of `.cirrus.yml` vs GHA always reads workflow YAML from "main").
* **NOT** prevent execution of Cirrus-CI MacOS tasks on release branches.  They will need 
  to be individually disabled so as to not count against minutes-pool.
* Use an older MacOS environment,  currently `latest` is "MacOS 12 
  Monterey", whereas Cirrus-CI was using "MacOS 13 Ventura".
* **NOT** synchronize execution with Cirrus-CI tasks.  This is possible to do, but fairly complex.
* **NOT** mitigate any unintended consequences due to the final CI-states not being joined in any way.

#### How to verify it

The new workflow will execute and pass, w/n `[CI:DOCS]` is present in the title.

#### Which issue(s) this PR fixes:

https://cirrus-ci.org/blog/2023/07/17/limiting-free-usage-of-cirrus-ci

#### Special notes for your reviewer:

This is an experimental initial implementation.  It will introduce several side-effects that need investigating.  Please do not merge yet.

#### Does this PR introduce a user-facing change?

```release-note
None
```