### PR TITLE
Integration tests: make skip_if_no_unshare check --map-users

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -635,6 +635,9 @@ function skip_if_no_unshare() {
   if ! unshare -Urmpf true ; then
     skip "unshare was not able to create a pid namespace"
   fi
+  if ! unshare -U --map-users $(id -u),0,1 true ; then
+    skip "unshare does not support --map-users"
+  fi
 }
 
 function start_git_daemon() {


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Check if `unshare` supports the `--map-users` option in `skip_if_no_unshare`, since we're depending on that in the only integration test that uses `skip_if_no_unshare`.

#### How to verify it

Updated test!

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```