### PR TITLE
[skip-ci] Makefile: update rpm target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,5 +218,13 @@ lint: install.tools
 # CAUTION: This is not a replacement for RPMs provided by your distro.
 # Only intended to build and test the latest unreleased changes.
 .PHONY: rpm
-rpm:
-	rpkg local
+rpm:  ## Build rpm packages
+	$(MAKE) -C rpm
+
+# Remember that rpms install exec to /usr/bin/buildah while a `make install`
+# installs them to /usr/local/bin/buildah which is likely before. Always use
+# a full path to test installed buildah or you risk to call another executable.
+.PHONY: rpm-install
+rpm-install: package  ## Install rpm packages
+	$(call err_if_empty,PKG_MANAGER) -y install rpm/RPMS/*/*.rpm
+	/usr/bin/buildah version

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,0 +1,12 @@
+.PHONY: rpm
+rpm:
+	$(shell /usr/bin/bash ./update-spec-version.sh)
+	spectool -g buildah.spec
+	rpmbuild -ba \
+		--define '_sourcedir $(shell pwd)' \
+		--define '_rpmdir %{_sourcedir}/RPMS' \
+		--define '_srcrpmdir %{_sourcedir}/SRPMS' \
+		--define '_builddir %{_sourcedir}/BUILD' \
+		buildah.spec
+	@echo ___RPMS can be found in rpm/RPMS/.___
+	@echo ___Undo any changes to Version, Source0 and %autosetup in rpm/buildah.spec before committing.___

--- a/rpm/update-spec-version.sh
+++ b/rpm/update-spec-version.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# This script will update the Version field in the spec which is set to 0 by
+# default. Useful for local manual rpm builds where the Version needs to be set
+# correctly.
+
+set -eox pipefail
+
+PACKAGE=buildah
+SPEC_FILE=$PACKAGE.spec
+VERSION=$(grep 'Version = ' ../define/types.go | cut -d\" -f2)
+RPM_VERSION=$(echo $VERSION | sed -e 's/^v//' -e 's/-/~/g')
+
+# Update spec file to use local changes
+sed -i "s/^Version:.*/Version: $RPM_VERSION/" $SPEC_FILE
+sed -i "s/^Source:.*/Source: $PACKAGE-$VERSION.tar.gz/" $SPEC_FILE
+sed -i "s/^%autosetup.*/%autosetup -Sgit -n %{name}-$VERSION/" $SPEC_FILE
+
+# Generate Source0 archive from HEAD
+(cd .. && git archive --format=tar.gz --prefix=$PACKAGE-$VERSION/ HEAD -o rpm/$PACKAGE-$VERSION.tar.gz)


### PR DESCRIPTION
rpkg is now deprecated. This commit makes the rpm target consistent with the one in Podman.

Using skip-ci as we don't need to run cirrus tests for this change.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:
updates Makefile's rpm target

#### How to verify it
run `make rpm`

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:
This could be useful in reverse dependency tests in c/common
See: https://github.com/containers/common/pull/1892

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

