### PR TITLE
integration test: handle new labels in "bud and test --unsetlabel"

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2296,24 +2296,32 @@ _EOF
 }
 
 @test "bud and test --unsetlabel" {
-  _prefetch registry.fedoraproject.org/fedora-minimal
+  base=registry.fedoraproject.org/fedora-minimal
+  _prefetch $base
+  target=exp
+
   run_buildah --version
   local -a output_fields=($output)
   buildah_version=${output_fields[2]}
-  run_buildah build $WITH_POLICY_JSON -t exp -f $BUDFILES/base-with-labels/Containerfile
 
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "license"}}' exp
-  expect_output "MIT" "license must be MIT from fedora base image"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' exp
-  expect_output "fedora" "name must be fedora from base image"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "vendor"}}' exp
-  expect_output "Fedora Project" "vendor must be fedora from base image"
+  buildah inspect --format '{{ .Docker.Config.Labels }}' $base
+  not_want_output='map[]'
+  assert "$output" != "$not_want_output" "expected some labels to be set in base image $base"
 
-  run_buildah build $WITH_POLICY_JSON --unsetlabel license --unsetlabel name --unsetlabel vendor --unsetlabel version --label hello=world -t exp -f $BUDFILES/base-with-labels/Containerfile
-  # no labels should be inherited from base image only the, buildah version label
+  labels=$(buildah inspect --format '{{ range $key, $value := .Docker.Config.Labels }}{{ $key }} {{end}}' $base)
+  labelflags="--label hello=world"
+  for label in $labels; do
+    if test $label != io.buildah.version ; then
+      labelflags="$labelflags --unsetlabel $label"
+    fi
+  done
+
+  run_buildah build $WITH_POLICY_JSON $labelflags -t $target --from $base $BUDFILES/base-with-labels
+
+  # no labels should be inherited from base image, only the buildah version label
   # and `hello=world` which we just added using cli flag
   want_output='map["hello":"world" "io.buildah.version":"'$buildah_version'"]'
-  run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' exp
+  run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' $target
   expect_output "$want_output"
 }
 

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -82,17 +82,18 @@ function check_matrix() {
 }
 
 @test "config --unsetlabel" {
-  _prefetch registry.fedoraproject.org/fedora-minimal
-  run_buildah from --quiet --pull=false $WITH_POLICY_JSON registry.fedoraproject.org/fedora-minimal
+  base=registry.fedoraproject.org/fedora-minimal
+  _prefetch $base
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON $base
   cid=$output
   run_buildah commit $WITH_POLICY_JSON $cid with-name-label
   run_buildah config --unsetlabel name $cid
   run_buildah commit $WITH_POLICY_JSON $cid without-name-label
 
   run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' with-name-label
-  expect_output "fedora" "name label should be set with value as fedora"
+  assert "$output" != "" "label should be set in base image"
   run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' without-name-label
-  expect_output "" "name label should be removed"
+  assert "$output" == "" "name label should be removed"
 }
 
 @test "config set empty entrypoint doesn't wipe cmd" {


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Instead of assuming which labels are set in our base image, and using the `--unsetlabel` flag to suppress them in a derived image, query the base image and unset all of them, except for our own version label.  The newly-current `fedora-minimal:40` has more labels set on it than `fedora-minimal:39` did, and I don't want to have to revise this test again in six months.

#### How to verify it

The "bud and test --unsetlabel" test should pass again.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```