### PR TITLE
AddAndCopyOptions: add CertPath, InsecureSkipTLSVerify, Retry fields

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -48,7 +48,8 @@ func createCommand(addCopy string, desc string, short string, opts *addCopyResul
 			return addAndCopyCmd(cmd, args, strings.ToUpper(addCopy), *opts)
 		},
 		Example: `buildah ` + addCopy + ` containerID '/myapp/app.conf'
-  buildah ` + addCopy + ` containerID '/myapp/app.conf' '/myapp/app.conf'`,
+  buildah ` + addCopy + ` containerID 'app.conf' '/myapp/app.conf'
+  buildah ` + addCopy + ` containerID 'app.conf' 'drop-in.conf' '/myapp/app.conf.d/'`,
 		Args: cobra.MinimumNArgs(1),
 	}
 }
@@ -64,10 +65,7 @@ func applyFlagVars(flags *pflag.FlagSet, opts *addCopyResults) {
 	if err := flags.MarkHidden("blob-cache"); err != nil {
 		panic(fmt.Sprintf("error marking blob-cache as hidden: %v", err))
 	}
-	flags.StringVar(&opts.certDir, "cert-dir", "", "use certificates at the specified path to access registries")
-	if err := flags.MarkHidden("cert-dir"); err != nil {
-		panic(fmt.Sprintf("error marking cert-dir as hidden: %v", err))
-	}
+	flags.StringVar(&opts.certDir, "cert-dir", "", "use certificates at the specified path to access registries and sources in HTTPS locations")
 	flags.StringVar(&opts.checksum, "checksum", "", "checksum the HTTP source content")
 	flags.StringVar(&opts.chown, "chown", "", "set the user and group ownership of the destination content")
 	flags.StringVar(&opts.chmod, "chmod", "", "set the access permissions of the destination content")
@@ -85,10 +83,7 @@ func applyFlagVars(flags *pflag.FlagSet, opts *addCopyResults) {
 	flags.IntVar(&opts.retry, "retry", cli.MaxPullPushRetries, "number of times to retry in case of failure when performing pull")
 	flags.StringVar(&opts.retryDelay, "retry-delay", cli.PullPushRetryDelay.String(), "delay between retries in case of pull failures")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "don't output a digest of the newly-added/copied content")
-	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing registries when pulling images. TLS verification cannot be used when talking to an insecure registry.")
-	if err := flags.MarkHidden("tls-verify"); err != nil {
-		panic(fmt.Sprintf("error marking tls-verify as hidden: %v", err))
-	}
+	flags.BoolVar(&opts.tlsVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing registries when pulling images, and when retrieving sources from HTTPS URLs. TLS verification cannot be used when talking to an insecure registry.")
 	flags.BoolVarP(&opts.removeSignatures, "remove-signatures", "", false, "don't copy signatures when pulling image")
 	if err := flags.MarkHidden("remove-signatures"); err != nil {
 		panic(fmt.Sprintf("error marking remove-signatures as hidden: %v", err))
@@ -160,14 +155,14 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 		return errors.New("--ignorefile option requires that you specify a context dir using --contextdir")
 	}
 
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+
 	var preserveOwnership bool
 	if iopts.from != "" {
 		if from, err = openBuilder(getContext(), store, iopts.from); err != nil && errors.Is(err, storage.ErrContainerUnknown) {
-			systemContext, err2 := parse.SystemContextFromOptions(c)
-			if err2 != nil {
-				return fmt.Errorf("building system context: %w", err2)
-			}
-
 			decryptConfig, err2 := cli.DecryptConfig(iopts.decryptionKeys)
 			if err2 != nil {
 				return fmt.Errorf("unable to obtain decrypt config: %w", err2)
@@ -243,6 +238,11 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 		Checksum:          iopts.checksum,
 		ContextDir:        contextdir,
 		IDMappingOptions:  idMappingOptions,
+		// These next two fields are set based on command line flags
+		// with more generic-sounding names.
+		CertPath:              systemContext.DockerCertPath,
+		InsecureSkipTLSVerify: systemContext.DockerInsecureSkipTLSVerify,
+		MaxRetries:            iopts.retry,
 	}
 	if iopts.contextdir != "" {
 		var excludes []string
@@ -252,6 +252,13 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 			return err
 		}
 		options.Excludes = excludes
+	}
+	if iopts.retryDelay != "" {
+		retryDelay, err := time.ParseDuration(iopts.retryDelay)
+		if err != nil {
+			return fmt.Errorf("unable to parse value provided %q as --retry-delay: %w", iopts.retryDelay, err)
+		}
+		options.RetryDelay = retryDelay
 	}
 
 	extractLocalArchives := verb == "ADD"

--- a/common.go
+++ b/common.go
@@ -73,7 +73,7 @@ func retryCopyImage(ctx context.Context, policyContext *signature.PolicyContext,
 		err           error
 		lastErr       error
 	)
-	err = retry.RetryIfNecessary(ctx, func() error {
+	err = retry.IfNecessary(ctx, func() error {
 		manifestBytes, err = cp.Image(ctx, policyContext, dest, src, copyOptions)
 		if registry != nil && registry.Transport().Name() != docker.Transport.Name() {
 			lastErr = err

--- a/docs/buildah-add.1.md
+++ b/docs/buildah-add.1.md
@@ -23,6 +23,13 @@ Defaults to false.
 Note: You can also override the default value of --add-history by setting the
 BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
 
+**--cert-dir** *path*
+
+Use certificates at *path* (\*.crt, \*.cert, \*.key) when connecting to
+registries for pulling images named with the **--from** flag, and when
+connecting to HTTPS servers when fetching sources from locations specified with
+HTTPS URLs.  The default certificates directory is _/etc/containers/certs.d_.
+
 **--checksum** *checksum*
 
 Checksum the source content. The value of *checksum* must be a standard
@@ -59,15 +66,24 @@ Refrain from printing a digest of the added content.
 
 **--retry** *attempts*
 
-Number of times to retry in case of failure when performing pull of images from registry.
+Number of times to retry in case of failure when pulling images from registries
+or retrieving content from HTTPS URLs.
 
 Defaults to `3`.
 
 **--retry-delay** *duration*
 
-Duration of delay between retry attempts in case of failure when performing pull of images from registry.
+Duration of delay between retry attempts in case of failure when pulling images
+from registries or retrieving content from HTTPS URLs.
 
 Defaults to `2s`.
+
+**--tls-verify** *bool-value*
+
+Require verification of certificates when retrieving sources from HTTPS
+locations, or when pulling images referred to with the **--from*** flag
+(defaults to true).  TLS verification cannot be used when talking to an
+insecure registry.
 
 ## EXAMPLE
 

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -183,7 +183,8 @@ given.
 
 **--cert-dir** *path*
 
-Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
+Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry
+and retrieve contents from HTTPS locations for ADD instructions.
 The default certificates directory is _/etc/containers/certs.d_.
 
 **--cgroup-parent**=""
@@ -994,7 +995,7 @@ When --timestamp is set, the created timestamp is always set to the time specifi
 
 **--tls-verify** *bool-value*
 
-Require HTTPS and verification of certificates when talking to container registries (defaults to true).  TLS verification cannot be used when talking to an insecure registry.
+Require HTTPS and verification of certificates when talking to container registries (defaults to true) and retrieving content from HTTPS locations for ADD instructions.  TLS verification cannot be used when talking to an insecure registry.
 
 **--ulimit** *type*=*soft-limit*[:*hard-limit*]
 

--- a/docs/buildah-copy.1.md
+++ b/docs/buildah-copy.1.md
@@ -21,6 +21,12 @@ Defaults to false.
 Note: You can also override the default value of --add-history by setting the
 BUILDAH\_HISTORY environment variable. `export BUILDAH_HISTORY=true`
 
+**--cert-dir** *path*
+
+Use certificates at *path* (\*.crt, \*.cert, \*.key) when connecting to
+registries for pulling images named with the **--from** flag.  The default
+certificates directory is _/etc/containers/certs.d_.
+
 **--checksum** *checksum*
 
 Checksum the source content. The value of *checksum* must be a standard
@@ -69,6 +75,12 @@ Defaults to `3`.
 Duration of delay between retry attempts in case of failure when performing pull of images from registry.
 
 Defaults to `2s`.
+
+**--tls-verify** *bool-value*
+
+Require verification of certificates when pulling images referred to with the
+**--from*** flag (defaults to true).  TLS verification cannot be used when
+talking to an insecure registry.
 
 ## EXAMPLE
 

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.3.1
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/docker/docker v27.1.1+incompatible
+	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0
 	github.com/fsouza/go-dockerclient v1.11.1
 	github.com/hashicorp/go-multierror v1.1.1
@@ -83,7 +84,6 @@ require (
 	github.com/disiqueira/gotree/v3 v3.0.2 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
-	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.2 // indirect

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -592,6 +592,13 @@ func (s *StageExecutor) performCopy(excludes []string, copies ...imagebuilder.Co
 			IDMappingOptions:  idMappingOptions,
 			StripSetuidBit:    stripSetuid,
 			StripSetgidBit:    stripSetgid,
+			// The values for these next two fields are ultimately
+			// based on command line flags with names that sound
+			// much more generic.
+			CertPath:              s.executor.systemContext.DockerCertPath,
+			InsecureSkipTLSVerify: s.executor.systemContext.DockerInsecureSkipTLSVerify,
+			MaxRetries:            s.executor.maxPullPushRetries,
+			RetryDelay:            s.executor.retryPullPushDelay,
 		}
 		if len(copy.Files) > 0 {
 			// If we are copying heredoc files, we need to temporary place

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2486,14 +2486,14 @@ _EOF
 #
 #  Usage:  _test_http  SUBDIRECTORY  URL_PATH  [EXTRA ARGS]
 #
-#     SUBDIRECTORY   is a subdirectory path under the 'buds' subdirectory.
+#     SUBDIRECTORY   is a subdirectory path under the 'bud' subdirectory.
 #                    This will be the argument to starthttpd(), i.e. where
 #                    the httpd will serve files.
 #
 #     URL_PATH       is the path requested by buildah from the http server,
 #                    probably 'Dockerfile' or 'context.tar'
 #
-#     [EXTRA ARGS]   if present, will be passed to buildah on the 'bud'
+#     [EXTRA ARGS]   if present, will be passed to buildah on the 'build'
 #                    command line; it is intended for '-f subdir/Dockerfile'.
 #
 function _test_http() {

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -101,7 +101,7 @@ function starthttpd() { # directory [working-directory-or-"" [certfile, keyfile]
         echo error creating temporary file
         exit 1
     fi
-    sh -c "./serve ${1:-${BATS_TMPDIR}} 0 ${portfile} "${3}" "${4}" ${pidfile} &"
+    sh -c "./serve ${1:-${BATS_TMPDIR}} 0 \"${portfile}\" \"${3}\" \"${4}\" ${pidfile} &"
     waited=0
     while ! test -s ${pidfile} ; do
         sleep 0.1

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -81,21 +81,42 @@ EOF
     PODMAN_REGISTRY_OPTS="${regconfopt}"
 }
 
-function starthttpd() {
+function starthttpd() { # directory [working-directory-or-"" [certfile, keyfile]]
+    if test -n "$4" ; then
+      if ! openssl req -newkey rsa:4096 -nodes -sha256 -keyout "$4" -x509 -days 2 -addext "subjectAltName = DNS:localhost" -out "$3" -subj "/CN=localhost" ; then
+        die error creating new key and certificate
+      fi
+      chmod 644 "$3"
+      chmod 600 "$4"
+    fi
     pushd ${2:-${TEST_SCRATCH_DIR}} > /dev/null
     go build -o serve ${TEST_SOURCES}/serve/serve.go
     portfile=$(mktemp)
     if test -z "${portfile}"; then
-        echo error creating temporaty file
+        echo error creating temporary file
         exit 1
     fi
-    ./serve ${1:-${BATS_TMPDIR}} 0 ${portfile} &
-    HTTP_SERVER_PID=$!
+    pidfile=$(mktemp)
+    if test -z "${pidfile}"; then
+        echo error creating temporary file
+        exit 1
+    fi
+    sh -c "./serve ${1:-${BATS_TMPDIR}} 0 ${portfile} "${3}" "${4}" ${pidfile} &"
+    waited=0
+    while ! test -s ${pidfile} ; do
+        sleep 0.1
+        if test $((++waited)) -ge 300 ; then
+            echo test http server did not write pid file within timeout
+            exit 1
+        fi
+    done
+    HTTP_SERVER_PID=$(cat ${pidfile})
+    rm -f ${pidfile}
     waited=0
     while ! test -s ${portfile} ; do
         sleep 0.1
         if test $((++waited)) -ge 300 ; then
-            echo test http server did not start within timeout
+            echo test http server did not start listening within timeout
             exit 1
         fi
     done


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add `CertPath` and `InsecureSkipTLSVerify` flags to `AddAndCopyOptions`, and connect the CLI flag values passed to `buildah add` and `buildah build` so that `Builder.Add()` gets those.

Add `MaxRetries` and `RetryDelay` fields to `AddAndCopyOptions`, and connect them to the values passed on the command line to `buildah add` and `buildah build`.

#### How to verify it

New integration tests!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah add` and ADD instructions used with `buildah build` now use configured CA certificates and retry settings when retrieving contents from HTTPS locations.
```