### PR TITLE
Ensure the mount type is always BindMount by default

### DIFF
--- a/run_common.go
+++ b/run_common.go
@@ -1509,8 +1509,6 @@ func checkIfMountDestinationPreExists(root string, dest string) (bool, error) {
 //
 // If this function succeeds, the caller must unlock runMountArtifacts.TargetLocks (when??)
 func (b *Builder) runSetupRunMounts(mountPoint string, mounts []string, sources runMountInfo, idMaps IDMaps) ([]specs.Mount, *runMountArtifacts, error) {
-	// If `type` is not set default to TypeBind
-	mountType := define.TypeBind
 	mountTargets := make([]string, 0, 10)
 	tmpFiles := make([]string, 0, len(mounts))
 	mountImages := make([]string, 0, 10)
@@ -1532,6 +1530,10 @@ func (b *Builder) runSetupRunMounts(mountPoint string, mounts []string, sources 
 		var agent *sshagent.AgentServer
 		var tl *lockfile.LockFile
 		tokens := strings.Split(mount, ",")
+
+		// If `type` is not set default to TypeBind
+		mountType := define.TypeBind
+
 		for _, field := range tokens {
 			if strings.HasPrefix(field, "type=") {
 				kv := strings.Split(field, "=")

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6064,6 +6064,16 @@ _EOF
   run_buildah rmi -f testbud
 }
 
+@test "bud-with-multiple-mount-keeps-default-bind-mount" {
+  skip_if_no_runtime
+  skip_if_in_container
+  local contextdir=${TEST_SCRATCH_DIR}/buildkit-mount
+  cp -R $BUDFILES/buildkit-mount $contextdir
+  run_buildah build -t testbud $WITH_POLICY_JSON -f $contextdir/Dockerfilemultiplemounts $contextdir/
+  expect_output --substring "hello"
+  run_buildah rmi -f testbud
+}
+
 @test "bud with user in groups" {
   target=bud-group
   run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/group

--- a/tests/bud/buildkit-mount/Dockerfilemultiplemounts
+++ b/tests/bud/buildkit-mount/Dockerfilemultiplemounts
@@ -1,0 +1,8 @@
+FROM alpine
+RUN mkdir /test
+# use option z if selinux is enabled
+# Order here is important, 'type=Bind' is the default, we want to make sure
+# it stays at it
+RUN --mount=type=cache,target=/test/cache,z \
+    --mount=source=input_file,target=/test/input_file,z \
+    cat /test/input_file


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Previously, when mounting multiple mounts, if any mount had a `type` specified, it would override the default type for subsequent mounts.

This meant, for example, that having a RUN step like:

```
RUN --mount=type=cache,target=/cache --mount=source=.,target=/src
```

would incorrectly mount the second source as a cache, instead of a bind-mount.

This fix ensures the default is reset between each iteration of the loop, ensuring we get the right mount type.

#### How to verify it

Try to build the provided Dockerfile without the patch applied. This will fail, complaining that `/test/input_file` is a directory.

Now apply the patch and see that it correctly outputs `hello`.

Any variation of mounts before one not specifying `type` would also work.

#### Which issue(s) this PR fixes:

None, I can create one if required.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Technically, this is a breaking change for users using buildah, as their mounts might change types. I am unsure what to write here, can someone please provide guidance, or update the release notes?

```release-note

```

