### PR TITLE
Make buildah match podman for handling of ulimits

### DIFF
--- a/define/types.go
+++ b/define/types.go
@@ -54,6 +54,9 @@ const (
 	SNP TeeType = "snp"
 )
 
+// DefaultRlimitValue is the value set by default for nofile and nproc
+const RLimitDefaultValue = uint64(1048576)
+
 // TeeType is a supported trusted execution environment type.
 type TeeType string
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6602,3 +6602,18 @@ _EOF
   expect_output --substring "localhost/foo/bar"
   expect_output --substring "localhost/bar"
 }
+
+@test "build test default ulimits" {
+  skip_if_no_runtime
+  _prefetch alpine
+
+  run podman run --rm alpine sh -c "echo -n Files=; awk '/open files/{print \$4 \"/\" \$5}' /proc/self/limits"
+  podman_files=$output
+
+  run podman run --rm alpine sh -c "echo -n Processes=; awk '/processes/{print \$3 \"/\" \$4}' /proc/self/limits"
+  podman_processes=$output
+
+  CONTAINERS_CONF=/dev/null run_buildah build --no-cache --pull=false $WITH_POLICY_JSON -t foo/bar $BUDFILES/bud.limits
+  expect_output --substring "$podman_files"
+  expect_output --substring "$podman_processes"
+}

--- a/tests/bud/bud.limits/Containerfile
+++ b/tests/bud/bud.limits/Containerfile
@@ -1,0 +1,4 @@
+# Containerfile
+FROM alpine
+RUN echo -n "Files="; awk '/open files/{print $4 "/" $5}' /proc/self/limits
+RUN echo -n "Processes="; awk '/processes/{print $3 "/" $4}' /proc/self/limits


### PR DESCRIPTION
Podman currently sets the ulimits of nofile and nproc to max in rootless mode, if the user does not override.

Buildah on the other hand just passes in the current defaults.

Podman build should match podman run, and this will fix that problem.

Fixes: https://github.com/containers/buildah/issues/5273

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Buildah now sets the maximum ulimits nofile and nproc by default.
```

