### PR TITLE
[release-1.31] Bump to 1.31.1, bump c/common to 0.55.3, remove zstd:chunked refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Changelog
 
+## v1.31.1 (2023-08-09)
+    [release-1.31] Remove zstd:chunked from man, bump c/common to v0.55.3
+    CI:BUILD] RPM: define gobuild macro for rhel/centos stream
+    [release-1.31] Bump c/common
+
 ## v1.31.0 (2023-06-30)
 
     Bump c/common to 0.55.1 and c/image to 5.26.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+- Changelog for v1.31.1 (2023-08-09)
+  *[release-1.31] Remove zstd:chunked from man, bump c/common to v0.55.3
+  * CI:BUILD] RPM: define gobuild macro for rhel/centos stream
+  * [release-1.31] Bump c/common
+
 - Changelog for v1.31.0 (2023-06-30)
   * Bump c/common to 0.55.1 and c/image to 5.26.1
   * Bump c/image to 5.26.0 and c/common to 0.54.0

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.31.1"
+	Version = "1.31.2-dev"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.31.0"
+	Version = "1.31.1"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/docs/buildah-push.1.md
+++ b/docs/buildah-push.1.md
@@ -40,7 +40,7 @@ The default certificates directory is _/etc/containers/certs.d_.
 
 **--compression-format** *format*
 
-Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.
+Specifies the compression format to use.  Supported values are: `gzip` and `zstd`.
 
 **--compression-level** *level*
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/containerd v1.7.2
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.3.0
-	github.com/containers/common v0.55.2
+	github.com/containers/common v0.55.3
 	github.com/containers/image/v5 v5.26.1
 	github.com/containers/ocicrypt v1.1.7
 	github.com/containers/storage v1.48.0

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl3
 github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q6mVDp5H1HnjM=
 github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
-github.com/containers/common v0.55.2 h1:Cd+vmkUPDrPvL2v4Te1Wew6SIZdn4/XiyiBRT9IbcGg=
-github.com/containers/common v0.55.2/go.mod h1:ZKPllYOZ2xj2rgWRdnHHVvWg6ru4BT28En8mO8DMMPk=
+github.com/containers/common v0.55.3 h1:mhNQRU4OgW1wpmmKMFSYRn42+hr8SEVSPFdKML3WZik=
+github.com/containers/common v0.55.3/go.mod h1:ZKPllYOZ2xj2rgWRdnHHVvWg6ru4BT28En8mO8DMMPk=
 github.com/containers/image/v5 v5.26.1 h1:8y3xq8GO/6y8FR+nAedHPsAFiAtOrab9qHTBpbqaX8g=
 github.com/containers/image/v5 v5.26.1/go.mod h1:IwlOGzTkGnmfirXxt0hZeJlzv1zVukE03WZQ203Z9GA=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -51,7 +51,7 @@ const (
 	BoltDBStateStore RuntimeStateStore = iota
 )
 
-var validImageVolumeModes = []string{"bind", "tmpfs", "ignore"}
+var validImageVolumeModes = []string{_typeBind, "tmpfs", "ignore"}
 
 // ProxyEnv is a list of Proxy Environment variables
 var ProxyEnv = []string{

--- a/vendor/github.com/containers/common/pkg/config/config_darwin.go
+++ b/vendor/github.com/containers/common/pkg/config/config_darwin.go
@@ -14,6 +14,9 @@ const (
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
 	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
+
+	// Mount type for mounting host dir
+	_typeBind = "bind"
 )
 
 // podman remote clients on darwin cannot use unshare.isRootless() to determine the configuration file locations.

--- a/vendor/github.com/containers/common/pkg/config/config_freebsd.go
+++ b/vendor/github.com/containers/common/pkg/config/config_freebsd.go
@@ -14,6 +14,9 @@ const (
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
 	DefaultSignaturePolicyPath = "/usr/local/etc/containers/policy.json"
+
+	// Mount type for mounting host dir
+	_typeBind = "nullfs"
 )
 
 // podman remote clients on freebsd cannot use unshare.isRootless() to determine the configuration file locations.

--- a/vendor/github.com/containers/common/pkg/config/config_linux.go
+++ b/vendor/github.com/containers/common/pkg/config/config_linux.go
@@ -17,6 +17,9 @@ const (
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
 	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
+
+	// Mount type for mounting host dir
+	_typeBind = "bind"
 )
 
 func selinuxEnabled() bool {

--- a/vendor/github.com/containers/common/pkg/config/config_windows.go
+++ b/vendor/github.com/containers/common/pkg/config/config_windows.go
@@ -12,6 +12,9 @@ const (
 	// DefaultSignaturePolicyPath is the default value for the
 	// policy.json file.
 	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
+
+	// Mount type for mounting host dir
+	_typeBind = "bind"
 )
 
 // podman remote clients on windows cannot use unshare.isRootless() to determine the configuration file locations.

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -377,7 +377,7 @@ default_sysctls = [
 #active_service = "production"
 
 # The compression format to use when pushing an image.
-# Valid options are: `gzip`, `zstd` and `zstd:chunked`.
+# Valid options are: `gzip` and `zstd`.
 #
 #compression_format = "gzip"
 

--- a/vendor/github.com/containers/common/pkg/config/containers.conf-freebsd
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf-freebsd
@@ -307,7 +307,7 @@ default_sysctls = [
 #active_service = production
 
 # The compression format to use when pushing an image.
-# Valid options are: `gzip`, `zstd` and `zstd:chunked`.
+# Valid options are: `gzip` and `zstd`.
 #
 #compression_format = "gzip"
 

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -28,7 +28,7 @@ const (
 	_defaultTransport = "docker://"
 
 	// _defaultImageVolumeMode is a mode to handle built-in image volumes.
-	_defaultImageVolumeMode = "bind"
+	_defaultImageVolumeMode = _typeBind
 )
 
 var (

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.55.2"
+const Version = "0.55.3"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -91,7 +91,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.3.0
 ## explicit; go 1.20
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/common v0.55.2
+# github.com/containers/common v0.55.3
 ## explicit; go 1.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
Remove zstd:chunked from man pages as it's not supported in RHEL yet.  This is targeted to RHEL 8.9/9.3
Bump c/common to v0.55.3
Bump version  to 1.31.1 then 1.31.2-dev

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

