### PR TITLE
[release-1.29] bump version to v1.29.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 # Changelog
 
+## v1.29.2 (2023-10-31)
+
+    Mask /sys/devices/virtual/powercap by default
+    remove registry.centos.org
+    Cirrus: Increase conformance-test timeout
+    Cirrus: Add CI self-destruct condition on EOL date
+    Bump to c/common v0.51.2
+
 ## v1.29.1 (2023-02-15)
+
     update to c/image 5.24.1
 
 ## v1.29.0 (2023-01-25)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+- Changelog for v1.29.2 (2023-10-31)
+  * Mask /sys/devices/virtual/powercap by default
+  * remove registry.centos.org
+  * Cirrus: Increase conformance-test timeout
+  * Cirrus: Add CI self-destruct condition on EOL date
+  * Bump to c/common v0.51.2
+
 - Changelog for v1.29.1 (2023-02-15)
   * Update to c/image 5.24.1
 

--- a/define/types.go
+++ b/define/types.go
@@ -30,7 +30,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.29.1"
+	Version = "1.29.2"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Bump the version number to v1.29.2.

#### How to verify it

No code changes, no new tests.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The release-1.29 branch is used by openshift/builder's 4.13 branch.

#### Does this PR introduce a user-facing change?

```release-note
None
```