### PR TITLE
run: Allow using just one jail per container on FreeBSD

### DIFF
--- a/pkg/jail/jail.go
+++ b/pkg/jail/jail.go
@@ -4,10 +4,13 @@
 package jail
 
 import (
+	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"unsafe"
 
+	"github.com/containers/buildah/pkg/util"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -27,6 +30,11 @@ const (
 type config struct {
 	params map[string]interface{}
 }
+
+var (
+	needVnetJailOnce sync.Once
+	needVnetJail     bool
+)
 
 func NewConfig() *config {
 	return &config{
@@ -177,4 +185,48 @@ func (j *jail) Set(jconf *config) error {
 	jconf.Set("jid", j.jid)
 	_, err := jailSet(jconf, JAIL_UPDATE)
 	return err
+}
+
+// Return true if its necessary to have a separate jail to own the vnet.  For
+// FreeBSD 13.3 and later, we don't need a separate vnet jail since it is
+// possible to configure the network without either attaching to the container's
+// jail or trusting the ifconfig and route utilities in the container. If for
+// any reason, we fail to parse the OS version, we default to returning true.
+func NeedVnetJail() bool {
+	needVnetJailOnce.Do(func() {
+		needVnetJail = true
+		version, err := util.ReadKernelVersion()
+		if err != nil {
+			logrus.Errorf("failed to determine OS version: %v", err)
+			return
+		}
+		// Expected formats "<major>.<minor>-<RELEASE|STABLE|CURRENT>" optionally
+		// followed by "-<patchlevel>"
+		parts := strings.Split(string(version), "-")
+		if len(parts) < 2 {
+			logrus.Errorf("unexpected OS version: %s", version)
+			return
+		}
+		ver := strings.Split(parts[0], ".")
+		if len(parts) != 2 {
+			logrus.Errorf("unexpected OS version: %s", version)
+			return
+		}
+
+		// FreeBSD 13.3 and later have support for 'ifconfig -j' and 'route -j'
+		major, err := strconv.Atoi(ver[0])
+		if err != nil {
+			logrus.Errorf("unexpected OS version: %s", version)
+			return
+		}
+		minor, err := strconv.Atoi(ver[1])
+		if err != nil {
+			logrus.Errorf("unexpected OS version: %s", version)
+			return
+		}
+		if major > 13 || (major == 13 && minor > 2) {
+			needVnetJail = false
+		}
+	})
+	return needVnetJail
 }


### PR DESCRIPTION
In FreeBSD-14.0, it is possible to configure a jail's network settings from outside the jail using ifconfig and route's new '-j' option. This removes the need for a separate jail to own the container's vnet.

This support will also be present in future FreeBSD-13.x releases starting with FreeBSD-13.3.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This reduces the complexity and cost of running containers on FreeBSD 14

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

