### PR TITLE
Bump to 1.33.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # Changelog
 
+## v1.33.2 (2023-11-22)
+
+    Update minimum to golang 1.20
+    fix(deps): update module github.com/fsouza/go-dockerclient to v1.10.0
+    fix(deps): update module github.com/moby/buildkit to v0.12.3
+    Bump to v1.33.2-dev
+
 ## v1.33.1 (2023-11-18)
 
     fix(deps): update module github.com/moby/buildkit to v0.11.4 [security]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+- Changelog for v1.33.2 (2023-11-22)
+  * Update minimum to golang 1.20
+  * fix(deps): update module github.com/fsouza/go-dockerclient to v1.10.0
+  * fix(deps): update module github.com/moby/buildkit to v0.12.3
+  * Bump to v1.33.2-dev
+
 - Changelog for v1.33.1 (2023-11-18)
   * fix(deps): update module github.com/moby/buildkit to v0.11.4 [security]
   * test,heredoc: use fedora instead of docker.io/library/python:latest

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.33.2-dev"
+	Version = "1.33.2"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.33.2"
+	Version = "1.33.3-dev"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
I'm doing some mad git hackery unlike anything I've done before.  I'm attempting to merge this commit between these two existing commits:

commit [12b205f69876bf09bb6dfe03adcdefad5d4ee9f8](https://github.com/containers/buildah/commit/12b205f69876bf09bb6dfe03adcdefad5d4ee9f8)
Remove makefile targets entrypoint{,.gz} for non x86_64

and 

commit [c36ab60ca472e182e3dcd0d51df3f383b108a665](https://github.com/containers/buildah/commit/c36ab60ca472e182e3dcd0d51df3f383b108a665)
 Merge pull request #5007 from containers/renovate/github.com-fsouza-go-dockerclient-1.x

That way, we will get just the changes added after 1.33.1 that deal with removing bloat and won't get the non-versioned c/{project} version bumps too.  I can then in theory make v1.33.2 with only the bloat fixes.

:crossed_fingers: 

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

