### PR TITLE
Cross-build on Fedora

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -137,15 +137,9 @@ cross_build_task:
     alias: cross_build
     only_if: >-
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
-
-    osx_instance:
-        image: ghcr.io/cirruslabs/macos-ventura-base:latest
-
+    env:
+        HOME: /root
     script:
-        - brew update
-        - brew install go
-        - brew install go-md2man
-        - brew install gpgme
         - go version
         - make cross CGO_ENABLED=0
 


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Executing a golang cross-compile on an expensive resource such as a Mac has questionable overall value.  Switch to running on a default Fedora VM instead.

#### How to verify it

The `cross_build` task will complete without any errors.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Ref. discussion: https://github.com/containers/buildah/pull/5551#issuecomment-2146144584

#### Does this PR introduce a user-facing change?

```release-note
None
```

