### PR TITLE
imagebuildah.StageExecutor.prepare(): log the --platform flag

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -860,12 +860,15 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		from = base
 	}
 	displayFrom := from
+	if ib.Platform != "" {
+		displayFrom = "--platform=" + ib.Platform + " " + displayFrom
+	}
 
 	// stage.Name will be a numeric string for all stages without an "AS" clause
 	asImageName := stage.Name
 	if asImageName != "" {
 		if _, err := strconv.Atoi(asImageName); err != nil {
-			displayFrom = from + " AS " + asImageName
+			displayFrom += " AS " + asImageName
 		}
 	}
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6838,3 +6838,11 @@ _EOF
   run_buildah build $WITH_POLICY_JSON --no-cache --isolation chroot --secret id=MYSECRET -t test -f $contextdir/Dockerfile
   expect_output --substring "SOMESECRETDATA"
 }
+
+@test "build-logs-from-platform" {
+  run_buildah info --format '{{.host.os}}/{{.host.arch}}{{if .host.variant}}/{{.host.variant}}{{ end }}'
+  local platform="$output"
+  echo FROM --platform=$platform busybox > ${TEST_SCRATCH_DIR}/Containerfile
+  run_buildah build ${TEST_SCRATCH_DIR}
+  expect_output --substring "\-\-platform=$platform"
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

If FROM was used with a --platform flag, then the imagebuilder.Builder will have its Platform field set, and we should include it when logging the instruction.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Prompted by https://github.com/containers/podman/issues/23046.

#### Does this PR introduce a user-facing change?

```release-note
None
```