### PR TITLE
[CI:DOCS] Stop rebasing renovate PRs automatically 

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,10 +42,6 @@
     "github>containers/automation//renovate/defaults.json5"
   ],
 
-  // Permit automatic rebasing when base-branch changes by more than
-  // one commit.
-  "rebaseWhen": "behind-base-branch",
-
   /*************************************************
    *** Repository-specific configuration options ***
    *************************************************/

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,7 @@
 
         podman run -it \
             -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z \
-            docker.io/renovate/renovate:latest \
+            ghcr.io/renovatebot/renovate:latest \
             renovate-config-validator
      3. Commit.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Whenever a PR's target branch moves, Renovate was reconfigured to rebase
all of it's PRs and re-run CI.  This is annoying for developers, stop
it.

#### How to verify it

After merging, renovate will stop automatically rebasing it's PRs.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Podman behaves as desired, it is also using the default setting of "do not rebase".

#### Does this PR introduce a user-facing change?

```release-note
None
```

