### PR TITLE
conformance: add a test that tries to chowning a volume

### DIFF
--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -3102,6 +3102,11 @@ var internalTestCases = []testCase{
 		contextDir:        "multistage/copyback",
 		dockerUseBuildKit: true,
 	},
+
+	{
+		name:       "chown-volume",
+		contextDir: "chown-volume",
+	},
 }
 
 func TestCommit(t *testing.T) {

--- a/tests/conformance/testdata/chown-volume/Dockerfile
+++ b/tests/conformance/testdata/chown-volume/Dockerfile
@@ -1,0 +1,9 @@
+FROM busybox AS first
+RUN mkdir /volumea /volumeb /volumec
+RUN touch -r /bin/ls /volumea /volumeb /volumec
+VOLUME /volumea
+VOLUME /volumeb
+VOLUME /volumec
+
+FROM first
+RUN chown 1000:1000 /volumea /volumeb /volumec


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Add a conformance test that attempts to "chown" a volume declared in a base image, which produces different results depending on whether we're using the BuildKit-based builder or the V1 "classic" builder.  For now, don't try to change our behavior, and continue imitating the behavior of the classic builder.

#### How to verify it

New conformance test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
