### PR TITLE
Fixing the owner of the storage.conf.

### DIFF
--- a/contrib/buildahimage/Containerfile
+++ b/contrib/buildahimage/Containerfile
@@ -99,7 +99,8 @@ RUN sed -e 's|^#mount_program|mount_program|g' \
         -e 's|^graphroot|#graphroot|g' \
         -e 's|^runroot|#runroot|g' \
         /etc/containers/storage.conf \
-        > /home/build/.config/containers/storage.conf
+        > /home/build/.config/containers/storage.conf && \
+        chown build:build /home/build/.config/containers/storage.conf
 
 VOLUME /var/lib/containers
 VOLUME /home/build/.local/share/containers


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
In the Containerfile for the buildah image when the containers storage.conf file is created for the build user, the file is owned by root by adding a chown for the build user after the file is created it will then be owned by the build user.

#### How to verify it
cd contrib/buildahimage
buildah build -t buildah:test -f Containerfile .
podman run --rm -u 1000 buildah:test ls -l /home/build/.config/containers/storage.conf

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:
A new PR of https://github.com/containers/buildah/pull/4993 with a shorter git commit title so it can pass the CI.

#### Does this PR introduce a user-facing change?

None
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

