### PR TITLE
Add some NetBSD support

### DIFF
--- a/copier/hardlink_uint64.go
+++ b/copier/hardlink_uint64.go
@@ -1,5 +1,5 @@
-//go:build (linux && !mips && !mipsle && !mips64 && !mips64le) || freebsd
-// +build linux,!mips,!mipsle,!mips64,!mips64le freebsd
+//go:build (linux && !mips && !mipsle && !mips64 && !mips64le) || freebsd || netbsd
+// +build linux,!mips,!mipsle,!mips64,!mips64le freebsd netbsd
 
 package copier
 

--- a/copier/hardlink_unix.go
+++ b/copier/hardlink_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || darwin || freebsd
-// +build linux darwin freebsd
+//go:build !windows
+// +build !windows
 
 package copier
 

--- a/define/mount_unsupported.go
+++ b/define/mount_unsupported.go
@@ -1,5 +1,5 @@
-//go:build darwin || windows
-// +build darwin windows
+//go:build darwin || windows || netbsd
+// +build darwin windows netbsd
 
 package define
 

--- a/pkg/util/uptime_netbsd.go
+++ b/pkg/util/uptime_netbsd.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func clockGettime(clockid int32, time *unix.Timespec) (err error) {
+	_, _, e1 := unix.Syscall(unix.SYS_CLOCK_GETTIME, uintptr(clockid), uintptr(unsafe.Pointer(time)), 0)
+	if e1 != 0 {
+		return e1
+	}
+	return nil
+}
+
+func ReadUptime() (time.Duration, error) {
+	tv, err := unix.SysctlTimeval("kern.boottime")
+	if err != nil {
+		return 0, err
+	}
+	sec, nsec := tv.Unix()
+	return time.Now().Sub(time.Unix(sec, nsec)), nil
+}

--- a/pkg/util/version_unix.go
+++ b/pkg/util/version_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || freebsd || darwin
-// +build linux freebsd darwin
+//go:build !windows
+// +build !windows
 
 package util
 

--- a/util/util_unix.go
+++ b/util/util_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || darwin || freebsd
-// +build linux darwin freebsd
+//go:build linux || darwin || freebsd || netbsd
+// +build linux darwin freebsd netbsd
 
 package util
 


### PR DESCRIPTION
I've been using podman on NetBSD, which uses some buildah code as a dependency.
I will note that buildah itself is not working (aside from building with the `buildah` target after these changes), but it would be nice not to have to patch the vendored buildah code in podman.

/kind other