### PR TITLE
fix links to containerignore doc

### DIFF
--- a/docs/buildah-add.1.md
+++ b/docs/buildah-add.1.md
@@ -89,7 +89,7 @@ buildah add containerID 'passwd' 'certs.d' /etc
 
 ## FILES
 
-### .containerignore
+### .containerignore/.dockerignore
 
 If a .containerignore or .dockerignore file exists in the context directory,
 `buildah add` reads its contents. If both exist, then .containerignore is used.
@@ -135,7 +135,7 @@ Exclude all doc files except Help.doc when copying content into the container.
 
 This functionality is compatible with the handling of .containerignore files described here:
 
-https://github.com/containers/buildah/blob/main/docs/containerignore.5.md
+https://github.com/containers/common/blob/main/docs/containerignore.5.md
 
 ## SEE ALSO
 buildah(1), containerignore(5)

--- a/docs/buildah-add.1.md
+++ b/docs/buildah-add.1.md
@@ -89,7 +89,7 @@ buildah add containerID 'passwd' 'certs.d' /etc
 
 ## FILES
 
-### .containerignore/.dockerignore
+### .containerignore or .dockerignore
 
 If a .containerignore or .dockerignore file exists in the context directory,
 `buildah add` reads its contents. If both exist, then .containerignore is used.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -1401,7 +1401,7 @@ Exclude all doc files except Help.doc from the image.
 
 This functionality is compatible with the handling of .containerignore files described here:
 
-https://github.com/containers/buildah/blob/main/docs/containerignore.5.md
+https://github.com/containers/common/blob/main/docs/containerignore.5.md
 
 **registries.conf** (`/etc/containers/registries.conf`)
 

--- a/docs/buildah-copy.1.md
+++ b/docs/buildah-copy.1.md
@@ -133,7 +133,7 @@ Exclude all doc files except Help.doc when copying content into the container.
 
 This functionality is compatible with the handling of .containerignore files described here:
 
-https://github.com/containers/buildah/blob/main/docs/containerignore.5.md
+https://github.com/containers/common/blob/main/docs/containerignore.5.md
 
 ## SEE ALSO
 buildah(1), containerignore(5)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Documentation

#### How to verify it

N/A

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

In the selection of the ignore file, the logic is wrong; the comment here https://github.com/containers/buildah/blob/main/pkg/parse/parse.go#L1290 says that <file>.containerignore will be preferend but the code obviously does the opposite since the <file>.dockerignore is checked for in the second if.

Proving test: https://github.com/Pvlerick/buildah/blob/container-ignore-file-priority/pkg/parse/parse_test.go#L233

However, changing this logic is a breaking change, and this [file].dockerignore/[file].containerignore is not documented (at least I didn't find any mention of it)

#### Does this PR introduce a user-facing change?

NO

```release-note

```

