### PR TITLE
[CI:BUILD] RPM: fix buildtags

### DIFF
--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -119,9 +119,9 @@ export CGO_CFLAGS+=" -m64 -mtune=generic -fcf-protection=full"
 export CNI_VERSION=`grep '^# github.com/containernetworking/cni ' src/modules.txt | sed 's,.* ,,'`
 export LDFLAGS="-X main.buildInfo=`date +%s` -X main.cniVersion=${CNI_VERSION}"
 
-export BUILDTAGS='seccomp exclude_graphdriver_devicemapper $(hack/systemd_tag.sh) $hack/libsubid_tag.sh)'
+export BUILDTAGS="seccomp exclude_graphdriver_devicemapper $(hack/systemd_tag.sh) $(hack/libsubid_tag.sh)"
 %if !%{defined build_with_btrfs}
-export BUILDTAGS+=' btrfs_noversion exclude_graphdriver_btrfs'
+export BUILDTAGS+=" btrfs_noversion exclude_graphdriver_btrfs"
 %endif
 
 %gobuild -o bin/%{name} ./cmd/%{name}


### PR DESCRIPTION
buildtags mentioned as $(hack/foobar.sh) need double quotes to get
correctly read.

Fixes: #4944

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

fixes buildtags in rpm

#### How to verify it

see packit build logs if you're curious

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

#4944 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

