### PR TITLE
Support zstd compression in image commit

### DIFF
--- a/image.go
+++ b/image.go
@@ -155,9 +155,9 @@ func computeLayerMIMEType(what string, layerCompression archive.Compression) (om
 			// how to decompress them, we can't try to compress layers with xz.
 			return "", "", errors.New("media type for xz-compressed layers is not defined")
 		case archive.Zstd:
-			// Until the image specs define a media type for zstd-compressed layers, even if we know
-			// how to decompress them, we can't try to compress layers with zstd.
-			return "", "", errors.New("media type for zstd-compressed layers is not defined")
+			omediaType = v1.MediaTypeImageLayerZstd
+			dmediaType = "application/vnd.docker.image.rootfs.diff.tar.zstd"
+			logrus.Debugf("compressing %s with zstd", what)
 		default:
 			logrus.Debugf("compressing %s with unknown compressor(?)", what)
 		}


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Without this change, specifying `Compression: imagebuildah.Zstd` in `imagebuildah`'s `BuildOptions fails, so it is not possible to push cache to a registry with zstd compression.

https://github.com/opencontainers/image-spec/blob/main/media-types.md defines a media type for zstd-compressed layers, so I don't think the comment about lack of a defined media type is still applicable.

#### How to verify it

Specify `Compression: imagebuildah.Zstd` when building an image using `imagebuildah.BuildDockerfiles`,.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

n/a

#### Does this PR introduce a user-facing change?

```release-note
None
```