### PR TITLE
[release-1.32] .cirrus.yml: run tests relative to the release-1.32 branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
     #### Global variables used for all tasks
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
-    DEST_BRANCH: "main"
+    DEST_BRANCH: "release-1.32"
     GOPATH: "/var/tmp/go"
     GOSRC: "${GOPATH}/src/github.com/containers/buildah"
     # Overrides default location (/tmp/cirrus) for repo clone


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Tell Cirrus to use `release-1.32` as a baseline instead of `main`.

#### How to verify it

If tests keep passing, that'll be good sign.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```