### PR TITLE
Fix FreeBSD version parsing

### DIFF
--- a/pkg/jail/jail_test.go
+++ b/pkg/jail/jail_test.go
@@ -1,0 +1,42 @@
+//go:build freebsd
+// +build freebsd
+
+package jail
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseVersion(t *testing.T) {
+	tt := []struct {
+		version                  string
+		shouldFail               bool
+		kind                     string
+		major, minor, patchlevel int
+	}{
+		{"14.0-RELEASE", false, "RELEASE", 14, 0, 0},
+		{"14.0-RELEASE-p3", false, "RELEASE", 14, 0, 3},
+		{"13.2-STABLE", false, "STABLE", 13, 2, 0},
+		{"14.0-STABLE", false, "STABLE", 14, 0, 0},
+		{"15.0-CURRENT", false, "CURRENT", 15, 0, 0},
+
+		{"14-RELEASE", true, "", -1, -1, -1},
+		{"14.1-STABLE-p1", true, "", -1, -1, -1},
+		{"14-RELEASE-p3", true, "", -1, -1, -1},
+	}
+	for _, tc := range tt {
+		kind, major, minor, patchlevel, err := parseVersion(tc.version)
+		if tc.shouldFail {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, kind, tc.kind)
+			assert.Equal(t, major, tc.major)
+			assert.Equal(t, minor, tc.minor)
+			assert.Equal(t, patchlevel, tc.patchlevel)
+		}
+
+	}
+}


### PR DESCRIPTION
It was generating an error when parsing "14.0-RELEASE-p4" due to a stupid bug when attempting to check that the version part only has two parts.

When I wrote this originally, I was using systems running either 13.2-STABLE or 14.0-CURRENT and didn't properly take into account the patchleve. This factors out the version parsing and adds a unit test.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It forces Podman and Buildah to use two jails for each container instead of one when run on the latest iteration of FreeBSD 14.0

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

