### PR TITLE
Add OverrideChanges and OverrideConfig to CommitOptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ LIBSECCOMP_COMMIT := release-2.3
 
 EXTRA_LDFLAGS ?=
 BUILDAH_LDFLAGS := $(GO_LDFLAGS) '-X main.GitCommit=$(GIT_COMMIT) -X main.buildInfo=$(SOURCE_DATE_EPOCH) -X main.cniVersion=$(CNI_COMMIT) $(EXTRA_LDFLAGS)'
-SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go define/*.go docker/*.go internal/mkcw/*.go internal/mkcw/types/*.go internal/parse/*.go internal/source/*.go internal/util/*.go manifests/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go pkg/util/*.go util/*.go
+SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go define/*.go docker/*.go internal/config/*.go internal/mkcw/*.go internal/mkcw/types/*.go internal/parse/*.go internal/source/*.go internal/util/*.go manifests/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go pkg/util/*.go util/*.go
 
 LINTFLAGS ?=
 

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -305,7 +305,7 @@ func updateConfig(builder *buildah.Builder, c *cobra.Command, iopts configResult
 		conditionallyAddHistory(builder, c, "/bin/sh -c #(nop) LABEL %s", strings.Join(iopts.label, " "))
 	}
 	// unset labels if any
-	for _, key := range  iopts.unsetLabels {
+	for _, key := range iopts.unsetLabels {
 		builder.UnsetLabel(key)
 	}
 	if c.Flag("workingdir").Changed {

--- a/commit.go
+++ b/commit.go
@@ -110,6 +110,14 @@ type CommitOptions struct {
 	// UnsetEnvs is a list of environments to not add to final image.
 	// Deprecated: use UnsetEnv() before committing instead.
 	UnsetEnvs []string
+	// OverrideConfig is an optional Schema2Config which can override parts
+	// of the working container's configuration for the image that is being
+	// committed.
+	OverrideConfig *manifest.Schema2Config
+	// OverrideChanges is a slice of Dockerfile-style instructions to make
+	// to the configuration of the image that is being committed, after
+	// OverrideConfig is applied.
+	OverrideChanges []string
 }
 
 var (

--- a/docs/buildah-commit.1.md
+++ b/docs/buildah-commit.1.md
@@ -33,6 +33,18 @@ environment variable. `export REGISTRY_AUTH_FILE=path`
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
 The default certificates directory is _/etc/containers/certs.d_.
 
+**--change**, **-c** *"INSTRUCTION"*
+
+Apply the change to the committed image that would have been made if it had
+been built using a Containerfile which included the specified instruction.
+This option can be specified multiple times.
+
+**--config** *filename*
+
+Read a JSON-encoded version of an image configuration object from the specified
+file, and merge the values from it with the configuration of the image being
+committed.
+
 **--creds** *creds*
 
 The [username[:password]] to use to authenticate with the registry if required.

--- a/internal/config/convert.go
+++ b/internal/config/convert.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"github.com/containers/image/v5/manifest"
+	dockerclient "github.com/fsouza/go-dockerclient"
+)
+
+// Schema2ConfigFromGoDockerclientConfig converts a go-dockerclient Config
+// structure to a manifest Schema2Config.
+func Schema2ConfigFromGoDockerclientConfig(config *dockerclient.Config) *manifest.Schema2Config {
+	overrideExposedPorts := make(map[manifest.Schema2Port]struct{})
+	for port := range config.ExposedPorts {
+		overrideExposedPorts[manifest.Schema2Port(port)] = struct{}{}
+	}
+	var overrideHealthCheck *manifest.Schema2HealthConfig
+	if config.Healthcheck != nil {
+		overrideHealthCheck = &manifest.Schema2HealthConfig{
+			Test:        config.Healthcheck.Test,
+			StartPeriod: config.Healthcheck.StartPeriod,
+			Interval:    config.Healthcheck.Interval,
+			Timeout:     config.Healthcheck.Timeout,
+			Retries:     config.Healthcheck.Retries,
+		}
+	}
+	labels := make(map[string]string)
+	for k, v := range config.Labels {
+		labels[k] = v
+	}
+	volumes := make(map[string]struct{})
+	for v := range config.Volumes {
+		volumes[v] = struct{}{}
+	}
+	s2config := &manifest.Schema2Config{
+		Hostname:        config.Hostname,
+		Domainname:      config.Domainname,
+		User:            config.User,
+		AttachStdin:     config.AttachStdin,
+		AttachStdout:    config.AttachStdout,
+		AttachStderr:    config.AttachStderr,
+		ExposedPorts:    overrideExposedPorts,
+		Tty:             config.Tty,
+		OpenStdin:       config.OpenStdin,
+		StdinOnce:       config.StdinOnce,
+		Env:             append([]string{}, config.Env...),
+		Cmd:             append([]string{}, config.Cmd...),
+		Healthcheck:     overrideHealthCheck,
+		ArgsEscaped:     config.ArgsEscaped,
+		Image:           config.Image,
+		Volumes:         volumes,
+		WorkingDir:      config.WorkingDir,
+		Entrypoint:      append([]string{}, config.Entrypoint...),
+		NetworkDisabled: config.NetworkDisabled,
+		MacAddress:      config.MacAddress,
+		OnBuild:         append([]string{}, config.OnBuild...),
+		Labels:          labels,
+		StopSignal:      config.StopSignal,
+		Shell:           config.Shell,
+	}
+	if config.StopTimeout != 0 {
+		s2config.StopTimeout = &config.StopTimeout
+	}
+	return s2config
+}
+
+// GoDockerclientConfigFromSchema2Config converts a manifest Schema2Config
+// to a go-dockerclient config structure.
+func GoDockerclientConfigFromSchema2Config(s2config *manifest.Schema2Config) *dockerclient.Config {
+	overrideExposedPorts := make(map[dockerclient.Port]struct{})
+	for port := range s2config.ExposedPorts {
+		overrideExposedPorts[dockerclient.Port(port)] = struct{}{}
+	}
+	var healthCheck *dockerclient.HealthConfig
+	if s2config.Healthcheck != nil {
+		healthCheck = &dockerclient.HealthConfig{
+			Test:        s2config.Healthcheck.Test,
+			StartPeriod: s2config.Healthcheck.StartPeriod,
+			Interval:    s2config.Healthcheck.Interval,
+			Timeout:     s2config.Healthcheck.Timeout,
+			Retries:     s2config.Healthcheck.Retries,
+		}
+	}
+	labels := make(map[string]string)
+	for k, v := range s2config.Labels {
+		labels[k] = v
+	}
+	volumes := make(map[string]struct{})
+	for v := range s2config.Volumes {
+		volumes[v] = struct{}{}
+	}
+	config := &dockerclient.Config{
+		Hostname:        s2config.Hostname,
+		Domainname:      s2config.Domainname,
+		User:            s2config.User,
+		AttachStdin:     s2config.AttachStdin,
+		AttachStdout:    s2config.AttachStdout,
+		AttachStderr:    s2config.AttachStderr,
+		PortSpecs:       nil,
+		ExposedPorts:    overrideExposedPorts,
+		Tty:             s2config.Tty,
+		OpenStdin:       s2config.OpenStdin,
+		StdinOnce:       s2config.StdinOnce,
+		Env:             append([]string{}, s2config.Env...),
+		Cmd:             append([]string{}, s2config.Cmd...),
+		Healthcheck:     healthCheck,
+		ArgsEscaped:     s2config.ArgsEscaped,
+		Image:           s2config.Image,
+		Volumes:         volumes,
+		WorkingDir:      s2config.WorkingDir,
+		Entrypoint:      append([]string{}, s2config.Entrypoint...),
+		NetworkDisabled: s2config.NetworkDisabled,
+		MacAddress:      s2config.MacAddress,
+		OnBuild:         append([]string{}, s2config.OnBuild...),
+		Labels:          labels,
+		StopSignal:      s2config.StopSignal,
+		Shell:           s2config.Shell,
+	}
+	if s2config.StopTimeout != nil {
+		config.StopTimeout = *s2config.StopTimeout
+	}
+	return config
+}

--- a/internal/config/convert_test.go
+++ b/internal/config/convert_test.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/containers/buildah/util"
+	"github.com/containers/image/v5/manifest"
+	dockerclient "github.com/fsouza/go-dockerclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fillAllFields recursively fills in 1 or "1" for every field in the passed-in
+// structure, and that slices and maps have at least one value in them.
+func fillAllFields[pStruct any](t *testing.T, st pStruct) {
+	v := reflect.ValueOf(st)
+	if v.Kind() == reflect.Pointer {
+		v = reflect.Indirect(v)
+	}
+	fillAllValueFields(t, v)
+}
+
+func fillAllValueFields(t *testing.T, v reflect.Value) {
+	fields := reflect.VisibleFields(v.Type())
+	for _, field := range fields {
+		if field.Anonymous {
+			// all right, fine, keep your secrets
+			continue
+		}
+		f := v.FieldByName(field.Name)
+		var keyType, elemType reflect.Type
+		if field.Type.Kind() == reflect.Map {
+			keyType = field.Type.Key()
+		}
+		switch field.Type.Kind() {
+		case reflect.Array, reflect.Chan, reflect.Map, reflect.Pointer, reflect.Slice:
+			elemType = field.Type.Elem()
+		}
+		fillValue(t, f, field.Name, field.Type.Kind(), keyType, elemType)
+	}
+}
+
+func fillValue(t *testing.T, value reflect.Value, name string, kind reflect.Kind, keyType, elemType reflect.Type) {
+	switch kind {
+	case reflect.Invalid,
+		reflect.Array, reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer,
+		reflect.Float32, reflect.Float64,
+		reflect.Complex64, reflect.Complex128:
+		require.NotEqualf(t, kind, kind, "unhandled %s field %s: tests require updating", kind, name)
+	case reflect.Bool:
+		value.SetBool(true)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		value.SetInt(1)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		value.SetUint(1)
+	case reflect.Map:
+		if value.IsNil() {
+			value.Set(reflect.MakeMap(value.Type()))
+		}
+		keyPtr := reflect.New(keyType)
+		key := reflect.Indirect(keyPtr)
+		fillValue(t, key, name, keyType.Kind(), nil, nil)
+		elemPtr := reflect.New(elemType)
+		elem := reflect.Indirect(elemPtr)
+		fillValue(t, elem, name, elemType.Kind(), nil, nil)
+		value.SetMapIndex(key, reflect.Indirect(elem))
+	case reflect.Slice:
+		vPtr := reflect.New(elemType)
+		v := reflect.Indirect(vPtr)
+		fillValue(t, v, name, elemType.Kind(), nil, nil)
+		value.Set(reflect.Append(reflect.MakeSlice(value.Type(), 0, 1), v))
+	case reflect.String:
+		value.SetString("1")
+	case reflect.Struct:
+		fillAllValueFields(t, value)
+	case reflect.Pointer:
+		p := reflect.New(elemType)
+		fillValue(t, reflect.Indirect(p), name, elemType.Kind(), nil, nil)
+		value.Set(p)
+	}
+}
+
+// checkAllFields recursively checks that every field not listed in allowZeroed
+// is not set to its zero value, that every slice is not empty, and that every
+// map has at least one entry.  It makes an additional exception for structs
+// which have no defined fields.
+func checkAllFields[pStruct any](t *testing.T, st pStruct, allowZeroed []string) {
+	v := reflect.ValueOf(st)
+	if v.Kind() == reflect.Pointer {
+		v = reflect.Indirect(v)
+	}
+	checkAllValueFields(t, v, "", allowZeroed)
+}
+
+func checkAllValueFields(t *testing.T, v reflect.Value, name string, allowedToBeZero []string) {
+	fields := reflect.VisibleFields(v.Type())
+	for _, field := range fields {
+		if field.Anonymous {
+			// all right, fine, keep your secrets
+			continue
+		}
+		fieldName := field.Name
+		if name != "" {
+			fieldName = name + "." + field.Name
+		}
+		if util.StringInSlice(fieldName, allowedToBeZero) {
+			continue
+		}
+		f := v.FieldByName(field.Name)
+		var elemType reflect.Type
+		switch field.Type.Kind() {
+		case reflect.Array, reflect.Chan, reflect.Map, reflect.Pointer, reflect.Slice:
+			elemType = field.Type.Elem()
+		}
+		checkValue(t, f, fieldName, field.Type.Kind(), elemType, allowedToBeZero)
+	}
+}
+
+func checkValue(t *testing.T, value reflect.Value, name string, kind reflect.Kind, elemType reflect.Type, allowedToBeZero []string) {
+	if kind != reflect.Invalid {
+		switch kind {
+		case reflect.Map:
+			assert.Falsef(t, value.IsZero(), "map field %s not set when it was not already expected to be left unpopulated by conversion", name)
+			keys := value.MapKeys()
+			for i := 0; i < len(keys); i++ {
+				v := value.MapIndex(keys[i])
+				checkValue(t, v, name+"{"+keys[i].String()+"}", elemType.Kind(), nil, allowedToBeZero)
+			}
+		case reflect.Slice:
+			assert.Falsef(t, value.IsZero(), "slice field %s not set when it was not already expected to be left unpopulated by conversion", name)
+			for i := 0; i < value.Len(); i++ {
+				v := value.Index(i)
+				checkValue(t, v, name+"["+strconv.Itoa(i)+"]", elemType.Kind(), nil, allowedToBeZero)
+			}
+		case reflect.Struct:
+			if fields := reflect.VisibleFields(value.Type()); len(fields) != 0 {
+				// structs which are defined with no fields are okay
+				assert.Falsef(t, value.IsZero(), "slice field %s not set when it was not already expected to be left unpopulated by conversion", name)
+			}
+			checkAllValueFields(t, value, name, allowedToBeZero)
+		case reflect.Pointer:
+			assert.Falsef(t, value.IsZero(), "pointer field %s not set when it was not already expected to be left unpopulated by conversion", name)
+			checkValue(t, reflect.Indirect(value), name, elemType.Kind(), nil, allowedToBeZero)
+		}
+	}
+}
+
+func TestGoDockerclientConfigFromSchema2Config(t *testing.T) {
+	var input manifest.Schema2Config
+	fillAllFields(t, &input)
+	output := GoDockerclientConfigFromSchema2Config(&input)
+	// make exceptions for fields in "output" which have no corresponding field in "input"
+	notInSchema2Config := []string{"CPUSet", "CPUShares", "DNS", "Memory", "KernelMemory", "MemorySwap", "MemoryReservation", "Mounts", "PortSpecs", "PublishService", "SecurityOpts", "VolumeDriver", "VolumesFrom"}
+	checkAllFields(t, output, notInSchema2Config)
+}
+
+func TestSchema2ConfigFromGoDockerclientConfig(t *testing.T) {
+	var input dockerclient.Config
+	fillAllFields(t, &input)
+	output := Schema2ConfigFromGoDockerclientConfig(&input)
+	// make exceptions for fields in "output" which have no corresponding field in "input"
+	notInDockerConfig := []string{}
+	checkAllFields(t, output, notInDockerConfig)
+}

--- a/internal/config/executor.go
+++ b/internal/config/executor.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	dockerclient "github.com/fsouza/go-dockerclient"
+	"github.com/openshift/imagebuilder"
+)
+
+// configOnlyExecutor implements the Executor interface that an
+// imagebuilder.Builder expects to be able to call to do some heavy lifting,
+// but it just refuses to do the work of ADD, COPY, or RUN.  It also doesn't
+// care if the working directory exists in a container, because it's really
+// only concerned with letting the Builder's RunConfig get updated by changes
+// from a Dockerfile.  Try anything more than that and it'll return an error.
+type configOnlyExecutor struct{}
+
+func (g *configOnlyExecutor) Preserve(path string) error {
+	return errors.New("ADD/COPY/RUN not supported as changes")
+}
+
+func (g *configOnlyExecutor) EnsureContainerPath(path string) error {
+	return nil
+}
+
+func (g *configOnlyExecutor) EnsureContainerPathAs(path, user string, mode *os.FileMode) error {
+	return nil
+}
+
+func (g *configOnlyExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) error {
+	if len(copies) == 0 {
+		return nil
+	}
+	return errors.New("ADD/COPY not supported as changes")
+}
+
+func (g *configOnlyExecutor) Run(run imagebuilder.Run, config dockerclient.Config) error {
+	return errors.New("RUN not supported as changes")
+}
+
+func (g *configOnlyExecutor) UnrecognizedInstruction(step *imagebuilder.Step) error {
+	return fmt.Errorf("did not understand change instruction %q", step.Original)
+}

--- a/internal/config/executor_test.go
+++ b/internal/config/executor_test.go
@@ -1,0 +1,5 @@
+package config
+
+import "github.com/openshift/imagebuilder"
+
+var _ imagebuilder.Executor = &configOnlyExecutor{}

--- a/internal/config/override.go
+++ b/internal/config/override.go
@@ -1,0 +1,181 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/containers/buildah/docker"
+	"github.com/containers/image/v5/manifest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/openshift/imagebuilder"
+)
+
+// firstStringElseSecondString takes two strings, and returns the first
+// string if it isn't empty, else the second string
+func firstStringElseSecondString(first, second string) string {
+	if first != "" {
+		return first
+	}
+	return second
+}
+
+// firstSliceElseSecondSlice takes two string slices, and returns the first
+// slice of strings if it has contents, else the second slice
+func firstSliceElseSecondSlice(first, second []string) []string {
+	if len(first) > 0 {
+		return append([]string{}, first...)
+	}
+	return append([]string{}, second...)
+}
+
+// firstSlicePairElseSecondSlicePair takes two pairs of string slices, and
+// returns the first pair of slices if either has contents, else the second
+// pair
+func firstSlicePairElseSecondSlicePair(firstA, firstB, secondA, secondB []string) ([]string, []string) {
+	if len(firstA) > 0 || len(firstB) > 0 {
+		return append([]string{}, firstA...), append([]string{}, firstB...)
+	}
+	return append([]string{}, secondA...), append([]string{}, secondB...)
+}
+
+// mergeEnv combines variables from a and b into a single environment slice. if
+// a and b both provide values for the same variable, the value from b is
+// preferred
+func mergeEnv(a, b []string) []string {
+	index := make(map[string]int)
+	results := make([]string, 0, len(a)+len(b))
+	for _, kv := range append(append([]string{}, a...), b...) {
+		k, _, specifiesValue := strings.Cut(kv, "=")
+		if !specifiesValue {
+			if value, ok := os.LookupEnv(kv); ok {
+				kv = kv + "=" + value
+			} else {
+				kv = kv + "="
+			}
+		}
+		if i, seen := index[k]; seen {
+			results[i] = kv
+		} else {
+			index[k] = len(results)
+			results = append(results, kv)
+		}
+	}
+	return results
+}
+
+// Override takes a buildah docker config and an OCI ImageConfig, and applies a
+// mixture of a slice of Dockerfile-style instructions and fields from a config
+// blob to them both
+func Override(dconfig *docker.Config, oconfig *v1.ImageConfig, overrideChanges []string, overrideConfig *manifest.Schema2Config) error {
+	if len(overrideChanges) > 0 {
+		if overrideConfig == nil {
+			overrideConfig = &manifest.Schema2Config{}
+		}
+		// Parse the set of changes as we would a Dockerfile.
+		changes := strings.Join(overrideChanges, "\n")
+		parsed, err := imagebuilder.ParseDockerfile(strings.NewReader(changes))
+		if err != nil {
+			return fmt.Errorf("parsing change set %+v: %w", changes, err)
+		}
+		// Create a dummy builder object to process configuration-related
+		// instructions.
+		subBuilder := imagebuilder.NewBuilder(nil)
+		// Convert the incoming data into an initial RunConfig.
+		subBuilder.RunConfig = *GoDockerclientConfigFromSchema2Config(overrideConfig)
+		// Process the change instructions one by one.
+		for _, node := range parsed.Children {
+			var step imagebuilder.Step
+			if err := step.Resolve(node); err != nil {
+				return fmt.Errorf("resolving change %q: %w", node.Original, err)
+			}
+			if err := subBuilder.Run(&step, &configOnlyExecutor{}, true); err != nil {
+				return fmt.Errorf("processing change %q: %w", node.Original, err)
+			}
+		}
+		// Pull settings out of the dummy builder's RunConfig.
+		overrideConfig = Schema2ConfigFromGoDockerclientConfig(&subBuilder.RunConfig)
+	}
+	if overrideConfig != nil {
+		// Apply changes from a possibly-provided possibly-changed config struct.
+		dconfig.Hostname = firstStringElseSecondString(overrideConfig.Hostname, dconfig.Hostname)
+		dconfig.Domainname = firstStringElseSecondString(overrideConfig.Domainname, dconfig.Domainname)
+		dconfig.User = firstStringElseSecondString(overrideConfig.User, dconfig.User)
+		oconfig.User = firstStringElseSecondString(overrideConfig.User, oconfig.User)
+		dconfig.AttachStdin = overrideConfig.AttachStdin
+		dconfig.AttachStdout = overrideConfig.AttachStdout
+		dconfig.AttachStderr = overrideConfig.AttachStderr
+		if len(overrideConfig.ExposedPorts) > 0 {
+			dexposedPorts := make(map[docker.Port]struct{})
+			oexposedPorts := make(map[string]struct{})
+			for port := range dconfig.ExposedPorts {
+				dexposedPorts[port] = struct{}{}
+			}
+			for port := range overrideConfig.ExposedPorts {
+				dexposedPorts[docker.Port(port)] = struct{}{}
+			}
+			for port := range oconfig.ExposedPorts {
+				oexposedPorts[port] = struct{}{}
+			}
+			for port := range overrideConfig.ExposedPorts {
+				oexposedPorts[string(port)] = struct{}{}
+			}
+			dconfig.ExposedPorts = dexposedPorts
+			oconfig.ExposedPorts = oexposedPorts
+		}
+		dconfig.Tty = overrideConfig.Tty
+		dconfig.OpenStdin = overrideConfig.OpenStdin
+		dconfig.StdinOnce = overrideConfig.StdinOnce
+		if len(overrideConfig.Env) > 0 {
+			dconfig.Env = mergeEnv(dconfig.Env, overrideConfig.Env)
+			oconfig.Env = mergeEnv(oconfig.Env, overrideConfig.Env)
+		}
+		dconfig.Entrypoint, dconfig.Cmd = firstSlicePairElseSecondSlicePair(overrideConfig.Entrypoint, overrideConfig.Cmd, dconfig.Entrypoint, dconfig.Cmd)
+		oconfig.Entrypoint, oconfig.Cmd = firstSlicePairElseSecondSlicePair(overrideConfig.Entrypoint, overrideConfig.Cmd, oconfig.Entrypoint, oconfig.Cmd)
+		if overrideConfig.Healthcheck != nil {
+			dconfig.Healthcheck = &docker.HealthConfig{
+				Test:        append([]string{}, overrideConfig.Healthcheck.Test...),
+				Interval:    overrideConfig.Healthcheck.Interval,
+				Timeout:     overrideConfig.Healthcheck.Timeout,
+				StartPeriod: overrideConfig.Healthcheck.StartPeriod,
+				Retries:     overrideConfig.Healthcheck.Retries,
+			}
+		}
+		dconfig.ArgsEscaped = overrideConfig.ArgsEscaped
+		dconfig.Image = firstStringElseSecondString(overrideConfig.Image, dconfig.Image)
+		if len(overrideConfig.Volumes) > 0 {
+			if dconfig.Volumes == nil {
+				dconfig.Volumes = make(map[string]struct{})
+			}
+			if oconfig.Volumes == nil {
+				oconfig.Volumes = make(map[string]struct{})
+			}
+			for volume := range overrideConfig.Volumes {
+				dconfig.Volumes[volume] = struct{}{}
+				oconfig.Volumes[volume] = struct{}{}
+			}
+		}
+		dconfig.WorkingDir = firstStringElseSecondString(overrideConfig.WorkingDir, dconfig.WorkingDir)
+		oconfig.WorkingDir = firstStringElseSecondString(overrideConfig.WorkingDir, oconfig.WorkingDir)
+		dconfig.NetworkDisabled = overrideConfig.NetworkDisabled
+		dconfig.MacAddress = overrideConfig.MacAddress
+		dconfig.OnBuild = overrideConfig.OnBuild
+		if len(overrideConfig.Labels) > 0 {
+			if dconfig.Labels == nil {
+				dconfig.Labels = make(map[string]string)
+			}
+			if oconfig.Labels == nil {
+				oconfig.Labels = make(map[string]string)
+			}
+			for k, v := range overrideConfig.Labels {
+				dconfig.Labels[k] = v
+				oconfig.Labels[k] = v
+			}
+		}
+		dconfig.StopSignal = overrideConfig.StopSignal
+		oconfig.StopSignal = overrideConfig.StopSignal
+		dconfig.StopTimeout = overrideConfig.StopTimeout
+		dconfig.Shell = firstSliceElseSecondSlice(overrideConfig.Shell, dconfig.Shell)
+	}
+	return nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add an OverrideChanges and an OverrideConfig field to CommitOptions, both of which can be used to make last-minute edits to the configuration of an image that we're committing.

#### How to verify it

New unit tests!
New conformance tests!

#### Which issue(s) this PR fixes:

This is part of fixing [RHEL-14922](https://issues.redhat.com/browse/RHEL-14922)

#### Special notes for your reviewer:

Still have to work up the podman side of this, so it's a WIP for now.

#### Does this PR introduce a user-facing change?

```release-note
`buildah commit` now accepts optional `--change` and `--config` options, which can be used to make last-minute changes to the configuration of an image when it is committed.
```