### PR TITLE
tests: set _CONTAINERS_USERNS_CONFIGURED=done for libnetwork

### DIFF
--- a/tests/chroot.bats
+++ b/tests/chroot.bats
@@ -96,9 +96,9 @@ load helpers
   # and --map-groups, but fedora 37's is too old, so the older OUTER,INNER,SIZE
   # (using commas instead of colons as field separators) will have to do
   echo "env | sort" >> ${TEST_SCRATCH_DIR}/script.sh
-  echo "unshare -Umpf --mount-proc --setuid 0 --setgid 0 --map-users=${subid},0,${rangesize} --map-groups=${subid},0,${rangesize} ${COPY_BINARY} ${storageopts} dir:$_BUILDAH_IMAGE_CACHEDIR/$baseimagef containers-storage:$baseimage" >> ${TEST_SCRATCH_DIR}/script.sh
+  echo "env _CONTAINERS_USERNS_CONFIGURED=done unshare -Umpf --mount-proc --setuid 0 --setgid 0 --map-users=${subid},0,${rangesize} --map-groups=${subid},0,${rangesize} ${COPY_BINARY} ${storageopts} dir:$_BUILDAH_IMAGE_CACHEDIR/$baseimagef containers-storage:$baseimage" >> ${TEST_SCRATCH_DIR}/script.sh
   # try to do a build with all of the volume mounts
-  echo "unshare -Umpf --mount-proc --setuid 0 --setgid 0 --map-users=${subid},0,${rangesize} --map-groups=${subid},0,${rangesize} ${BUILDAH_BINARY} ${BUILDAH_REGISTRY_OPTS} ${storageopts} build --isolation chroot --pull=never $mounts $context" >> ${TEST_SCRATCH_DIR}/script.sh
+  echo "env _CONTAINERS_USERNS_CONFIGURED=done unshare -Umpf --mount-proc --setuid 0 --setgid 0 --map-users=${subid},0,${rangesize} --map-groups=${subid},0,${rangesize} ${BUILDAH_BINARY} ${BUILDAH_REGISTRY_OPTS} ${storageopts} build --isolation chroot --pull=never $mounts $context" >> ${TEST_SCRATCH_DIR}/script.sh
   # run that whole script in a nested mount namespace with no $XDG_...
   # variables leaked into it
   if is_rootless ; then


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Starting in common 0.59.1, github.com/containers/common's libnetwork no longer attempts to detect when it's running in a user namespace to decide where a lock file that it uses will be.  Since this test is doing user namespace setup on its own as part of the test, we need to explicitly tell it to not use the one that belongs to the node's root user.

#### How to verify it

Updated integration test!

#### Which issue(s) this PR fixes:

Unblocks #5567.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```