### PR TITLE
build --all-platforms: skip some base "image" platforms

### DIFF
--- a/tests/bud/from-base/Containerfile
+++ b/tests/bud/from-base/Containerfile
@@ -1,0 +1,2 @@
+FROM base
+ADD . .


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When figuring out which platforms the base images allow us to build derived images for, screen out any images with non-empty artifactType values.  Also screen out any which use empty values or the word "unknown" in the OS and Architecture platform fields, and any Architecture values that the compiler hasn't heard of.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes #5331.

#### Special notes for your reviewer:

An alternate to the approach taken by #5334.

#### Does this PR introduce a user-facing change?

```release-note
Building with `--all-platforms` will now refrain from building for platforms with OS or Architecture values that are empty or set to the value "unknown".  Additionally, "Architecture" values that are not recognized by the Go compiler will also be skipped.
```