### PR TITLE
Integration tests: fake up a replacement for nixery.dev/shell

### DIFF
--- a/tests/bud/no-history/Dockerfile
+++ b/tests/bud/no-history/Dockerfile
@@ -1,7 +1,9 @@
 # The important thing about that first base image is that it has no history
-# entries, but it does have at least one layer.
+# entries, but it does have at least one layer.  This base image is built
+# during the test that uses this Dockerfile, and isn't in a registry.
 
-FROM nixery.dev/shell AS first-stage
+FROM fakeregistry.podman.invalid/notreal AS first-stage
+COPY --from=busybox / /
 RUN date > /date1.txt
 RUN sleep 1 > /sleep1.txt
 


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Build a fake layers-but-no-history image that should work more or less as well for the tests that we were previously using nixery.dev/shell for.

#### How to verify it

Updated integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```