### PR TITLE
[skip-ci] rpm: use go-rpm-macros supported vendoring

### DIFF
--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -146,7 +146,7 @@ rm %{buildroot}%{_datadir}/%{name}/test/system/tools/build/*
 %{!?_licensedir:%global license %doc}
 
 %files
-%license LICENSE
+%license LICENSE vendor/modules.txt
 %doc README.md
 %{_bindir}/%{name}
 %{_mandir}/man1/%{name}*


### PR DESCRIPTION
This removes the need for any `Provides: bundled()` we needed in spec files.

The updated Provides will be visible in the build logs and can also be verified with `rpm -q --provides $RPM_FILE`.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:
fixes an rpm packaging issue

#### How to verify it
`rpm -q --provides $GENERATED_RPM` will show you a list of bundled Provides. You can generate rpm with `make rpm`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

