### PR TITLE
source-push: add support for `--digestfile`

### DIFF
--- a/cmd/buildah/source.go
+++ b/cmd/buildah/source.go
@@ -122,6 +122,7 @@ func init() {
 	sourceCommand.AddCommand(sourcePushCommand)
 	sourcePushFlags := sourcePushCommand.Flags()
 	sourcePushFlags.StringVar(&sourcePushOptions.Credentials, "creds", "", "use `[username[:password]]` for accessing the registry")
+	sourcePushFlags.StringVar(&sourcePushOptions.DigestFile, "digestfile", "", "after copying the artifact, write the digest of the resulting image to the file")
 	sourcePushFlags.BoolVar(&sourcePushOptions.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	sourcePushFlags.BoolVarP(&sourcePushOptions.Quiet, "quiet", "q", false, "don't output push progress information")
 }

--- a/docs/buildah-source-push.1.md
+++ b/docs/buildah-source-push.1.md
@@ -20,6 +20,10 @@ The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
 
+**--digestfile** *digestfile*
+
+After copying the image, write the digest of the resulting image to the file.
+
 **--quiet**, **-q**
 
 Suppress the progress output when pushing a source image.

--- a/internal/source/push.go
+++ b/internal/source/push.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
@@ -21,6 +22,8 @@ type PushOptions struct {
 	Credentials string
 	// Quiet the progress bars when pushing.
 	Quiet bool
+	// If set after copying the artifact, write the digest of the resulting image to the file
+	DigestFile string
 }
 
 // Push the source image at `sourcePath` to `imageInput` at a container
@@ -61,8 +64,19 @@ func Push(ctx context.Context, sourcePath string, imageInput string, options Pus
 	if !options.Quiet {
 		copyOpts.ReportWriter = os.Stderr
 	}
-	if _, err := copy.Image(ctx, policyContext, destRef, srcRef, copyOpts); err != nil {
+	manifestBytes, err := copy.Image(ctx, policyContext, destRef, srcRef, copyOpts)
+	if err != nil {
 		return fmt.Errorf("pushing source image: %w", err)
+	}
+
+	if options.DigestFile != "" {
+		manifestDigest, err := manifest.Digest(manifestBytes)
+		if err != nil {
+			return fmt.Errorf("computing digest of manifest of source: %w", err)
+		}
+		if err = os.WriteFile(options.DigestFile, []byte(manifestDigest.String()), 0644); err != nil {
+			return fmt.Errorf("failed to write digest to file %q: %w", options.DigestFile, err)
+		}
 	}
 
 	return nil

--- a/tests/source.bats
+++ b/tests/source.bats
@@ -134,9 +134,11 @@ load helpers
   run_buildah source push --quiet --tls-verify=false --creds testuser:testpassword $srcdir localhost:${REGISTRY_PORT}/source:test
   expect_output ""
   # --quiet=false (implicit)
-  run_buildah source push --tls-verify=false --creds testuser:testpassword $srcdir localhost:${REGISTRY_PORT}/source:test
+  run_buildah source push --digestfile=${TEST_SCRATCH_DIR}/digest.txt --tls-verify=false --creds testuser:testpassword $srcdir localhost:${REGISTRY_PORT}/source:test
   expect_output --substring "Copying blob"
   expect_output --substring "Copying config"
+  cat ${TEST_SCRATCH_DIR}/digest.txt
+  test -s ${TEST_SCRATCH_DIR}/digest.txt
 
   pulldir=${TEST_SCRATCH_DIR}/pulledsource
   # --quiet=true


### PR DESCRIPTION
Allow writing digest of the pushed source to the specified `digestfile`

Closes: https://github.com/containers/buildah/issues/5399

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
source-push: add support for --digestfile
```

Closes: https://github.com/containers/buildah/issues/5399

