### PR TITLE
[CI:BUILD] rpm: spdx compatible license field

### DIFF
--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -36,7 +36,8 @@ Epoch: 102
 # copr and koji builds.
 # If you're reading this on dist-git, the version is automatically filled in by Packit.
 Version: 0
-License: Apache-2.0 and BSD-2-Clause and BSD-3-Clause and ISC and MIT and MPL-2.0
+# The `AND` needs to be uppercase in the License for SPDX compatibility
+License: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND MPL-2.0
 Release: %autorelease
 %if %{defined golang_arches_future}
 ExclusiveArch: %{golang_arches_future}


### PR DESCRIPTION
The lowercase `and` in the License field isn't compatible with spdx license format.

This commit replaces all `and` with `AND` in the License field in spec.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


 /kind other

#### What this PR does / why we need it:

rpm license fix

#### How to verify it

use the `license-fedora2spdx` tool if you're curious.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None. Only affects rpms.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

