### PR TITLE
fix CentOS/RHEL build - no BATS there

### DIFF
--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -86,7 +86,9 @@ or
 Summary: Tests for %{name}
 
 Requires: %{name} = %{version}-%{release}
+%if %{defined fedora}
 Requires: bats
+%endif
 Requires: bzip2
 Requires: podman
 Requires: golang


### PR DESCRIPTION
#### What type of PR is this?
kind bug

#### What this PR does / why we need it:
Without this PR CentOS 10/ RHEL10 build would fail as it doesn't have BATS package.

#### How to verify it
"rpm -qp --requires buildah*.rpm | grep bats" should output nothing on non-Fedora.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
