### PR TITLE
unit tests: use test-specific policy.json and registries.conf

### DIFF
--- a/buildah_test.go
+++ b/buildah_test.go
@@ -6,11 +6,19 @@ import (
 	"os"
 	"testing"
 
+	imagetypes "github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	"github.com/containers/storage/types"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	testSystemContext = imagetypes.SystemContext{
+		SignaturePolicyPath:      "tests/policy.json",
+		SystemRegistriesConfPath: "tests/registries.conf",
+	}
 )
 
 func TestMain(m *testing.M) {
@@ -68,7 +76,8 @@ func TestOpenBuilderCommonBuildOpts(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, container)
 	b, err = ImportBuilder(ctx, store, ImportOptions{
-		Container: container.ID,
+		Container:           container.ID,
+		SignaturePolicyPath: testSystemContext.SignaturePolicyPath,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, b.CommonBuildOpts)

--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -18,7 +18,10 @@ import (
 var (
 	signaturePolicyPath = ""
 	storeOptions, _     = storage.DefaultStoreOptions()
-	testSystemContext   = types.SystemContext{}
+	testSystemContext   = types.SystemContext{
+		SignaturePolicyPath:      "../../tests/policy.json",
+		SystemRegistriesConfPath: "../../tests/registries.conf",
+	}
 )
 
 func TestMain(m *testing.M) {

--- a/convertcw_test.go
+++ b/convertcw_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/containers/buildah/internal/mkcw"
 	mkcwtypes "github.com/containers/buildah/internal/mkcw/types"
-	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,7 +67,6 @@ func (d *dummyAttestationHandler) ServeHTTP(rw http.ResponseWriter, req *http.Re
 
 func TestCWConvertImage(t *testing.T) {
 	ctx := context.TODO()
-	systemContext := &types.SystemContext{}
 	for _, status := range []int{http.StatusOK, http.StatusInternalServerError} {
 		for _, ignoreChainRetrievalErrors := range []bool{false, true} {
 			for _, ignoreAttestationErrors := range []bool{false, true} {
@@ -110,8 +108,9 @@ func TestCWConvertImage(t *testing.T) {
 						AttestationURL:          "http://" + addr.String(),
 						IgnoreAttestationErrors: ignoreAttestationErrors,
 						Slop:                    "16MB",
+						SignaturePolicyPath:     testSystemContext.SignaturePolicyPath,
 					}
-					id, _, _, err := CWConvertImage(ctx, systemContext, store, options)
+					id, _, _, err := CWConvertImage(ctx, &testSystemContext, store, options)
 					if status != http.StatusOK && !ignoreAttestationErrors {
 						assert.Error(t, err)
 						return


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

In unit tests that create a `SystemContext`, point that `SystemContext` at the testing signature policy and registries configuration.  This should cause us to pay attention to mirroring settings for images used by this set of tests.

#### How to verify it

Unit tests should be slightly more reliable.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```