### PR TITLE
conformance tests: use go-dockerclient for BuildKit builds

### DIFF
--- a/tests/conformance/testdata/env/precedence/Dockerfile
+++ b/tests/conformance/testdata/env/precedence/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 FROM busybox
 ENV a=b
 ENV c=d


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test 

#### What this PR does / why we need it:

go-dockerclient gained the ability to let us ask for a build kicked off using its API to be done using BuildKit, so we don't have to work around that by calling the Docker client package any more when doing conformance testing.

The go-dockerclient method also reports errors in a way that's easier for us to consume, which we didn't have fully debugged on the other code path.

#### How to verify it

Updated conformance tests!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```