### PR TITLE
commit: force omitHistory if the parent has layers but no history

### DIFF
--- a/image.go
+++ b/image.go
@@ -1048,10 +1048,20 @@ func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageR
 	}
 
 	parent := ""
+	forceOmitHistory := false
 	if b.FromImageID != "" {
 		parentDigest := digest.NewDigestFromEncoded(digest.Canonical, b.FromImageID)
 		if parentDigest.Validate() == nil {
 			parent = parentDigest.String()
+		}
+		if !options.OmitHistory && len(b.OCIv1.History) == 0 && len(b.OCIv1.RootFS.DiffIDs) != 0 {
+			// Parent had layers, but no history.  We shouldn't confuse
+			// our own confidence checks by adding history for layers
+			// that we're adding, creating an image with multiple layers,
+			// only some of which have history entries, which would be
+			// broken in confusing ways.
+			b.Logger.Debugf("parent image %q had no history but had %d layers, assuming OmitHistory", b.FromImageID, len(b.OCIv1.RootFS.DiffIDs))
+			forceOmitHistory = true
 		}
 	}
 
@@ -1074,7 +1084,7 @@ func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageR
 		preferredManifestType: manifestType,
 		squash:                options.Squash,
 		confidentialWorkload:  options.ConfidentialWorkloadOptions,
-		omitHistory:           options.OmitHistory,
+		omitHistory:           options.OmitHistory || forceOmitHistory,
 		emptyLayer:            options.EmptyLayer && !options.Squash && !options.ConfidentialWorkloadOptions.Convert,
 		idMappingOptions:      &b.IDMappingOptions,
 		parent:                parent,

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4371,6 +4371,12 @@ EOM
   expect_output ""
 }
 
+@test "bud-implicit-no-history" {
+  _prefetch nixery.dev/shell
+  run_buildah build $WITH_POLICY_JSON --layers=false $BUDFILES/no-history
+  run_buildah build $WITH_POLICY_JSON --layers=true  $BUDFILES/no-history
+}
+
 @test "bud with encrypted FROM image" {
   _prefetch busybox
   local contextdir=${TEST_SCRATCH_DIR}/tmp

--- a/tests/bud/no-history/Dockerfile
+++ b/tests/bud/no-history/Dockerfile
@@ -1,0 +1,10 @@
+# The important thing about that first base image is that it has no history
+# entries, but it does have at least one layer.
+
+FROM nixery.dev/shell AS first-stage
+RUN date > /date1.txt
+RUN sleep 1 > /sleep1.txt
+
+FROM first-stage
+RUN date > /date2.txt
+RUN sleep 1 > /sleep2.txt


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If the parent image has layers but no history, force our own omitHistory setting on.

The alternative is to create a history that only explains the presence of some of the layers in our output image, which looks broken to everyone who might consume that image, including ourselves if we try to use it as a base image later.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes https://github.com/containers/podman/issues/21094.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```