### PR TITLE
Execute cross-build task using PW pool

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,23 +135,36 @@ vendor_task:
 cross_build_task:
     name: "Cross Compile"
     alias: cross_build
-    only_if: >-
+    only_if: |
+        ($CIRRUS_BRANCH =~ "pull/.*" ||
+         $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH) &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
-
-    osx_instance:
-        image: ghcr.io/cirruslabs/macos-ventura-base:latest
-
-    script:
-        - brew update
-        - brew install go
-        - brew install go-md2man
-        - brew install gpgme
+    persistent_worker: &mac_pw
+        labels:
+            os: darwin
+            arch: arm64
+            purpose: prod
+    env:
+        CIRRUS_WORKING_DIR: "$HOME/ci/task-${CIRRUS_TASK_ID}"
+        # Prevent cache-pollution fron one task to the next.
+        GOPATH: "$CIRRUS_WORKING_DIR/.go"
+        GOCACHE: "$CIRRUS_WORKING_DIR/.go/cache"
+        GOENV: "$CIRRUS_WORKING_DIR/.go/support"
+        GOSRC: "$HOME/ci/task-${CIRRUS_TASK_ID}"
+        TMPDIR: "/private/tmp/ci"
+    # This host is/was shared with potentially many other CI tasks.
+    # The previous task may have been canceled or aborted.
+    prep_script: &mac_cleanup "contrib/cirrus/mac_cleanup.sh"
+    build_script:
+        - mkdir -p "$TMPDIR"
         - go version
         - make cross CGO_ENABLED=0
-
     binary_artifacts:
         path: ./bin/*
-
+    # This host is/was shared with potentially many other CI tasks.
+    # Ensure nothing is left running while waiting for the next task.
+    always:
+        task_cleanup_script: *mac_cleanup
 
 unit_task:
     name: 'Unit tests w/ $STORAGE_DRIVER'

--- a/contrib/cirrus/mac_cleanup.sh
+++ b/contrib/cirrus/mac_cleanup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This script is intended to be called by Cirrus-CI on a Mac M1 persistent worker.
+# It performs a best-effort attempt at cleaning up from one task execution to the next.
+# Since it run both before and after tasks, it must exit cleanly if there was a cleanup
+# failure (i.e. file or directory not found).
+
+# Help anybody debugging side-effects, since failures are ignored (by necessity).
+set +e -x
+
+# These are the main processes which could leak out of testing.
+killall podman vfkit gvproxy make go ginkgo
+
+mkdir -p $TMPDIR
+
+# Golang will leave behind lots of read-only bits, ref:
+# https://go.dev/ref/mod#module-cache
+# However other tools/scripts could also set things read-only.
+# At this point in CI, we really want all this stuff gone-gone,
+# so there's actually zero-chance it can interfere.
+chmod -R u+w $TMPDIR/* $TMPDIR/.??*
+
+# This is defined as $TMPDIR during setup.  Name must be kept
+# "short" as sockets may reside here.  Darwin suffers from
+# the same limited socket-pathname character-length restriction
+# as Linux.
+rm -rf $TMPDIR/* $TMPDIR/.??*
+
+# Don't change or clobber anything under $CIRRUS_WORKING_DIR for
+# the currently running task.  But make sure we have write permission
+# (go get sets dependencies ro) for everything else, before removing it.
+# First make everything writeable - see the "Golang will..." comment above.
+# shellcheck disable=SC2154
+find "$HOME/ci" -mindepth 1 -maxdepth 1 \
+    -not -name "*task-${CIRRUS_TASK_ID}*" -prune -exec chmod -R u+w '{}' +
+find "$HOME/ci" -mindepth 1 -maxdepth 1 \
+    -not -name "*task-${CIRRUS_TASK_ID}*" -prune -exec rm -rf '{}' +
+
+# Bash scripts exit with the status of the last command.
+true


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Previously this task ran using the Cirrus-CI compute service, consuming
compute credits.  However, since podman is already using a persistent
worker pool for CI, it can also be leveraged for use here.  Since Mac
resources are relatively expensive, it also makes financial sense to
re-use infrastructure where possible.

#### How to verify it

The `cross_build_task` will pass, and a manual check of the worker it ran on will show no abnormalities.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

* This change also restricts the cross-build task to only running on
  the default branch.  This is necessary because the PW Pool environment
  is always rolling forward and may not match what was in place at the
  time a release-branch was created.
* This runs buildah tasks on the infra originally designed for
  podman-machine testing.  Coordinating changes to the underlying
  setup/automation for two repos is more complex and challenging.
* Payment to Cirrus for Mac compute resources is a manual process,
  as opposed to automated cloud-payments.
* The more the podman-machine CI infra is shared, the cheaper
  maintaining it becomes.

#### Does this PR introduce a user-facing change?

```release-note
None
```

