### PR TITLE
[release-1.31] Bump to v1.31.2 and then to v1.31.3-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Changelog
 
+## v1.31.2 (2023-08-10)
+    [release-1.31] Bump to v1.31.2
+
 ## v1.31.1 (2023-08-09)
     [release-1.31] Remove zstd:chunked from man, bump c/common to v0.55.3
     CI:BUILD] RPM: define gobuild macro for rhel/centos stream

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+-Changelog for v1.31.2 (2023-08-10)
+  * [release-1.31] Bump to v1.31.2
+
 - Changelog for v1.31.1 (2023-08-09)
   *[release-1.31] Remove zstd:chunked from man, bump c/common to v0.55.3
   * CI:BUILD] RPM: define gobuild macro for rhel/centos stream

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.31.2"
+	Version = "1.31.3-dev"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.31.2-dev"
+	Version = "1.31.2"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it
When creating a tag for v1.31.1 after bumping the version, I discovered I had already created a 1.31.1 tag and had neglected to bump the version there.  Bumping to 1.31.2 here, then will tag with that release.


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

