### PR TITLE
Allow users to specify no-dereference

### DIFF
--- a/internal/volumes/volumes.go
+++ b/internal/volumes/volumes.go
@@ -54,6 +54,7 @@ func CacheParent() string {
 	return filepath.Join(tmpdir.GetTempDir(), buildahCacheDir+"-"+strconv.Itoa(unshare.GetRootlessUID()))
 }
 
+// FIXME: this code needs to be merged with pkg/parse/parse.go ValidateVolumeOpts
 // GetBindMount parses a single bind mount entry from the --mount flag.
 // Returns specifiedMount and a string which contains name of image that we mounted otherwise its empty.
 // Caller is expected to perform unmount of any mounted images
@@ -89,7 +90,10 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
 			// Alias for "ro"
 			newMount.Options = append(newMount.Options, "ro")
 			mountReadability = true
-		case "shared", "rshared", "private", "rprivate", "slave", "rslave", "Z", "z", "U":
+		case "shared", "rshared", "private", "rprivate", "slave", "rslave", "Z", "z", "U", "no-dereference":
+			if hasArgValue {
+				return newMount, "", fmt.Errorf("%v: %w", val, errBadOptionArg)
+			}
 			newMount.Options = append(newMount.Options, argName)
 		case "from":
 			if !hasArgValue {


### PR DESCRIPTION
We have this same parsing code in 3 maybe 4 places in our sources, Someone needs to go through it all and get this to be parsed in less places.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
no-dereference on mounts is now supported
```
[NO NEW TESTS NEEDED]

