### PR TITLE
[CI:DOCS] Add golang 1.21 update warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,21 @@
 module github.com/containers/buildah
 
-go 1.20
+// Minimum required golang version
+go 1.20 // *****  ATTENTION  WARNING  CAUTION  DANGER  ******
+
+//         Go versions 1.21 and later will AUTO-UPDATE based
+//         on currently running tools and the (new) `toolchain`
+//         value (when also increasing the `go` value above).
+//         ref: https://go.dev/doc/toolchain  Because several
+//         different distros and distro-versions build from
+//         this code, golang version consistency is
+//         desireable.  After manually updating to 1.21, a
+//         `toolchain` specificication should be added to pin
+//         the version and block auto-updates.  This does not
+//         block any future changes to the `go` value.
+//         Ref: Upstream discussion:
+//         https://github.com/golang/go/issues/65847
+//         *****  ATTENTION  WARNING  CAUTION  DANGER  ******
 
 require (
 	github.com/containerd/containerd v1.7.13


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

This is needed on the off-chance that some tool or a human suggests updating the minimum version to 1.21 or later. Since doing so would cause Fedora and Debian to start behaving differently WRT builds.

#### How to verify it

Carefully read comment.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Ref: https://github.com/containers/podman/pull/22073

#### Does this PR introduce a user-facing change?

```release-note
None
```

