### PR TITLE
[release-1.35] Bump c/common to v0.58.1, Buildah to v1.35.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Changelog
 
+## v1.35.3 (2024-03-28)
+
+    [release-1.35] Bump c/common to v0.58.1
+
 ## v1.35.2 (2024-03-22)
 
     [release-1.35] CVE-2024-24786 protobuf to 1.33

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+- Changelog for v1.35.3 (2024-03-28)
+  * [release-1.35] Bump c/common to v0.58.1
+
 - Changelog for v1.35.2 (2024-03-22)
   * [release-1.35] CVE-2024-24786 protobuf to 1.33
   * [release-1.35] Bump to v1.35.2-dev

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.35.2"
+	Version = "1.35.3"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/containerd v1.7.13
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.4.0
-	github.com/containers/common v0.58.0
+	github.com/containers/common v0.58.1
 	github.com/containers/image/v5 v5.30.0
 	github.com/containers/luksy v0.0.0-20240212203526-ceb12d4fd50c
 	github.com/containers/ocicrypt v1.1.9

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/containerd/containerd v1.7.13
 	github.com/containernetworking/cni v1.1.2
-	github.com/containernetworking/plugins v1.4.0
 	github.com/containers/common v0.58.1
 	github.com/containers/image/v5 v5.30.0
 	github.com/containers/luksy v0.0.0-20240212203526-ceb12d4fd50c
@@ -60,6 +59,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
 	github.com/containerd/typeurl/v2 v2.1.1 // indirect
+	github.com/containernetworking/plugins v1.4.0 // indirect
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl3
 github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/containernetworking/plugins v1.4.0 h1:+w22VPYgk7nQHw7KT92lsRmuToHvb7wwSv9iTbXzzic=
 github.com/containernetworking/plugins v1.4.0/go.mod h1:UYhcOyjefnrQvKvmmyEKsUA+M9Nfn7tqULPpH0Pkcj0=
-github.com/containers/common v0.58.0 h1:iQuwMxDD4ubZ9s1tmgdsiaHxMU4TdVBpV6kctJc6Bk8=
-github.com/containers/common v0.58.0/go.mod h1:l3vMqanJGj7tZ3W/i76gEJ128VXgFUO1tLaohJXPvdk=
+github.com/containers/common v0.58.1 h1:E1DN9Lr7kgMVQy7AXLv1CYQCiqnweklMiYWbf0KOnqY=
+github.com/containers/common v0.58.1/go.mod h1:l3vMqanJGj7tZ3W/i76gEJ128VXgFUO1tLaohJXPvdk=
 github.com/containers/image/v5 v5.30.0 h1:CmHeSwI6W2kTRWnUsxATDFY5TEX4b58gPkaQcEyrLIA=
 github.com/containers/image/v5 v5.30.0/go.mod h1:gSD8MVOyqBspc0ynLsuiMR9qmt8UQ4jpVImjmK0uXfk=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=

--- a/run.go
+++ b/run.go
@@ -3,10 +3,12 @@ package buildah
 import (
 	"fmt"
 	"io"
+	"net"
 
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/internal"
 	"github.com/containers/buildah/pkg/sshagent"
+	"github.com/containers/common/libnetwork/etchosts"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/lockfile"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -206,4 +208,13 @@ type IDMaps struct {
 	rootGID    int
 	processUID int
 	processGID int
+}
+
+// netResult type to hold network info for hosts/resolv.conf
+type netResult struct {
+	entries           etchosts.HostEntries
+	dnsServers        []string
+	excludeIPs        []net.IP
+	ipv6              bool
+	keepHostResolvers bool
 }

