### PR TITLE
Integration tests: fixup use of _prefetch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -164,7 +164,7 @@ unit_task:
       - vendor
       - cross_build
 
-    timeout_in: 1h
+    timeout_in: 90m
 
     matrix:
         - env:

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -265,7 +265,7 @@ stuff/mystuff"
 }
 
 @test "add from image" {
-  _prefetch busybox
+  _prefetch busybox ubuntu
   run_buildah from --quiet $WITH_POLICY_JSON busybox
   cid=$output
   run_buildah add --quiet $WITH_POLICY_JSON --from ubuntu $cid /etc/passwd /tmp/passwd # should pull the image, absolute path

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3478,14 +3478,13 @@ _EOF
   target=leading-args
   run_buildah build $WITH_POLICY_JSON -t ${target} --build-arg=VERSION=musl -f $BUDFILES/leading-args/Dockerfile $BUDFILES/leading-args
 
-  #Verify https://github.com/containers/buildah/issues/4312
+  # Verify https://github.com/containers/buildah/issues/4312
   # stage `FROM stage_${my_env}` must be resolved with default arg value and build should be successful.
   run_buildah build $WITH_POLICY_JSON -t source -f $BUDFILES/multi-stage-builds/Dockerfile.arg_in_stage
 
-  #Verify https://github.com/containers/buildah/issues/4573
+  # Verify https://github.com/containers/buildah/issues/4573
   # stage `COPY --from=stage_${my_env}` must be resolved with default arg value and build should be successful.
   run_buildah build $WITH_POLICY_JSON -t source -f $BUDFILES/multi-stage-builds/Dockerfile.arg_in_copy
-
 }
 
 @test "bud-with-healthcheck" {
@@ -5244,7 +5243,6 @@ _EOF
   expect_output --substring "Pushing cache"
   # should not pull cache if its already in local storage
   assert "$output" !~ "Cache pulled"
-
 }
 
 @test "build test pushing and pulling from remote cache sources - after adding content summary" {
@@ -5318,7 +5316,6 @@ _EOF
   expect_output --substring "Pushing cache"
   # should not pull cache if its already in local storage
   assert "$output" !~ "Cache pulled"
-
 }
 
 @test "build test run mounting stage cached from remote cache source" {
@@ -5478,7 +5475,6 @@ _EOF
   if [ -z "${found_runtime}" ]; then
     die "Did not find 'runc' nor 'crun' in \$PATH - could not run this test!"
   fi
-
 }
 
 @test "bud - invalid runtime flags test" {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3455,18 +3455,6 @@ _EOF
   expect_output --substring "FROM alpine"
 }
 
