### PR TITLE
stage_executor: allow images without layers 

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1033,7 +1033,13 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// squash the contents of the base image.  Whichever is
 			// the case, we need to commit() to create a new image.
 			logCommit(s.output, -1)
-			if imgID, ref, err = s.commit(ctx, s.getCreatedBy(nil, ""), false, s.output, s.executor.squash, lastStage); err != nil {
+			emptyLayer := false
+			if s.builder.FromImageID == "" {
+				// No base image means there's nothing to put in a
+				// layer, so don't create one.
+				emptyLayer = true
+			}
+			if imgID, ref, err = s.commit(ctx, s.getCreatedBy(nil, ""), emptyLayer, s.output, s.executor.squash, lastStage); err != nil {
 				return "", nil, fmt.Errorf("committing base container: %w", err)
 			}
 			// Generate build output if needed.

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -89,6 +89,15 @@ _EOF
   validate_instance_compression "3" "$list" "arm64" "zstd"
 }
 
+@test "no layer should be created on scratch" {
+  run_buildah build --layers --label "label1=value1" -t test -f $BUDFILES/from-scratch/Containerfile
+  run_buildah inspect -f '{{len .Docker.RootFS.DiffIDs}}' test
+  expect_output "0" "layer should not exist"
+  run_buildah build --layers -t test -f $BUDFILES/from-scratch/Containerfile
+  run_buildah inspect -f '{{len .Docker.RootFS.DiffIDs}}' test
+  expect_output "0" "layer should not exist"
+}
+
 @test "bud: build push with --force-compression" {
   skip_if_no_podman
   local contextdir=${TEST_SCRATCH_DIR}/bud/platform


### PR DESCRIPTION
A build case where base is `scratch` and nothing else, then produce image without layer.

This matches with `buildkit` and `docker`.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
 stage_executor: allow images without layers
```

