### PR TITLE
pkg/chrootuser: Ignore comments when parsing /etc/group on FreeBSD

### DIFF
--- a/pkg/chrootuser/user_test.go
+++ b/pkg/chrootuser/user_test.go
@@ -1,0 +1,40 @@
+package chrootuser
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testGroupData = `# comment
+  # indented comment
+wheel:*:0:root
+daemon:*:1:
+kmem:*:2:
+`
+
+func TestParseStripComments(t *testing.T) {
+	// Test reading group file, ignoring comment lines
+	rc := bufio.NewScanner(strings.NewReader(testGroupData))
+	line, ok := scanWithoutComments(rc)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, line, "wheel:*:0:root")
+}
+
+func TestParseNextGroup(t *testing.T) {
+	// Test parsing group file
+	rc := bufio.NewScanner(strings.NewReader(testGroupData))
+	expected := []lookupGroupEntry{
+		lookupGroupEntry{"wheel", 0, "root"},
+		lookupGroupEntry{"daemon", 1, ""},
+		lookupGroupEntry{"kmem", 2, ""},
+	}
+	for _, exp := range expected {
+		grp := parseNextGroup(rc)
+		assert.NotNil(t, grp)
+		assert.Equal(t, *grp, exp)
+	}
+	assert.Nil(t, parseNextGroup(rc))
+}


### PR DESCRIPTION
On FreeBSD systems, /etc/group typically looks like this:
```
# $FreeBSD$
#
wheel:*:0:root,dfr
daemon:*:1:
kmem:*:2:
sys:*:3:
...
```

This caused an error for a Containerfile that created a user, then used ```COPY --chown=myuser:mygroup```. 

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind cleanup

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

