### PR TITLE
Make sure that pathnames picked up from the environment are absolute

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/storage/pkg/chrootarchive"
 	"github.com/containers/storage/pkg/unshare"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
 )
 
 // LookupImage returns *Image to corresponding imagename or id
@@ -53,7 +54,11 @@ func NormalizePlatform(platform v1.Platform) v1.Platform {
 // GetTempDir returns base for a temporary directory on host.
 func GetTempDir() string {
 	if tmpdir, ok := os.LookupEnv("TMPDIR"); ok {
-		return tmpdir
+		abs, err := filepath.Abs(tmpdir)
+		if err == nil {
+			return abs
+		}
+		logrus.Warnf("ignoring TMPDIR from environment, evaluating it: %v", err)
 	}
 	containerConfig, err := config.Default()
 	if err != nil {

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -19,6 +19,7 @@ import (
 	internalParse "github.com/containers/buildah/internal/parse"
 	internalUtil "github.com/containers/buildah/internal/util"
 	"github.com/containers/buildah/pkg/sshagent"
+	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/parse"
 	"github.com/containers/image/v5/docker/reference"
@@ -449,9 +450,13 @@ func SystemContextFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name strin
 
 func getAuthFile(authfile string) string {
 	if authfile != "" {
-		return authfile
+		absAuthfile, err := filepath.Abs(authfile)
+		if err == nil {
+			return absAuthfile
+		}
+		logrus.Warnf("ignoring passed-in auth file path, evaluating it: %v", err)
 	}
-	return os.Getenv("REGISTRY_AUTH_FILE")
+	return auth.GetDefaultAuthFile()
 }
 
 // PlatformFromOptions parses the operating system (os) and architecture (arch)

--- a/pkg/sshagent/sshagent.go
+++ b/pkg/sshagent/sshagent.go
@@ -201,8 +201,13 @@ func NewSource(paths []string) (*Source, error) {
 	if len(paths) == 0 {
 		socket = os.Getenv("SSH_AUTH_SOCK")
 		if socket == "" {
-			return nil, errors.New("$SSH_AUTH_SOCK not set")
+			return nil, errors.New("SSH_AUTH_SOCK not set in environment")
 		}
+		absSocket, err := filepath.Abs(socket)
+		if err != nil {
+			return nil, fmt.Errorf("evaluating SSH_AUTH_SOCK in environment: %w", err)
+		}
+		socket = absSocket
 	}
 	for _, p := range paths {
 		if socket != "" {


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

When we read TMPDIR and SSH_AUTH_SOCK from the environment, convert them to absolute paths before using them.  Call auth.GetDefaultAuthFile() instead of reading REGISTRY_AUTH_FILE.

#### How to verify it

I'm going to mark this as not needing new tests because we always pass the values we read to `filepath.Abs()`, and tests that set TMPDIR and SSH_AUTH_SOCK already exist.  If this breaks anything, then this should break those tests.

#### Which issue(s) this PR fixes:

Fixes part of RHELPLAN-167391.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```