### PR TITLE
set makefile target internal/mkcw/embed/entrypoint.gz as .PHONY on non x86_64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,17 +73,16 @@ bin/buildah: $(SOURCES) cmd/buildah/*.go internal/mkcw/embed/entrypoint.gz
 	$(GO_BUILD) $(BUILDAH_LDFLAGS) $(GO_GCFLAGS) "$(GOGCFLAGS)" -o $@ $(BUILDFLAGS) ./cmd/buildah
 
 ifneq ($(shell as --version | grep x86_64),)
+internal/mkcw/embed/entrypoint.gz: internal/mkcw/embed/entrypoint
+	$(RM) $@
+	gzip -k $^
+
 internal/mkcw/embed/entrypoint: internal/mkcw/embed/entrypoint.s
 	$(AS) -o $(patsubst %.s,%.o,$^) $^
 	$(LD) -o $@ $(patsubst %.s,%.o,$^)
 	strip $@
-else
-.PHONY: internal/mkcw/embed/entrypoint
 endif
 
-internal/mkcw/embed/entrypoint.gz: internal/mkcw/embed/entrypoint
-	$(RM) $@
-	gzip -k $^
 
 .PHONY: buildah
 buildah: bin/buildah


### PR DESCRIPTION
The target internal/mkcw/embed/entrypoint is only built on x86_64, but internal/mkcw/embed/entrypoint.gz is run on all arches. This causes build failures on anything non x86_64 as internal/mkcw/embed/entrypoint is not build.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

To support running `make` on anything non x86_64.

#### How to verify it

Run `make` on a non-x86_64 machine.

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
None
```

