### PR TITLE
Split up error messages for missing --sbom related flags

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -814,8 +814,11 @@ func SBOMScanOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name str
 		return nil, fmt.Errorf("invalid value for --sbom-purl-output: %w", err)
 	}
 
-	if options.Image == "" || len(options.Commands) == 0 || (options.SBOMOutput == "" && options.ImageSBOMOutput == "" && options.PURLOutput == "" && options.ImagePURLOutput == "") {
-		return options, fmt.Errorf("sbom configuration missing one or more of (%q, %q, %q, %q, %q or %q)", "--sbom-scanner-imag", "--sbom-scanner-command", "--sbom-output", "--sbom-image-output", "--sbom-purl-output", "--sbom-image-purl-output")
+	if options.Image == "" || len(options.Commands) == 0 {
+		return options, fmt.Errorf("sbom configuration missing one or more of (%q or %q)", "--sbom-scanner-image", "--sbom-scanner-command")
+	}
+	if options.SBOMOutput == "" && options.ImageSBOMOutput == "" && options.PURLOutput == "" && options.ImagePURLOutput == "" {
+		return options, fmt.Errorf("sbom configuration missing one or more of (%q, %q, %q or %q)", "--sbom-output", "--sbom-image-output", "--sbom-purl-output", "--sbom-image-purl-output")
 	}
 	if len(options.Commands) > 1 && options.MergeStrategy == "" {
 		return options, fmt.Errorf("sbom configuration included multiple %q values but no %q value", "--sbom-scanner-command", "--sbom-merge-strategy")


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Split up the diagnostic for missing SBOM generation settings so that we can more easily tell the difference between "you didn't tell me where to put the output files" and "I don't know how to generate things".

#### How to verify it

Use `--sbom` and forget to specify options for where to save the generated files, and wonder if the presets aren't working right.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Not really a bug, but I've confused myself enough times that this probably needed to be changed.

#### Does this PR introduce a user-facing change?

```release-note
None
```