### PR TITLE
Dev/tsweeney/buildah 1 34 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 # Changelog
 
+## v1.34.1 (2024-02-21)
+
+    [release-1.34] Vendor bumps
+    manifest: addCompression use default from containers.conf
+    Build with CNI support on FreeBSD
+    tests: retrofit test for heredoc summary
+    build, heredoc: show heredoc summary in build output
+    docs: correct default authfile path
+    Make buildah match podman for handling of ulimits
+    imagebuildah: fix crash with empty RUN
+    docs: move footnotes to where they're applicable
+    Run codespell on code
+    Fix FreeBSD version parsing
+    Allow users to specify no-dereference
+    Fix a build break on FreeBSD
+    Remove a bad FROM line
+    commit: force omitHistory if the parent has layers but no history
+    docs: fix a couple of typos
+    stage_executor,heredoc: honor interpreter in heredoc
+    stage_executor,layers: burst cache if heredoc content is changed
+    Replace map[K]bool with map[K]struct{} where it makes sense
+    Replace strings.SplitN with strings.Cut
+    Document use of containers-transports values in buildah
+    commit: add a --add-file flag
+    mkcw: populate the rootfs using an overlay
+    Ignore errors if label.Relabel returns ENOSUP
+    manifest: addCompression use default from containers.conf
+
 ## v1.34.0 (2023-12-11)
 
     vendor: update c/{common,image,storage}

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,30 @@
+- Changelog for v1.34.1 (2024-02-21)
+  * [release-1.34] Vendor bumps
+  * manifest: addCompression use default from containers.conf
+  * Build with CNI support on FreeBSD
+  * tests: retrofit test for heredoc summary
+  * build, heredoc: show heredoc summary in build output
+  * docs: correct default authfile path
+  * Make buildah match podman for handling of ulimits
+  * imagebuildah: fix crash with empty RUN
+  * docs: move footnotes to where they're applicable
+  * Run codespell on code
+  * Fix FreeBSD version parsing
+  * Allow users to specify no-dereference
+  * Fix a build break on FreeBSD
+  * Remove a bad FROM line
+  * commit: force omitHistory if the parent has layers but no history
+  * docs: fix a couple of typos
+  * stage_executor,heredoc: honor interpreter in heredoc
+  * stage_executor,layers: burst cache if heredoc content is changed
+  * Replace map[K]bool with map[K]struct{} where it makes sense
+  * Replace strings.SplitN with strings.Cut
+  * Document use of containers-transports values in buildah
+  * commit: add a --add-file flag
+  * mkcw: populate the rootfs using an overlay
+  * Ignore errors if label.Relabel returns ENOSUP
+  * manifest: addCompression use default from containers.conf
+
 - Changelog for v1.34.0 (2023-12-11)
   * vendor: update c/{common,image,storage}
   * run: Allow using just one jail per container on FreeBSD

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.34.0"
+	Version = "1.34.1"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.34.1"
+	Version = "1.34.2-dev"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
Bump Buildah in the release-1.34 branch to v1.34.1, and then to v1.34.2-dev.  This will allow us to release a v1.34.1 with some security fixes prior to v1.35 release later this spring.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

