### PR TITLE
Switch packit configuration to use epel-9-$arch instead of centos-stream+epel-next-9-$arch

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,8 +22,8 @@ jobs:
       - fedora-eln-aarch64
       - centos-stream+epel-next-8-x86_64
       - centos-stream+epel-next-8-aarch64
-      - centos-stream+epel-next-9-x86_64
-      - centos-stream+epel-next-9-aarch64
+      - epel-9-x86_64
+      - epel-9-aarch64
     additional_repos:
       - "copr://rhcontainerbot/podman-next"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

This mirrors a change which was just made in https://github.com/containers/podman/pull/22432.  The version of golang in the previously-used chroot was missing the `crypto/ecdsa.HashSign()` symbol which `github.com/containers/libtrust` attempts to call when built with the `libtrust_openssl` tag.

#### How to verify it

Tests should start passing.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```