### PR TITLE
manifest, push: add support for `--retry` and `--retry-delay`

### DIFF
--- a/docs/buildah-manifest-push.1.md
+++ b/docs/buildah-manifest-push.1.md
@@ -79,6 +79,18 @@ Don't output progress information when pushing lists.
 
 Don't copy signatures when pushing images.
 
+**--retry** *attempts*
+
+Number of times to retry in case of failure when performing push of images to registry.
+
+Defaults to `3`.
+
+**--retry-delay** *duration*
+
+Duration of delay between retry attempts in case of failure when performing push of images to registry.
+
+Defaults to `2s`.
+
 **--rm**
 
 Delete the manifest list or image index from local storage if pushing succeeds.

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -115,6 +115,24 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     assert "$status" -eq 0 "status code of grep for expected instance digest"
 }
 
+@test "manifest-push with retry" {
+    run_buildah manifest create foo
+    run_buildah manifest add --all foo ${IMAGE_LIST}
+    run_buildah manifest push --retry 4 --retry-delay 4s $WITH_POLICY_JSON foo dir:${TEST_SCRATCH_DIR}/pushed
+    case "$(go env GOARCH 2> /dev/null)" in
+	    amd64) IMAGE_LIST_EXPECTED_INSTANCE_DIGEST=${IMAGE_LIST_AMD64_INSTANCE_DIGEST} ;;
+	    arm64) IMAGE_LIST_EXPECTED_INSTANCE_DIGEST=${IMAGE_LIST_ARM64_INSTANCE_DIGEST} ;;
+	    arm) IMAGE_LIST_EXPECTED_INSTANCE_DIGEST=${IMAGE_LIST_ARM_INSTANCE_DIGEST} ;;
+	    ppc64le) IMAGE_LIST_EXPECTED_INSTANCE_DIGEST=${IMAGE_LIST_PPC64LE_INSTANCE_DIGEST} ;;
+	    s390x) IMAGE_LIST_EXPECTED_INSTANCE_DIGEST=${IMAGE_LIST_S390X_INSTANCE_DIGEST} ;;
+	    *) skip "current arch \"$(go env GOARCH 2> /dev/null)\" not present in manifest list" ;;
+    esac
+
+    run grep ${IMAGE_LIST_EXPECTED_INSTANCE_DIGEST##sha256} ${TEST_SCRATCH_DIR}/pushed/manifest.json
+    assert "$status" -eq 0 "status code of grep for expected instance digest"
+}
+
+
 @test "manifest-push-all" {
     run_buildah manifest create foo
     run_buildah manifest add --all foo ${IMAGE_LIST}


### PR DESCRIPTION
Just like `buildah push`, `buildah manifest push` should also support `--retry` and `--retry-delay` options, see documentation in same commit for more details.

Closes: https://github.com/containers/buildah/issues/5254

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:
Closes: https://github.com/containers/buildah/issues/5254

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
manifest, push: add support for --retry and --retry-delay
```

