### PR TITLE
CI: bump VMs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,7 +32,7 @@ env:
     DEBIAN_NAME: "debian-13"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c20240222t143004z-f39f38d13"
+    IMAGE_SUFFIX: "c20240320t153921z-f39f38d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     DEBIAN_CACHE_IMAGE_NAME: "debian-${IMAGE_SUFFIX}"
@@ -221,7 +221,6 @@ integration_task:
             DISTRO_NV: "${DEBIAN_NAME}"
             IMAGE_NAME: "${DEBIAN_CACHE_IMAGE_NAME}"
             STORAGE_DRIVER: 'vfs'
-            CI_DESIRED_RUNTIME: runc
         # OVERLAY
         - env:
             DISTRO_NV: "${FEDORA_NAME}"
@@ -235,7 +234,6 @@ integration_task:
             DISTRO_NV: "${DEBIAN_NAME}"
             IMAGE_NAME: "${DEBIAN_CACHE_IMAGE_NAME}"
             STORAGE_DRIVER: 'overlay'
-            CI_DESIRED_RUNTIME: runc
 
     gce_instance:
         image_name: "$IMAGE_NAME"


### PR DESCRIPTION
* pasta 2024-03-20 on all Fedoras
* crun 1.14.4 everywhere

See https://github.com/containers/automation_images/pull/337#issuecomment-2010128930

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```