### PR TITLE
run: use `internal.GetTempDir` with `os.MkdirTemp` for root and bundle path

### DIFF
--- a/image.go
+++ b/image.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/docker"
 	"github.com/containers/buildah/internal/mkcw"
+	"github.com/containers/buildah/internal/tmpdir"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
@@ -374,7 +375,7 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, sc *types.System
 	logrus.Debugf("layer list: %q", layers)
 
 	// Make a temporary directory to hold blobs.
-	path, err := os.MkdirTemp(os.TempDir(), define.Package)
+	path, err := os.MkdirTemp(tmpdir.GetTempDir(), define.Package)
 	if err != nil {
 		return nil, fmt.Errorf("creating temporary directory to hold layer blobs: %w", err)
 	}

--- a/internal/tmpdir/tmpdir_test.go
+++ b/internal/tmpdir/tmpdir_test.go
@@ -2,6 +2,7 @@ package tmpdir
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/containers/common/pkg/config"
@@ -23,6 +24,14 @@ func TestGetTempDir(t *testing.T) {
 	require.NoError(t, err)
 	tmpdir = GetTempDir()
 	assert.Equal(t, tmpdir, "/tmp/bogus")
+	err = os.Unsetenv("TMPDIR")
+	require.NoError(t, err)
+
+	// relative TMPDIR should be automatically converted to absolute
+	err = os.Setenv("TMPDIR", ".")
+	require.NoError(t, err)
+	tmpdir = GetTempDir()
+	assert.True(t, filepath.IsAbs(tmpdir), "path from GetTempDir should always be absolute")
 	err = os.Unsetenv("TMPDIR")
 	require.NoError(t, err)
 

--- a/pkg/sshagent/sshagent.go
+++ b/pkg/sshagent/sshagent.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containers/buildah/internal/tmpdir"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
@@ -79,7 +80,7 @@ func (a *AgentServer) Serve(processLabel string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	serveDir, err := os.MkdirTemp("", ".buildah-ssh-sock")
+	serveDir, err := os.MkdirTemp(tmpdir.GetTempDir(), ".buildah-ssh-sock")
 	if err != nil {
 		return "", err
 	}

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/buildah/copier"
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/internal"
+	"github.com/containers/buildah/internal/tmpdir"
 	"github.com/containers/buildah/pkg/jail"
 	"github.com/containers/buildah/pkg/overlay"
 	"github.com/containers/buildah/pkg/parse"
@@ -72,7 +73,7 @@ func setChildProcess() error {
 }
 
 func (b *Builder) Run(command []string, options RunOptions) error {
-	p, err := os.MkdirTemp("", Package)
+	p, err := os.MkdirTemp(tmpdir.GetTempDir(), define.Package)
 	if err != nil {
 		return err
 	}

--- a/run_linux.go
+++ b/run_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/buildah/copier"
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/internal"
+	"github.com/containers/buildah/internal/tmpdir"
 	"github.com/containers/buildah/internal/volumes"
 	"github.com/containers/buildah/pkg/overlay"
 	"github.com/containers/buildah/pkg/parse"
@@ -71,7 +72,7 @@ func setChildProcess() error {
 
 // Run runs the specified command in the container's root filesystem.
 func (b *Builder) Run(command []string, options RunOptions) error {
-	p, err := os.MkdirTemp("", define.Package)
+	p, err := os.MkdirTemp(tmpdir.GetTempDir(), define.Package)
 	if err != nil {
 		return err
 	}
@@ -499,7 +500,7 @@ func setupSlirp4netnsNetwork(config *config.Config, netns, cid string, options [
 		Mask: res.Subnet.Mask,
 	}}
 	netStatus := map[string]nettypes.StatusBlock{
-		slirp4netns.BinaryName: nettypes.StatusBlock{
+		slirp4netns.BinaryName: {
 			Interfaces: map[string]nettypes.NetInterface{
 				"tap0": {
 					Subnets: []nettypes.NetAddress{{IPNet: subnet}},
@@ -541,7 +542,7 @@ func setupPasta(config *config.Config, netns string, options []string) (func(), 
 		Mask: net.IPv4Mask(255, 255, 255, 0),
 	}}
 	netStatus := map[string]nettypes.StatusBlock{
-		slirp4netns.BinaryName: nettypes.StatusBlock{
+		slirp4netns.BinaryName: {
 			Interfaces: map[string]nettypes.NetInterface{
 				"tap0": {
 					Subnets: []nettypes.NetAddress{{IPNet: subnet}},


### PR DESCRIPTION
Projects which are using buildah as a library and set `TMPDIR` manually can stumble upon a use-case where `TMPDIR` was set to a relative path.

Such as `export TMPDIR=.` in such case buildah will try to create a temporary root using `Mkdirtemp` leading to a point where bundle is not generated correctly since path was relative.

Following use case can be resolved by making sure that buildah always converts relative path to absolute path and `GetTempDir` does it well.

Example reproducer with podman

```Dockerfile
FROM alpine
RUN echo hello
```

```console
export TMPDIR=.
podman build --no-cache -t test .
```

Expected failure
```console
STEP 1/2: FROM alpine
STEP 2/2: RUN echo hello
error running container: checking permissions on "buildah2341274198": stat buildah2341274198: no such file or directory
ERRO[0000] did not get container create message from subprocess: EOF
Error: building at STEP "RUN echo hello": while running runtime: exit status 1
```

Closes: RHEL-2598

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it
* Integration test cannot be added as it can be only reproduced by projects which are using buildah as a library ( such as podman ) however reproducer for podman is given to verify the bug.

* Unit test added for `GetTempDir` to make sure it is converting relative values to `TMPDIR` to absolute

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
run: use internal.GetTempDir instead of os.MkdirTemp
```

