### PR TITLE
mkcw: populate the rootfs using an overlay

### DIFF
--- a/convertcw.go
+++ b/convertcw.go
@@ -171,6 +171,7 @@ func CWConvertImage(ctx context.Context, systemContext *types.SystemContext, sto
 		Slop:                     options.Slop,
 		FirmwareLibrary:          options.FirmwareLibrary,
 		Logger:                   logger,
+		GraphOptions:             store.GraphOptions(),
 	}
 	rc, workloadConfig, err := mkcw.Archive(sourceDir, &source.OCIv1, archiveOptions)
 	if err != nil {

--- a/convertcw_test.go
+++ b/convertcw_test.go
@@ -72,7 +72,7 @@ func TestCWConvertImage(t *testing.T) {
 	for _, status := range []int{http.StatusOK, http.StatusInternalServerError} {
 		for _, ignoreChainRetrievalErrors := range []bool{false, true} {
 			for _, ignoreAttestationErrors := range []bool{false, true} {
-				t.Run(fmt.Sprintf("status=%d,ignoreChainRetrievalErrors=%v,ignoreAttestationErrors=%v", status, ignoreChainRetrievalErrors, ignoreAttestationErrors), func(t *testing.T) {
+				t.Run(fmt.Sprintf("status~%d~ignoreChainRetrievalErrors~%v~ignoreAttestationErrors~%v", status, ignoreChainRetrievalErrors, ignoreAttestationErrors), func(t *testing.T) {
 					// create a per-test Store object
 					storeOptions := storage.StoreOptions{
 						GraphRoot:       t.TempDir(),

--- a/define/types.go
+++ b/define/types.go
@@ -121,7 +121,7 @@ type ConfidentialWorkloadOptions struct {
 	AttestationURL           string
 	CPUs                     int
 	Memory                   int
-	TempDir                  string
+	TempDir                  string // used for the temporary plaintext copy of the disk image
 	TeeType                  TeeType
 	IgnoreAttestationErrors  bool
 	WorkloadID               string

--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"errors"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 // Options type holds various configuration options for overlay
@@ -180,7 +180,7 @@ func Unmount(contentDir string) error {
 	}
 
 	// Ignore EINVAL as the specified merge dir is not a mount point
-	if err := unix.Unmount(mergeDir, 0); err != nil && !errors.Is(err, os.ErrNotExist) && err != unix.EINVAL {
+	if err := system.Unmount(mergeDir); err != nil && !errors.Is(err, os.ErrNotExist) && !errors.Is(err, syscall.EINVAL) {
 		return fmt.Errorf("unmount overlay %s: %w", mergeDir, err)
 	}
 	return nil

--- a/pkg/overlay/overlay_freebsd.go
+++ b/pkg/overlay/overlay_freebsd.go
@@ -18,6 +18,9 @@ import (
 // But allows api to set custom workdir, upperdir and other overlay options
 // Following API is being used by podman at the moment
 func MountWithOptions(contentDir, source, dest string, opts *Options) (mount specs.Mount, Err error) {
+	if opts == nil {
+		opts = &Options{}
+	}
 	if opts.ReadOnly {
 		// Read-only overlay mounts can be simulated with nullfs
 		mount.Source = source

--- a/pkg/overlay/overlay_linux.go
+++ b/pkg/overlay/overlay_linux.go
@@ -17,6 +17,9 @@ import (
 // But allows api to set custom workdir, upperdir and other overlay options
 // Following API is being used by podman at the moment
 func MountWithOptions(contentDir, source, dest string, opts *Options) (mount specs.Mount, Err error) {
+	if opts == nil {
+		opts = &Options{}
+	}
 	mergeDir := filepath.Join(contentDir, "merge")
 
 	// Create overlay mount options for rw/ro.

--- a/pkg/overlay/overlay_unsupported.go
+++ b/pkg/overlay/overlay_unsupported.go
@@ -1,0 +1,20 @@
+//go:build !freebsd && !linux
+// +build !freebsd,!linux
+
+package overlay
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// MountWithOptions creates a subdir of the contentDir based on the source directory
+// from the source system.  It then mounts up the source directory on to the
+// generated mount point and returns the mount point to the caller.
+// But allows api to set custom workdir, upperdir and other overlay options
+// Following API is being used by podman at the moment
+func MountWithOptions(contentDir, source, dest string, opts *Options) (mount specs.Mount, err error) {
+	return mount, fmt.Errorf("read/write overlay mounts not supported on %q", runtime.GOOS)
+}

--- a/tests/mkcw.bats
+++ b/tests/mkcw.bats
@@ -49,12 +49,15 @@ function mkcw_check_image() {
     skip "cryptsetup not found"
   fi
   _prefetch busybox
+  _prefetch bash
 
   echo -n mkcw-convert > "$TEST_SCRATCH_DIR"/key
+  # image has one layer, check with all-lower-case TEE type name
   run_buildah mkcw --ignore-attestation-errors --type snp --passphrase=mkcw-convert busybox busybox-cw
   mkcw_check_image busybox-cw
-  run_buildah mkcw --ignore-attestation-errors --type SNP --passphrase=mkcw-convert busybox busybox-cw
-  mkcw_check_image busybox-cw
+  # image has multiple layers, check with all-upper-case TEE type name
+  run_buildah mkcw --ignore-attestation-errors --type SNP --passphrase=mkcw-convert bash bash-cw
+  mkcw_check_image bash-cw
 }
 
 @test "mkcw-commit" {
@@ -63,10 +66,10 @@ function mkcw_check_image() {
   if ! which cryptsetup > /dev/null 2> /dev/null ; then
     skip "cryptsetup not found"
   fi
-  _prefetch busybox
+  _prefetch bash
 
   echo -n "mkcw commit" > "$TEST_SCRATCH_DIR"/key
-  run_buildah from busybox
+  run_buildah from bash
   ctrID="$output"
   run_buildah commit --iidfile "$TEST_SCRATCH_DIR"/iid --cw type=SEV,ignore_attestation_errors,passphrase="mkcw commit" "$ctrID"
   mkcw_check_image $(cat "$TEST_SCRATCH_DIR"/iid)


### PR DESCRIPTION
#### What type of PR is this?

/kind design

#### What this PR does / why we need it:

When using the working container's rootfs to populate a plaintext disk image with mkfs, instead of writing .krun_config.json to the rootfs and then removing it afterward (since we don't want it to show up if the same working container is later committed to non confidential-workload image), mount an overlay filesystem using a temporary directory as the upper and the rootfs as the lower, create the .krun_config.json file in the overlay filesystem, and use the overlay filesystem as the source directory for mkfs.

#### How to verify it

Updated a test to make sure we don't break when base images have multiple layers.

#### Which issue(s) this PR fixes:

Modifying the roots during `commit` is inherently racy.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```