### PR TITLE
pr-should-include-tests: use GitHub label, not commit text

### DIFF
--- a/tests/validate/pr-should-include-tests
+++ b/tests/validate/pr-should-include-tests
@@ -2,14 +2,13 @@
 #
 # Intended for use in CI: check git commits, barf if no tests added.
 #
+ME=$(basename $0)
+
+# Github label which allows overriding this check
+OVERRIDE_LABEL="No New Tests"
 
 # Docs-only changes are excused
 if [[ "${CIRRUS_CHANGE_TITLE}" =~ CI:DOCS ]]; then
-    exit 0
-fi
-
-# So are PRs where 'NO NEW TESTS NEEDED' appears in the Github message
-if [[ "${CIRRUS_CHANGE_MESSAGE}" =~ NO.NEW.TESTS.NEEDED ]]; then
     exit 0
 fi
 
@@ -39,16 +38,16 @@ fi
 # Nothing changed under test subdirectory.
 #
 # This is OK if the only files being touched are "safe" ones.
-filtered_changes=$(git diff --name-status $base $head |
-                       awk '{print $2}'               |
-                       fgrep -vx .cirrus.yml          |
-                       fgrep -vx .gitignore           |
-                       fgrep -vx changelog.txt        |
-                       fgrep -vx go.mod               |
-                       fgrep -vx go.sum               |
-                       fgrep -vx buildah.spec.rpkg    |
-                       fgrep -vx .golangci.yml        |
-                       fgrep -vx Makefile             |
+filtered_changes=$(git diff --name-status $base $head   |
+                       awk '{print $2}'                 |
+                       grep -F -vx .cirrus.yml          |
+                       grep -F -vx .gitignore           |
+                       grep -F -vx changelog.txt        |
+                       grep -F -vx go.mod               |
+                       grep -F -vx go.sum               |
+                       grep -F -vx buildah.spec.rpkg    |
+                       grep -F -vx .golangci.yml        |
+                       grep -F -vx Makefile             |
                        grep -E -v  '^[^/]+\.md$'        |
                        grep -E -v  '^\.github/'         |
                        grep -E -v  '^contrib/'          |
@@ -60,17 +59,41 @@ if [[ -z "$filtered_changes" ]]; then
     exit 0
 fi
 
-# One last chance: perhaps the developer included the magic '[NO TESTS NEEDED]'
-# string in an amended commit.
-if git log --format=%B ${base}..${head} | fgrep '[NO NEW TESTS NEEDED]'; then
-   exit 0
+# Nope. Only allow if the github 'no-tests-needed' label is set
+if [[ -z "$CIRRUS_PR" ]]; then
+    echo "$ME: cannot query github: \$CIRRUS_PR is undefined" >&2
+    exit 1
 fi
-if git log --format=%B ${base}..${head} | fgrep '[NO TESTS NEEDED]'; then
-   exit 0
+if [[ -z "$CIRRUS_REPO_CLONE_TOKEN" ]]; then
+    echo "$ME: cannot query github: \$CIRRUS_REPO_CLONE_TOKEN is undefined" >&2
+    exit 1
+fi
+
+query="{
+  \"query\": \"query {
+  repository(owner: \\\"containers\\\", name: \\\"buildah\\\") {
+    pullRequest(number: $CIRRUS_PR) {
+      labels(first: 100) {
+        nodes {
+          name
+        }
+      }
+    }
+  }
+}\"
+}"
+
+result=$(curl -s -H "Authorization: bearer $CIRRUS_REPO_CLONE_TOKEN" -H "Accept: application/vnd.github.antiope-preview+json" -H "Content-Type: application/json" -X POST --data @- https://api.github.com/graphql <<<"$query")
+
+labels=$(jq -r '.data.repository.pullRequest.labels.nodes[].name' <<<"$result")
+
+if grep -F -x -q "$OVERRIDE_LABEL" <<<"$labels"; then
+    # PR has the label set
+    exit 0
 fi
 
 cat <<EOF
-$(basename $0): PR does not include changes in the 'tests' directory
+$ME: PR does not include changes in the 'tests' directory
 
 Please write a regression test for what you're fixing. Even if it
 seems trivial or obvious, try to add a test that will prevent
@@ -81,8 +104,8 @@ tests, possibly just adding a small step to a similar existing test.
 Every second counts in CI.
 
 If your commit really, truly does not need tests, you can proceed
-by adding '[NO NEW TESTS NEEDED]' to the body of your commit message.
-Please think carefully before doing so.
+by asking a repo maintainer to set the '$OVERRIDE_LABEL' github label.
+This will only be done when there's no reasonable alternative.
 EOF
 
 exit 1


### PR DESCRIPTION
...to allow bypassing the check. Just like on podman.

Also, bring up to code:
  - grep -F, not fgrep
  - fix regression test script (was using wrong branch envariable)
  - add new test case

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```