### PR TITLE
docs: correct default authfile path

### DIFF
--- a/docs/buildah-login.1.md
+++ b/docs/buildah-login.1.md
@@ -12,7 +12,7 @@ and password. **buildah login** reads in the username and password from STDIN.
 The username and password can also be set using the **username** and **password** flags.
 The path of the authentication file can be specified by the user by setting the **authfile**
 flag. The default path used is **${XDG\_RUNTIME_DIR}/containers/auth.json**. If XDG_RUNTIME_DIR
-is not set, the default is /run/containers/$UID/auth.json.
+is not set, the default is /run/user/$UID/containers/auth.json.
 
 **buildah [GLOBAL OPTIONS]**
 


### PR DESCRIPTION
/kind documentation

```release-note
None
```

