### PR TITLE
Re-enable two conformance tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -188,6 +188,7 @@ conformance_task:
     matrix:
         - env:
             STORAGE_DRIVER: 'vfs'
+            TMPDIR: '/var/tmp'
         - env:
             STORAGE_DRIVER: 'overlay'
 

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -10,6 +10,9 @@ source $(dirname $0)/lib.sh
 
 req_env_vars OS_RELEASE_ID OS_RELEASE_VER GOSRC IN_PODMAN_IMAGE CIRRUS_CHANGE_TITLE
 
+msg "Running df."
+df -hT
+
 msg "Disabling git repository owner-check system-wide."
 # Newer versions of git bark if repo. files are unexpectedly owned.
 # This mainly affects rootless and containerized testing.  But

--- a/image.go
+++ b/image.go
@@ -322,7 +322,6 @@ func (i *containerImageRef) createConfigsAndManifests() (v1.Image, v1.Manifest, 
 	if err := json.Unmarshal(i.dconfig, &dimage); err != nil {
 		return v1.Image{}, v1.Manifest{}, docker.V2Image{}, docker.V2S2Manifest{}, err
 	}
-	dimage.Parent = docker.ID(i.parent)
 	dimage.Container = i.containerID
 	if dimage.Config != nil {
 		dimage.ContainerConfig = *dimage.Config

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -173,18 +173,6 @@ load helpers
         expect_output "$buildah_version"
 }
 
-@test "commit-parent-id" {
-  _prefetch alpine
-  run_buildah from --quiet --pull $WITH_POLICY_JSON alpine
-  cid=$output
-  run_buildah inspect --format '{{.FromImageID}}' $cid
-  iid=$output
-
-  run_buildah commit $WITH_POLICY_JSON --format docker $cid alpine-image
-  run_buildah inspect --format '{{.Docker.Parent}}' alpine-image
-  expect_output "sha256:$iid" "alpine-image -> .Docker.Parent"
-}
-
 @test "commit-container-id" {
   _prefetch alpine
   run_buildah from --quiet --pull $WITH_POLICY_JSON alpine

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1580,25 +1580,24 @@ var internalTestCases = []testCase{
 		},
 	},
 
-	// FIXME 2024-05-29 fails with latest buildah, see #5526
-//	{
-//		// from internal team chat
-//		name: "ci-pipeline-modified",
-//		dockerfileContents: strings.Join([]string{
-//			"FROM busybox",
-//			"WORKDIR /go/src/github.com/openshift/ocp-release-operator-sdk/",
-//			"ENV GOPATH=/go",
-//			"RUN env | grep -E -v '^(HOSTNAME|OLDPWD)=' | LANG=C sort | tee /env-contents.txt\n",
-//		}, "\n"),
-//		fsSkip: []string{
-//			"(dir):go:mtime",
-//			"(dir):go:(dir):src:mtime",
-//			"(dir):go:(dir):src:(dir):github.com:mtime",
-//			"(dir):go:(dir):src:(dir):github.com:(dir):openshift:mtime",
-//			"(dir):go:(dir):src:(dir):github.com:(dir):openshift:(dir):ocp-release-operator-sdk:mtime",
-//			"(dir):env-contents.txt:mtime",
-//		},
-//	},
+	{
+		// from internal team chat
+		name: "ci-pipeline-modified",
+		dockerfileContents: strings.Join([]string{
+			"FROM busybox",
+			"WORKDIR /go/src/github.com/openshift/ocp-release-operator-sdk/",
+			"ENV GOPATH=/go",
+			"RUN env | grep -E -v '^(HOSTNAME|OLDPWD)=' | LANG=C sort | tee /env-contents.txt\n",
+		}, "\n"),
+		fsSkip: []string{
+			"(dir):go:mtime",
+			"(dir):go:(dir):src:mtime",
+			"(dir):go:(dir):src:(dir):github.com:mtime",
+			"(dir):go:(dir):src:(dir):github.com:(dir):openshift:mtime",
+			"(dir):go:(dir):src:(dir):github.com:(dir):openshift:(dir):ocp-release-operator-sdk:mtime",
+			"(dir):env-contents.txt:mtime",
+		},
+	},
 
 	{
 		name:          "add-permissions",

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1493,12 +1493,11 @@ var internalTestCases = []testCase{
 		fsSkip:     []string{"(dir):usr:(dir):bin:mtime"},
 	},
 
-	// FIXME 2024-05-29 fails under vfs, see #5526
-//	{
-//		name:       "copy with --chown",
-//		contextDir: "copychown",
-//		fsSkip:     []string{"(dir):usr:(dir):bin:mtime", "(dir):usr:(dir):local:(dir):bin:mtime"},
-//	},
+	{
+		name:       "copy with --chown",
+		contextDir: "copychown",
+		fsSkip:     []string{"(dir):usr:(dir):bin:mtime", "(dir):usr:(dir):local:(dir):bin:mtime"},
+	},
 
 	{
 		name:       "directory with slash",

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -3107,6 +3107,24 @@ var internalTestCases = []testCase{
 		dockerUseBuildKit: true,
 		fsSkip:            []string{"(dir):etc:(dir):hostname"}, // buildkit does not create a phantom /etc/hostname
 	},
+
+	{
+		name: "workdir with trailing separator",
+		dockerfileContents: strings.Join([]string{
+			"FROM busybox",
+			"USER daemon",
+			"WORKDIR /tmp/",
+		}, "\n"),
+	},
+
+	{
+		name: "workdir without trailing separator",
+		dockerfileContents: strings.Join([]string{
+			"FROM busybox",
+			"USER daemon",
+			"WORKDIR /tmp",
+		}, "\n"),
+	},
 }
 
 func TestCommit(t *testing.T) {

--- a/tests/conformance/testdata/copychown/Dockerfile
+++ b/tests/conformance/testdata/copychown/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM quay.io/libpod/centos:7
 COPY --chown=1:2    script /usr/bin/script.12
 COPY --chown=1:adm  script /usr/bin/script.1-adm
 COPY --chown=1      script /usr/bin/script.1

--- a/tests/conformance/testdata/copyempty/Dockerfile
+++ b/tests/conformance/testdata/copyempty/Dockerfile
@@ -1,2 +1,2 @@
-FROM centos:8
+FROM quay.io/libpod/centos:7
 COPY "" /usr/local/tmp/

--- a/tests/conformance/testdata/copyempty/Dockerfile2
+++ b/tests/conformance/testdata/copyempty/Dockerfile2
@@ -1,2 +1,2 @@
-FROM centos:8
+FROM quay.io/libpod/centos:7
 COPY script1 "" script2 /usr/local/tmp/

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -150,7 +150,7 @@ load helpers
 
   start_registry
   run_buildah push $WITH_POLICY_JSON --tls-verify=false --creds testuser:testpassword docker.io/busybox:latest docker://localhost:${REGISTRY_PORT}/buildah/busybox:latest
-  docker login localhost:${REGISTRY_PORT} --username testuser --password testpassword
+  docker login localhost:${REGISTRY_PORT} --username testuser --password-stdin <<<testpassword
   docker pull localhost:${REGISTRY_PORT}/buildah/busybox:latest
   output=$(docker images)
   expect_output --substring "buildah/busybox"


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

* Stops setting the "parent" field when committing an image in Docker format.

#### How to verify it

New conformance tests for the bits we changed in imagebuilder!  Also, the ones we already had should all be passing again!

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The "parent" field is no longer set in committed images.
```