### PR TITLE
build,config: add support for `--unsetlabel`

### DIFF
--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -47,6 +47,7 @@ type configResults struct {
 	variant                string
 	volume                 []string
 	workingDir             string
+	unsetLabels            []string
 }
 
 func init() {
@@ -98,6 +99,7 @@ func init() {
 	flags.StringVar(&opts.variant, "variant", "", "set architecture `variant` of the target image")
 	flags.StringSliceVarP(&opts.volume, "volume", "v", []string{}, "add default `volume` path to be created for containers based on image (default [])")
 	flags.StringVar(&opts.workingDir, "workingdir", "", "set working `directory` for containers based on image")
+	flags.StringSliceVar(&opts.unsetLabels, "unsetlabel", nil, "remove image configuration label")
 
 	rootCmd.AddCommand(configCommand)
 
@@ -301,6 +303,10 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 			}
 		}
 		conditionallyAddHistory(builder, c, "/bin/sh -c #(nop) LABEL %s", strings.Join(iopts.label, " "))
+	}
+	// unset labels if any
+	for _, key := range  iopts.unsetLabels {
+		builder.UnsetLabel(key)
 	}
 	if c.Flag("workingdir").Changed {
 		builder.SetWorkDir(iopts.workingDir)

--- a/define/build.go
+++ b/define/build.go
@@ -318,6 +318,8 @@ type BuildOptions struct {
 	AllPlatforms bool
 	// UnsetEnvs is a list of environments to not add to final image.
 	UnsetEnvs []string
+	// UnsetLabels is a list of labels to not add to final image from base image.
+	UnsetLabels []string
 	// Envs is a list of environment variables to set in the final image.
 	Envs []string
 	// OSFeatures specifies operating system features the image requires.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -910,6 +910,10 @@ include:
 
 Unset environment variables from the final image.
 
+**--unsetlabel** *label*
+
+Unset the image label, causing the label not to be inherited from the base image.
+
 **--userns** *how*
 
 Sets the configuration for user namespaces when handling `RUN` instructions.

--- a/docs/buildah-config.1.md
+++ b/docs/buildah-config.1.md
@@ -200,6 +200,10 @@ Note: this setting is not present in the OCIv1 image format, so it is discarded 
 
 Set default *stop signal* for container. This signal will be sent when container is stopped, default is SIGINT.
 
+**--unsetlabel** *label*
+
+Unset the image label, causing the label not to be inherited from the base image.
+
 **--user**, **-u** *user*[:*group*]
 
 Set the default *user* to be used when running containers based on this image.

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -142,6 +142,7 @@ type Executor struct {
 	sshsources              map[string]*sshagent.Source
 	logPrefix               string
 	unsetEnvs               []string
+	unsetLabels             []string
 	processLabel            string // Shares processLabel of first stage container with containers of other stages in same build
 	mountLabel              string // Shares mountLabel of first stage container with containers of other stages in same build
 	buildOutput             string // Specifies instructions for any custom build output
@@ -300,6 +301,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		sshsources:                     sshsources,
 		logPrefix:                      logPrefix,
 		unsetEnvs:                      append([]string{}, options.UnsetEnvs...),
+		unsetLabels:                    append([]string{}, options.UnsetLabels...),
 		buildOutput:                    options.BuildOutput,
 		osVersion:                      options.OSVersion,
 		osFeatures:                     append([]string{}, options.OSFeatures...),

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -2042,6 +2042,9 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	if s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolUndefined || s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolTrue {
 		s.builder.SetLabel(buildah.BuilderIdentityAnnotation, define.Version)
 	}
+	for _, key := range s.executor.unsetLabels {
+		s.builder.UnsetLabel(key)
+	}
 	for _, annotationSpec := range s.executor.annotations {
 		annotation := strings.SplitN(annotationSpec, "=", 2)
 		if len(annotation) > 1 {

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -425,6 +425,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		Timestamp:               timestamp,
 		TransientMounts:         iopts.Volumes,
 		UnsetEnvs:               iopts.UnsetEnvs,
+		UnsetLabels:             iopts.UnsetLabels,
 	}
 	if iopts.Quiet {
 		options.ReportWriter = io.Discard

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -104,6 +104,7 @@ type BudResults struct {
 	LogRusage           bool
 	RusageLogFile       string
 	UnsetEnvs           []string
+	UnsetLabels         []string
 	Envs                []string
 	OSFeatures          []string
 	OSVersion           string
@@ -283,6 +284,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.BoolVar(&flags.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	fs.String("variant", "", "override the `variant` of the specified image")
 	fs.StringSliceVar(&flags.UnsetEnvs, "unsetenv", nil, "unset environment variable from final image")
+	fs.StringSliceVar(&flags.UnsetLabels, "unsetlabel", nil, "unset label when inheriting labels from base image")
 	return fs
 }
 
@@ -328,6 +330,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["target"] = commonComp.AutocompleteNone
 	flagCompletion["timestamp"] = commonComp.AutocompleteNone
 	flagCompletion["unsetenv"] = commonComp.AutocompleteNone
+	flagCompletion["unsetlabel"] = commonComp.AutocompleteNone
 	flagCompletion["variant"] = commonComp.AutocompleteNone
 	return flagCompletion
 }

--- a/tests/bud/base-with-labels/Containerfile
+++ b/tests/bud/base-with-labels/Containerfile
@@ -1,0 +1,2 @@
+FROM registry.fedoraproject.org/fedora-minimal
+RUN echo hello

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -81,6 +81,20 @@ function check_matrix() {
   check_matrix 'Config.Entrypoint' '[/bin/sh -c /ENTRYPOINT]'
 }
 
+@test "config --unsetlabel" {
+  _prefetch registry.fedoraproject.org/fedora-minimal
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON registry.fedoraproject.org/fedora-minimal
+  cid=$output
+  run_buildah commit $WITH_POLICY_JSON $cid with-name-label
+  run_buildah config --unsetlabel name $cid
+  run_buildah commit $WITH_POLICY_JSON $cid without-name-label
+
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' with-name-label
+  expect_output "fedora" "name label should be set with value as fedora"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' without-name-label
+  expect_output "" "name label should be removed"
+}
+
 @test "config set empty entrypoint doesn't wipe cmd" {
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output


### PR DESCRIPTION
Just like `--unsetenv` following flag allows to unset image label.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build: add support for `--unsetlabel`
config: add support for `--unsetlabel`
```

Closes: https://github.com/containers/buildah/issues/5063
