### PR TITLE
[release-1.29] conformance test: ignore file type bits when comparing layers

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -143,6 +143,7 @@ cross_build_task:
         image: ghcr.io/cirruslabs/macos-ventura-base:latest
 
     script:
+        - brew upgrade
         - brew update
         - brew install go
         - brew install go-md2man

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -778,7 +779,7 @@ func fsHeaderForEntry(hdr *tar.Header) FSHeader {
 		Name:     hdr.Name,
 		Linkname: hdr.Linkname,
 		Size:     hdr.Size,
-		Mode:     hdr.Mode,
+		Mode:     (hdr.Mode & int64(fs.ModePerm)),
 		UID:      hdr.Uid,
 		GID:      hdr.Gid,
 		ModTime:  hdr.ModTime,


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

When comparing layer payloads during conformance tests, mask off any file type bits that the tar headers in the layers might have included.  Extracted from #4829.

#### How to verify it

Conformance tests!

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```