### PR TITLE
[CI:BUILD] Packit: tag @packit-build team on copr build failures

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,7 +11,9 @@ srpm_build_deps:
 jobs:
   - job: copr_build
     trigger: pull_request
-    # keep in sync with https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next
+    notifications:
+      failure_comment:
+        message: "Ephemeral COPR build failed. @containers/packit-build please check."
     enable_net: true
     targets:
       - fedora-all-x86_64
@@ -28,6 +30,9 @@ jobs:
   # Run on commit to main branch
   - job: copr_build
     trigger: commit
+    notifications:
+      failure_comment:
+        message: "podman-next COPR build failed. @containers/packit-build please check."
     owner: rhcontainerbot
     project: podman-next
     enable_net: true


### PR DESCRIPTION
This change will auto-tag @containers/packit-build team in a github comment on every copr build failure.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


/kind other

#### What this PR does / why we need it:

Will tag @containers/packit-build team on packit build failures. Less hassle for humans.

#### How to verify it

See packit comments by `packit-as-a-service` bot on https://github.com/containers/podman/pull/20061

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

