### PR TITLE
Add a Variant to BuildOptions and defaults when only OS or arch

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -382,6 +382,9 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 	if systemContext.ArchitectureChoice != b.Architecture() {
 		systemContext.ArchitectureChoice = b.Architecture()
 	}
+	if systemContext.VariantChoice != b.Variant() {
+		systemContext.VariantChoice = b.Variant()
+	}
 	if systemContext.OSChoice != b.OS() {
 		systemContext.OSChoice = b.OS()
 	}

--- a/define/build.go
+++ b/define/build.go
@@ -281,6 +281,8 @@ type BuildOptions struct {
 	SignBy string
 	// Architecture specifies the target architecture of the image to be built.
 	Architecture string
+	// Variant specifies the target architecture variant of the image to be built.
+	Variant string
 	// Timestamp sets the created timestamp to the specified time, allowing
 	// for deterministic, content-addressable builds.
 	Timestamp *time.Time

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -125,6 +125,7 @@ type Executor struct {
 	deviceSpecs             []string
 	signBy                  string
 	architecture            string
+	variant                 string
 	timestamp               *time.Time
 	os                      string
 	maxPullPushRetries      int
@@ -282,6 +283,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		deviceSpecs:                    options.Devices,
 		signBy:                         options.SignBy,
 		architecture:                   options.Architecture,
+		variant:                        options.Variant,
 		timestamp:                      options.Timestamp,
 		os:                             options.OS,
 		maxPullPushRetries:             options.MaxPullPushRetries,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -2135,6 +2135,9 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	}
 	s.builder.SetHostname(config.Hostname)
 	s.builder.SetDomainname(config.Domainname)
+	if s.executor.architecture != "" || s.executor.variant != "" {
+		s.builder.SetVariant(s.executor.variant)
+	}
 	if s.executor.architecture != "" {
 		s.builder.SetArchitecture(s.executor.architecture)
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -251,15 +251,17 @@ expect_output --substring "hello"
   assert "$output" !~ "missing .* build argument" \
          "With explicit --os + --arch + --variant, buildah should not warn"
 
-  # FIXME FIXME FIXME: #4319: with --os only, buildah should not warn about OS
-  if false; then
-      run_buildah build $WITH_POLICY_JSON --os linux \
-                  -t source -f $containerfile
-      assert "$output" !~ "missing.*TARGETOS" \
-             "With explicit --os (but no arch/variant), buildah should not warn about TARGETOS"
-      # FIXME: add --arch test too, and maybe make this cleaner
-  fi
+  # Shouldn't warn about missing values with just --os
+  run_buildah build $WITH_POLICY_JSON --os linux \
+              -t source -f $containerfile
+  assert "$output" !~ "missing.*TARGET" \
+         "With explicit --os (but no arch/variant), buildah should not warn about TARGETOS"
 
+  # Likewise with --arch
+  run_buildah build $WITH_POLICY_JSON --arch amd64 \
+              -t source -f $containerfile
+  assert "$output" !~ "missing.*TARGET" \
+         "With explicit --arch (but no os), buildah should not warn about TARGETARCH"
 }
 
 @test "build-conflicting-isolation-chroot-and-network" {


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change
/kind bug

#### What this PR does / why we need it:

Add a Variant option to BuildOptions for API users, and use GOOS and GOARCH to fill in defaults when we were invoked with only the other specified, so that the various `TARGET...` build args will be set when one of `--os` or `--arch` or `--variant` are specified, instead of only when the `--platform` flag, which is still preferred, is used.

#### How to verify it

Updated integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The TARGETARCH, TARGETOS, TARGETVARIANT, and TARGETPLATFORM build arguments are now also initialized when a build is started with the --os, --arch, or --variant command line flags.  Using --platform instead is recommended.
```