### PR TITLE
copier: only ever pass Uid,Gid=0,0 to tar.FileInfoHeader()

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -1354,7 +1354,7 @@ func handleRename(rename map[string]string, name string) string {
 
 func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath string, options GetOptions, tw *tar.Writer, hardlinkChecker *hardlinkChecker, idMappings *idtools.IDMappings) error {
 	// build the header using the name provided
-	hdr, err := tar.FileInfoHeader(srcfi, symlinkTarget)
+	hdr, err := noLookupFileInfoHeader(srcfi, symlinkTarget)
 	if err != nil {
 		return fmt.Errorf("generating tar header for %s (%s): %w", contentPath, symlinkTarget, err)
 	}

--- a/copier/fiheader.go
+++ b/copier/fiheader.go
@@ -1,0 +1,18 @@
+package copier
+
+import (
+	"archive/tar"
+	"io/fs"
+)
+
+type suppressedSysIDsFileInfo struct {
+	fs.FileInfo
+}
+
+func noLookupFileInfoHeader(fileinfo fs.FileInfo, symlinkTarget string) (*tar.Header, error) {
+	hdr, err := tar.FileInfoHeader(suppressedSysIDsFileInfo{fileinfo}, symlinkTarget)
+	if err == nil {
+		copySysIDs(hdr, fileinfo)
+	}
+	return hdr, err
+}

--- a/copier/fiheader_test.go
+++ b/copier/fiheader_test.go
@@ -1,0 +1,49 @@
+//go:build linux || darwin || freebsd
+
+package copier
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoLookupFileInfoHeader(t *testing.T) {
+	tempDir := t.TempDir()
+
+	f1, err := os.CreateTemp(tempDir, "")
+	require.NoError(t, err, "while creating first temporary file")
+	defer f1.Close()
+	err = f1.Chown(1, 2)
+	require.NoError(t, err, "while chowning first temporary file")
+	err = f1.Sync()
+	require.NoError(t, err, "while syncing first temporary file")
+
+	f2, err := os.CreateTemp(tempDir, "")
+	require.NoError(t, err, "while creating second temporary file")
+	defer f2.Close()
+	err = f2.Chown(3, 4)
+	require.NoError(t, err, "while chowning second temporary file")
+	err = f2.Sync()
+	require.NoError(t, err, "while syncing second temporary file")
+
+	f1i, err := f1.Stat()
+	require.NoError(t, err, "statting first temporary file")
+	h1, err := noLookupFileInfoHeader(f1i, "")
+	require.NoError(t, err, "generating header for first temporary file")
+	f2i, err := f2.Stat()
+	require.NoError(t, err, "statting second temporary file")
+	h2, err := noLookupFileInfoHeader(f2i, "")
+	require.NoError(t, err, "generating header for second temporary file")
+
+	assert.NotEqual(t, 0, h1.Uid, "user owner of first temporary file should be not zero")
+	assert.NotEqual(t, 0, h2.Uid, "user owner of second temporary file should be not zero")
+	assert.NotEqual(t, 0, h1.Gid, "group owner of first temporary file should be not zero")
+	assert.NotEqual(t, 0, h2.Gid, "group owner of second temporary file should be not zero")
+	assert.Equal(t, "", h1.Uname, "user owner of first temporary file should have been left blank")
+	assert.Equal(t, "", h2.Uname, "user owner of second temporary file should have been left blank")
+	assert.Equal(t, "", h1.Gname, "group owner of first temporary file should have been left blank")
+	assert.Equal(t, "", h2.Gname, "group owner of second temporary file should have been left blank")
+}

--- a/copier/fiheader_unix.go
+++ b/copier/fiheader_unix.go
@@ -1,0 +1,29 @@
+//go:build linux || darwin || freebsd
+// +build linux darwin freebsd
+
+package copier
+
+import (
+	"archive/tar"
+	"io/fs"
+	"syscall"
+)
+
+func copySysIDs(hdr *tar.Header, fileinfo fs.FileInfo) {
+	sys := fileinfo.Sys()
+	if st, ok := sys.(*syscall.Stat_t); ok {
+		hdr.Uid = int(st.Uid)
+		hdr.Gid = int(st.Gid)
+		hdr.Uname, hdr.Gname = "", ""
+	}
+}
+
+func (nsfi suppressedSysIDsFileInfo) Sys() any {
+	sys := nsfi.FileInfo.Sys()
+	if st, ok := sys.(*syscall.Stat_t); ok {
+		copied := *st
+		copied.Uid, copied.Gid = 0, 0
+		return &copied
+	}
+	return sys
+}

--- a/copier/fiheader_windows.go
+++ b/copier/fiheader_windows.go
@@ -1,0 +1,9 @@
+package copier
+
+import (
+	"archive/tar"
+	"io/fs"
+)
+
+func copySysIDs(hdr *tar.Header, fileinfo fs.FileInfo) {
+}

--- a/copier/hardlink_windows.go
+++ b/copier/hardlink_windows.go
@@ -1,6 +1,3 @@
-//go:build !linux && !darwin
-// +build !linux,!darwin
-
 package copier
 
 import (


### PR DESCRIPTION
Let tar.FileInfoHeader() do most of what it needs to do, but only pass it Uid,Gid=0,0 so that it never looks up anything other than that pair. We'll copy those values from the fileinfo.Sys() data ourselves.  _Maybe_ this will speed up the unit tests.  If it does, I'll fill this form out properly.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

