### PR TITLE
[release-1.28] run the cross-compile test on M1 MacOS, not Intel

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -140,7 +140,7 @@ cross_build_task:
         $CIRRUS_CRON != 'multiarch'
 
     osx_instance:
-        image: 'big-sur-base'
+        image: ghcr.io/cirruslabs/macos-ventura-base:latest
 
     script:
         - brew update

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -191,7 +191,7 @@ conformance_task:
     gce_instance:
         image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
 
-    timeout_in: 25m
+    timeout_in: 45m
 
     matrix:
         - env:

--- a/install.md
+++ b/install.md
@@ -323,7 +323,7 @@ cat /etc/containers/registries.conf
 # and 'registries.block'.
 
 [registries.search]
-registries = ['docker.io', 'registry.fedoraproject.org', 'quay.io', 'registry.access.redhat.com', 'registry.centos.org']
+registries = ['docker.io', 'registry.fedoraproject.org', 'quay.io', 'registry.access.redhat.com']
 
 # If you need to access insecure registries, add the registry's fully-qualified name.
 # An insecure registry is one that does not have a valid SSL certificate or only does HTTP.

--- a/tests/conformance/testdata/Dockerfile.reusebase
+++ b/tests/conformance/testdata/Dockerfile.reusebase
@@ -1,4 +1,4 @@
-FROM registry.centos.org/centos/centos:centos7 AS base
+FROM docker.io/library/centos:centos7 AS base
 RUN touch -t 201701261659.13 /1
 ENV LOCAL=/1
 

--- a/tests/conformance/testdata/Dockerfile.shell
+++ b/tests/conformance/testdata/Dockerfile.shell
@@ -1,3 +1,3 @@
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 SHELL ["/bin/bash", "-xc"]
 RUN env

--- a/tests/conformance/testdata/copy/Dockerfile
+++ b/tests/conformance/testdata/copy/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 COPY script /usr/bin
 RUN ls -al /usr/bin/script

--- a/tests/conformance/testdata/copydir/Dockerfile
+++ b/tests/conformance/testdata/copydir/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 COPY dir /dir
 RUN ls -al /dir/file

--- a/tests/conformance/testdata/copyrename/Dockerfile
+++ b/tests/conformance/testdata/copyrename/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 COPY file1 /usr/bin/file2
 RUN ls -al /usr/bin/file2 && ! ls -al /usr/bin/file1

--- a/tests/conformance/testdata/copysymlink/Dockerfile
+++ b/tests/conformance/testdata/copysymlink/Dockerfile
@@ -1,2 +1,2 @@
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 COPY file-link.tar.gz /

--- a/tests/conformance/testdata/copysymlink/Dockerfile2
+++ b/tests/conformance/testdata/copysymlink/Dockerfile2
@@ -1,7 +1,7 @@
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 COPY file.tar.gz /
 RUN ln -s file.tar.gz file-link.tar.gz
 RUN ls -l /file-link.tar.gz
-FROM registry.centos.org/centos/centos:centos7
+FROM docker.io/library/centos:centos7
 COPY --from=0 /file-link.tar.gz /
 RUN ls -l /file-link.tar.gz

--- a/tests/test_buildah_rpm.sh
+++ b/tests/test_buildah_rpm.sh
@@ -12,7 +12,7 @@ load helpers
         skip_if_no_runtime
 
         # Build a container to use for building the binaries.
-        image=registry.centos.org/centos/centos:centos7
+        image=docker.io/library/centos:centos7
         cid=$(buildah from --pull --signature-policy ${TEST_SOURCES}/policy.json $image)
         root=$(buildah mount $cid)
         commit=$(git log --format=%H -n 1)


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

* Cirrus no longer supports running tests on Intel-based versions of MacOS, so we need to switch this test to use an M1-based version.
* The registry at registry.centos.org has been decommissioned, so update tests that referred to images that it hosted to use docker.io/library/centos in its place.

#### How to verify it

* The cross-compile test should pass again.
* Tests that used centos:7 as a base image should pass again.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Hopefully this will get #5119 passing.

#### Does this PR introduce a user-facing change?

```release-note
None
```