### PR TITLE
[release-1.32] tag v1.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Changelog
 
+## v1.32.1 (2023-10-23)
+
+    chroot.setupChrootBindMounts: pay more attention to flags
+
 ## v1.32.0 (2023-09-14)
 
     GetTmpDir is not using ImageCopyTmpdir correctly

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+- Changelog for v1.32.1 (2023-10-23)
+  * chroot.setupChrootBindMounts: pay more attention to flags
+
 - Changelog for v1.32.0 (2023-09-14)
   * GetTmpDir is not using ImageCopyTmpdir correctly
   * Run codespell on code

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.32.0"
+	Version = "1.32.1"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
Bump the published version number to v1.32.1 in preparation for tagging a release.