### PR TITLE
[release-1.26] CVE-2024-1753, Bump to Buildah v1.26.7

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -140,6 +140,7 @@ cross_build_task:
         image: ghcr.io/cirruslabs/macos-ventura-base:latest
 
     script:
+        - brew upgrade
         - brew update
         - brew install go
         - brew install go-md2man

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # Changelog
 
+## v1.26.7 (2024-04-01)
+
+    [release-1.26] conformance tests: don't break on trailing zeroes
+    [release-1.26] CVE-2024-1753 container escape fix
+    Mask /sys/devices/virtual/powercap by default
+    Use docker.io/library/centos instead of the one at registry.centos.org
+    Run the cross-compile test on M1 MacOS, not Intel
+
 ## v1.26.6 (2022-12-08)
 
     copier.Put(): clear up os/syscall mode bit confusion

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+- Changelog for v1.26.7 (2024-04-01)
+  * [release-1.26] conformance tests: don't break on trailing zeroes
+  * [release-1.26] CVE-2024-1753 container escape fix
+  * Mask /sys/devices/virtual/powercap by default
+  * Use docker.io/library/centos instead of the one at registry.centos.org
+  * Run the cross-compile test on M1 MacOS, not Intel
+
 - Changelog for v1.26.6 (2022-12-08)
   * copier.Put(): clear up os/syscall mode bit confusion
 

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in define/types.go too
-Version:        1.26.6
+Version:        1.26.7
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,6 +100,13 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Mon Apr 1 2024 Tom Sweeney <tsweeney@redhat.com> 1.26.7-1
+- [release-1.26] conformance tests: don't break on trailing zeroes
+- [release-1.26] CVE-2024-1753 container escape fix
+- Mask /sys/devices/virtual/powercap by default
+- Use docker.io/library/centos instead of the one at registry.centos.org
+- Run the cross-compile test on M1 MacOS, not Intel
+
 * Thu Dec 8 2022 Nalin Dahyabhai <nalin@redhat.com> 1.26.6-1
 - copier.Put(): clear up os/syscall mode bit confusion
 

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.26.6"
+	Version = "1.26.7"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+        "github.com/containers/buildah/copier"
 	"github.com/containers/buildah/internal"
 	internalUtil "github.com/containers/buildah/internal/util"
 	"github.com/containers/common/pkg/parse"
@@ -151,7 +152,11 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
 	// buildkit parity: support absolute path for sources from current build context
 	if contextDir != "" {
 		// path should be /contextDir/specified path
-		newMount.Source = filepath.Join(contextDir, filepath.Clean(string(filepath.Separator)+newMount.Source))
+                evaluated, err := copier.Eval(contextDir, newMount.Source, copier.EvalOptions{})
+                if err != nil {
+                    return newMount, "", err
+                }
+                newMount.Source = evaluated
 	} else {
 		// looks like its coming from `build run --mount=type=bind` allow using absolute path
 		// error out if no source is set

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4598,3 +4598,26 @@ _EOF
   echo checking:
   ! grep 'not fully killed' ${TEST_SCRATCH_DIR}/log
 }
+
+@test "build no write file on host - CVE-2024-1753" {
+  _prefetch alpine
+  cat > ${TEST_SCRATCH_DIR}/Containerfile << _EOF
+FROM alpine as base
+
+RUN ln -s / /rootdir
+
+FROM alpine
+
+RUN echo "With exploit show host root, not the container's root, and create /BIND_BREAKOUT in / on the host"
+RUN --mount=type=bind,from=base,source=/rootdir,destination=/exploit,rw ls -l /exploit; touch /exploit/BIND_BREAKOUT; ls -l /exploit
+
+_EOF
+
+  run_buildah build $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
+  expect_output --substring "/BIND_BREAKOUT"
+
+  run ls /BIND_BREAKOUT
+  rm -f /BIND_BREAKOUT
+  assert "$status" -eq 2 "exit code from ls"
+  expect_output --substring "No such file or directory"
+}

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -790,7 +791,7 @@ func fsHeaderForEntry(hdr *tar.Header) FSHeader {
 		Name:     hdr.Name,
 		Linkname: hdr.Linkname,
 		Size:     hdr.Size,
-		Mode:     hdr.Mode,
+		Mode:     (hdr.Mode & int64(fs.ModePerm)),
 		UID:      hdr.Uid,
 		GID:      hdr.Gid,
 		ModTime:  hdr.ModTime,

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
+
+	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/reexec"
 	dockertypes "github.com/docker/docker/api/types"
 	dockerdockerclient "github.com/docker/docker/client"
@@ -892,11 +894,15 @@ func saveReport(ctx context.Context, t *testing.T, ref types.ImageReference, dir
 // summarizeLayer reads a blob and returns a summary of the parts of its contents that we care about
 func summarizeLayer(t *testing.T, imageName string, blobInfo types.BlobInfo, reader io.Reader) (layer Layer) {
 	compressedDigest := digest.Canonical.Digester()
-	uncompressedBlob, _, err := compression.AutoDecompress(io.TeeReader(reader, compressedDigest.Hash()))
-	require.Nil(t, err, "error decompressing blob %+v for image %q", blobInfo, imageName)
+	counter := ioutils.NewWriteCounter(compressedDigest.Hash())
+	compressionAlgorithm, _, reader, err := compression.DetectCompressionFormat(reader)
+	require.NoErrorf(t, err, "error checking if blob %+v for image %q is compressed", blobInfo, imageName)
+	uncompressedBlob, wasCompressed, err := compression.AutoDecompress(io.TeeReader(reader, counter))
+	require.NoErrorf(t, err, "error decompressing blob %+v for image %q", blobInfo, imageName)
 	defer uncompressedBlob.Close()
 	uncompressedDigest := digest.Canonical.Digester()
-	tr := tar.NewReader(io.TeeReader(uncompressedBlob, uncompressedDigest.Hash()))
+	tarToRead := io.TeeReader(uncompressedBlob, uncompressedDigest.Hash())
+	tr := tar.NewReader(tarToRead)
 	hdr, err := tr.Next()
 	for err == nil {
 		header := fsHeaderForEntry(hdr)
@@ -911,8 +917,18 @@ func summarizeLayer(t *testing.T, imageName string, blobInfo types.BlobInfo, rea
 		hdr, err = tr.Next()
 	}
 	require.Equal(t, io.EOF, err, "unexpected error reading layer contents %+v for image %q", blobInfo, imageName)
+	_, err = io.Copy(io.Discard, tarToRead)
+	require.NoError(t, err, "reading out any not-usually-present zero padding at the end")
 	layer.CompressedDigest = compressedDigest.Digest()
-	require.Equal(t, blobInfo.Digest, layer.CompressedDigest, "calculated digest of compressed blob didn't match expected digest")
+	blobFormatDescription := "uncompressed"
+	if wasCompressed {
+		if compressionAlgorithm.Name() != "" {
+			blobFormatDescription = "compressed with " + compressionAlgorithm.Name()
+		} else {
+			blobFormatDescription = "compressed (?)"
+		}
+	}
+	require.Equalf(t, blobInfo.Digest, layer.CompressedDigest, "calculated digest of %s blob didn't match expected digest (expected length %d, actual length %d)", blobFormatDescription, blobInfo.Size, counter.Count)
 	layer.UncompressedDigest = uncompressedDigest.Digest()
 	return layer
 }


### PR DESCRIPTION
This Bumps Buildah to v1.26.7 and addresses CVE-2024-1753
https://issues.redhat.com/browse/RHEL-26773 
https://issues.redhat.com/browse/RHEL-26770 

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

