### PR TITLE
[release-1.24] conformance test: ignore file type bits when comparing layers

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -129,6 +129,7 @@ cross_build_task:
     env:
         PATH: "/usr/local/opt/go@1.18/bin:/opt/homebrew/opt/go@1.18/bin:$PATH"
     script:
+        - brew upgrade
         - brew update
         - brew install go@1.18
         - brew install go-md2man

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -788,7 +788,7 @@ func fsHeaderForEntry(hdr *tar.Header) FSHeader {
 		Name:     hdr.Name,
 		Linkname: hdr.Linkname,
 		Size:     hdr.Size,
-		Mode:     hdr.Mode,
+		Mode:     (hdr.Mode & int64(os.ModePerm)),
 		UID:      hdr.Uid,
 		GID:      hdr.Gid,
 		ModTime:  hdr.ModTime,


### PR DESCRIPTION
Manual cherry-pick of https://github.com/containers/buildah/pull/5257.