### PR TITLE
manifest add: complain if we get artifact flags without --artifact

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -533,6 +533,18 @@ func manifestAddCmd(c *cobra.Command, args []string, opts manifestAddOpts) error
 			return err
 		}
 	} else {
+		var changedArtifactFlags []string
+		for _, artifactOption := range []string{"artifact-type", "artifact-config", "artifact-config-type", "artifact-layer-type", "artifact-subject", "artifact-exclude-titles"} {
+			if c.Flags().Changed(artifactOption) {
+				changedArtifactFlags = append(changedArtifactFlags, "--"+artifactOption)
+			}
+		}
+		switch {
+		case len(changedArtifactFlags) == 1:
+			return fmt.Errorf("%s requires --artifact", changedArtifactFlags[0])
+		case len(changedArtifactFlags) > 1:
+			return fmt.Errorf("%s require --artifact", strings.Join(changedArtifactFlags, "/"))
+		}
 		var ref types.ImageReference
 		if ref, err = alltransports.ParseImageName(imageSpec); err != nil {
 			if ref, err = alltransports.ParseImageName(util.DefaultTransport + imageSpec); err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Complain if `manifest add` is invoked with any of "--artifact-type", "--artifact-config", "--artifact-config-type", "--artifact-layer-type", "--artifact-subject", "--artifact-exclude-titles", but not in conjunction with "--artifact".

#### How to verify it

Attempt to use one of the  "--artifact-type", "--artifact-config", "--artifact-config-type", "--artifact-layer-type", "--artifact-subject", or "--artifact-exclude-titles" flags with `buildah manifest add` without also specifying "--artifact".  It can be an easy thing to overlook, and if your filename happens to look like an image name, the error message you'd have gotten about it could be more confusing.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I added a check for this in https://github.com/containers/podman/pull/21653, and thought it would be a good idea to add it here, too.

#### Does this PR introduce a user-facing change?

```release-note
None
```