### PR TITLE
CI: Clarify Debian use for conformance tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -181,7 +181,7 @@ unit_task:
 
 
 conformance_task:
-    name: 'Build Conformance w/ $STORAGE_DRIVER'
+    name: 'Debian Conformance w/ $STORAGE_DRIVER'
     alias: conformance
     only_if: *not_build_docs
     depends_on: *smoke_vendor_cross


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

For many other CI tasks, the platform is included in the name.  For whatever reason this was never done for the conformance tests and can be confusing for maintainers.  Make it clear that they are running on Debian.

#### How to verify it

Manually look at the task names

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Ref: https://github.com/containers/buildah/pull/5526#issuecomment-2115333652

#### Does this PR introduce a user-facing change?

```release-note
None
```

