### PR TITLE
Don't set GOTOOLCHAIN=local

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,9 +54,5 @@
     "**/docs/**",
     "**/examples/**",
     "**/tests/**"
-  ],
-
-  "env": {
-    "GOTOOLCHAIN": "local"
-  }
+  ]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 export GOPROXY=https://proxy.golang.org
-export GOTOOLCHAIN=local
 
 APPARMORTAG := $(shell hack/apparmor_tag.sh)
 STORAGETAGS := exclude_graphdriver_devicemapper $(shell ./btrfs_tag.sh) $(shell ./btrfs_installed_tag.sh) $(shell ./hack/libsubid_tag.sh)


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

We can't set GOTOOLCHAIN in both the Makefile and in the renovate bot's configuration because the bot doesn't allow us to set that variable in its configuration, and we can only override that if we're hosting the bot ourselves, and I don't think that we are.

#### How to verify it

We'll see new PRs being filed by the bot again.

#### Which issue(s) this PR fixes:

Fixes #5512.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```