### PR TITLE
tests: enable pasta tests

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6449,10 +6449,6 @@ _EOF
   skip_if_chroot
   skip_if_root_environment "pasta only works rootless"
 
-  # FIXME: unskip when we have a new pasta version with:
-  # https://archives.passt.top/passt-dev/20230623082531.25947-2-pholzing@redhat.com/
-  skip "pasta bug prevents this from working"
-
   _prefetch alpine
 
   # pasta by default copies the host ip

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -727,11 +727,8 @@ function configure_and_check_user() {
 	skip_if_chroot
 	skip_if_root_environment "pasta only works rootless"
 
-	# FIXME: unskip when we have a new pasta version with:
-	# https://archives.passt.top/passt-dev/20230623082531.25947-2-pholzing@redhat.com/
-	skip "pasta bug prevents this from working"
-
-	run_buildah from --quiet --pull=false $WITH_POLICY_JSON debian
+	_prefetch alpine
+	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 
 	local hostname=h-$(random_string)


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake

/kind other

#### What this PR does / why we need it:
This should have been done a long time ago and this would have made clear that it did not work properly. However now that pasta is the default and we fixed all the remaining problems we can easily enable them.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

