### PR TITLE
buildah copy: preserve owner info with --from= a container or image

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -160,6 +160,7 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 		return errors.New("--ignorefile option requires that you specify a context dir using --contextdir")
 	}
 
+	var preserveOwnership bool
 	if iopts.from != "" {
 		if from, err = openBuilder(getContext(), store, iopts.from); err != nil && errors.Is(err, storage.ErrContainerUnknown) {
 			systemContext, err2 := parse.SystemContextFromOptions(c)
@@ -221,6 +222,7 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 			}
 		}()
 		idMappingOptions = &from.IDMappingOptions
+		preserveOwnership = true
 		contextdir = filepath.Join(fromMountPoint, iopts.contextdir)
 		for i := range args {
 			args[i] = filepath.Join(fromMountPoint, args[i])
@@ -235,11 +237,12 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 	builder.ContentDigester.Restart()
 
 	options := buildah.AddAndCopyOptions{
-		Chmod:            iopts.chmod,
-		Chown:            iopts.chown,
-		Checksum:         iopts.checksum,
-		ContextDir:       contextdir,
-		IDMappingOptions: idMappingOptions,
+		Chmod:             iopts.chmod,
+		Chown:             iopts.chown,
+		PreserveOwnership: preserveOwnership,
+		Checksum:          iopts.checksum,
+		ContextDir:        contextdir,
+		IDMappingOptions:  idMappingOptions,
 	}
 	if iopts.contextdir != "" {
 		var excludes []string

--- a/docs/buildah-copy.1.md
+++ b/docs/buildah-copy.1.md
@@ -28,11 +28,13 @@ container digest string. Only supported for HTTP sources.
 
 **--chmod** *permissions*
 
-Sets the access permissions of the destination content. Accepts the numerical format.
+Sets the access permissions of the destination content.  Accepts the numerical
+format.  If `--from` is not used, defaults to `0755`.
 
 **--chown** *owner*:*group*
 
-Sets the user and group ownership of the destination content.
+Sets the user and group ownership of the destination content.  If `--from` is
+not used, defaults to `0:0`.
 
 **--contextdir** *directory*
 
@@ -45,7 +47,8 @@ by symbolic links outside of the chroot will fail.
 Use the root directory of the specified working container or image as the root
 directory when resolving absolute source paths and the path of the context
 directory.  If an image needs to be pulled, options recognized by `buildah pull`
-can be used.
+can be used.  If `--chown` or `--chmod` are not used, permissions and ownership
+is preserved.
 
 **--ignorefile** *file*
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `buildah copy` is invoked with a `--from` flag, default to preserving ownerships that were set in the source container or image. Retain the "set it to 0:0 by default" behavior when `--from` is not being used.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes #5587.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
When `buildah copy` is given the `--from` flag, the ownership of items being copied from other images or containers will be preserved by default, for better consistency with handling of the `COPY` instruction in Dockerfiles.  The previous behavior can be forced by adding the `--chown=0:0` flag.
```

