### PR TITLE
containerImageRef.NewImageSource(): move the FROM comment to first

### DIFF
--- a/image.go
+++ b/image.go
@@ -721,18 +721,18 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, sc *types.System
 			Created:    &created,
 			CreatedBy:  i.createdBy,
 			Author:     oimage.Author,
-			Comment:    comment,
 			EmptyLayer: i.emptyLayer,
 		}
 		oimage.History = append(oimage.History, onews)
+		oimage.History[baseImageHistoryLen].Comment = comment
 		dnews := docker.V2S2History{
 			Created:    created,
 			CreatedBy:  i.createdBy,
 			Author:     dimage.Author,
-			Comment:    comment,
 			EmptyLayer: i.emptyLayer,
 		}
 		dimage.History = append(dimage.History, dnews)
+		dimage.History[baseImageHistoryLen].Comment = comment
 		appendHistory(i.postEmptyLayers)
 
 		// Add a history entry for the extra image content if we added a layer for it.

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1604,6 +1604,15 @@ _EOF
   expect_line_count 18
 }
 
+@test "bud with no --layers comment" {
+  _prefetch alpine
+  run_buildah build --pull-never $WITH_POLICY_JSON --layers=false --no-cache -t test $BUDFILES/use-layers
+  run_buildah images -a
+  expect_line_count 3
+  run_buildah inspect --format "{{index .Docker.History 2}}" test
+  expect_output --substring "FROM docker.io/library/alpine:latest"
+}
+
 @test "bud with --layers and single and two line Dockerfiles" {
   _prefetch alpine
   run_buildah inspect --format "{{.FromImageDigest}}" alpine


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If we're prepending history entries before the one for "this" commit, make sure the "FROM $baseimage" comment gets set on the first history entry that we add, not just the one goes with this (maybe) layer diff. In layers=false mode, the output was so, so confusing otherwise.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Images built using `buildah build` without `--layers=true` will describe their base image in the history entry for the first instruction that was processed, rather than the last.
```