### PR TITLE
StageExecutor.Execute: force a commit for --unsetenv, too

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1040,57 +1040,34 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 
 	if len(children) == 0 {
 		// There are no steps.
-		if s.builder.FromImageID == "" || s.executor.squash {
+		if s.builder.FromImageID == "" || s.executor.squash || s.executor.confidentialWorkload.Convert || len(s.executor.labels) > 0 || len(s.executor.annotations) > 0 || len(s.executor.unsetEnvs) > 0 || len(s.executor.unsetLabels) > 0 {
 			// We either don't have a base image, or we need to
-			// squash the contents of the base image.  Whichever is
-			// the case, we need to commit() to create a new image.
+			// transform the contents of the base image, or we need
+			// to make some changes to just the config blob.  Whichever
+			// is the case, we need to commit() to create a new image.
 			logCommit(s.output, -1)
-			emptyLayer := false
-			if s.builder.FromImageID == "" {
-				// No base image means there's nothing to put in a
-				// layer, so don't create one.
-				emptyLayer = true
-			}
+			// No base image means there's nothing to put in a
+			// layer, so don't create one.
+			emptyLayer := (s.builder.FromImageID == "")
 			if imgID, ref, err = s.commit(ctx, s.getCreatedBy(nil, ""), emptyLayer, s.output, s.executor.squash, lastStage); err != nil {
 				return "", nil, false, fmt.Errorf("committing base container: %w", err)
 			}
-			// Generate build output if needed.
-			if canGenerateBuildOutput {
-				if err := s.generateBuildOutput(buildOutputOption); err != nil {
-					return "", nil, false, err
-				}
-			}
-		} else if len(s.executor.labels) > 0 || len(s.executor.annotations) > 0 {
-			// The image would be modified by the labels passed
-			// via the command line, so we need to commit.
-			logCommit(s.output, -1)
-			if imgID, ref, err = s.commit(ctx, s.getCreatedBy(stage.Node, ""), true, s.output, s.executor.squash, lastStage); err != nil {
-				return "", nil, false, err
-			}
-			// Generate build output if needed.
-			if canGenerateBuildOutput {
-				if err := s.generateBuildOutput(buildOutputOption); err != nil {
-					return "", nil, false, err
-				}
-			}
 		} else {
-			// We don't need to squash the base image, and the
-			// image wouldn't be modified by the command line
-			// options, so just reuse the base image.
+			// We don't need to squash or otherwise transform the
+			// base image, and the image wouldn't be modified by
+			// the command line options, so just reuse the base
+			// image.
 			logCommit(s.output, -1)
 			if imgID, ref, err = s.tagExistingImage(ctx, s.builder.FromImageID, s.output); err != nil {
 				return "", nil, onlyBaseImage, err
 			}
 			onlyBaseImage = true
-			// If we have reached this point then our build is just performing a tag
-			// and it contains no steps or instructions (i.e Containerfile only contains
-			// `FROM <imagename> and nothing else so we will never end up committing this
-			// but instead just re-tag image. For such use-cases if `-o` or `--output` was
-			// specified honor that and export the contents of the current build anyways.
-			if canGenerateBuildOutput {
-				if err := s.generateBuildOutput(buildOutputOption); err != nil {
-					return "", nil, onlyBaseImage, err
-				}
+		}
+		// Generate build output from the new image, or the preexisting
+		// one if we didn't actually do anything, if needed.
+		if canGenerateBuildOutput {
+			if err := s.generateBuildOutput(buildOutputOption); err != nil {
+				return "", nil, onlyBaseImage, err
 			}
 		}
 		logImageID(imgID)
@@ -1124,7 +1101,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			if strings.Contains(flag, "--from") && command == "COPY" {
 				arr := strings.Split(flag, "=")
 				if len(arr) != 2 {
-					return "", nil, false, fmt.Errorf("%s: invalid --from flag, should be --from=<name|stage>", command)
+					return "", nil, false, fmt.Errorf("%s: invalid --from flag %q, should be --from=<name|stage>", command, flag)
 				}
 				// If arr[1] has an argument within it, resolve it to its
 				// value.  Otherwise just return the value found.
@@ -1415,7 +1392,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		}
 
 		// Note: If the build has squash, we must try to re-use as many layers as possible if cache is found.
-		// So only perform commit if its the lastInstruction of lastStage.
+		// So only perform commit if it's the lastInstruction of lastStage.
 		if cacheID != "" {
 			logCacheHit(cacheID)
 			// A suitable cached image was found, so we can just
@@ -1439,7 +1416,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// While committing we always set squash to false here
 			// because at this point we want to save history for
 			// layers even if its a squashed build so that they
-			// can be part of build-cache.
+			// can be part of the build cache.
 			imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), !s.stepRequiresLayer(step), commitName, false, lastStage && lastInstruction)
 			if err != nil {
 				return "", nil, false, fmt.Errorf("committing container for step %+v: %w", *step, err)
@@ -1470,7 +1447,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		}
 
 		if lastInstruction && lastStage {
-			if s.executor.squash {
+			if s.executor.squash || s.executor.confidentialWorkload.Convert {
 				// Create a squashed version of this image
 				// if we're supposed to create one and this
 				// is the last instruction of the last stage.
@@ -1531,6 +1508,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			}
 		}
 	}
+
 	return imgID, ref, onlyBaseImage, nil
 }
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1788,6 +1788,14 @@ _EOF
   expect_output "[container=buildah date=tomorrow]" "No Path should be defined"
   run_buildah inspect --type=image --format '{{.Docker.Config.Env}}' docker-${target}
   expect_output "[container=buildah date=tomorrow]" "No Path should be defined"
+  cat > $mytmpdir/Containerfile << _EOF
+FROM oci-${target}
+_EOF
+  run_buildah build --format docker --unsetenv PATH --unsetenv foo $WITH_POLICY_JSON -t docker-${target} -f $mytmpdir/Containerfile .
+  run_buildah inspect --type=image --format '{{.OCIv1.Config.Env}}' docker-${target}
+  expect_output "[date=today container=buildah]" "No Path should be defined"
+  run_buildah inspect --type=image --format '{{.Docker.Config.Env}}' docker-${target}
+  expect_output "[date=today container=buildah]" "No Path should be defined"
 }
 
 @test "bud with --env" {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When we don't have any instructions to process, but we do have an unsetEnv or unsetLabel list, force a commit, like we already did if we were passed an out-of-band labels or annotations list, or if we were squashing, and now also do so if we're doing a confidential workload.

#### How to verify it

Extended integration tests!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah build`ing a Containerfile with no instructions, with either `--unsetenv` or `--unsetlabel` specified on the command line, now correctly generates a new image.
```