### PR TITLE
[skip-ci] Packit: enable c10s downstream sync

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,8 +2,18 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-specfile_path: rpm/buildah.spec
+downstream_package_name: buildah
 upstream_tag_template: v{version}
+
+packages:
+  buildah-fedora:
+    pkg_tool: fedpkg
+    specfile_path: rpm/buildah.spec
+  buildah-centos:
+    pkg_tool: centpkg
+    specfile_path: rpm/buildah.spec
+  buildah-rhel:
+    specfile_path: rpm/buildah.spec
 
 srpm_build_deps:
   - make
@@ -11,35 +21,68 @@ srpm_build_deps:
 jobs:
   - job: copr_build
     trigger: pull_request
-    notifications:
+    packages: [buildah-fedora]
+    notifications: &copr_build_failure_notification
       failure_comment:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
-    enable_net: true
     targets:
-      - fedora-all-x86_64
-      - fedora-all-aarch64
-      - fedora-eln-x86_64
-      - fedora-eln-aarch64
+      fedora-all-x86_64: {}
+      fedora-all-aarch64: {}
+      fedora-eln-x86_64:
+        additional_repos:
+          - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/x86_64/"
+      fedora-eln-aarch64:
+        additional_repos:
+          - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/aarch64/"
+    enable_net: true
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [buildah-centos]
+    notifications: *copr_build_failure_notification
+    targets:
+      - centos-stream-9-x86_64
+      - centos-stream-9-aarch64
+      - centos-stream-10-x86_64
+      - centos-stream-10-aarch64
+    enable_net: true
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [buildah-rhel]
+    notifications: *copr_build_failure_notification
+    targets:
       - epel-9-x86_64
       - epel-9-aarch64
-    additional_repos:
-      - "copr://rhcontainerbot/podman-next"
+    enable_net: true
 
   # Run on commit to main branch
   - job: copr_build
     trigger: commit
+    packages: [buildah-fedora]
     notifications:
       failure_comment:
         message: "podman-next COPR build failed. @containers/packit-build please check."
+    branch: main
     owner: rhcontainerbot
     project: podman-next
     enable_net: true
 
+  # Sync to Fedora
   - job: propose_downstream
     trigger: release
+    packages: [buildah-fedora]
     update_release: false
     dist_git_branches:
       - fedora-all
+
+  # Sync to CentOS Stream
+  - job: propose_downstream
+    trigger: release
+    packages: [buildah-centos]
+    update_release: false
+    dist_git_branches:
+      - c10s
 
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
This commit will enable downstream syncing to CentOS Stream 10. The centos maintainer will need to manually run `packit propose-downstream` and `centpkg build` until better centos integration is in place.

This commit also builds both rhel9 and centos9 copr rpms so we can check for things like differences in golang compiler.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

enables downstream syncing to c10s

#### How to verify it

can't be verified pre-merge. After a release is cut, the centos maintainer will run `packit propose downstream -p buildah-centos` to trigger a centos merge request.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->
None


#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

