### PR TITLE
Rework parsing of --pull flags

### DIFF
--- a/define/pull.go
+++ b/define/pull.go
@@ -5,6 +5,9 @@ import (
 )
 
 // PullPolicy takes the value PullIfMissing, PullAlways, PullIfNewer, or PullNever.
+// N.B.: the enumeration values for this type differ from those used by
+// github.com/containers/common/pkg/config.PullPolicy (their zero values
+// indicate different policies), so they are not interchangeable.
 type PullPolicy int
 
 const (

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -10,6 +10,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommonBuildOptionsFromFlagSet(t *testing.T) {
@@ -191,6 +192,32 @@ func TestParsePlatform(t *testing.T) {
 
 	_, _, _, err = Platform("a")
 	assert.Error(t, err)
+}
+
+func TestParsePullPolicy(t *testing.T) {
+	testCases := map[string]bool{
+		"missing":    true,
+		"ifmissing":  true,
+		"notpresent": true,
+		"always":     true,
+		"true":       true,
+		"ifnewer":    true,
+		"newer":      true,
+		"false":      true,
+		"never":      true,
+		"trye":       false,
+		"truth":      false,
+	}
+	for value, result := range testCases {
+		t.Run(value, func(t *testing.T) {
+			policy, err := pullPolicyWithFlags(value, false, false)
+			if result {
+				require.NoErrorf(t, err, "expected value %q to be recognized", value)
+			} else {
+				require.Errorf(t, err, "did not expect value %q to be recognized as %q", value, policy.String())
+			}
+		})
+	}
 }
 
 func TestSplitStringWithColonEscape(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Rework parsing of --pull flags to add "newer" as an alias for "ifnewer", and to reject unrecognized values instead of treating them all as synonymous with "ifmissing".

#### How to verify it

New unit test!

#### Which issue(s) this PR fixes:

Fixes #5602

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Unrecognized values for the `--pull` command line flag are no longer silently treated as if they were "missing".
```