### PR TITLE
Reduce official image size

### DIFF
--- a/contrib/buildahimage/Containerfile
+++ b/contrib/buildahimage/Containerfile
@@ -19,7 +19,7 @@
 # that runs safely with privileges within the container.
 #
 
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora-minimal:latest
 ARG FLAVOR=stable
 
 label "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
@@ -34,24 +34,18 @@ RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking
 # up space.
-# TODO: rpm --setcaps... needed due to Fedora (base) image builds
-#       being (maybe still?) affected by
-#       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
-RUN dnf -y makecache && \
-    dnf -y update && \
-    rpm --setcaps shadow-utils 2>/dev/null && \
-    case "${FLAVOR}" in \
+RUN case "${FLAVOR}" in \
       stable) \
-        dnf -y install buildah fuse-overlayfs cpp --exclude container-selinux \
+        dnf5 -y install buildah fuse-overlayfs cpp --exclude container-selinux \
       ;; \
       testing) \
-        dnf -y install --enablerepo=updates-testing buildah fuse-overlayfs cpp \
+        dnf5 -y install --enablerepo=updates-testing buildah fuse-overlayfs cpp \
             --exclude container-selinux \
       ;; \
       upstream) \
-        dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
-        dnf -y copr enable rhcontainerbot/podman-next && \
-        dnf -y install buildah fuse-overlayfs \
+        dnf5 -y install 'dnf5-command(copr)' --enablerepo=updates-testing && \
+        dnf5 -y copr enable rhcontainerbot/podman-next && \
+        dnf5 -y install buildah fuse-overlayfs \
             --exclude container-selinux \
             --enablerepo=updates-testing  \
       ;; \
@@ -60,7 +54,7 @@ RUN dnf -y makecache && \
         exit 1 \
       ;; \
     esac && \
-    dnf -y clean all && \
+    dnf5 -y clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 ADD ./containers.conf /etc/containers/


### PR DESCRIPTION
Current image size is 728MB.

1. Switch to fedora-minimal. Requires switching to dnf5. shadow-utils is
no longer included in the base image, so the bits about it are renmoved.
728MB -> 650MB.
2. Don't update unrelated packages. 650MB -> 598MB.

Ultimately the image is still very large, which is driven by the veritable constellation of dependencies buildah installs.  Installing `buildah` in fedora-minimal gives you this plan:

