### PR TITLE
tests: Remove a bad FROM line

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -358,8 +358,9 @@ _EOF
   skip_if_in_container
   _prefetch busybox
   run_buildah build -t heredoc $WITH_POLICY_JSON -f $BUDFILES/heredoc/Containerfile.she_bang .
-  expect_output --substring "this is the output of test11"
-  expect_output --substring "this is the output of test12"
+  expect_output --substring "#
+this is the output of test11
+this is the output of test12"
 }
 
 @test "bud build with heredoc verify mount leak" {

--- a/tests/bud/heredoc/Containerfile.she_bang
+++ b/tests/bud/heredoc/Containerfile.she_bang
@@ -1,6 +1,7 @@
-FROM python:3.11-slim-bullseye
+FROM alpine
 RUN <<EOF
-#!/usr/bin/env python
-print('this is the output of test11')
-print('this is the output of test12')
+#!/usr/bin/env rev
+11tset fo tuptuo eht si siht
+21tset fo tuptuo eht si siht
+
 EOF


### PR DESCRIPTION
Some new heredoc test added "FROM blah blah python whatever",
an image that (presumably) exists on docker.io but does not
exist in our cache.

Plus, test was completely broken anyway. It would've found
the "this is the output" lines even without python, as
part of the verbose build.

Solution: don't use python. You don't need python to test a shebang.
You can use anything. 'cat' is traditional, but I choose 'rev'
because that makes it nearly impossible for the test to match
merely due to a build-step echo.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```