### PR TITLE
Don't try to look up names when committing images

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -376,15 +376,11 @@ func (b *Executor) resolveNameToImageRef(output string) (types.ImageReference, e
 	if imageRef, err := alltransports.ParseImageName(output); err == nil {
 		return imageRef, nil
 	}
-	runtime, err := libimage.RuntimeFromStore(b.store, &libimage.RuntimeOptions{SystemContext: b.systemContext})
+	resolved, err := libimage.NormalizeName(output)
 	if err != nil {
 		return nil, err
 	}
-	resolved, err := runtime.ResolveName(output)
-	if err != nil {
-		return nil, err
-	}
-	imageRef, err := storageTransport.Transport.ParseStoreReference(b.store, resolved)
+	imageRef, err := storageTransport.Transport.ParseStoreReference(b.store, resolved.String())
 	if err == nil {
 		return imageRef, nil
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6359,3 +6359,12 @@ _EOF
     false
   fi
 }
+
+@test "build with name path changes" {
+  _prefetch busybox
+  run_buildah build --no-cache --quiet --pull=false $WITH_POLICY_JSON -t foo/bar $BUDFILES/commit/name-path-changes/
+  run_buildah build --no-cache --quiet --pull=false $WITH_POLICY_JSON -t bar $BUDFILES/commit/name-path-changes/
+  run_buildah images
+  expect_output --substring "localhost/foo/bar"
+  expect_output --substring "localhost/bar"
+}

--- a/tests/bud/commit/name-path-changes/Dockerfile
+++ b/tests/bud/commit/name-path-changes/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+RUN pwd


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Don't try to look up an image by name when we're committing an image, because we don't want to accidentally take advantage of any fuzzy matching that libimage might start doing.  Instead, just use the normalization call.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes #5022 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```