### PR TITLE
stage_executor,layers: burst cache of `layers` if heredoc content is changed

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1725,7 +1725,14 @@ func (s *StageExecutor) getCreatedBy(node *parser.Node, addedContentSummary stri
 		if buildArgs != "" {
 			return "|" + strconv.Itoa(len(strings.Split(buildArgs, " "))) + " " + buildArgs + " /bin/sh -c " + node.Original[4:]
 		}
-		return "/bin/sh -c " + node.Original[4:]
+		result := "/bin/sh -c " + node.Original[4:]
+		if len(node.Heredocs) > 0 {
+			for _, doc := range node.Heredocs {
+				heredocContent := strings.TrimSpace(doc.Content)
+				result = result + "\n" + heredocContent
+			}
+		}
+		return result
 	case "ADD", "COPY":
 		destination := node
 		for destination.Next != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -293,6 +293,40 @@ _EOF
   run_buildah 1 run myctr ls -l subdir/
 }
 
+@test "bud --layers should not hit cache if heredoc is changed" {
+  local contextdir=${TEST_SCRATCH_DIR}/bud/platform
+  mkdir -p $contextdir
+
+  cat > $contextdir/Dockerfile << _EOF
+FROM alpine
+RUN <<EOF
+echo "Cache burst" >> /hello
+EOF
+RUN cat hello
+_EOF
+
+  # on first run since there is no cache so `Cache burst` must be printed
+  run_buildah build $WITH_POLICY_JSON --layers -t source -f $contextdir/Dockerfile
+  expect_output --substring "Cache burst"
+
+  # on second run since there is cache so `Cache burst` should not be printed
+  run_buildah build $WITH_POLICY_JSON --layers -t source -f $contextdir/Dockerfile
+  # output should not contain cache burst
+  assert "$output" !~ "Cache burst"
+
+  cat > $contextdir/Dockerfile << _EOF
+FROM alpine
+RUN <<EOF
+echo "Cache burst add diff" >> /hello
+EOF
+RUN cat hello
+_EOF
+
+  # on third run since we have changed heredoc so `Cache burst` must be printed.
+  run_buildah build $WITH_POLICY_JSON --layers -t source -f $contextdir/Dockerfile
+  expect_output --substring "Cache burst"
+}
+
 @test "bud build with heredoc content" {
   run_buildah build -t heredoc $WITH_POLICY_JSON -f $BUDFILES/heredoc/Containerfile .
   expect_output --substring "print first line from heredoc"


### PR DESCRIPTION
When using buildah with `--layers` then buildah must correctly burst layer cache if `heredoc` content is changed. Following is achieved via properly adding `heredoc` content to the history of the built image.

Closes: https://github.com/containers/buildah/issues/5225

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
Closes: https://github.com/containers/buildah/issues/5225

#### How to verify it
Newly added integration test

#### Which issue(s) this PR fixes:
Closes: https://github.com/containers/buildah/issues/5225

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
stage_executor,layers: burst cache of layers if heredoc content is changed
```

