### PR TITLE
Don't expand RUN heredocs ourselves, let the shell do it

### DIFF
--- a/docker/types.go
+++ b/docker/types.go
@@ -60,9 +60,10 @@ type HealthConfig struct {
 	Test []string `json:",omitempty"`
 
 	// Zero means to inherit. Durations are expressed as integer nanoseconds.
-	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
-	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
-	StartPeriod time.Duration `json:",omitempty"` // Time to wait after the container starts before running the first check.
+	Interval      time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout       time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+	StartPeriod   time.Duration `json:",omitempty"` // Time to wait after the container starts before running the first check.
+	StartInterval time.Duration `json:",omitempty"` // Time to wait between checks during the StartPeriod.
 
 	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/docker/docker v26.1.2+incompatible
 	github.com/docker/go-units v0.5.0
-	github.com/fsouza/go-dockerclient v1.10.1
+	github.com/fsouza/go-dockerclient v1.11.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/moby/buildkit v0.12.5
@@ -41,7 +41,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc
 	github.com/opencontainers/selinux v1.11.0
-	github.com/openshift/imagebuilder v1.2.6
+	github.com/openshift/imagebuilder v1.2.9
 	github.com/seccomp/libseccomp-golang v0.10.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/fsouza/go-dockerclient v1.10.1 h1:bSU5Wu2ARdub+iv9VtoDsN8yBUI0vgflmshbeQLKhvc=
-github.com/fsouza/go-dockerclient v1.10.1/go.mod h1:dyzGriw6v3pK4O4O1u/X+vXxDDsrnLLkCqYkcLsDq2k=
+github.com/fsouza/go-dockerclient v1.11.0 h1:4ZAk6W7rPAtPXm7198EFqA5S68rwnNQORxlOA5OurCA=
+github.com/fsouza/go-dockerclient v1.11.0/go.mod h1:0I3TQCRseuPTzqlY4Y3ajfsg2VAdMQoazrkxJTiJg8s=
 github.com/go-jose/go-jose/v3 v3.0.3 h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k=
 github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
@@ -294,8 +294,8 @@ github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc h1:
 github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc/go.mod h1:8tx1helyqhUC65McMm3x7HmOex8lO2/v9zPuxmKHurs=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/openshift/imagebuilder v1.2.6 h1:ge+HILDVaB3c65KhH0nrM/Z1f9EdN8NUqxigd4qGqqo=
-github.com/openshift/imagebuilder v1.2.6/go.mod h1:6VbTJ5CK7+OOTWcQlc/Cp86ML7pKlxOwCJNESQPbtgw=
+github.com/openshift/imagebuilder v1.2.9 h1:830/kg5FWtpLsQ6JcCQ23qOeb/KfzMK66pai544rAUI=
+github.com/openshift/imagebuilder v1.2.9/go.mod h1:KkkXOyRjJlZEXWQtHNBNzVHqh4vf/0xX5cDIQ2gr+5I=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -3102,6 +3102,13 @@ var internalTestCases = []testCase{
 		contextDir:        "multistage/copyback",
 		dockerUseBuildKit: true,
 	},
+
+	{
+		name:              "heredoc-quoting",
+		dockerfile:        "Dockerfile.heredoc-quoting",
+		dockerUseBuildKit: true,
+		fsSkip:            []string{"(dir):etc:(dir):hostname"}, // buildkit does not create a phantom /etc/hostname
+	},
 }
 
 func TestCommit(t *testing.T) {

--- a/tests/conformance/testdata/Dockerfile.heredoc-quoting
+++ b/tests/conformance/testdata/Dockerfile.heredoc-quoting
@@ -1,0 +1,215 @@
+FROM busybox
+ARG argA=argvA
+ENV varA=valueA
+
+# An argument, an environment variable, and one set in the heredoc
+RUN <<EOF
+varB=valueB
+touch /run-argA=$argA.unquoted1.txt
+touch /run-varA=$varA.unquoted1.txt
+touch /run-varB=$varB.unquoted1.txt
+EOF
+
+# An argument, an environment variable, and one set in the heredoc
+RUN <<EOF
+varB=valueB
+touch /run-argA="$argA".unquoted2.txt
+touch /run-varA="$varA".unquoted2.txt
+touch /run-varB="$varB".unquoted2.txt
+EOF
+
+# An argument, an environment variable overridden in the heredoc, and one set in the heredoc
+RUN <<EOF
+varA=valueA2
+varB=valueB
+touch /run-argA="$argA".unquoted3.txt
+touch /run-varA="$varA".unquoted3.txt
+touch /run-varB="$varB".unquoted3.txt
+EOF
+
+# An overridden argument, an environment variable overridden in the heredoc, and one set in the heredoc
+RUN <<EOF
+argA=argvA2
+varA=valueA2
+varB=valueB
+touch /run-argA="$argA".unquoted4.txt
+touch /run-varA="$varA".unquoted4.txt
+touch /run-varB="$varB".unquoted4.txt
+EOF
+
+# An argument, an environment variable, and one set in the heredoc
+RUN <<"EOF"
+varB=valueB
+touch /run-argA=$argA.quoted1.txt
+touch /run-varA=$varA.quoted1.txt
+touch /run-varB=$varB.quoted1.txt
+EOF
+
+# An argument, an environment variable, and one set in the heredoc
+RUN <<"EOF"
+varB=valueB
+touch /run-argA="$argA".quoted2.txt
+touch /run-varA="$varA".quoted2.txt
+touch /run-varB="$varB".quoted2.txt
+EOF
+
+# An argument, an environment variable overridden in the heredoc, and one set in the heredoc
+RUN <<"EOF"
+varA=valueA2
+varB=valueB
+touch /run-argA="$argA".quoted3.txt
+touch /run-varA="$varA".quoted3.txt
+touch /run-varB="$varB".quoted3.txt
+EOF
+
+# An overridden argument, an environment variable overridden in the heredoc, and one set in the heredoc
+RUN <<"EOF"
+argA=argvA2
+varA=valueA2
+varB=valueB
+touch /run-argA="$argA".quoted4.txt
+touch /run-varA="$varA".quoted4.txt
+touch /run-varB="$varB".quoted4.txt
+EOF
+
+# An argument, an environment variable, and one set in the heredoc
+COPY <<EOF /copy-unquoted1.txt
+varB=valueB
+touch /argA=$argA
+touch /varA=$varA
+touch /varB=$varB
+EOF
+
+# An argument, an environment variable, and one set in the heredoc
+COPY <<EOF /copy-unquoted2.txt
+varB=valueB
+argA="$argA"
+varA="$varA"
+varB="$varB"
+EOF
+
+# An argument, an environment variable overridden in the heredoc, and one set in the heredoc
+COPY <<EOF /copy-unquoted3.txt
+varA=valueA2
+varB=valueB
+argA="$argA"
+varA="$varA"
+varB="$varB"
+EOF
+
+# An overridden argument, an environment variable overridden in the heredoc, and one set in the heredoc
+COPY <<EOF /copy-unquoted4.txt
+argA=argvA2
+varA=valueA2
+varB=valueB
+argA="$argA"
+varA="$varA"
+varB="$varB"
+EOF
+
+# An argument, an environment variable, and one set in the heredoc
+COPY <<"EOF" /copy-quoted1.txt
+varB=valueB
+argA=$argA
+varA=$varA
+varB=$varB
+EOF
+
+# An argument, an environment variable, and one set in the heredoc
+COPY <<"EOF" /copy-quoted2.txt
+varB=valueB
+argA="$argA"
+varA="$varA"
+varB="$varB"
+EOF
+
+# An argument, an environment variable overridden in the heredoc, and one set in the heredoc
+COPY <<"EOF" /copy-quoted3.txt
+varA=valueA2
+varB=valueB
+argA="$argA"
+varA="$varA"
+varB="$varB"
+EOF
+
+# An overridden argument, an environment variable overridden in the heredoc, and one set in the heredoc
+COPY <<"EOF" /copy-quoted4.txt
+argA=argvA2
+varA=valueA2
+varB=valueB
+argA="$argA"
+varA="$varA"
+varB="$varB"
+EOF
+
+# An argument, an environment variable, and one set in the heredoc
+ADD <<EOF /add-unquoted1.txt
+varB=valueB
+touch /argA=$argA
+touch /varA=$varA
+touch /varB=$varB
+EOF
+
+# An argument, an environment variable, and one set in the heredoc
+ADD <<EOF /add-unquoted2.txt
+varB=valueB
+argA="$argA"
+varA="$varA"
+varB="$varB"
+EOF
+
+# An argument, an environment variable overridden in the heredoc, and one set in the heredoc
+ADD <<EOF /add-unquoted3.txt
+varA=valueA2
+varB=valueB
+argA="$argA"
+varA="$varA"
+varB="$varB"
+EOF
+
+# An overridden argument, an environment variable overridden in the heredoc, and one set in the heredoc
+ADD <<EOF /add-unquoted4.txt
+argA=argvA2
+varA=valueA2
+varB=valueB
+argA="$argA"
+varA="$varA"
+varB="$varB"
+EOF
+
+# An argument, an environment variable, and one set in the heredoc
+ADD <<"EOF" /add-quoted1.txt
+varB=valueB
+argA=$argA
+varA=$varA
+varB=$varB
+EOF
+
+# An argument, an environment variable, and one set in the heredoc
+ADD <<"EOF" /add-quoted2.txt
+varB=valueB
+argA="$argA"
+varA="$varA"
+varB="$varB"
+EOF
+
+# An argument, an environment variable overridden in the heredoc, and one set in the heredoc
+ADD <<"EOF" /add-quoted3.txt
+varA=valueA2
+varB=valueB
+argA="$argA"
+varA="$varA"
+varB="$varB"
+EOF
+
+# An overridden argument, an environment variable overridden in the heredoc, and one set in the heredoc
+ADD <<"EOF" /add-quoted4.txt
+argA=argvA2
+varA=valueA2
+varB=valueB
+argA="$argA"
+varA="$varA"
+varB="$varB"
+EOF
+
+RUN touch -r /etc/passwd /*.txt

--- a/vendor/github.com/fsouza/go-dockerclient/container.go
+++ b/vendor/github.com/fsouza/go-dockerclient/container.go
@@ -389,9 +389,10 @@ type HealthConfig struct {
 	Test []string `json:"Test,omitempty" yaml:"Test,omitempty" toml:"Test,omitempty"`
 
 	// Zero means to inherit. Durations are expressed as integer nanoseconds.
-	Interval    time.Duration `json:"Interval,omitempty" yaml:"Interval,omitempty" toml:"Interval,omitempty"`          // Interval is the time to wait between checks.
-	Timeout     time.Duration `json:"Timeout,omitempty" yaml:"Timeout,omitempty" toml:"Timeout,omitempty"`             // Timeout is the time to wait before considering the check to have hung.
-	StartPeriod time.Duration `json:"StartPeriod,omitempty" yaml:"StartPeriod,omitempty" toml:"StartPeriod,omitempty"` // The start period for the container to initialize before the retries starts to count down.
+	Interval      time.Duration `json:"Interval,omitempty" yaml:"Interval,omitempty" toml:"Interval,omitempty"`                // Interval is the time to wait between checks.
+	Timeout       time.Duration `json:"Timeout,omitempty" yaml:"Timeout,omitempty" toml:"Timeout,omitempty"`                   // Timeout is the time to wait before considering the check to have hung.
+	StartPeriod   time.Duration `json:"StartPeriod,omitempty" yaml:"StartPeriod,omitempty" toml:"StartPeriod,omitempty"`       // The start period for the container to initialize before the retries starts to count down.
+	StartInterval time.Duration `json:"StartInterval,omitempty" yaml:"StartInterval,omitempty" toml:"StartInterval,omitempty"` // The start interval is the time to wait between checks during the start period.
 
 	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.
@@ -555,6 +556,7 @@ type HostConfig struct {
 	PublishAllPorts      bool                   `json:"PublishAllPorts,omitempty" yaml:"PublishAllPorts,omitempty" toml:"PublishAllPorts,omitempty"`
 	ReadonlyRootfs       bool                   `json:"ReadonlyRootfs,omitempty" yaml:"ReadonlyRootfs,omitempty" toml:"ReadonlyRootfs,omitempty"`
 	AutoRemove           bool                   `json:"AutoRemove,omitempty" yaml:"AutoRemove,omitempty" toml:"AutoRemove,omitempty"`
+	Annotations          map[string]string      `json:"Annotations,omitempty" yaml:"Annotations,omitempty" toml:"Annotations,omitempty"`
 }
 
 // NetworkingConfig represents the container's networking configuration for each of its interfaces

--- a/vendor/github.com/openshift/imagebuilder/.travis.yml
+++ b/vendor/github.com/openshift/imagebuilder/.travis.yml
@@ -9,7 +9,11 @@ go:
   - "1.20"
 
 before_install:
+  - sudo systemctl stop docker.service && sudo systemctl stop docker.socket
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - yes | sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update -q -y
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - docker pull busybox
   - docker pull centos:7
   - chmod -R go-w ./dockerclient/testdata

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/client.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/client.go
@@ -1058,7 +1058,7 @@ func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []s
 			}
 			chmod = func(h *tar.Header, r io.Reader) (data []byte, update bool, skip bool, err error) {
 				mode := h.Mode &^ 0o777
-				mode |= parsed & 0o777
+				mode |= parsed & 0o7777
 				h.Mode = mode
 				return nil, false, false, nil
 			}

--- a/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
+++ b/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
@@ -11,8 +11,8 @@
 # Customize from here.
 #
 
-%global golang_version 1.8.1
-%{!?version: %global version 1.2.6}
+%global golang_version 1.19
+%{!?version: %global version 1.2.9}
 %{!?release: %global release 1}
 %global package_name imagebuilder
 %global product_name Container Image Builder

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -377,8 +377,8 @@ github.com/felixge/httpsnoop
 # github.com/fsnotify/fsnotify v1.7.0
 ## explicit; go 1.17
 github.com/fsnotify/fsnotify
-# github.com/fsouza/go-dockerclient v1.10.1
-## explicit; go 1.20
+# github.com/fsouza/go-dockerclient v1.11.0
+## explicit; go 1.21
 github.com/fsouza/go-dockerclient
 # github.com/go-jose/go-jose/v3 v3.0.3
 ## explicit; go 1.12
@@ -644,7 +644,7 @@ github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift/imagebuilder v1.2.6
+# github.com/openshift/imagebuilder v1.2.9
 ## explicit; go 1.19
 github.com/openshift/imagebuilder
 github.com/openshift/imagebuilder/dockerclient


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When handling RUN instructions that use heredoc syntax, don't bother interpolating environment variables and argument values, and let the command that's running handle it.

Try to improve error reporting when we're committing an image, so that we don't lose out-of-space errors through layers of compression and editing of file headers in the layer diffs.

#### How to verify it

New conformance test!

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

We fail to build e.g. https://github.com/devfile/developer-images/tree/main/universal/ubi8 when the heredoc references environment variables which are set in the heredoc itself, since we currently expand them before passing the heredoc as an argument to the command being invoked.

#### Does this PR introduce a user-facing change?

```release-note
Environment variables referenced in RUN instructions which use heredoc syntax will now be evaluated by the command being invoked rather than by the builder.
```