### PR TITLE
Support passing of ULimits as -1 to mean max

### DIFF
--- a/pkg/util/resource_unix.go
+++ b/pkg/util/resource_unix.go
@@ -1,0 +1,38 @@
+//go:build linux || freebsd || darwin
+// +build linux freebsd darwin
+
+package util
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/docker/go-units"
+)
+
+func ParseUlimit(ulimit string) (*units.Ulimit, error) {
+	ul, err := units.ParseUlimit(ulimit)
+	if err != nil {
+		return nil, fmt.Errorf("ulimit option %q requires name=SOFT:HARD, failed to be parsed: %w", ulimit, err)
+	}
+
+	if ul.Hard != -1 && ul.Soft == -1 {
+		return ul, nil
+	}
+
+	rl, err := ul.GetRlimit()
+	if err != nil {
+		return nil, err
+	}
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(rl.Type, &limit); err != nil {
+		return nil, err
+	}
+	if ul.Soft == -1 {
+		ul.Soft = int64(limit.Cur)
+	}
+	if ul.Hard == -1 {
+		ul.Hard = int64(limit.Max)
+	}
+	return ul, nil
+}

--- a/pkg/util/resource_unix_test.go
+++ b/pkg/util/resource_unix_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseUlimit(t *testing.T) {
+	_, err := ParseUlimit("bogus")
+	assert.NotNil(t, err)
+
+	ul, err := ParseUlimit("memlock=100:200")
+	assert.Nil(t, err)
+	assert.Equal(t, ul.Soft, int64(100))
+	assert.Equal(t, ul.Hard, int64(200))
+
+	var limit syscall.Rlimit
+	err = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit)
+	assert.Nil(t, err)
+
+	ul, err = ParseUlimit("nofile=-1:-1")
+	assert.Nil(t, err)
+	assert.Equal(t, ul.Soft, int64(limit.Cur))
+	assert.Equal(t, ul.Hard, int64(limit.Max))
+
+	ul, err = ParseUlimit("nofile=100:-1")
+	assert.Nil(t, err)
+	assert.Equal(t, ul.Soft, int64(100))
+	assert.Equal(t, ul.Hard, int64(limit.Max))
+}

--- a/pkg/util/resource_windows.go
+++ b/pkg/util/resource_windows.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/docker/go-units"
+)
+
+func ParseUlimit(ulimit string) (*units.Ulimit, error) {
+	ul, err := units.ParseUlimit(ulimit)
+	if err != nil {
+		return nil, fmt.Errorf("ulimit option %q requires name=SOFT:HARD, failed to be parsed: %w", ulimit, err)
+	}
+
+	return ul, nil
+}

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/buildah/pkg/jail"
 	"github.com/containers/buildah/pkg/overlay"
 	"github.com/containers/buildah/pkg/parse"
+	butil "github.com/containers/buildah/pkg/util"
 	"github.com/containers/buildah/util"
 	"github.com/containers/common/libnetwork/resolvconf"
 	nettypes "github.com/containers/common/libnetwork/types"
@@ -559,7 +560,7 @@ func addRlimits(ulimit []string, g *generate.Generator, defaultUlimits []string)
 
 	ulimit = append(defaultUlimits, ulimit...)
 	for _, u := range ulimit {
-		if ul, err = units.ParseUlimit(u); err != nil {
+		if ul, err = butil.ParseUlimit(u); err != nil {
 			return fmt.Errorf("ulimit option %q requires name=SOFT:HARD, failed to be parsed: %w", u, err)
 		}
 

--- a/run_linux.go
+++ b/run_linux.go
@@ -22,6 +22,7 @@ import (
 	internalParse "github.com/containers/buildah/internal/parse"
 	"github.com/containers/buildah/pkg/overlay"
 	"github.com/containers/buildah/pkg/parse"
+	butil "github.com/containers/buildah/pkg/util"
 	"github.com/containers/buildah/util"
 	"github.com/containers/common/libnetwork/pasta"
 	"github.com/containers/common/libnetwork/resolvconf"
@@ -873,7 +874,7 @@ func addRlimits(ulimit []string, g *generate.Generator, defaultUlimits []string)
 
 	ulimit = append(defaultUlimits, ulimit...)
 	for _, u := range ulimit {
-		if ul, err = units.ParseUlimit(u); err != nil {
+		if ul, err = butil.ParseUlimit(u); err != nil {
 			return fmt.Errorf("ulimit option %q requires name=SOFT:HARD, failed to be parsed: %w", u, err)
 		}
 


### PR DESCRIPTION
Docker allows the passing of -1 to indicate the maximum limit allowed for the current process.

Fixes: https://github.com/containers/podman/issues/19319

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
You can now specify -1 for valures when setting ulimits to indicate maximum.
```

