### PR TITLE
[skip-ci] GHA: Attempt to fix discussion_lock workflow

### DIFF
--- a/.github/workflows/discussion_lock.yml
+++ b/.github/workflows/discussion_lock.yml
@@ -15,5 +15,6 @@ jobs:
     uses: containers/podman/.github/workflows/discussion_lock.yml@main
     secrets: inherit
     permissions:
+      contents: read
       issues: write
       pull-requests: write


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

After initial merge, manually running this workflow [resulted in the following error](https://github.com/containers/buildah/actions/runs/5980317356):

```
Invalid workflow file: .github/workflows/discussion_lock.yml#L14
The workflow is not valid. .github/workflows/discussion_lock.yml (Line:
14, Col: 3): Error calling workflow
'containers/podman/.github/workflows/discussion_lock.yml@main'. The
workflow is requesting 'contents: read', but is only allowed 'contents:
none'.
```

Attempt to fix this by adding `contents: read` permission.  Why this isn't the default, and exactly what the meaning of `none` is for all the other permissions is a mystery (and it's not documented).

Ref: https://github.com/containers/buildah/pull/4991

#### How to verify it

Complex, difficult and very inconvenient.  The "easy" way is to merge it and manually run to see if it works (at all) :cry: 

#### Which issue(s) this PR fixes:

Fixes #4991

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

