### PR TITLE
Fix a build break on FreeBSD

### DIFF
--- a/add.go
+++ b/add.go
@@ -23,7 +23,6 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/hashicorp/go-multierror"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/opencontainers/runc/libcontainer/userns"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -438,7 +437,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 						ChmodDirs:     nil,
 						ChownFiles:    nil,
 						ChmodFiles:    nil,
-						IgnoreDevices: userns.RunningInUserNS(),
+						IgnoreDevices: runningInUserNS(),
 					}
 					putErr = copier.Put(extractDirectory, extractDirectory, putOptions, io.TeeReader(pipeReader, hasher))
 				}
@@ -579,7 +578,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 						ChmodDirs:       nil,
 						ChownFiles:      nil,
 						ChmodFiles:      nil,
-						IgnoreDevices:   userns.RunningInUserNS(),
+						IgnoreDevices:   runningInUserNS(),
 					}
 					putErr = copier.Put(extractDirectory, extractDirectory, putOptions, io.TeeReader(pipeReader, hasher))
 				}

--- a/add_common.go
+++ b/add_common.go
@@ -1,0 +1,8 @@
+//go:build !linux
+// +build !linux
+
+package buildah
+
+func runningInUserNS() bool {
+	return false
+}

--- a/add_linux.go
+++ b/add_linux.go
@@ -1,0 +1,9 @@
+package buildah
+
+import (
+	"github.com/opencontainers/runc/libcontainer/userns"
+)
+
+func runningInUserNS() bool {
+	return userns.RunningInUserNS()
+}


### PR DESCRIPTION
The build breaks trying to build libcontainer/userns which no longer builds on FreeBSD. Fortunately we only need this for userns.RunningInUserNS so this change moves that call to a linux-only file and adds a stub for FreeBSD.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### How to verify it

On a FreeBSD system:
```
gmake bin/buildah
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
[NO NEW TESTS NEEDED]
