### PR TITLE
build, heredoc: show `heredoc` summary in build output

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1217,7 +1217,24 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		}
 		logrus.Debugf("Parsed Step: %+v", *step)
 		if !s.executor.quiet {
-			s.log("%s", step.Original)
+			logMsg := step.Original
+			if len(step.Heredocs) > 0 {
+				summarizeHeredoc := func(doc string) string {
+					doc = strings.TrimSpace(doc)
+					lines := strings.Split(strings.ReplaceAll(doc, "\r\n", "\n"), "\n")
+					summary := lines[0]
+					if len(lines) > 1 {
+						summary += "..."
+					}
+					return summary
+				}
+
+				for _, doc := range node.Heredocs {
+					heredocContent := summarizeHeredoc(doc.Content)
+					logMsg = logMsg + " (" + heredocContent + ")"
+				}
+			}
+			s.log("%s", logMsg)
 		}
 
 		// Check if there's a --from if the step command is COPY.

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -301,18 +301,19 @@ _EOF
 FROM alpine
 RUN <<EOF
 echo "Cache burst" >> /hello
+echo "Cache burst second line" >> /hello
 EOF
 RUN cat hello
 _EOF
 
   # on first run since there is no cache so `Cache burst` must be printed
   run_buildah build $WITH_POLICY_JSON --layers -t source -f $contextdir/Dockerfile
-  expect_output --substring "Cache burst"
+  expect_output --substring "Cache burst second line"
 
   # on second run since there is cache so `Cache burst` should not be printed
   run_buildah build $WITH_POLICY_JSON --layers -t source -f $contextdir/Dockerfile
   # output should not contain cache burst
-  assert "$output" !~ "Cache burst"
+  assert "$output" !~ "Cache burst second line"
 
   cat > $contextdir/Dockerfile << _EOF
 FROM alpine
@@ -324,7 +325,7 @@ _EOF
 
   # on third run since we have changed heredoc so `Cache burst` must be printed.
   run_buildah build $WITH_POLICY_JSON --layers -t source -f $contextdir/Dockerfile
-  expect_output --substring "Cache burst"
+  expect_output --substring "Cache burst add diff"
 }
 
 @test "bud build with heredoc content" {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -344,6 +344,13 @@ _EOF
   expect_output --substring "this is the output of test7 part3"
   expect_output --substring "this is the output of test8 part1"
   expect_output --substring "this is the output of test8 part2"
+
+  # verify that build output contains summary of heredoc content
+  expect_output --substring 'RUN <<EOF \(echo "print first line from heredoc"...)'
+  expect_output --substring 'RUN <<EOF \(echo "Heredoc writing first file" >> /file1...)'
+  expect_output --substring 'RUN python3 <<EOF \(with open\("/file2", "w") as f:...)'
+  expect_output --substring 'ADD <<EOF /index.html \(\(your index page goes here))'
+  expect_output --substring 'COPY <<robots.txt <<humans.txt /test/ \(\(robots content)) \(\(humans content))'
 }
 
 @test "bud build with heredoc content which is a bash file" {


### PR DESCRIPTION
Buildah must show summary of heredoc content in build output so its easy for developers to understand which heredoc got executed, this is similar to what buildkit does for heredoc content.

See: https://github.com/moby/buildkit/blob/master/frontend/dockerfile/dockerfile2llb/convert.go#L1853

Output is similar to how `buildkit` produces `heredoc` summary for build output.

Sample output of buildah

```console
STEP 1/5: FROM docker.io/library/python:latest
STEP 2/5: RUN <<EOF (echo "Hello" >> /hello...)
STEP 3/5: RUN python3 <<EOF (with open("/hello", "w") as f:...)
STEP 4/5: RUN ls -a
```

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build, heredoc: show heredoc summary in build output
```

