### PR TITLE
Clear CommonBuildOpts when loading Builder status

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -433,6 +433,9 @@ func OpenBuilder(store storage.Store, container string) (*Builder, error) {
 	b.store = store
 	b.fixupConfig(nil)
 	b.setupLogger()
+	if b.CommonBuildOpts == nil {
+		b.CommonBuildOpts = &CommonBuildOptions{}
+	}
 	return b, nil
 }
 
@@ -469,6 +472,9 @@ func OpenBuilderByPath(store storage.Store, path string) (*Builder, error) {
 			b.store = store
 			b.fixupConfig(nil)
 			b.setupLogger()
+			if b.CommonBuildOpts == nil {
+				b.CommonBuildOpts = &CommonBuildOptions{}
+			}
 			return b, nil
 		}
 		if err != nil {
@@ -506,6 +512,9 @@ func OpenAllBuilders(store storage.Store) (builders []*Builder, err error) {
 			b.store = store
 			b.setupLogger()
 			b.fixupConfig(nil)
+			if b.CommonBuildOpts == nil {
+				b.CommonBuildOpts = &CommonBuildOptions{}
+			}
 			builders = append(builders, b)
 			continue
 		}

--- a/buildah_test.go
+++ b/buildah_test.go
@@ -1,0 +1,69 @@
+package buildah
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/containers/storage"
+	"github.com/containers/storage/types"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	debug := false
+	if InitReexec() {
+		return
+	}
+	flag.BoolVar(&debug, "debug", false, "turn on debug logging")
+	flag.Parse()
+	logrus.SetLevel(logrus.ErrorLevel)
+	if debug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	os.Exit(m.Run())
+}
+
+func TestOpenBuilderCommonBuildOpts(t *testing.T) {
+	ctx := context.TODO()
+	store, err := storage.GetStore(types.StoreOptions{
+		RunRoot:         t.TempDir(),
+		GraphRoot:       t.TempDir(),
+		GraphDriverName: "vfs",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _, err := store.Shutdown(true); assert.NoError(t, err) })
+	b, err := NewBuilder(ctx, store, BuilderOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, b.CommonBuildOpts)
+	b.CommonBuildOpts = nil
+	builderContainerID := b.ContainerID
+	err = b.Save()
+	require.NoError(t, err)
+	b, err = OpenBuilder(store, builderContainerID)
+	require.NoError(t, err)
+	require.NotNil(t, b.CommonBuildOpts)
+	builders, err := OpenAllBuilders(store)
+	require.NoError(t, err)
+	for _, b := range builders {
+		require.NotNil(t, b.CommonBuildOpts)
+	}
+	imageID, _, _, err := b.Commit(ctx, nil, CommitOptions{})
+	require.NoError(t, err)
+	b, err = ImportBuilderFromImage(ctx, store, ImportFromImageOptions{
+		Image: imageID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, b.CommonBuildOpts)
+	container, err := store.CreateContainer("", nil, imageID, "", "", &storage.ContainerOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, container)
+	b, err = ImportBuilder(ctx, store, ImportOptions{
+		Container: container.ID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, b.CommonBuildOpts)
+}

--- a/import.go
+++ b/import.go
@@ -107,6 +107,7 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 			GIDMap:         gidmap,
 		},
 		NetworkInterface: netInt,
+		CommonBuildOpts:  &CommonBuildOptions{},
 	}
 
 	if err := builder.initConfig(ctx, image, systemContext); err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When loading `Builder` structures from disk, initialize the `CommonBuildOpts` field to point to an zeroed structure instead of leaving it `nil`, if no value was initialized when the structure was decoded from disk.

#### How to verify it

New unit test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```