-@test "bud with dir for file but no Dockerfile in dir" {
-  target=alpine-image
-  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f $BUDFILES/empty-dir $BUDFILES/empty-dir
-  expect_output --substring "no such file or directory"
-}
-
-@test "bud with bad dir Dockerfile" {
-  target=alpine-image
-  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f ${TEST_SOURCES}/baddirname ${TEST_SOURCES}/baddirname
-  expect_output --substring "no such file or directory"
-}
-
 @test "bud with ARG before FROM default value" {
   _prefetch busybox
   target=leading-args-default
@@ -3511,7 +3499,6 @@ _EOF
 
 @test "bud with copy-from and cache" {
   _prefetch busybox
-  target=busybox-image
   run_buildah build $WITH_POLICY_JSON --layers --iidfile ${TEST_SCRATCH_DIR}/iid1 -f $BUDFILES/copy-from/Dockerfile2 $BUDFILES/copy-from
   cat ${TEST_SCRATCH_DIR}/iid1
   test -s ${TEST_SCRATCH_DIR}/iid1
@@ -3970,17 +3957,18 @@ _EOF
 }
 
 @test "bud with specified context should fail if directory contains no Dockerfile" {
-  run_buildah 125 build $WITH_POLICY_JSON "$TEST_SCRATCH_DIR"
+  mkdir -p $TEST_SCRATCH_DIR/empty-dir
+  run_buildah 125 build $WITH_POLICY_JSON "$TEST_SCRATCH_DIR"/empty-dir
   expect_output --substring "no such file or directory"
 }
 
-@test "bud with specified context should fail if assumed Dockerfile is a directory" {
+@test "bud with specified context should fail if Dockerfile in context directory is actually a file" {
   mkdir -p "$TEST_SCRATCH_DIR"/Dockerfile
   run_buildah 125 build $WITH_POLICY_JSON "$TEST_SCRATCH_DIR"
   expect_output --substring "is not a file"
 }
 
-@test "bud with specified context should fail if context contains not-existing Dockerfile" {
+@test "bud with specified context should fail if context directory does not exist" {
   run_buildah 125 build $WITH_POLICY_JSON "$TEST_SCRATCH_DIR"/Dockerfile
   expect_output --substring "no such file or directory"
 }

--- a/tests/bud/cache-mount-locked/Containerfile
+++ b/tests/bud/cache-mount-locked/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:8
+FROM alpine
 
 ARG WIPE_CACHE
 

--- a/tests/bud/cache-mount-locked/Containerfile
+++ b/tests/bud/cache-mount-locked/Containerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/cache1,sharing=locked \
     fi; \
     echo "foo" > /cache1/foo.txt; \
     ls -l /cache1; \
-    chmod --recursive g=u /cache1; \
+    chmod -R g=u /cache1; \
     : ;
 
 # Cache was wiped-out but lock should not hang here: https://github.com/containers/buildah/issues/4342

--- a/tests/containers_conf.bats
+++ b/tests/containers_conf.bats
@@ -146,7 +146,6 @@ _EOF
 retry=10
 retry_delay="5s"
 EOF
-    _prefetch alpine
     CONTAINERS_CONF=${TEST_SCRATCH_DIR}/containers.conf run_buildah build --help
     expect_output --substring "retry.*\(default 10\)"
     expect_output --substring "retry-delay.*\(default \"5s\"\)"

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -20,7 +20,7 @@ load helpers
 }
 
 @test "from-with-digest" {
-  run_buildah pull alpine
+  _prefetch alpine
   run_buildah inspect --format "{{.FromImageID}}" alpine
   digest=$output
 

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -69,6 +69,7 @@ EOF
     # Common options for all buildah and podman invocations
     ROOTDIR_OPTS="--root ${TEST_SCRATCH_DIR}/root --runroot ${TEST_SCRATCH_DIR}/runroot --storage-driver ${STORAGE_DRIVER}"
     BUILDAH_REGISTRY_OPTS="--registries-conf ${TEST_SOURCES}/registries.conf --registries-conf-dir ${TEST_SCRATCH_DIR}/registries.d --short-name-alias-conf ${TEST_SCRATCH_DIR}/cache/shortnames.conf"
+    COPY_REGISTRY_OPTS="--registries-conf ${TEST_SOURCES}/registries.conf --registries-conf-dir ${TEST_SCRATCH_DIR}/registries.d --short-name-alias-conf ${TEST_SCRATCH_DIR}/cache/shortnames.conf"
     PODMAN_REGISTRY_OPTS="--registries-conf ${TEST_SOURCES}/registries.conf"
 }
 
@@ -162,7 +163,7 @@ function _prefetch() {
             rm -fr $_BUILDAH_IMAGE_CACHEDIR/$fname
             echo "# [copy docker://$img dir:$_BUILDAH_IMAGE_CACHEDIR/$fname]" >&2
             for attempt in $(seq 3) ; do
-                if copy docker://"$img" dir:$_BUILDAH_IMAGE_CACHEDIR/$fname ; then
+                if copy $COPY_REGISTRY_OPTS docker://"$img" dir:$_BUILDAH_IMAGE_CACHEDIR/$fname ; then
                     break
                 fi
                 sleep 5

--- a/tests/overlay.bats
+++ b/tests/overlay.bats
@@ -9,6 +9,7 @@ load helpers
     skip "skipping overlay test because \$STORAGE_DRIVER = $STORAGE_DRIVER"
   fi
   image=alpine
+  _prefetch $image
   mkdir ${TEST_SCRATCH_DIR}/lower
   touch ${TEST_SCRATCH_DIR}/lower/foo
 
@@ -38,6 +39,7 @@ load helpers
     skip "skipping overlay test because \$STORAGE_DRIVER = $STORAGE_DRIVER"
   fi
   image=alpine
+  _prefetch $image
   mkdir -m 770 ${TEST_SCRATCH_DIR}/lower
   chown 1:1 ${TEST_SCRATCH_DIR}/lower
   permission=$(stat -c "%a %u %g" ${TEST_SCRATCH_DIR}/lower)
@@ -68,6 +70,7 @@ load helpers
     skip "skipping overlay test because \$STORAGE_DRIVER = $STORAGE_DRIVER"
   fi
   image=alpine
+  _prefetch $image
   mkdir ${TEST_SCRATCH_DIR}/a:lower
   touch ${TEST_SCRATCH_DIR}/a:lower/foo
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -554,6 +554,7 @@ function configure_and_check_user() {
 @test "run-builtin-volume-omitted" {
 	# This image is known to include a volume, but not include the mountpoint
 	# in the image.
+	_prefetch quay.io/libpod/registry:volume_omitted
 	run_buildah from --quiet --pull=ifmissing $WITH_POLICY_JSON quay.io/libpod/registry:volume_omitted
 	cid=$output
 	run_buildah mount $cid
@@ -807,6 +808,7 @@ $output"
 @test "run --network=none and --isolation chroot must conflict" {
 	skip_if_no_runtime
 
+	_prefetch alpine
 	run_buildah from --quiet --pull=ifmissing $WITH_POLICY_JSON alpine
 	cid=$output
 	# should fail by default
@@ -817,6 +819,7 @@ $output"
 @test "run --network=private must mount a fresh /sys" {
 	skip_if_no_runtime
 
+	_prefetch alpine
 	run_buildah from --quiet --pull=ifmissing $WITH_POLICY_JSON alpine
 	cid=$output
         # verify there is no /sys/kernel/security in the container, that would mean /sys
@@ -827,6 +830,7 @@ $output"
 @test "run --network should override build --network" {
 	skip_if_no_runtime
 
+	_prefetch alpine
 	run_buildah from --network=none --quiet --pull=ifmissing $WITH_POLICY_JSON alpine
 	cid=$output
 	# should fail by default


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

* There were a number of integration tests which _should_ run faster if they used the _prefetch function to load cached copies of images that they'd otherwise have had to pull from a registry.
* There was at least one test that was calling _prefetch for an image that it didn't use.
* When prefetching images, we hadn''t been using the same registry configuration (including rewrites, short names, and mirror settings) that we passed to the buildah binary when we called it later, meaning that we didn't prefetch the copies of images that we've intentionally mirrored elsewhere.
* Some tests were removing images before returning, when storage is cleaned up and initialized fresh for every test, so they didn't need to bother.

#### How to verify it

So many updated integration tests!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```