### PR TITLE
Setting --arch should set the TARGETARCH build arg

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -221,6 +222,9 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 	systemContext := options.SystemContext
 	for _, platform := range options.Platforms {
 		platformContext := *systemContext
+		if platform.OS == "" {
+			platform.OS = runtime.GOOS
+		}
 		platformSpec := internalUtil.NormalizePlatform(v1.Platform{
 			OS:           platform.OS,
 			Architecture: platform.Arch,

--- a/tests/bud/platform-sets-args/Containerfile
+++ b/tests/bud/platform-sets-args/Containerfile
@@ -4,3 +4,7 @@ ARG TARGETOS
 ARG TARGETPLATFORM
 ARG TARGETVARIANT
 ENV nothing="multiarch-safe statement that will result in a built image"
+run echo TARGETARCH=${TARGETARCH}
+run echo TARGETOS=${TARGETOS}
+run echo TARGETPLATFORM=${TARGETPLATFORM}
+run echo TARGETVARIANT=${TARGETVARANT}

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -3566,11 +3566,11 @@ func TestCommit(t *testing.T) {
 				derivedBuilder, err := buildah.NewBuilder(ctx, store, buildah.BuilderOptions{
 					FromImage: buildahID,
 				})
+				require.NoErrorf(t, err, "creating the derived container with buildah")
 				defer func(builder *buildah.Builder) {
 					err := builder.Delete()
 					assert.NoErrorf(t, err, "removing the derived container")
 				}(derivedBuilder)
-				require.NoErrorf(t, err, "creating the derived container with buildah")
 				var overrideConfig *manifest.Schema2Config
 				if test.derivedConfig != nil {
 					overrideConfig = config.Schema2ConfigFromGoDockerclientConfig(test.derivedConfig)


### PR DESCRIPTION
Also fix a long standing FIXME in the test framework.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
--arch option now causes the TARGETARCH and TARGETPLATFORM  build args to get modified
```

