### PR TITLE
Use buildah repo rather than podman repo

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2354,16 +2354,16 @@ function validate_instance_compression {
 }
 
 @test "bud-github-context-with-branch-subdir-commit" {
+  subdir=tests/bud/from-scratch
   target=github-image
-  gitrepo=https://github.com/containers/podman.git#main:contrib/hello
+  gitrepo=https://github.com/containers/buildah.git#main:$subdir
   run_buildah build $WITH_POLICY_JSON -t ${target} "${gitrepo}"
   # check syntax only for subdirectory
-  gitrepo=https://github.com/containers/podman.git#:contrib/hello
+  gitrepo=https://github.com/containers/buildah.git#:$subdir
   run_buildah build $WITH_POLICY_JSON -t ${target} "${gitrepo}"
   # Try pulling repo with specific commit
-  # `contrib/helloimage` is only present on or before `40ba9f10e5fbdd3c9d36389107b8bf1caec6cef0`
-  # hence following test verifies if we are fetching the right commit.
-  gitrepo=https://github.com/containers/podman.git#40ba9f10e5fbdd3c9d36389107b8bf1caec6cef0:contrib/helloimage
+  # This commit is the initial commit, which used Dockerfile rather then Containerfile
+  gitrepo=https://github.com/containers/buildah.git#761597056c8dc2bb1efd67e937a196ddff1fa7a6:$subdir
   run_buildah build $WITH_POLICY_JSON -t ${target} "${gitrepo}"
 }
 


### PR DESCRIPTION
The Podman repo changed and removed a subdir that this tests was relying on.  Rather then relying on a different repo, it would be better to stick to buildah repo for github tests.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

