### PR TITLE
Use Epoch: 2 and respect the epoch in dependencies.

### DIFF
--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -28,6 +28,8 @@ Name: buildah
 # Set different Epoch for copr
 %if %{defined copr_username}
 Epoch: 102
+%else
+Epoch: 2
 %endif
 # DO NOT TOUCH the Version string!
 # The TRUE source of this specfile is:
@@ -85,7 +87,7 @@ or
 %package tests
 Summary: Tests for %{name}
 
-Requires: %{name} = %{version}-%{release}
+Requires: %{name} = %{epoch}:%{version}-%{release}
 %if %{defined fedora}
 Requires: bats
 %endif


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:
By default buildah spec doesn't respect Epoch. Also we need a minimal Epoch for current c10s deployments.

#### How to verify it
Check Epoch of the package after build.

