### PR TITLE
build: add support for `--inherit-labels`

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -228,6 +228,9 @@ type BuildOptions struct {
 	// ID mapping options to use if we're setting up our own user namespace
 	// when handling RUN instructions.
 	IDMappingOptions *IDMappingOptions
+	// InheritLabels allows users to specify if they want
+	// to inheritlabels from base image or not.
+	InheritLabels types.OptionalBool
 	// AddCapabilities is a list of capabilities to add to the default set when
 	// handling RUN instructions.
 	AddCapabilities []string

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -484,6 +484,10 @@ Path to an alternative .containerignore (.dockerignore) file.
 Write the built image's ID to the file.  When `--platform` is specified more
 than once, attempting to use this option will trigger an error.
 
+**--inherit-labels** *bool-value*
+
+Allows users to specify if they want to inherit labels from base image or not. (Default is `true`).
+
 **--ipc** *how*
 
 Sets the configuration for IPC namespaces when handling `RUN` instructions.

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -81,6 +81,7 @@ type Executor struct {
 	additionalTags                 []string
 	log                            func(format string, args ...interface{}) // can be nil
 	in                             io.Reader
+	inheritLabels                  types.OptionalBool
 	out                            io.Writer
 	err                            io.Writer
 	signaturePolicyPath            string
@@ -235,6 +236,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		excludes:                       excludes,
 		groupAdd:                       options.GroupAdd,
 		ignoreFile:                     options.IgnoreFile,
+		inheritLabels:                  options.InheritLabels,
 		pullPolicy:                     options.PullPolicy,
 		registry:                       options.Registry,
 		ignoreUnrecognizedInstructions: options.IgnoreUnrecognizedInstructions,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -830,6 +830,11 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 			RootFS:          rootfs,
 		}
 		dImage.Config = &dImage.ContainerConfig
+		if s.executor.inheritLabels == types.OptionalBoolFalse {
+			// If user has selected `--inherit-labels=false` lets not
+			// inherit labels from base image.
+			dImage.Config.Labels = nil
+		}
 		err = ib.FromImage(&dImage, node)
 		if err != nil {
 			if err2 := builder.Delete(); err2 != nil {

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -388,6 +388,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		IIDFile:                 iopts.Iidfile,
 		IgnoreFile:              iopts.IgnoreFile,
 		In:                      stdin,
+		InheritLabels:           types.NewOptionalBool(iopts.InheritLabels),
 		Isolation:               isolation,
 		Jobs:                    &iopts.Jobs,
 		Labels:                  iopts.Label,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -71,6 +71,7 @@ type BudResults struct {
 	Format              string
 	From                string
 	Iidfile             string
+	InheritLabels       bool
 	Label               []string
 	LayerLabel          []string
 	Logfile             string
@@ -216,6 +217,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.CacheTTL, "cache-ttl", "", "only consider cache images under specified duration.")
 	fs.StringVar(&flags.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	fs.BoolVar(&flags.Compress, "compress", false, "this is a legacy option, which has no effect on the image")
+	fs.BoolVar(&flags.InheritLabels, "inherit-labels", true, "inherit labels from base image")
 	fs.StringArrayVar(&flags.CPPFlags, "cpp-flag", []string{}, "set additional flag to pass to C preprocessor (cpp)")
 	fs.StringVar(&flags.Creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	fs.StringVarP(&flags.CWOptions, "cw", "", "", "confidential workload `options`")
@@ -312,6 +314,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["jobs"] = commonComp.AutocompleteNone
 	flagCompletion["label"] = commonComp.AutocompleteNone
 	flagCompletion["layer-label"] = commonComp.AutocompleteNone
+	flagCompletion["inherit-labels"] = commonComp.AutocompleteNone
 	flagCompletion["logfile"] = commonComp.AutocompleteDefault
 	flagCompletion["manifest"] = commonComp.AutocompleteDefault
 	flagCompletion["os"] = commonComp.AutocompleteNone

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2090,6 +2090,25 @@ _EOF
   done
 }
 
+@test "bud and test inherit-labels" {
+  run_buildah --version
+  local -a output_fields=($output)
+  buildah_version=${output_fields[2]}
+  run_buildah build $WITH_POLICY_JSON -t exp -f $BUDFILES/base-with-labels/Containerfile
+
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "license"}}' exp
+  expect_output "MIT" "license must be MIT from fedora base image"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' exp
+  expect_output "fedora" "name must be fedora from base image"
+
+  run_buildah build $WITH_POLICY_JSON --inherit-labels=false --label hello=world -t exp -f $BUDFILES/base-with-labels/Containerfile
+  # no labels should be inherited from base image only the, buildah version label
+  # and `hello=world` which we just added using cli flag
+  want_output='map["hello":"world" "io.buildah.version":"'$buildah_version'"]'
+  run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' exp
+  expect_output "$want_output"
+}
+
 @test "build using intermediate images should not inherit label" {
   _prefetch alpine
 

--- a/tests/bud/base-with-labels/Containerfile
+++ b/tests/bud/base-with-labels/Containerfile
@@ -1,0 +1,2 @@
+FROM registry.fedoraproject.org/fedora-minimal
+RUN echo hello


### PR DESCRIPTION
Allows users to specify if they want to inherit labels from base image or not.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build: add support for --inherit-labels
```

