### PR TITLE
[CI:DOCS] Replace troff code with markdown in buildah-{copy,add}.1.md

### DIFF
--- a/docs/buildah-add.1.md
+++ b/docs/buildah-add.1.md
@@ -89,7 +89,7 @@ buildah add containerID 'passwd' 'certs.d' /etc
 If a .containerignore or .dockerignore file exists in the context directory,
 `buildah add` reads its contents. If both exist, then .containerignore is used.
 
-When the \fB\fC\-\-ignorefile\fR option is specified Buildah reads it and
+When the `--ignorefile` option is specified Buildah reads it and
 uses it to decide which content to exclude when copying content into the
 working container.
 

--- a/docs/buildah-copy.1.md
+++ b/docs/buildah-copy.1.md
@@ -87,7 +87,7 @@ buildah copy containerID 'passwd' 'certs.d' /etc
 If the .containerignore/.dockerignore file exists in the context directory,
 `buildah copy` reads its contents. If both exist, then .containerignore is used.
 
-When the \fB\fC\-\-ignorefile\fR option is specified Buildah reads it and
+When the `--ignorefile` option is specified Buildah reads it and
 uses it to decide which content to exclude when copying content into the
 working container.
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind documentation

#### What this PR does / why we need it:

Markdown source for the two man pages included `troff` formatting, which was being escaped away to regular text when the man pages were generated. This PR replaces the troff formatting with the expected markdown formatting.
#### How to verify it
By inspection: The man pages will no longer display `\fB\fC...`, etc.

#### Which issue(s) this PR fixes:
None
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

