### PR TITLE
createConfigsAndManifests: clear history before cw-specific logic

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/containerd/containerd/platforms"
+	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
 	internalUtil "github.com/containers/buildah/internal/util"
 	"github.com/containers/buildah/pkg/parse"
@@ -672,7 +673,7 @@ func baseImages(dockerfilenames []string, dockerfilecontents [][]byte, from stri
 							}
 						}
 						base := child.Next.Value
-						if base != "scratch" && !nicknames[base] {
+						if base != "" && base != buildah.BaseImageFakeName && !nicknames[base] {
 							headingArgs := argsMapToSlice(stage.Builder.HeadingArgs)
 							userArgs := argsMapToSlice(stage.Builder.Args)
 							// append heading args so if --build-arg key=value is not

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -762,7 +762,7 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 							b.fromOverride = ""
 						}
 						base := child.Next.Value
-						if base != "scratch" {
+						if base != "" && base != buildah.BaseImageFakeName {
 							if replaceBuildContext, ok := b.additionalBuildContexts[child.Next.Value]; ok {
 								if replaceBuildContext.IsImage {
 									child.Next.Value = replaceBuildContext.Value

--- a/new.go
+++ b/new.go
@@ -140,7 +140,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 
 	systemContext := getSystemContext(store, options.SystemContext, options.SignaturePolicyPath)
 
-	if options.FromImage != "" && options.FromImage != "scratch" {
+	if options.FromImage != "" && options.FromImage != BaseImageFakeName {
 		imageRuntime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
 		if err != nil {
 			return nil, err

--- a/new_test.go
+++ b/new_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/containers/storage"
+	"github.com/openshift/imagebuilder"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetImageName(t *testing.T) {
@@ -25,4 +27,9 @@ func TestGetImageName(t *testing.T) {
 			t.Errorf("test case '%s' failed: expected %#v but got %#v", tc.caseName, tc.expected, res)
 		}
 	}
+}
+
+func TestNoBaseImageSpecifierIsScratch(t *testing.T) {
+	assert.Equal(t, "scratch", imagebuilder.NoBaseImageSpecifier) // juuuuust in case
+	assert.Equal(t, "scratch", BaseImageFakeName)
 }

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -519,13 +519,9 @@ func DefaultPlatform() string {
 // Platform separates the platform string into os, arch and variant,
 // accepting any of $arch, $os/$arch, or $os/$arch/$variant.
 func Platform(platform string) (os, arch, variant string, err error) {
-	if platform == "local" || platform == "" || platform == "/" {
+	platform = strings.Trim(platform, "/")
+	if platform == "local" || platform == "" {
 		return Platform(DefaultPlatform())
-	}
-	if platform[len(platform)-1] == '/' || platform[0] == '/' {
-		// If --platform string has format as `some/plat/string/`
-		// or `/some/plat/string` make it `some/plat/string`
-		platform = strings.Trim(platform, "/")
 	}
 	platformSpec, err := platforms.Parse(platform)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

*  During a commit, clear the docker-format rootfs and history information before we clear other fields in the config for confidential workload cases, so that it's easier for maintainers to track that it exactly parallels what we're doing with the OCI format data.
* Simplify `pkg/parse.Platform()` a bit.
* Where we use `"scratch"` as a constant, use a named constant instead of just sprinkling the string in assorted places.

#### How to verify it

Nothing should start breaking, but I added a unit test to make sure the constant we're using doesn't get changed out from under us.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```