### PR TITLE
Fix caching when mounting a cached stage with COPY/ADD

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1402,7 +1402,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			}
 		}
 
-		needsCacheKey := (len(s.executor.cacheFrom) != 0 || len(s.executor.cacheTo) != 0) && !avoidLookingCache
+		needsCacheKey := (len(s.executor.cacheFrom) != 0 && !avoidLookingCache) || len(s.executor.cacheTo) != 0
 
 		// If we have to commit for this instruction, only assign the
 		// stage's configured output name to the last layer.
@@ -1433,7 +1433,6 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// and copy the content.
 			canMatchCacheOnlyAfterRun = (step.Command == command.Add || step.Command == command.Copy)
 			if canMatchCacheOnlyAfterRun {
-				s.didExecute = true
 				if err = ib.Run(step, s, noRunsRemaining); err != nil {
 					logrus.Debugf("Error building at step %+v: %v", *step, err)
 					return "", nil, false, fmt.Errorf("building at STEP \"%s\": %w", step.Message, err)
@@ -1469,6 +1468,9 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 						pulledAndUsedCacheImage = true
 					}
 				}
+			}
+			if canMatchCacheOnlyAfterRun && cacheID == "" {
+				s.didExecute = true
 			}
 		}
 

--- a/tests/bud/cache-from-stage/Containerfile
+++ b/tests/bud/cache-from-stage/Containerfile
@@ -1,0 +1,5 @@
+FROM scratch AS stage1
+COPY / /
+
+FROM alpine
+RUN --mount=type=bind,from=stage1,target=/mnt echo hi > test

--- a/tests/bud/cache-from-stage/testfile
+++ b/tests/bud/cache-from-stage/testfile
@@ -1,0 +1,1 @@
+Hi, I'm a test file.  Enjoy the test.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A comment states that `avoidLookingCache` is set when a previous stage that executed as part of the build is referenced by `--mount`, to avoid reusing content from an older build of the stage:

    // Only attempt to find cache if its needed, this part
    // so that if a step is using RUN --mount and mounts
    // previous stages then it uses the freshly built stage
    // of re-using the older stage from the store.

However, stages consisting of `COPY`/`ADD` seem to be flagged with `didExecute` even if they were fetched from cache instead. I believe this is an oversight, and these stages should not prevent subsequent caching.

Also, `avoidLookingCache` would prevent a cache push, but I think it should only prevent cache lookups, since populating the cache is still useful in these caess.

#### How to verify it

Run the provided test case.

#### Which issue(s) this PR fixes:

Consider the test case added in this PR:

```
FROM scratch AS stage1
COPY / /

FROM alpine
RUN --mount=type=bind,from=stage1,target=/mnt echo hi > test
```

Without this fix, the `RUN` step skips cache completely when running with `--cache-from` and `--cache-to`. Cache is neither pulled nor pushed for this step, even when the `COPY` in `stage1` is cached. This seems to happen because `stage1` has the `didExecute` flag set, regardless of whether the stage was cached or not.

#### Special notes for your reviewer:

It's very possible I'm misunderstanding something, but I believe the `RUN` step in test case I've added wrongly skips cache, and I'd appreciate some pointers in the right direction if what I've proposed here isn't the right solution.

#### Does this PR introduce a user-facing change?

None
