### PR TITLE
Nuke the new nixery image

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4398,9 +4398,8 @@ EOM
 }
 
 @test "bud-implicit-no-history" {
-  _prefetch nixery.dev/shell
-  run_buildah build $WITH_POLICY_JSON --layers=false $BUDFILES/no-history
-  run_buildah build $WITH_POLICY_JSON --layers=true  $BUDFILES/no-history
+  run_buildah build $WITH_POLICY_JSON --layers=false --build-arg SAFEIMAGE=$SAFEIMAGE $BUDFILES/no-history
+  run_buildah build $WITH_POLICY_JSON --layers=true  --build-arg SAFEIMAGE=$SAFEIMAGE $BUDFILES/no-history
 }
 
 @test "bud with encrypted FROM image" {

--- a/tests/bud/no-history/Dockerfile
+++ b/tests/bud/no-history/Dockerfile
@@ -1,7 +1,8 @@
 # The important thing about that first base image is that it has no history
 # entries, but it does have at least one layer.
 
-FROM nixery.dev/shell AS first-stage
+ARG SAFEIMAGE
+FROM $SAFEIMAGE AS first-stage
 RUN date > /date1.txt
 RUN sleep 1 > /sleep1.txt
 


### PR DESCRIPTION
Registry has been down for a day. This is blocking all CI.

Switch to $SAFEIMAGE, our quay.io testimage.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```