### PR TITLE
imagebuildah: fix crash with empty RUN

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1737,11 +1737,15 @@ func (s *StageExecutor) getCreatedBy(node *parser.Node, addedContentSummary stri
 		buildArgs := s.getBuildArgsKey()
 		return "/bin/sh -c #(nop) ARG " + buildArgs
 	case "RUN":
+		shArg := ""
 		buildArgs := s.getBuildArgsResolvedForRun()
-		if buildArgs != "" {
-			return "|" + strconv.Itoa(len(strings.Split(buildArgs, " "))) + " " + buildArgs + " /bin/sh -c " + node.Original[4:]
+		if len(node.Original) > 4 {
+			shArg = node.Original[4:]
 		}
-		result := "/bin/sh -c " + node.Original[4:]
+		if buildArgs != "" {
+			return "|" + strconv.Itoa(len(strings.Split(buildArgs, " "))) + " " + buildArgs + " /bin/sh -c " + shArg
+		}
+		result := "/bin/sh -c " + shArg
 		if len(node.Heredocs) > 0 {
 			for _, doc := range node.Heredocs {
 				heredocContent := strings.TrimSpace(doc.Content)

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -952,3 +952,18 @@ _EOF
 		fi
 	done
 }
+
+@test "empty run statement doesn't crash" {
+	skip_if_no_runtime
+
+	_prefetch alpine
+
+	cd ${TEST_SCRATCH_DIR}
+
+	printf 'FROM alpine\nRUN \\\n echo && echo' > Dockerfile
+	run_buildah bud --pull=false --layers .
+
+	printf 'FROM alpine\nRUN\n echo && echo' > Dockerfile
+	run_buildah ? bud --pull=false --layers .
+        expect_output --substring -- "-c requires an argument"
+}


### PR DESCRIPTION
fix a crash when RUN is executed without any argument.

Closes: https://github.com/containers/buildah/issues/5312

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other


/kind bug

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a crash in "buildah bud" that could happen when a RUN directive has no arguments.
```

