### PR TITLE
`make vendor-in-container`: use the caller's Go cache if it exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,11 @@ test-unit: tests/testreport/testreport
 	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover $(RACEFLAGS) ./cmd/buildah -args --root $$tmp/root --runroot $$tmp/runroot --storage-driver vfs --signature-policy $(shell pwd)/tests/policy.json --registries-conf $(shell pwd)/tests/registries.conf
 
 vendor-in-container:
-	podman run --privileged --rm --env HOME=/root -v `pwd`:/src -w /src docker.io/library/golang:1.21 make vendor
+	if test -d `go env GOCACHE` && test -w `go env GOCACHE` ; then \
+		podman run --privileged --rm --env HOME=/root -v `go env GOCACHE`:/root/.cache/go-build --env GOCACHE=/root/.cache/go-build -v `pwd`:/src -w /src docker.io/library/golang:1.21 make vendor ; \
+	else \
+		podman run --privileged --rm --env HOME=/root -v `pwd`:/src -w /src docker.io/library/golang:1.21 make vendor ; \
+	fi
 
 .PHONY: vendor
 vendor:


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

If the $(go env GOCACHE) directory exists and is writeable, bind-mount it into the container that we're running to do the vendoring.

#### How to verify it

Runing `make vendor-in-container` outside of CI should be noticeably faster.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```