### PR TITLE
commit: set "parent" for docker format only when requested

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -128,6 +128,10 @@ type CommitOptions struct {
 	// SBOMScanOptions encapsulates options which control whether or not we
 	// run scanners on the rootfs that we're about to commit, and how.
 	SBOMScanOptions []SBOMScanOptions
+	// CompatSetParent causes the "parent" field to be set when committing
+	// the image in Docker format.  Newer BuildKit-based builds don't set
+	// this field.
+	CompatSetParent types.OptionalBool
 }
 
 var (

--- a/define/build.go
+++ b/define/build.go
@@ -366,4 +366,8 @@ type BuildOptions struct {
 	// LookupReferenceFunc used to look up destination references for cache
 	// pushes
 	CachePushDestinationLookupReferenceFunc libimage.LookupReferenceFunc
+	// CompatSetParent causes the "parent" field to be set in the image's
+	// configuration when committing in Docker format.  Newer
+	// BuildKit-based docker build doesn't set this field.
+	CompatSetParent types.OptionalBool
 }

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -160,6 +160,7 @@ type Executor struct {
 	confidentialWorkload                    define.ConfidentialWorkloadOptions
 	sbomScanOptions                         []define.SBOMScanOptions
 	cdiConfigDir                            string
+	compatSetParent                         types.OptionalBool
 }
 
 type imageTypeAndHistoryAndDiffIDs struct {
@@ -316,6 +317,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		confidentialWorkload:                    options.ConfidentialWorkload,
 		sbomScanOptions:                         options.SBOMScanOptions,
 		cdiConfigDir:                            options.CDIConfigDir,
+		compatSetParent:                         options.CompatSetParent,
 	}
 	if exec.err == nil {
 		exec.err = os.Stderr

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -2252,6 +2252,7 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		RetryDelay:            s.executor.retryPullPushDelay,
 		HistoryTimestamp:      s.executor.timestamp,
 		Manifest:              s.executor.manifest,
+		CompatSetParent:       s.executor.compatSetParent,
 	}
 	if finalInstruction {
 		options.ConfidentialWorkloadOptions = s.executor.confidentialWorkload


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

Make setting the Parent field in the config blob of a docker format image optional (yes, we're bringing it back!), since it no longer appears to be set by newer versions of docker build.

#### How to verify it

Updated conformance tests!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

For the moment I expect this to be more useful for API consumers, but it could be exposed at the command line if we needed it to be.

#### Does this PR introduce a user-facing change?

```release-note
None
```