### PR TITLE
Stop using DefaultNetworkSysctl and use containers.conf only

### DIFF
--- a/define/types.go
+++ b/define/types.go
@@ -58,8 +58,8 @@ const (
 type TeeType string
 
 var (
-	// DefaultCapabilities is the list of capabilities which we grant by
-	// default to containers which are running under UID 0.
+	// Deprecated: DefaultCapabilities values should be retrieved from
+	// github.com/containers/common/pkg/config
 	DefaultCapabilities = []string{
 		"CAP_AUDIT_WRITE",
 		"CAP_CHOWN",
@@ -75,8 +75,8 @@ var (
 		"CAP_SETUID",
 		"CAP_SYS_CHROOT",
 	}
-	// DefaultNetworkSysctl is the list of Kernel parameters which we
-	// grant by default to containers which are running under UID 0.
+	// Deprecated: DefaultNetworkSysctl values should be retrieved from
+	// github.com/containers/common/pkg/config
 	DefaultNetworkSysctl = map[string]string{
 		"net.ipv4.ping_group_range": "0 0",
 	}

--- a/run_linux.go
+++ b/run_linux.go
@@ -773,20 +773,6 @@ func setupNamespaces(logger *logrus.Logger, g *generate.Generator, namespaceOpti
 		if err := addSysctl([]string{"net"}); err != nil {
 			return false, "", false, err
 		}
-		for name, val := range define.DefaultNetworkSysctl {
-			// Check that the sysctl we are adding is actually supported
-			// by the kernel
-			p := filepath.Join("/proc/sys", strings.Replace(name, ".", "/", -1))
-			_, err := os.Stat(p)
-			if err != nil && !errors.Is(err, os.ErrNotExist) {
-				return false, "", false, err
-			}
-			if err == nil {
-				g.AddLinuxSysctl(name, val)
-			} else {
-				logger.Warnf("ignoring sysctl %s since %s doesn't exist", name, p)
-			}
-		}
 	}
 	return configureNetwork, networkString, configureUTS, nil
 }

--- a/tests/containers_conf.bats
+++ b/tests/containers_conf.bats
@@ -115,7 +115,6 @@ EOF
     cat >${TEST_SCRATCH_DIR}/containers.conf << EOF
 [containers]
 default_sysctls = [
-  "net.ipv4.ping_group_range=0 0",
   "net.ipv4.tcp_timestamps=123"
 ]
 EOF
@@ -123,7 +122,19 @@ EOF
     cat >${TEST_SCRATCH_DIR}/Containerfile << _EOF
 FROM alpine
 RUN echo -n "timestamp="; cat /proc/sys/net/ipv4/tcp_timestamps
+RUN echo -n "ping_group_range="; cat /proc/sys/net/ipv4/ping_group_range
 _EOF
+
+    run_buildah build ${TEST_SCRATCH_DIR}
+    expect_output --substring "timestamp=1"
+    expect_output --substring "ping_group_range=0.*0"
+
     CONTAINERS_CONF=${TEST_SCRATCH_DIR}/containers.conf run_buildah build ${TEST_SCRATCH_DIR}
     expect_output --substring "timestamp=123"
+    if is_rootless ; then
+       expect_output --substring "ping_group_range=65534.*65534"
+    else
+       expect_output --substring "ping_group_range=1.*0"
+    fi
+
 }

--- a/util/types.go
+++ b/util/types.go
@@ -10,11 +10,11 @@ const (
 )
 
 var (
-	// DefaultCapabilities is the list of capabilities which we grant by
-	// default to containers which are running under UID 0.
-	DefaultCapabilities = define.DefaultCapabilities
+	// Deprecated: DefaultCapabilities values should be retrieved from
+	// github.com/containers/common/pkg/config
+	DefaultCapabilities = define.DefaultCapabilities //nolint
 
-	// DefaultNetworkSysctl is the list of Kernel parameters which we
-	// grant by default to containers which are running under UID 0.
-	DefaultNetworkSysctl = define.DefaultNetworkSysctl
+	// Deprecated: DefaultNetworkSysctl values should be retrieved from
+	// github.com/containers/common/pkg/config
+	DefaultNetworkSysctl = define.DefaultNetworkSysctl //nolint
 )


### PR DESCRIPTION
Also mark uses of DefaultCapabilities as Deprecated.

Fixes: https://github.com/containers/buildah/issues/5155

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
DefaultNetworkSysctl is not hard coded any longer and follows containers.conf
```