--- a/run_common.go
+++ b/run_common.go
@@ -35,7 +35,6 @@ import (
 	"github.com/containers/common/libnetwork/network"
 	"github.com/containers/common/libnetwork/resolvconf"
 	netTypes "github.com/containers/common/libnetwork/types"
-	netUtil "github.com/containers/common/libnetwork/util"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/subscriptions"
 	imageTypes "github.com/containers/image/v5/types"
@@ -55,50 +54,13 @@ import (
 	"golang.org/x/term"
 )
 
-// addResolvConf copies files from host and sets them up to bind mount into container
-func (b *Builder) addResolvConf(rdir string, chownOpts *idtools.IDPair, dnsServers, dnsSearch, dnsOptions []string, namespaces []specs.LinuxNamespace) (string, error) {
-	defaultConfig, err := config.Default()
-	if err != nil {
-		return "", fmt.Errorf("failed to get config: %w", err)
-	}
-
-	nameservers := make([]string, 0, len(defaultConfig.Containers.DNSServers.Get())+len(dnsServers))
-	nameservers = append(nameservers, defaultConfig.Containers.DNSServers.Get()...)
-	nameservers = append(nameservers, dnsServers...)
-
-	keepHostServers := false
-	// special check for slirp ip
-	if len(nameservers) == 0 && b.Isolation == IsolationOCIRootless {
-		for _, ns := range namespaces {
-			if ns.Type == specs.NetworkNamespace && ns.Path == "" {
-				keepHostServers = true
-				// if we are using slirp4netns, also add the built-in DNS server.
-				logrus.Debugf("adding slirp4netns 10.0.2.3 built-in DNS server")
-				nameservers = append([]string{"10.0.2.3"}, nameservers...)
-			}
-		}
-	}
-
-	searches := make([]string, 0, len(defaultConfig.Containers.DNSSearches.Get())+len(dnsSearch))
-	searches = append(searches, defaultConfig.Containers.DNSSearches.Get()...)
-	searches = append(searches, dnsSearch...)
-
-	options := make([]string, 0, len(defaultConfig.Containers.DNSOptions.Get())+len(dnsOptions))
-	options = append(options, defaultConfig.Containers.DNSOptions.Get()...)
-	options = append(options, dnsOptions...)
-
+func (b *Builder) createResolvConf(rdir string, chownOpts *idtools.IDPair) (string, error) {
 	cfile := filepath.Join(rdir, "resolv.conf")
-	if err := resolvconf.New(&resolvconf.Params{
-		Path:            cfile,
-		Namespaces:      namespaces,
-		IPv6Enabled:     true, // TODO we should check if we have ipv6
-		KeepHostServers: keepHostServers,
-		Nameservers:     nameservers,
-		Searches:        searches,
-		Options:         options,
-	}); err != nil {
-		return "", fmt.Errorf("building resolv.conf for container %s: %w", b.ContainerID, err)
+	f, err := os.Create(cfile)
+	if err != nil {
+		return "", err
 	}
+	defer f.Close()
 
 	uid := 0
 	gid := 0
@@ -106,7 +68,7 @@ func (b *Builder) addResolvConf(rdir string, chownOpts *idtools.IDPair, dnsServe
 		uid = chownOpts.UID
 		gid = chownOpts.GID
 	}
-	if err = os.Chown(cfile, uid, gid); err != nil {
+	if err = f.Chown(uid, gid); err != nil {
 		return "", err
 	}
 
@@ -116,57 +78,61 @@ func (b *Builder) addResolvConf(rdir string, chownOpts *idtools.IDPair, dnsServe
 	return cfile, nil
 }
 
-// generateHosts creates a containers hosts file
-func (b *Builder) generateHosts(rdir string, chownOpts *idtools.IDPair, imageRoot string, spec *specs.Spec) (string, error) {
-	conf, err := config.Default()
+// addResolvConf copies files from host and sets them up to bind mount into container
+func (b *Builder) addResolvConfEntries(file string, networkNameServer []string,
+	namespaces []specs.LinuxNamespace, keepHostServers, ipv6 bool) error {
+	defaultConfig, err := config.Default()
 	if err != nil {
-		return "", err
+		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	path, err := etchosts.GetBaseHostFile(conf.Containers.BaseHostsFile, imageRoot)
-	if err != nil {
-		return "", err
+	dnsServers, dnsSearch, dnsOptions := b.CommonBuildOpts.DNSServers, b.CommonBuildOpts.DNSSearch, b.CommonBuildOpts.DNSOptions
+	nameservers := make([]string, 0, len(defaultConfig.Containers.DNSServers.Get())+len(dnsServers))
+	nameservers = append(nameservers, defaultConfig.Containers.DNSServers.Get()...)
+	nameservers = append(nameservers, dnsServers...)
+
+	searches := make([]string, 0, len(defaultConfig.Containers.DNSSearches.Get())+len(dnsSearch))
+	searches = append(searches, defaultConfig.Containers.DNSSearches.Get()...)
+	searches = append(searches, dnsSearch...)
+
+	options := make([]string, 0, len(defaultConfig.Containers.DNSOptions.Get())+len(dnsOptions))
+	options = append(options, defaultConfig.Containers.DNSOptions.Get()...)
+	options = append(options, dnsOptions...)
+
+	if len(nameservers) == 0 {
+		nameservers = networkNameServer
 	}
 
-	var entries etchosts.HostEntries
-	isHost := true
-	if spec.Linux != nil {
-		for _, ns := range spec.Linux.Namespaces {
-			if ns.Type == specs.NetworkNamespace {
-				isHost = false
-				break
-			}
-		}
-	}
-	// add host entry for local ip when running in host network
-	if spec.Hostname != "" && isHost {
-		ip := netUtil.GetLocalIP()
-		if ip != "" {
-			entries = append(entries, etchosts.HostEntry{
-				Names: []string{spec.Hostname},
-				IP:    ip,
-			})
-		}
-	}
-
-	targetfile := filepath.Join(rdir, "hosts")
-	if err := etchosts.New(&etchosts.Params{
-		BaseFile:                 path,
-		ExtraHosts:               b.CommonBuildOpts.AddHost,
-		HostContainersInternalIP: etchosts.GetHostContainersInternalIP(conf, nil, nil),
-		TargetFile:               targetfile,
-		ContainerIPs:             entries,
+	if err := resolvconf.New(&resolvconf.Params{
+		Path:            file,
+		Namespaces:      namespaces,
+		IPv6Enabled:     ipv6,
+		KeepHostServers: keepHostServers,
+		Nameservers:     nameservers,
+		Searches:        searches,
+		Options:         options,
 	}); err != nil {
-		return "", err
+		return fmt.Errorf("building resolv.conf for container %s: %w", b.ContainerID, err)
 	}
 
+	return nil
+}
+
+// createHostsFile creates a containers hosts file
+func (b *Builder) createHostsFile(rdir string, chownOpts *idtools.IDPair) (string, error) {
+	targetfile := filepath.Join(rdir, "hosts")
+	f, err := os.Create(targetfile)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
 	uid := 0
 	gid := 0
 	if chownOpts != nil {
 		uid = chownOpts.UID
 		gid = chownOpts.GID
 	}
-	if err = os.Chown(targetfile, uid, gid); err != nil {
+	if err := f.Chown(uid, gid); err != nil {
 		return "", err
 	}
 	if err := relabel(targetfile, b.MountLabel, false); err != nil {
@@ -174,6 +140,25 @@ func (b *Builder) generateHosts(rdir string, chownOpts *idtools.IDPair, imageRoo
 	}
 
 	return targetfile, nil
+}
+
+func (b *Builder) addHostsEntries(file, imageRoot string, entries etchosts.HostEntries, exculde []net.IP) error {
+	conf, err := config.Default()
+	if err != nil {
+		return err
+	}
+
+	base, err := etchosts.GetBaseHostFile(conf.Containers.BaseHostsFile, imageRoot)
+	if err != nil {
+		return err
+	}
+	return etchosts.New(&etchosts.Params{
+		BaseFile:                 base,
+		ExtraHosts:               b.CommonBuildOpts.AddHost,
+		HostContainersInternalIP: etchosts.GetHostContainersInternalIPExcluding(conf, nil, nil, exculde),
+		TargetFile:               file,
+		ContainerIPs:             entries,
+	})
 }
 
 // generateHostname creates a containers /etc/hostname file
@@ -1122,7 +1107,7 @@ func runUsingRuntimeMain() {
 }
 
 func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options RunOptions, configureNetwork bool, networkString string,
-	moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName, buildContainerName, hostsFile string) (err error) {
+	moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName, buildContainerName, hostsFile, resolvFile string) (err error) {
 	// Lock the caller to a single OS-level thread.
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -1238,8 +1223,14 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 			// only add hosts if we manage the hosts file
 			if hostsFile != "" {
 				entries := etchosts.GetNetworkHostEntries(netstatus, spec.Hostname, buildContainerName)
-				// make sure to sync this with (b *Builder) generateHosts()
-				err = etchosts.Add(hostsFile, entries)
+				err = b.addHostsEntries(hostsFile, rootPath, entries, nil)
+				if err != nil {
+					return err
+				}
+			}
+
+			if resolvFile != "" {
+				err = b.addResolvConfEntries(resolvFile, nil, spec.Linux.Namespaces, true, true)
 				if err != nil {
 					return err
 				}

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -22,8 +22,10 @@ import (
 	"github.com/containers/buildah/pkg/parse"
 	butil "github.com/containers/buildah/pkg/util"
 	"github.com/containers/buildah/util"
+	"github.com/containers/common/libnetwork/etchosts"
 	"github.com/containers/common/libnetwork/resolvconf"
 	nettypes "github.com/containers/common/libnetwork/types"
+	netUtil "github.com/containers/common/libnetwork/util"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/lockfile"
@@ -204,19 +206,49 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 
 	hostsFile := ""
 	if !options.NoHosts && !slices.Contains(volumes, config.DefaultHostsFile) && options.ConfigureNetwork != define.NetworkDisabled {
-		hostsFile, err = b.generateHosts(path, rootIDPair, mountPoint, spec)
+		hostsFile, err = b.createHostsFile(path, rootIDPair)
 		if err != nil {
 			return err
 		}
 		bindFiles[config.DefaultHostsFile] = hostsFile
+
+		// Only add entries here if we do not have to setup network,
+		// if we do we have to do it much later after the network setup.
+		if !configureNetwork {
+			var entries etchosts.HostEntries
+			// add host entry for local ip when running in host network
+			if spec.Hostname != "" {
+				ip := netUtil.GetLocalIP()
+				if ip != "" {
+					entries = append(entries, etchosts.HostEntry{
+						Names: []string{spec.Hostname},
+						IP:    ip,
+					})
+				}
+			}
+			err = b.addHostsEntries(hostsFile, mountPoint, entries, nil)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
+	resolvFile := ""
 	if !slices.Contains(volumes, resolvconf.DefaultResolvConf) && options.ConfigureNetwork != define.NetworkDisabled && !(len(b.CommonBuildOpts.DNSServers) == 1 && strings.ToLower(b.CommonBuildOpts.DNSServers[0]) == "none") {
-		resolvFile, err := b.addResolvConf(path, rootIDPair, b.CommonBuildOpts.DNSServers, b.CommonBuildOpts.DNSSearch, b.CommonBuildOpts.DNSOptions, nil)
+		resolvFile, err = b.createResolvConf(path, rootIDPair)
 		if err != nil {
 			return err
 		}
 		bindFiles[resolvconf.DefaultResolvConf] = resolvFile
+
+		// Only add entries here if we do not have to do setup network,
+		// if we do we have to do it much later after the network setup.
+		if !configureNetwork {
+			err = b.addResolvConfEntries(resolvFile, nil, nil, false, true)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	runMountInfo := runMountInfo{
@@ -290,7 +322,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		} else {
 			moreCreateArgs = nil
 		}
-		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, networkString, moreCreateArgs, spec, mountPoint, path, containerName, b.Container, hostsFile)
+		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, networkString, moreCreateArgs, spec, mountPoint, path, containerName, b.Container, hostsFile, resolvFile)
 	case IsolationChroot:
 		err = chroot.RunUsingChroot(spec, path, homeDir, options.Stdin, options.Stdout, options.Stderr)
 	default:

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -202,13 +202,13 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	}
 	rootIDPair := &idtools.IDPair{UID: int(rootUID), GID: int(rootGID)}
 
-	hostFile := ""
+	hostsFile := ""
 	if !options.NoHosts && !slices.Contains(volumes, config.DefaultHostsFile) && options.ConfigureNetwork != define.NetworkDisabled {
-		hostFile, err = b.generateHosts(path, rootIDPair, mountPoint, spec)
+		hostsFile, err = b.generateHosts(path, rootIDPair, mountPoint, spec)
 		if err != nil {
 			return err
 		}
-		bindFiles[config.DefaultHostsFile] = hostFile
+		bindFiles[config.DefaultHostsFile] = hostsFile
 	}
 
 	if !slices.Contains(volumes, resolvconf.DefaultResolvConf) && options.ConfigureNetwork != define.NetworkDisabled && !(len(b.CommonBuildOpts.DNSServers) == 1 && strings.ToLower(b.CommonBuildOpts.DNSServers[0]) == "none") {
@@ -290,7 +290,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		} else {
 			moreCreateArgs = nil
 		}
-		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, networkString, moreCreateArgs, spec, mountPoint, path, containerName, b.Container, hostFile)
+		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, networkString, moreCreateArgs, spec, mountPoint, path, containerName, b.Container, hostsFile)
 	case IsolationChroot:
 		err = chroot.RunUsingChroot(spec, path, homeDir, options.Stdin, options.Stdout, options.Stderr)
 	default:

--- a/run_linux.go
+++ b/run_linux.go
@@ -260,22 +260,22 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	}
 	rootIDPair := &idtools.IDPair{UID: int(rootUID), GID: int(rootGID)}
 
-	hostFile := ""
+	hostsFile := ""
 	if !options.NoHosts && !slices.Contains(volumes, config.DefaultHostsFile) && options.ConfigureNetwork != define.NetworkDisabled {
-		hostFile, err = b.generateHosts(path, rootIDPair, mountPoint, spec)
+		hostsFile, err = b.generateHosts(path, rootIDPair, mountPoint, spec)
 		if err != nil {
 			return err
 		}
-		bindFiles[config.DefaultHostsFile] = hostFile
+		bindFiles[config.DefaultHostsFile] = hostsFile
 	}
 
 	if !options.NoHostname && !(slices.Contains(volumes, "/etc/hostname")) {
-		hostFile, err := b.generateHostname(path, spec.Hostname, rootIDPair)
+		hostnameFile, err := b.generateHostname(path, spec.Hostname, rootIDPair)
 		if err != nil {
 			return err
 		}
 		// Bind /etc/hostname
-		bindFiles["/etc/hostname"] = hostFile
+		bindFiles["/etc/hostname"] = hostnameFile
 	}
 
 	if !slices.Contains(volumes, resolvconf.DefaultResolvConf) && options.ConfigureNetwork != define.NetworkDisabled && !(len(b.CommonBuildOpts.DNSServers) == 1 && strings.ToLower(b.CommonBuildOpts.DNSServers[0]) == "none") {
@@ -362,7 +362,7 @@ rootless=%d
 			moreCreateArgs = append(moreCreateArgs, "--no-pivot")
 		}
 		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, networkString, moreCreateArgs, spec,
-			mountPoint, path, define.Package+"-"+filepath.Base(path), b.Container, hostFile)
+			mountPoint, path, define.Package+"-"+filepath.Base(path), b.Container, hostsFile)
 	case IsolationChroot:
 		err = chroot.RunUsingChroot(spec, path, homeDir, options.Stdin, options.Stdout, options.Stderr)
 	case IsolationOCIRootless:
@@ -371,7 +371,7 @@ rootless=%d
 			moreCreateArgs = append(moreCreateArgs, "--no-pivot")
 		}
 		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, networkString, moreCreateArgs, spec,
-			mountPoint, path, define.Package+"-"+filepath.Base(path), b.Container, hostFile)
+			mountPoint, path, define.Package+"-"+filepath.Base(path), b.Container, hostsFile)
 	default:
 		err = errors.New("don't know how to run this command")
 	}

--- a/vendor/github.com/containers/common/libnetwork/internal/rootlessnetns/netns_linux.go
+++ b/vendor/github.com/containers/common/libnetwork/internal/rootlessnetns/netns_linux.go
@@ -158,7 +158,8 @@ func (n *Netns) setupPasta(nsPath string) error {
 		Netns:        nsPath,
 		ExtraOptions: []string{"--pid", pidPath},
 	}
-	if err := pasta.Setup(&pastaOpts); err != nil {
+	res, err := pasta.Setup2(&pastaOpts)
+	if err != nil {
 		return fmt.Errorf("setting up Pasta: %w", err)
 	}
 
@@ -185,11 +186,9 @@ func (n *Netns) setupPasta(nsPath string) error {
 		Namespaces: []specs.LinuxNamespace{
 			{Type: specs.NetworkNamespace},
 		},
-		// TODO: Need a way to determine if there is a valid v6 address on any
-		// external interface of the system.
-		IPv6Enabled:     false,
+		IPv6Enabled:     res.IPv6,
 		KeepHostServers: true,
-		Nameservers:     []string{},
+		Nameservers:     res.DNSForwardIPs,
 	}); err != nil {
 		return wrapError("create resolv.conf", err)
 	}

--- a/vendor/github.com/containers/common/libnetwork/pasta/types.go
+++ b/vendor/github.com/containers/common/libnetwork/pasta/types.go
@@ -1,0 +1,15 @@
+package pasta
+
+import "net"
+
+const BinaryName = "pasta"
+
+type SetupResult struct {
+	// IpAddresses configured by pasta
+	IPAddresses []net.IP
+	// DNSForwardIP is the ip used in --dns-forward, it should be added as first
+	// entry to resolv.conf in the container.
+	DNSForwardIPs []string
+	// IPv6 says whenever pasta run with ipv6 support
+	IPv6 bool
+}

--- a/vendor/github.com/containers/common/libnetwork/slirp4netns/const.go
+++ b/vendor/github.com/containers/common/libnetwork/slirp4netns/const.go
@@ -1,5 +1,7 @@
 package slirp4netns
 
+import "net"
+
 const (
 	ipv6ConfDefaultAcceptDadSysctl = "/proc/sys/net/ipv6/conf/default/accept_dad"
 	BinaryName                     = "slirp4netns"
@@ -10,3 +12,13 @@ const (
 	// default slirp4ns subnet
 	defaultSubnet = "10.0.2.0/24"
 )
+
+// SetupResult return type from Setup()
+type SetupResult struct {
+	// Pid of the created slirp4netns process
+	Pid int
+	// Subnet which is used by slirp4netns
+	Subnet *net.IPNet
+	// IPv6 whenever Ipv6 is enabled in slirp4netns
+	IPv6 bool
+}

--- a/vendor/github.com/containers/common/libnetwork/slirp4netns/slirp4netns.go
+++ b/vendor/github.com/containers/common/libnetwork/slirp4netns/slirp4netns.go
@@ -86,16 +86,6 @@ type SetupOptions struct {
 	Pdeathsig syscall.Signal
 }
 
-// SetupResult return type from Setup()
-type SetupResult struct {
-	// Pid of the created slirp4netns process
-	Pid int
-	// Subnet which is used by slirp4netns
-	Subnet *net.IPNet
-	// IPv6 whenever Ipv6 is enabled in slirp4netns
-	IPv6 bool
-}
-
 type logrusDebugWriter struct {
 	prefix string
 }

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.58.0"
+const Version = "0.58.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -106,7 +106,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.4.0
 ## explicit; go 1.20
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/common v0.58.0
+# github.com/containers/common v0.58.1
 ## explicit; go 1.20
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring


### PR DESCRIPTION
In preparation for the Podman v5.0.1 release.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

