### PR TITLE
Properly handle build --pull=false

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -491,7 +491,9 @@ func PullPolicyFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name string) 
 	if err != nil {
 		return 0, err
 	}
-	if pullNeverFlagValue || strings.EqualFold(pullFlagValue, "never") {
+	if pullNeverFlagValue ||
+		strings.EqualFold(pullFlagValue, "never") ||
+		strings.EqualFold(pullFlagValue, "false") {
 		pullPolicy = define.PullNever
 	}
 	logrus.Debugf("Pull Policy for pull [%v]", pullPolicy)

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -371,7 +371,11 @@ load helpers
   echo "$output"
   expect_output --substring "busybox: image not known"
 
-  run_buildah from $WITH_POLICY_JSON --pull=false busybox
+  run_buildah 125 from $WITH_POLICY_JSON --pull=false busybox
+  echo "$output"
+  expect_output --substring "busybox: image not known"
+
+  run_buildah from $WITH_POLICY_JSON --pull=ifmissing busybox
   echo "$output"
   expect_output --substring "busybox-working-container"
 

--- a/tests/registries.bats
+++ b/tests/registries.bats
@@ -8,11 +8,11 @@ load helpers
     image2=$2
 
     # Create a container by specifying the image with one name.
-    run_buildah --retry from --quiet --pull=false $WITH_POLICY_JSON $image1
+    run_buildah --retry from --quiet --pull=ifmissing $WITH_POLICY_JSON $image1
     cid1=$output
 
     # Create a container by specifying the image with another name.
-    run_buildah --retry from --quiet --pull=false $WITH_POLICY_JSON $image2
+    run_buildah --retry from --quiet --pull=ifmissing $WITH_POLICY_JSON $image2
     cid2=$output
 
     # Get their image IDs.  They should be the same one.

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -554,7 +554,7 @@ function configure_and_check_user() {
 @test "run-builtin-volume-omitted" {
 	# This image is known to include a volume, but not include the mountpoint
 	# in the image.
-	run_buildah from --quiet --pull=false $WITH_POLICY_JSON quay.io/libpod/registry:volume_omitted
+	run_buildah from --quiet --pull=ifmissing $WITH_POLICY_JSON quay.io/libpod/registry:volume_omitted
 	cid=$output
 	run_buildah mount $cid
 	mnt=$output
@@ -803,7 +803,7 @@ $output"
 @test "run --network=none and --isolation chroot must conflict" {
 	skip_if_no_runtime
 
-	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
+	run_buildah from --quiet --pull=ifmissing $WITH_POLICY_JSON alpine
 	cid=$output
 	# should fail by default
 	run_buildah 125 run --isolation=chroot --network=none $cid wget google.com
@@ -813,7 +813,7 @@ $output"
 @test "run --network=private must mount a fresh /sys" {
 	skip_if_no_runtime
 
-	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
+	run_buildah from --quiet --pull=ifmissing $WITH_POLICY_JSON alpine
 	cid=$output
         # verify there is no /sys/kernel/security in the container, that would mean /sys
         # was bind mounted from the host.
@@ -823,7 +823,7 @@ $output"
 @test "run --network should override build --network" {
 	skip_if_no_runtime
 
-	run_buildah from --network=none --quiet --pull=false $WITH_POLICY_JSON alpine
+	run_buildah from --network=none --quiet --pull=ifmissing $WITH_POLICY_JSON alpine
 	cid=$output
 	# should fail by default
 	run_buildah 1 run $cid wget google.com


### PR DESCRIPTION
buildah build --pull=false is documented to never pull the image, but it is currently ignored.

Fixes: https://github.com/containers/podman/issues/21783

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

