### PR TITLE
push: `--force-compression` should be `true` with `--compression-format`

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -878,6 +878,13 @@ func manifestPushCmd(c *cobra.Command, args []string, opts pushOptions) error {
 	if c.Flag("compression-level").Changed {
 		systemContext.CompressionLevel = &opts.compressionLevel
 	}
+	if c.Flag("compression-format").Changed {
+		if !c.Flag("force-compression").Changed {
+			// If `compression-format` is set and no value for `--force-compression`
+			// is selected then defaults to `true`.
+			opts.forceCompressionFormat = true
+		}
+	}
 
 	return manifestPush(systemContext, store, listImageSpec, destSpec, opts)
 }

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -199,6 +199,13 @@ func pushCmd(c *cobra.Command, args []string, iopts pushOptions) error {
 	if err != nil {
 		return fmt.Errorf("unable to parse value provided %q as --retry-delay: %w", iopts.retryDelay, err)
 	}
+	if c.Flag("compression-format").Changed {
+		if !c.Flag("force-compression").Changed {
+			// If `compression-format` is set and no value for `--force-compression`
+			// is selected then defaults to `true`.
+			iopts.forceCompressionFormat = true
+		}
+	}
 
 	options := buildah.PushOptions{
 		Compression:            compress,

--- a/docs/buildah-manifest-push.1.md
+++ b/docs/buildah-manifest-push.1.md
@@ -64,7 +64,8 @@ After copying the image, write the digest of the resulting image to the file.
 
 **--force-compression**
 
-Use the specified compression algorithm even if the destination contains a differently-compressed variant already.
+If set, push uses the specified compression algorithm even if the destination contains a differently-compressed variant already.
+Defaults to `true` if `--compression-format` is explicitly specified on the command-line, `false` otherwise.
 
 **--format**, **-f**
 

--- a/docs/buildah-push.1.md
+++ b/docs/buildah-push.1.md
@@ -72,7 +72,8 @@ The [protocol:keyfile] specifies the encryption protocol, which can be JWE (RFC7
 
 **--force-compression**
 
-Use the specified compression algorithm even if the destination contains a differently-compressed variant already.
+If set, push uses the specified compression algorithm even if the destination contains a differently-compressed variant already.
+Defaults to `true` if `--compression-format` is explicitly specified on the command-line, `false` otherwise.
 
 **--format**, **-f**
 


### PR DESCRIPTION
With discussion from here:
https://github.com/containers/podman/pull/19640, it was decided that `--force-compression` must be automatically `true` in case when `--compression-format` is set. Following PR does that.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
push: --force-compression should be true with --compression-format
```

