### PR TITLE
[v1.34] tests: skip_if_no_unshare(): check for --setuid

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -638,6 +638,9 @@ function skip_if_no_unshare() {
   if ! unshare -U --map-users $(id -u),0,1 true ; then
     skip "unshare does not support --map-users"
   fi
+  if ! unshare -Ur --setuid 0 true ; then
+    skip "unshare does not support --setuid"
+  fi
 }
 
 function start_git_daemon() {


### PR DESCRIPTION
unshare on RHEL8 does not support --setuid. This is causing gating tests to fail.

Solution: check for option, skip test if unavailable

Clean cherry-pick of #5360

```release-note
None
```

