### PR TITLE
[release-1.22] conformance test: ignore file type bits when comparing layers

### DIFF
--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -737,7 +737,7 @@ func fsHeaderForEntry(hdr *tar.Header) FSHeader {
 		Name:     hdr.Name,
 		Linkname: hdr.Linkname,
 		Size:     hdr.Size,
-		Mode:     hdr.Mode,
+		Mode:     (hdr.Mode & int64(os.ModePerm)),
 		UID:      hdr.Uid,
 		GID:      hdr.Gid,
 		ModTime:  hdr.ModTime,


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

When comparing layer payloads during conformance tests, mask off any file type bits that the tar headers in the layers might have included.  Extracted from #4829.

#### How to verify it

Conformance tests!

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```