### PR TITLE
GetTmpDir is not using ImageCopyTmpdir correctly

### DIFF
--- a/internal/tmpdir/tmpdir.go
+++ b/internal/tmpdir/tmpdir.go
@@ -17,10 +17,8 @@ func GetTempDir() string {
 		}
 		logrus.Warnf("ignoring TMPDIR from environment, evaluating it: %v", err)
 	}
-	containerConfig, err := config.Default()
-	if err != nil {
-		tmpdir, err := containerConfig.ImageCopyTmpDir()
-		if err != nil {
+	if containerConfig, err := config.Default(); err == nil {
+		if tmpdir, err := containerConfig.ImageCopyTmpDir(); err == nil {
 			return tmpdir
 		}
 	}

--- a/internal/tmpdir/tmpdir_test.go
+++ b/internal/tmpdir/tmpdir_test.go
@@ -1,0 +1,49 @@
+package tmpdir
+
+import (
+	"os"
+	"testing"
+
+	"github.com/containers/common/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTempDir(t *testing.T) {
+	// test default
+	err := os.Unsetenv("TMPDIR")
+	require.NoError(t, err)
+	err = os.Setenv("CONTAINERS_CONF", "/dev/null")
+	require.NoError(t, err)
+	tmpdir := GetTempDir()
+	assert.Equal(t, "/var/tmp", tmpdir)
+
+	// test TMPDIR Environment
+	err = os.Setenv("TMPDIR", "/tmp/bogus")
+	require.NoError(t, err)
+	tmpdir = GetTempDir()
+	assert.Equal(t, tmpdir, "/tmp/bogus")
+	err = os.Unsetenv("TMPDIR")
+	require.NoError(t, err)
+
+	f, err := os.CreateTemp("", "containers.conf-")
+	require.NoError(t, err)
+	// close and remove the temporary file at the end of the program
+	defer f.Close()
+	defer os.Remove(f.Name())
+	data := []byte("[engine]\nimage_copy_tmp_dir=\"/mnt\"\n")
+	_, err = f.Write(data)
+	require.NoError(t, err)
+
+	err = os.Setenv("CONTAINERS_CONF", f.Name())
+	require.NoError(t, err)
+	// force config reset of default containers.conf
+	options := config.Options{
+		SetDefault: true,
+	}
+	_, err = config.New(&options)
+	require.NoError(t, err)
+	tmpdir = GetTempDir()
+	assert.Equal(t, "/mnt", tmpdir)
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix handling of image_copy_tmp_dir from containers.conf
```

