### PR TITLE
build: be more selective about specifying the default OS

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -222,7 +222,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 	systemContext := options.SystemContext
 	for _, platform := range options.Platforms {
 		platformContext := *systemContext
-		if platform.OS == "" {
+		if platform.OS == "" && platform.Arch != "" {
 			platform.OS = runtime.GOOS
 		}
 		platformSpec := internalUtil.NormalizePlatform(v1.Platform{

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6811,3 +6811,17 @@ _EOF
   assert "$status" -eq 2 "exit code from ls"
   expect_output --substring "No such file or directory"
 }
+
+@test "pull policy" {
+  echo FROM busybox > ${TEST_SCRATCH_DIR}/Containerfile
+  arch=amd64
+  if test $(arch) = x86_64 ; then
+    arch=arm64
+  fi
+  # specifying the arch should trigger "just pull it anyway" in containers/common
+  run_buildah build --pull=missing --arch $arch --iidfile ${TEST_SCRATCH_DIR}/image1.txt ${TEST_SCRATCH_DIR}
+  # not specifying the arch should trigger "yeah, fine, whatever we already have is fine" in containers/common
+  run_buildah build --pull=missing --iidfile ${TEST_SCRATCH_DIR}/image2.txt ${TEST_SCRATCH_DIR}
+  # both of these should have just been the base image's ID, which shouldn't have changed the second time around
+  cmp ${TEST_SCRATCH_DIR}/image1.txt ${TEST_SCRATCH_DIR}/image2.txt
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Only add the default OS to a build target platform struct if the architecture was specified without one, so that the pull logic in containers/common doesn't override our pull policy when it doesn't need to.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

This should restore the ability to use `--pull=missing`, which was inadvertently broken in #5478.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```