### PR TITLE
[CI:DOCS] Add comment re: Total Success task name

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -323,6 +323,8 @@ in_podman_task:
 # set of tasks all passed, and allows confirming that based on the status
 # of this task.
 success_task:
+    # N/B: The prow merge-bot (tide) is sensitized to this exact name, DO NOT CHANGE IT.
+    # Ref: https://github.com/openshift/release/pull/48909
     name: "Total Success"
     alias: success
 


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Add important comment and link reminding maintainers not to change the success-aggregation task name.

#### How to verify it

N/A

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Previously it was possible for tide to merge a PR w/ a canceled "Total Success". Please wait for https://github.com/openshift/release/pull/48909 to merge.  A half-day after that, the `tide` bot will begin respecting the "Total Success" Cirrus-CI task status.  Just so long as nobody ever changes the task name :smiley: 

#### Does this PR introduce a user-facing change?

```release-note
None
```

