### PR TITLE
[CI:DOCS] Revert "Reduce official image size"

### DIFF
--- a/contrib/buildahimage/Containerfile
+++ b/contrib/buildahimage/Containerfile
@@ -19,7 +19,7 @@
 # that runs safely with privileges within the container.
 #
 
-FROM registry.fedoraproject.org/fedora-minimal:latest
+FROM registry.fedoraproject.org/fedora:latest
 ARG FLAVOR=stable
 
 label "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
@@ -34,18 +34,24 @@ RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking
 # up space.
-RUN case "${FLAVOR}" in \
+# TODO: rpm --setcaps... needed due to Fedora (base) image builds
+#       being (maybe still?) affected by
+#       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
+RUN dnf -y makecache && \
+    dnf -y update && \
+    rpm --setcaps shadow-utils 2>/dev/null && \
+    case "${FLAVOR}" in \
       stable) \
-        dnf5 -y install buildah fuse-overlayfs cpp --exclude container-selinux \
+        dnf -y install buildah fuse-overlayfs cpp --exclude container-selinux \
       ;; \
       testing) \
-        dnf5 -y install --enablerepo=updates-testing buildah fuse-overlayfs cpp \
+        dnf -y install --enablerepo=updates-testing buildah fuse-overlayfs cpp \
             --exclude container-selinux \
       ;; \
       upstream) \
-        dnf5 -y install 'dnf5-command(copr)' --enablerepo=updates-testing && \
-        dnf5 -y copr enable rhcontainerbot/podman-next && \
-        dnf5 -y install buildah fuse-overlayfs \
+        dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
+        dnf -y copr enable rhcontainerbot/podman-next && \
+        dnf -y install buildah fuse-overlayfs \
             --exclude container-selinux \
             --enablerepo=updates-testing  \
       ;; \
@@ -54,7 +60,7 @@ RUN case "${FLAVOR}" in \
         exit 1 \
       ;; \
     esac && \
-    dnf5 -y clean all && \
+    dnf -y clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 ADD ./containers.conf /etc/containers/


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Unanticipated missing `dnf` functionality likely negatively impacts a significant number of image users.  Further exploration of size reduction is needed, but we cannot (likely) swap to `microdnf` easily.

This reverts commit cdb1a4ff8eec302320342f28ebc956e487a214bb.

#### How to verify it

Not required, this reverts to previous state.

#### Which issue(s) this PR fixes:

Fixes: #5349

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

