### PR TITLE
chroot: setSeccomp add support for `ArchPARISC(64)` and `ArchRISCV64`

### DIFF
--- a/chroot/seccomp.go
+++ b/chroot/seccomp.go
@@ -79,9 +79,11 @@ func setSeccomp(spec *specs.Spec) error {
 		case specs.ArchS390X:
 			return libseccomp.ArchS390X
 		case specs.ArchPARISC:
-			/* fallthrough */ /* for now */
+			return libseccomp.ArchPARISC
 		case specs.ArchPARISC64:
-			/* fallthrough */ /* for now */
+			return libseccomp.ArchPARISC64
+		case specs.ArchRISCV64:
+			return libseccomp.ArchRISCV64
 		default:
 			logrus.Errorf("unmappable arch %v", specArch)
 		}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind cleanup


#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None

```release-note
None
```

[NO NEW TESTS NEEDED]