### PR TITLE
[skip-ci] GHA: Closed issue/PR comment-lock test

### DIFF
--- a/.github/workflows/discussion_lock.yml
+++ b/.github/workflows/discussion_lock.yml
@@ -1,0 +1,19 @@
+---
+
+# See also:
+# https://github.com/containers/podman/blob/main/.github/workflows/discussion_lock.yml
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+  # Debug: Allow triggering job manually in github-actions WebUI
+  workflow_dispatch: {}
+
+jobs:
+  # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+  closed_issue_discussion_lock:
+    uses: containers/podman/.github/workflows/discussion_lock.yml@main
+    secrets: inherit
+    permissions:
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
/kind other

#### What this PR does / why we need it:

Lock discussions on closed PRs and Issues after 90-days of inactivity.

Ref:
     https://github.com/containers/podman/discussions/19012
and
     https://github.com/containers/podman/pull/19691
and
     https://github.com/containers/podman/pull/19700

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

There's no easy way to test this before merging since it involves passing secret env. vars. :cry: 

#### Does this PR introduce a user-facing change?


```release-note
None
```

