### PR TITLE
Bump github.com/openshift/imagebuilder from v1.2.10 to v1.2.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc
 	github.com/opencontainers/selinux v1.11.0
-	github.com/openshift/imagebuilder v1.2.10
+	github.com/openshift/imagebuilder v1.2.11
 	github.com/seccomp/libseccomp-golang v0.10.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc h1:
 github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc/go.mod h1:8tx1helyqhUC65McMm3x7HmOex8lO2/v9zPuxmKHurs=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/openshift/imagebuilder v1.2.10 h1:n0BS4R6D4jFdWWuuV1RmeqDabOAbKpq90F4ygzCo1es=
-github.com/openshift/imagebuilder v1.2.10/go.mod h1:KkkXOyRjJlZEXWQtHNBNzVHqh4vf/0xX5cDIQ2gr+5I=
+github.com/openshift/imagebuilder v1.2.11 h1:4EmEMyiLr7jlskS1h6V6smdcrQSGLRdcIeaXeV3F8EM=
+github.com/openshift/imagebuilder v1.2.11/go.mod h1:KkkXOyRjJlZEXWQtHNBNzVHqh4vf/0xX5cDIQ2gr+5I=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f h1:/UDgs8FGMqwnHagNDPGOlts35QkhAZ8by3DR7nMih7M=
 github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -349,6 +349,26 @@ func (s *StageExecutor) volumeCacheRestore() error {
 // Copy copies data into the working tree.  The "Download" field is how
 // imagebuilder tells us the instruction was "ADD" and not "COPY".
 func (s *StageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) error {
+	for _, cp := range copies {
+		if cp.KeepGitDir {
+			if cp.Download {
+				return errors.New("ADD --keep-git-dir is not supported")
+			}
+			return errors.New("COPY --keep-git-dir is not supported")
+		}
+		if cp.Link {
+			return errors.New("COPY --link is not supported")
+		}
+		if cp.Parents {
+			return errors.New("COPY --parents is not supported")
+		}
+		if len(cp.Excludes) > 0 {
+			if cp.Download {
+				return errors.New("ADD --excludes is not supported")
+			}
+			return errors.New("COPY --excludes is not supported")
+		}
+	}
 	s.builder.ContentDigester.Restart()
 	return s.performCopy(excludes, copies...)
 }

--- a/vendor/github.com/openshift/imagebuilder/builder.go
+++ b/vendor/github.com/openshift/imagebuilder/builder.go
@@ -30,12 +30,29 @@ type Copy struct {
 	Download bool
 	// If set, the owner:group for the destination.  This value is passed
 	// to the executor for handling.
-	Chown    string
-	Chmod    string
+	Chown string
+	Chmod string
+	// If set, a checksum which the source must match, or be rejected.
 	Checksum string
 	// Additional files which need to be created by executor for this
 	// instruction.
 	Files []File
+	// If set, when the source is a URL for a remote Git repository,
+	// refrain from stripping out the .git subdirectory after cloning it.
+	KeepGitDir bool
+	// If set, instead of adding these items to the rootfs and picking them
+	// up as part of a subsequent diff generation, build an archive of them
+	// and include it as an independent layer.
+	Link bool
+	// If set, preserve leading directories in the paths of items being
+	// copied, relative to either the top of the build context, or to the
+	// "pivot point", a location in the source path marked by a path
+	// component named "." (i.e., where "/./" occurs in the path).
+	Parents bool
+	// Exclusion patterns, a la .dockerignore, relative to either the top
+	// of a directory tree being copied, or the "pivot point", a location
+	// in the source path marked by a path component named ".".
+	Excludes []string
 }
 
 // File defines if any additional file needs to be created

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/client.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/client.go
@@ -882,6 +882,18 @@ func (e *ClientExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) er
 		if copy.Checksum != "" {
 			return fmt.Errorf("ADD --checksum not supported")
 		}
+		if copy.Link {
+			return fmt.Errorf("ADD or COPY --link not supported")
+		}
+		if copy.Parents {
+			return fmt.Errorf("COPY --parents not supported")
+		}
+		if copy.KeepGitDir {
+			return fmt.Errorf("ADD --keep-git-dir not supported")
+		}
+		if len(copy.Excludes) > 0 {
+			return fmt.Errorf("ADD or COPY --exclude not supported")
+		}
 		if len(copy.Files) > 0 {
 			return fmt.Errorf("Heredoc syntax is not supported")
 		}

--- a/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
+++ b/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
@@ -12,7 +12,7 @@
 #
 
 %global golang_version 1.19
-%{!?version: %global version 1.2.10}
+%{!?version: %global version 1.2.11}
 %{!?release: %global release 1}
 %global package_name imagebuilder
 %global product_name Container Image Builder

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -641,7 +641,7 @@ github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift/imagebuilder v1.2.10
+# github.com/openshift/imagebuilder v1.2.11
 ## explicit; go 1.19
 github.com/openshift/imagebuilder
 github.com/openshift/imagebuilder/dockerclient


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Bump github.com/openshift/imagebuilder from v1.2.10 to v1.2.11 and, for now, reject COPY or ADD instructions that use the new flags that it recognizes that we don't yet implement.

#### How to verify it

It shouldn't be rejecting anything that the current tests do.  As we implement the new features, any tests that we added to ensure that they were rejected would have to be thrown away, so this PR currently doesn't add any.

#### Which issue(s) this PR fixes:

Fixes part of https://github.com/containers/podman/issues/23046.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```