### PR TITLE
Use the parent's image ID in the config that we pass to imagebuilder

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -832,7 +832,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 			}
 		}
 		dImage := docker.Image{
-			Parent:          builder.FromImage,
+			Parent:          builder.FromImageID,
 			ContainerConfig: dConfig,
 			Container:       builder.Container,
 			Author:          builder.Maintainer(),


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When initializing imagebuilder's copy of the working container's configuration, fill in the ID of the parent image where the type would have one, instead of the name we used to find that image.

imagebuilder doesn't reference the field in the struct we're passing in, so this change is really just about tidiness.

#### How to verify it

Nothing to verify, really.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```