### PR TITLE
stage_executor,heredoc: honor interpreter in heredoc

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -354,6 +354,14 @@ _EOF
   expect_output --substring "this is the output of test10"
 }
 
+@test "bud build with heredoc content with inline interpreter" {
+  skip_if_in_container
+  _prefetch busybox
+  run_buildah build -t heredoc $WITH_POLICY_JSON -f $BUDFILES/heredoc/Containerfile.she_bang .
+  expect_output --substring "this is the output of test11"
+  expect_output --substring "this is the output of test12"
+}
+
 @test "bud build with heredoc verify mount leak" {
   skip_if_in_container
   _prefetch alpine

--- a/tests/bud/heredoc/Containerfile.she_bang
+++ b/tests/bud/heredoc/Containerfile.she_bang
@@ -1,0 +1,6 @@
+FROM python:3.11-slim-bullseye
+RUN <<EOF
+#!/usr/bin/env python
+print('this is the output of test11')
+print('this is the output of test12')
+EOF


### PR DESCRIPTION
If there are any shebang in heredoc file then buildah must honor that. Consider a case of

```Dockerfile
FROM python:3.11-slim-bullseye
RUN <<EOF
#!/usr/bin/env python
print('hello world')
EOF
```

Closes: https://github.com/containers/buildah/issues/5251

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it
New Integration test

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
stage_executor,heredoc: honor interpreter/shebang in heredoc
```

