### PR TITLE
add/copy: make sure we handle relative path names correctly

### DIFF
--- a/add.go
+++ b/add.go
@@ -456,9 +456,11 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		// Iterate through every item that matched the glob.
 		itemsCopied := 0
 		for _, glob := range localSourceStat.Globbed {
-			rel, err := filepath.Rel(contextDir, glob)
-			if err != nil {
-				return fmt.Errorf("computing path of %q relative to %q: %w", glob, contextDir, err)
+			rel := glob
+			if filepath.IsAbs(glob) {
+				if rel, err = filepath.Rel(contextDir, glob); err != nil {
+					return fmt.Errorf("computing path of %q relative to %q: %w", glob, contextDir, err)
+				}
 			}
 			if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 				return fmt.Errorf("possible escaping context directory error: %q is outside of %q", glob, contextDir)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Make sure that `add` and `copy` handle relative paths given as input correctly, both with and without a context directory being specified.

#### How to verify it

New integration tests!

#### Which issue(s) this PR fixes:

Fixes #5049.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah add` and `buildah copy` should correctly handle relative path names for sources when the `--context-directory` flag is used.
```