```
Package                            Arch    Version              Repository      Size
Upgrading:
 alternatives                      aarch64 1.26-1.fc39          updates    218.2 KiB
  replacing alternatives           aarch64 1.25-1.fc39          <unknown>  218.2 KiB
 bash                              aarch64 5.2.26-1.fc39        updates      8.3 MiB
  replacing bash                   aarch64 5.2.21-1.fc39        <unknown>    8.3 MiB
 crypto-policies                   noarch  20231204-1.git1e3a2e updates    149.3 KiB
  replacing crypto-policies        noarch  20231113-1.gitb402e8 <unknown>  149.1 KiB
 glibc                             aarch64 2.38-16.fc39         updates      9.7 MiB
  replacing glibc                  aarch64 2.38-11.fc39         <unknown>    9.7 MiB
 glibc-common                      aarch64 2.38-16.fc39         updates      2.6 MiB
  replacing glibc-common           aarch64 2.38-11.fc39         <unknown>    2.6 MiB
 glibc-minimal-langpack            aarch64 2.38-16.fc39         updates      0.0   B
  replacing glibc-minimal-langpack aarch64 2.38-11.fc39         <unknown>    0.0   B
 gnutls                            aarch64 3.8.3-1.fc39         updates      3.4 MiB
  replacing gnutls                 aarch64 3.8.1-1.fc39         <unknown>    3.4 MiB
 libacl                            aarch64 2.3.1-9.fc39         updates    196.0 KiB
  replacing libacl                 aarch64 2.3.1-8.fc39         <unknown>  196.0 KiB
 libblkid                          aarch64 2.39.3-5.fc39        updates    392.9 KiB
  replacing libblkid               aarch64 2.39.2-1.fc39        <unknown>  392.9 KiB
 libcap                            aarch64 2.48-9.fc39          updates      1.4 MiB
  replacing libcap                 aarch64 2.48-7.fc39          <unknown>    1.4 MiB
 libgcc                            aarch64 13.2.1-6.fc39        updates    349.7 KiB
  replacing libgcc                 aarch64 13.2.1-4.fc39        <unknown>  349.8 KiB
 libidn2                           aarch64 2.3.7-1.fc39         updates    457.1 KiB
  replacing libidn2                aarch64 2.3.4-3.fc39         <unknown>  451.0 KiB
 libmount                          aarch64 2.39.3-5.fc39        updates    484.1 KiB
  replacing libmount               aarch64 2.39.2-1.fc39        <unknown>  484.1 KiB
 libsmartcols                      aarch64 2.39.3-5.fc39        updates    288.1 KiB
  replacing libsmartcols           aarch64 2.39.2-1.fc39        <unknown>  288.1 KiB
 libuuid                           aarch64 2.39.3-5.fc39        updates    197.5 KiB
  replacing libuuid                aarch64 2.39.2-1.fc39        <unknown>  197.5 KiB
 readline                          aarch64 8.2-6.fc39           updates    689.1 KiB
  replacing readline               aarch64 8.2-4.fc39           <unknown>  689.1 KiB
 systemd-libs                      aarch64 254.9-1.fc39         updates      2.4 MiB
  replacing systemd-libs           aarch64 254.5-2.fc39         <unknown>    2.4 MiB
 util-linux-core                   aarch64 2.39.3-5.fc39        updates      6.1 MiB
   replacing util-linux-core       aarch64 2.39.2-1.fc39        <unknown>    5.9 MiB
Installing:
 buildah                           aarch64 1.34.0-1.fc39        updates     28.7 MiB
Installing dependencies:
 audit-libs                        aarch64 3.1.2-8.fc39         updates    547.2 KiB
 containers-common                 noarch  4:1-99.fc39          updates    124.4 KiB
 containers-common-extra           noarch  4:1-99.fc39          updates      0.0   B
 cracklib                          aarch64 2.9.11-2.fc39        fedora     934.7 KiB
 criu                              aarch64 3.19-2.fc39          updates      1.6 MiB
 crun                              aarch64 1.14.3-1.fc39        updates    554.2 KiB
 dbus                              aarch64 1:1.14.10-1.fc39     fedora       0.0   B
 dbus-broker                       aarch64 35-2.fc39            updates    614.2 KiB
 dbus-common                       noarch  1:1.14.10-1.fc39     fedora      11.2 KiB
 device-mapper                     aarch64 1.02.197-1.fc39      updates    630.3 KiB
 device-mapper-libs                aarch64 1.02.197-1.fc39      updates    511.4 KiB
 duktape                           aarch64 2.7.0-5.fc39         fedora     928.1 KiB
 elfutils-default-yama-scope       noarch  0.190-4.fc39         updates      1.8 KiB
 expat                             aarch64 2.6.0-1.fc39         updates    532.9 KiB
 fuse-common                       aarch64 3.16.1-1.fc39        fedora      38.0   B
 fuse3                             aarch64 3.16.1-1.fc39        fedora     457.7 KiB
 fuse3-libs                        aarch64 3.16.1-1.fc39        fedora     353.5 KiB
 gnupg2                            aarch64 2.4.3-4.fc39         updates     12.1 MiB
 gpgme                             aarch64 1.20.0-5.fc39        fedora     805.1 KiB
 gzip                              aarch64 1.12-6.fc39          fedora     475.8 KiB
 iptables-legacy                   aarch64 1.8.9-5.fc39         fedora     207.8 KiB
 iptables-legacy-libs              aarch64 1.8.9-5.fc39         fedora     410.4 KiB
 iptables-libs                     aarch64 1.8.9-5.fc39         fedora      19.2 MiB
 jansson                           aarch64 2.13.1-7.fc39        fedora     220.4 KiB
 json-c                            aarch64 0.17-1.fc39          fedora     202.4 KiB
 kmod                              aarch64 30-6.fc39            fedora     316.5 KiB
 kmod-libs                         aarch64 30-6.fc39            fedora     287.3 KiB
 libargon2                         aarch64 20190702-3.fc39      fedora     213.1 KiB
 libassuan                         aarch64 2.5.6-2.fc39         fedora     279.4 KiB
 libatomic                         aarch64 13.2.1-6.fc39        updates    196.8 KiB
 libb2                             aarch64 0.98.1-9.fc39        fedora     202.1 KiB
 libbsd                            aarch64 0.11.7-5.fc39        fedora     485.7 KiB
 libcap-ng                         aarch64 0.8.3-8.fc39         fedora     416.4 KiB
 libeconf                          aarch64 0.5.2-1.fc39         fedora     204.0 KiB
 libedit                           aarch64 3.1-48.20230828cvs.f fedora     343.8 KiB
 libfdisk                          aarch64 2.39.3-5.fc39        updates    494.9 KiB
 libgcrypt                         aarch64 1.10.2-2.fc39        fedora       1.1 MiB
 libgomp                           aarch64 13.2.1-6.fc39        updates    545.5 KiB
 libgpg-error                      aarch64 1.47-2.fc39          fedora       1.1 MiB
 libibverbs                        aarch64 46.0-4.fc39          fedora       3.9 MiB
 libksba                           aarch64 1.6.4-2.fc39         fedora     522.9 KiB
 libmd                             aarch64 1.1.0-2.fc39         fedora     238.9 KiB
 libmnl                            aarch64 1.0.5-3.fc39         fedora     223.2 KiB
 libnet                            aarch64 1.3-1.fc39           updates    228.7 KiB
 libnetfilter_conntrack            aarch64 1.0.9-2.fc39         fedora     279.5 KiB
 libnfnetlink                      aarch64 1.0.1-24.fc39        fedora     213.8 KiB
 libnftnl                          aarch64 1.2.6-2.fc39         fedora     286.1 KiB
 libnl3                            aarch64 3.9.0-1.fc39         updates      1.7 MiB
 libnsl2                           aarch64 2.0.0-6.fc39         fedora     221.9 KiB
 libpcap                           aarch64 14:1.10.4-2.fc39     fedora     489.6 KiB
 libseccomp                        aarch64 2.5.3-6.fc39         fedora     243.2 KiB
 libsecret                         aarch64 0.21.2-1.fc39        updates    873.3 KiB
 libsemanage                       aarch64 3.5-4.fc39           fedora     364.2 KiB
 libslirp                          aarch64 4.7.0-4.fc39         fedora     278.6 KiB
 libtirpc                          aarch64 1.3.4-0.rc2.fc39     updates    274.7 KiB
 libusb1                           aarch64 1.0.26-3.fc39        fedora     241.0 KiB
 mpdecimal                         aarch64 2.5.1-7.fc39         fedora     328.7 KiB
 netavark                          aarch64 1.10.3-1.fc39        updates     10.0 MiB
 nftables                          aarch64 1:1.0.7-3.fc39       fedora       1.2 MiB
 npth                              aarch64 1.6-14.fc39          fedora     221.4 KiB
 pam-libs                          aarch64 1.5.3-3.fc39         updates    607.9 KiB
 pcsc-lite                         aarch64 2.0.1-1.fc39         updates    354.7 KiB
 pcsc-lite-libs                    aarch64 2.0.1-1.fc39         updates    200.5 KiB
 polkit                            aarch64 123-1.fc39.1         updates      1.4 MiB
 polkit-libs                       aarch64 123-1.fc39.1         updates    415.2 KiB
 polkit-pkla-compat                aarch64 0.1-26.fc39          fedora     425.7 KiB
 protobuf-c                        aarch64 1.4.1-5.fc39         fedora     225.1 KiB
 python-pip-wheel                  noarch  23.2.1-1.fc39        fedora       1.5 MiB
 python3                           aarch64 3.12.1-2.fc39        updates    211.8 KiB
 python3-libs                      aarch64 3.12.1-2.fc39        updates     51.9 MiB
 qemu-user-static-aarch64          aarch64 2:8.1.3-3.fc39       updates     12.9 MiB
 qemu-user-static-alpha            aarch64 2:8.1.3-3.fc39       updates      3.5 MiB
 qemu-user-static-arm              aarch64 2:8.1.3-3.fc39       updates      9.1 MiB
 qemu-user-static-cris             aarch64 2:8.1.3-3.fc39       updates      3.4 MiB
 qemu-user-static-hexagon          aarch64 2:8.1.3-3.fc39       updates      5.8 MiB
 qemu-user-static-hppa             aarch64 2:8.1.3-3.fc39       updates      3.5 MiB
 qemu-user-static-loongarch64      aarch64 2:8.1.3-3.fc39       updates      3.8 MiB
 qemu-user-static-m68k             aarch64 2:8.1.3-3.fc39       updates      3.7 MiB
 qemu-user-static-microblaze       aarch64 2:8.1.3-3.fc39       updates      6.9 MiB
 qemu-user-static-mips             aarch64 2:8.1.3-3.fc39       updates     26.4 MiB
 qemu-user-static-nios2            aarch64 2:8.1.3-3.fc39       updates      3.4 MiB
 qemu-user-static-or1k             aarch64 2:8.1.3-3.fc39       updates      3.4 MiB
 qemu-user-static-ppc              aarch64 2:8.1.3-3.fc39       updates     13.5 MiB
 qemu-user-static-riscv            aarch64 2:8.1.3-3.fc39       updates      9.2 MiB
 qemu-user-static-s390x            aarch64 2:8.1.3-3.fc39       updates      3.9 MiB
 qemu-user-static-sh4              aarch64 2:8.1.3-3.fc39       updates      7.0 MiB
 qemu-user-static-sparc            aarch64 2:8.1.3-3.fc39       updates     10.8 MiB
 qemu-user-static-x86              aarch64 2:8.1.3-3.fc39       updates      8.1 MiB
 qemu-user-static-xtensa           aarch64 2:8.1.3-3.fc39       updates     13.7 MiB
 shadow-utils                      aarch64 2:4.14.0-2.fc39      updates      7.1 MiB
 shadow-utils-subid                aarch64 2:4.14.0-2.fc39      updates    394.8 KiB
 systemd                           aarch64 254.9-1.fc39         updates     25.0 MiB
 systemd-pam                       aarch64 254.9-1.fc39         updates      1.2 MiB
 tpm2-tss                          aarch64 4.0.1-6.fc39         updates      3.2 MiB
 tzdata                            noarch  2024a-2.fc39         updates      1.6 MiB
 xkeyboard-config                  noarch  2.40-1.fc39          updates      6.6 MiB
 yajl                              aarch64 2.1.0-22.fc39        fedora     598.4 KiB
Installing weak dependencies:
 aardvark-dns                      aarch64 1.10.0-1.fc39        updates      2.1 MiB
 cracklib-dicts                    aarch64 2.9.11-2.fc39        fedora       9.3 MiB
 criu-libs                         aarch64 3.19-2.fc39          updates    196.7 KiB
 cryptsetup-libs                   aarch64 2.6.1-3.fc39         fedora       2.1 MiB
 diffutils                         aarch64 3.10-3.fc39          fedora       2.1 MiB
 elfutils-debuginfod-client        aarch64 0.190-4.fc39         updates    396.8 KiB
 elfutils-libelf                   aarch64 0.190-4.fc39         updates      1.1 MiB
 elfutils-libs                     aarch64 0.190-4.fc39         updates      1.0 MiB
 fuse-overlayfs                    aarch64 1.12-2.fc39          fedora     218.8 KiB
 glibc-langpack-en                 aarch64 2.38-16.fc39         updates      5.7 MiB
 gnupg2-smime                      aarch64 2.4.3-4.fc39         updates    739.1 KiB
 libbpf                            aarch64 2:1.1.0-4.fc39       fedora     458.5 KiB
 libpwquality                      aarch64 1.4.5-6.fc39         fedora       1.1 MiB
 libxkbcommon                      aarch64 1.6.0-1.fc39         updates    597.3 KiB
 passt                             aarch64 0^20231230.gf091893- updates    784.7 KiB
 pcsc-lite-ccid                    aarch64 1.5.5-1.fc39         updates      1.9 MiB
 pinentry                          aarch64 1.2.1-4.fc39         fedora     361.7 KiB
 python-unversioned-command        noarch  3.12.1-2.fc39        updates     23.0   B
 qemu-user-static                  aarch64 2:8.1.3-3.fc39       updates     44.6 KiB
 qrencode-libs                     aarch64 4.1.1-5.fc39         fedora     300.9 KiB
 slirp4netns                       aarch64 1.2.2-1.fc39         updates    225.6 KiB
 systemd-networkd                  aarch64 254.9-1.fc39         updates      2.3 MiB
 systemd-resolved                  aarch64 254.9-1.fc39         updates    704.8 KiB
 tar                               aarch64 2:1.35-2.fc39        fedora       3.1 MiB

Transaction Summary:
 Installing:      122 packages
 Upgrading:        18 packages
 Replacing:        18 packages

Total size of inbound packages is 89 MiB. Need to download 89 MiB.
After this operation 390 MiB will be used (install 427 MiB, remove 37MiB).
```

There's a lot of confusing stuff in there, and we can't do anything to fix that here.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### How to verify it
Build the image locally and use it to build itself.

#### Which issue(s) this PR fixes:
See #5321. I won't say it fixes the issue. The image is still huge.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes.

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed the base image of the official buidah image to fedora-minimal to reduce its size.
```

