### PR TITLE
pkg/util.MirrorToTempFileIfPathIsDescriptor(): don't leak an fd

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/containers/buildah/pkg/parse"
 )
 
 // Mirrors path to a tmpfile if path points to a
@@ -17,7 +19,7 @@ import (
 func MirrorToTempFileIfPathIsDescriptor(file string) (string, bool) {
 	// one use-case is discussed here
 	// https://github.com/containers/buildah/issues/3070
-	if !strings.HasPrefix(file, "/dev/fd") {
+	if !strings.HasPrefix(file, "/dev/fd/") {
 		return file, false
 	}
 	b, err := os.ReadFile(file)
@@ -25,10 +27,11 @@ func MirrorToTempFileIfPathIsDescriptor(file string) (string, bool) {
 		// if anything goes wrong return original path
 		return file, false
 	}
-	tmpfile, err := os.CreateTemp(os.TempDir(), "buildah-temp-file")
+	tmpfile, err := os.CreateTemp(parse.GetTempDir(), "buildah-temp-file")
 	if err != nil {
 		return file, false
 	}
+	defer tmpfile.Close()
 	if _, err := tmpfile.Write(b); err != nil {
 		// if anything goes wrong return original path
 		return file, false


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `MirrorToTempFileIfPathIsDescriptor()` creates a file, it doesn't actually close the file handle.

#### How to verify it

Tests added in #3498 should keep passing.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```