### PR TITLE
Replace libimage.LookupReferenceFunc with the manifests version

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/containers/common/libimage"
+	"github.com/containers/common/libimage/manifests"
 	nettypes "github.com/containers/common/libnetwork/types"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
@@ -349,23 +349,23 @@ type BuildOptions struct {
 	CDIConfigDir string
 	// CachePullSourceLookupReferenceFunc is an optional LookupReferenceFunc
 	// used to look up source references for cache pulls.
-	CachePullSourceLookupReferenceFunc libimage.LookupReferenceFunc
+	CachePullSourceLookupReferenceFunc manifests.LookupReferenceFunc
 	// CachePullDestinationLookupReferenceFunc is an optional generator
 	// function which provides a LookupReferenceFunc used to look up
 	// destination references for cache pulls.
 	//
 	// BlobDirectory will be ignored for cache pulls if this option is set.
-	CachePullDestinationLookupReferenceFunc func(srcRef types.ImageReference) libimage.LookupReferenceFunc
+	CachePullDestinationLookupReferenceFunc func(srcRef types.ImageReference) manifests.LookupReferenceFunc
 	// CachePushSourceLookupReferenceFunc is an optional generator function
 	// which provides a LookupReferenceFunc used to look up source
 	// references for cache pushes.
 	//
 	// BlobDirectory will be ignored for cache pushes if this option is set.
-	CachePushSourceLookupReferenceFunc func(dest types.ImageReference) libimage.LookupReferenceFunc
+	CachePushSourceLookupReferenceFunc func(dest types.ImageReference) manifests.LookupReferenceFunc
 	// CachePushDestinationLookupReferenceFunc is an optional
 	// LookupReferenceFunc used to look up destination references for cache
 	// pushes
-	CachePushDestinationLookupReferenceFunc libimage.LookupReferenceFunc
+	CachePushDestinationLookupReferenceFunc manifests.LookupReferenceFunc
 	// CompatSetParent causes the "parent" field to be set in the image's
 	// configuration when committing in Docker format.  Newer
 	// BuildKit-based docker build doesn't set this field.

--- a/define/build_test.go
+++ b/define/build_test.go
@@ -1,0 +1,10 @@
+package define
+
+import (
+	"github.com/containers/common/libimage"
+	"github.com/containers/common/libimage/manifests"
+)
+
+// We changed a field of the latter type to the former, so make sure they're
+// still type aliases so that doing so doesn't break API.
+var _ libimage.LookupReferenceFunc = manifests.LookupReferenceFunc(nil)


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

Change fields of the `github.com/containers/common/libimage.LookupReferenceFunc` type to be of the `github.com/containers/common/libimage/manifests.LookupReferenceFunc` type.  The two types are aliases for each other, but the libimage package refuses to build when podman is using us as a dependency of its remote client.

Note that the `CachePullSourceLookupReferenceFunc`, `CachePullDestinationLookupReferenceFunc`, `CachePushSourceLookupReferenceFunc`, and `CachePushDestinationLookupReferenceFunc` callbacks in `define.BuildOptions` aren't currently proxied for podman remote clients.

#### How to verify it

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Alternate approaches include moving the type aliases from `copier.go` in `github.com/containers/common/libimage` to a new file that doesn't have build constraints, or having podman actually define its own API types instead of just including ours.

#### Does this PR introduce a user-facing change?

```release-note
None
```

