### PR TITLE
[release-1.34] CVE-2024-1753 fix, bump Buildah to v1.34.2, then to v1.34.3-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+## v1.34.2 (2024-03-19)
+
+    [release-1.34] CVE-2024-1753 container escape fix
+    tests: skip_if_no_unshare(): check for --setuid
+    [release-1.34] Bump to v1.34.2-dev
+
 ## v1.34.1 (2024-02-21)
 
     [release-1.34] Vendor bumps

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+- Changelog for v1.34.2 (2024-03-19)
+  * [release-1.34] CVE-2024-1753 container escape fix
+  * tests: skip_if_no_unshare(): check for --setuid
+  * [release-1.34] Bump to v1.34.2-dev
+
 - Changelog for v1.34.1 (2024-02-21)
   * [release-1.34] Vendor bumps
   * manifest: addCompression use default from containers.conf

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.34.2"
+	Version = "1.34.3-dev"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.34.2-dev"
+	Version = "1.34.2"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/internal/volumes/volumes.go
+++ b/internal/volumes/volumes.go
@@ -11,6 +11,7 @@ import (
 
 	"errors"
 
+	"github.com/containers/buildah/copier"
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/internal"
 	internalParse "github.com/containers/buildah/internal/parse"
@@ -189,7 +190,11 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
 	// buildkit parity: support absolute path for sources from current build context
 	if contextDir != "" {
 		// path should be /contextDir/specified path
-		newMount.Source = filepath.Join(contextDir, filepath.Clean(string(filepath.Separator)+newMount.Source))
+		evaluated, err := copier.Eval(contextDir, newMount.Source, copier.EvalOptions{})
+		if err != nil {
+			return newMount, "", err
+		}
+		newMount.Source = evaluated
 	} else {
 		// looks like its coming from `build run --mount=type=bind` allow using absolute path
 		// error out if no source is set

--- a/tests/blobcache.bats
+++ b/tests/blobcache.bats
@@ -61,8 +61,7 @@ function _check_matches() {
 	run_buildah login --tls-verify=false --authfile ${TEST_SCRATCH_DIR}/test.auth --username testuser --password testpassword localhost:${REGISTRY_PORT}
 	outputdir=${TEST_SCRATCH_DIR}/outputdir
 	mkdir -p ${outputdir}
-	run podman run --rm --mount type=bind,src=${TEST_SCRATCH_DIR}/test.auth,target=/test.auth,Z --mount type=bind,src=${outputdir},target=/output,Z --net host quay.io/skopeo/stable copy --preserve-digests --authfile=/test.auth --tls-verify=false docker://registry.fedoraproject.org/fedora-minimal dir:/output
-
+	podman run --rm --mount type=bind,src=${TEST_SCRATCH_DIR}/test.auth,target=/test.auth,Z --mount type=bind,src=${outputdir},target=/output,Z --net host quay.io/skopeo/stable copy --preserve-digests --authfile=/test.auth --tls-verify=false docker://registry.fedoraproject.org/fedora-minimal dir:/output
 	run_buildah rmi --all -f
 	run_buildah pull dir:${outputdir}
 	run_buildah images -a --format '{{.ID}}'

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6625,3 +6625,26 @@ _EOF
   expect_output --substring "$podman_files"
   expect_output --substring "$podman_processes"
 }
+
+@test "build no write file on host - CVE-2024-1753" {
+  _prefetch alpine
+  cat > ${TEST_SCRATCH_DIR}/Containerfile << _EOF
+FROM alpine as base
+
+RUN ln -s / /rootdir
+
+FROM alpine
+
+# With exploit show host root, not the container's root, and create /BIND_BREAKOUT in / on the host
+RUN --mount=type=bind,from=base,source=/rootdir,destination=/exploit,rw ls -l /exploit; touch /exploit/BIND_BREAKOUT; ls -l /exploit
+
+_EOF
+
+  run_buildah build $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
+  expect_output --substring "/BIND_BREAKOUT"
+
+  run ls /BIND_BREAKOUT
+  rm -f /BIND_BREAKOUT
+  assert "$status" -eq 2 "exit code from ls"
+  expect_output --substring "No such file or directory"
+}

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/reexec"
 	dockertypes "github.com/docker/docker/api/types"
 	dockerdockerclient "github.com/docker/docker/client"
@@ -934,11 +935,15 @@ func saveReport(ctx context.Context, t *testing.T, ref types.ImageReference, dir
 // summarizeLayer reads a blob and returns a summary of the parts of its contents that we care about
 func summarizeLayer(t *testing.T, imageName string, blobInfo types.BlobInfo, reader io.Reader) (layer Layer) {
 	compressedDigest := digest.Canonical.Digester()
-	uncompressedBlob, _, err := compression.AutoDecompress(io.TeeReader(reader, compressedDigest.Hash()))
+	counter := ioutils.NewWriteCounter(compressedDigest.Hash())
+	compressionAlgorithm, _, reader, err := compression.DetectCompressionFormat(reader)
+	require.NoErrorf(t, err, "error checking if blob %+v for image %q is compressed", blobInfo, imageName)
+	uncompressedBlob, wasCompressed, err := compression.AutoDecompress(io.TeeReader(reader, counter))
 	require.NoErrorf(t, err, "error decompressing blob %+v for image %q", blobInfo, imageName)
 	defer uncompressedBlob.Close()
 	uncompressedDigest := digest.Canonical.Digester()
-	tr := tar.NewReader(io.TeeReader(uncompressedBlob, uncompressedDigest.Hash()))
+	tarToRead := io.TeeReader(uncompressedBlob, uncompressedDigest.Hash())
+	tr := tar.NewReader(tarToRead)
 	hdr, err := tr.Next()
 	for err == nil {
 		header := fsHeaderForEntry(hdr)
@@ -953,8 +958,18 @@ func summarizeLayer(t *testing.T, imageName string, blobInfo types.BlobInfo, rea
 		hdr, err = tr.Next()
 	}
 	require.Equal(t, io.EOF, err, "unexpected error reading layer contents %+v for image %q", blobInfo, imageName)
+	_, err = io.Copy(io.Discard, tarToRead)
+	require.NoError(t, err, "reading out any not-usually-present zero padding at the end")
 	layer.CompressedDigest = compressedDigest.Digest()
-	require.Equal(t, blobInfo.Digest, layer.CompressedDigest, "calculated digest of compressed blob didn't match expected digest")
+	blobFormatDescription := "uncompressed"
+	if wasCompressed {
+		if compressionAlgorithm.Name() != "" {
+			blobFormatDescription = "compressed with " + compressionAlgorithm.Name()
+		} else {
+			blobFormatDescription = "compressed (?)"
+		}
+	}
+	require.Equalf(t, blobInfo.Digest, layer.CompressedDigest, "calculated digest of %s blob didn't match expected digest (expected length %d, actual length %d)", blobFormatDescription, blobInfo.Size, counter.Count)
 	layer.UncompressedDigest = uncompressedDigest.Digest()
 	return layer
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

