### PR TITLE
Makefile: set GOTOOLCHAIN=local

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,4 +56,7 @@
     "**/tests/**"
   ],
 
+  "env": {
+    "GOTOOLCHAIN": "local"
+  }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Set GOTOOLCHAIN=local for all make targets, and for renovate.

Have the "vendor" target (and by extension, "vendor-in-container", which our validation in CI uses) clear any "toolchain" directive that might have been added to go.mod through manual invocations of the compiler.

At this point, we probably don't need to be checking for Go module support, so switch to assuming it's available.

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```