### PR TITLE
Log the platform for build errors during multi-platform builds

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -267,6 +267,9 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 			}
 			thisID, thisRef, err := buildDockerfilesOnce(ctx, store, loggerPerPlatform, logPrefix, platformOptions, paths, files)
 			if err != nil {
+				if errorContext := strings.TrimSpace(logPrefix); errorContext != "" {
+					return fmt.Errorf("%s: %w", errorContext, err)
+				}
 				return err
 			}
 			instancesLock.Lock()


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

When a multi-platform build fails and we hand an error back, add the platform to the error's context so that it's easier to tell at the end of the log which platform the build failed for.

#### How to verify it

Build with multiple `--platform` values (e.g. `--platform linux/arm64,linux/amd64,linux/ppc64le,linux/s390x`), and have one or more of them fail.  Example:
```Dockerfile
FROM fedora
RUN test `arch` = x86_64
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Nothing earth-shattering, just something to make troubleshooting a little bit easier.

#### Does this PR introduce a user-facing change?

```release-note
When a build which uses multiple --platform flags fails, the error message will indicate which platform experienced the failure.
```