### PR TITLE
conformance tests: use mirror.gcr.io for most images

### DIFF
--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -15,15 +15,18 @@ Conformance tests use Docker CE to build images to be compared with images built
 
 ## Run conformance tests
 
-First, pull base images used by various conformance tests:
+These are the base images used by various conformance tests:
 ```
 bash
-docker pull alpine
-docker pull busybox
+docker pull mirror.gcr.io/alpine
+docker pull mirror.gcr.io/busybox
 docker pull quay.io/libpod/centos:7
+docker pull registry.fedoraproject.org/fedora-minimal:41-aarch64
+docker pull registry.fedoraproject.org/fedora-minimal:41-amd64
+docker pull registry.fedoraproject.org/fedora-minimal
 ```
 
-Then you can run all of the tests with go test:
+You can run all of the tests with go test (and under `buildah unshare` or `podman unshare` if you're not root):
 ```
 go test -v -timeout=30m -tags "$(./btrfs_tag.sh) $(./btrfs_installed_tag.sh)" ./tests/conformance
 ```

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -1666,7 +1666,7 @@ var internalTestCases = []testCase{
 	{
 		name:          "transient-mount",
 		contextDir:    "transientmount",
-		buildahRegex:  "file2.*?FROM busybox ENV name value",
+		buildahRegex:  "file2.*?FROM mirror.gcr.io/busybox ENV name value",
 		withoutDocker: true,
 		transientMounts: []string{
 			"@@TEMPDIR@@:/mountdir" + selinuxMountFlag(),
@@ -1678,7 +1678,7 @@ var internalTestCases = []testCase{
 		// from internal team chat
 		name: "ci-pipeline-modified",
 		dockerfileContents: strings.Join([]string{
-			"FROM busybox",
+			"FROM mirror.gcr.io/busybox",
 			"WORKDIR /go/src/github.com/openshift/ocp-release-operator-sdk/",
 			"ENV GOPATH=/go",
 			"RUN env | grep -E -v '^(HOSTNAME|OLDPWD)=' | LANG=C sort | tee /env-contents.txt\n",
@@ -1864,7 +1864,7 @@ var internalTestCases = []testCase{
 		// list in the image repository would do
 		name: "stage-container-as-source-plus-hardlinks",
 		dockerfileContents: strings.Join([]string{
-			"FROM busybox@sha256:9ddee63a712cea977267342e8750ecbc60d3aab25f04ceacfa795e6fce341793 AS build",
+			"FROM mirror.gcr.io/busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7 AS build",
 			"RUN mkdir -p /target/subdir",
 			"RUN cp -p /etc/passwd /target/",
 			"RUN ln /target/passwd /target/subdir/passwd",
@@ -2119,7 +2119,7 @@ var internalTestCases = []testCase{
 		// possibly around https://github.com/moby/moby/pull/38599
 		name: "setuid-file-in-other-stage",
 		dockerfileContents: strings.Join([]string{
-			"FROM busybox",
+			"FROM mirror.gcr.io/busybox",
 			"RUN mkdir /a && echo whatever > /a/setuid && chmod u+xs /a/setuid && touch -t @1485449953 /a/setuid",
 			"RUN mkdir /b && echo whatever > /b/setgid && chmod g+xs /b/setgid && touch -t @1485449953 /b/setgid",
 			"RUN mkdir /c && echo whatever > /c/sticky && chmod o+x /c/sticky && chmod +t /c/sticky && touch -t @1485449953 /c/sticky",
@@ -2273,7 +2273,7 @@ var internalTestCases = []testCase{
 	{
 		name: "multi-stage-through-base",
 		dockerfileContents: strings.Join([]string{
-			"FROM alpine AS base",
+			"FROM mirror.gcr.io/alpine AS base",
 			"RUN touch -t @1485449953 /1",
 			"ENV LOCAL=/1",
 			"RUN find $LOCAL",
@@ -2286,11 +2286,11 @@ var internalTestCases = []testCase{
 	{
 		name: "multi-stage-derived", // from #2415
 		dockerfileContents: strings.Join([]string{
-			"FROM busybox as layer",
+			"FROM mirror.gcr.io/busybox as layer",
 			"RUN touch /root/layer",
 			"FROM layer as derived",
 			"RUN touch -t @1485449953 /root/derived ; rm /root/layer",
-			"FROM busybox AS output",
+			"FROM mirror.gcr.io/busybox AS output",
 			"COPY --from=layer /root /root",
 		}, "\n"),
 		fsSkip: []string{"(dir):root:mtime", "(dir):root:(dir):layer:mtime"},
@@ -2886,7 +2886,7 @@ var internalTestCases = []testCase{
 	{
 		name: "copy-from-owner", // from issue #2518
 		dockerfileContents: strings.Join([]string{
-			`FROM alpine`,
+			`FROM mirror.gcr.io/alpine`,
 			`RUN set -ex; touch -t @1485449953 /test; chown 65:65 /test`,
 			`FROM scratch`,
 			`USER 66:66`,
@@ -2898,7 +2898,7 @@ var internalTestCases = []testCase{
 	{
 		name: "copy-from-owner-with-chown", // issue #2518, but with chown to override
 		dockerfileContents: strings.Join([]string{
-			`FROM alpine`,
+			`FROM mirror.gcr.io/alpine`,
 			`RUN set -ex; touch -t @1485449953 /test; chown 65:65 /test`,
 			`FROM scratch`,
 			`USER 66:66`,
@@ -2911,7 +2911,7 @@ var internalTestCases = []testCase{
 		name:       "copy-for-user", // flip side of issue #2518
 		contextDir: "copy",
 		dockerfileContents: strings.Join([]string{
-			`FROM alpine`,
+			`FROM mirror.gcr.io/alpine`,
 			`USER 66:66`,
 			`COPY /script /script`,
 		}, "\n"),
@@ -2921,7 +2921,7 @@ var internalTestCases = []testCase{
 		name:       "copy-for-user-with-chown", // flip side of issue #2518, but with chown to override
 		contextDir: "copy",
 		dockerfileContents: strings.Join([]string{
-			`FROM alpine`,
+			`FROM mirror.gcr.io/alpine`,
 			`USER 66:66`,
 			`COPY --chown=1:1 /script /script`,
 		}, "\n"),
@@ -3173,7 +3173,7 @@ var internalTestCases = []testCase{
 		name: "workdir-owner", // from issue #3620
 		dockerfileContents: strings.Join([]string{
 			`# syntax=docker/dockerfile:1.4`,
-			`FROM alpine`,
+			`FROM mirror.gcr.io/alpine`,
 			`USER daemon`,
 			`WORKDIR /created/directory`,
 			`RUN ls /created`,
@@ -3204,7 +3204,7 @@ var internalTestCases = []testCase{
 	{
 		name: "workdir with trailing separator",
 		dockerfileContents: strings.Join([]string{
-			"FROM busybox",
+			"FROM mirror.gcr.io/busybox",
 			"USER daemon",
 			"WORKDIR /tmp/",
 		}, "\n"),
@@ -3213,7 +3213,7 @@ var internalTestCases = []testCase{
 	{
 		name: "workdir without trailing separator",
 		dockerfileContents: strings.Join([]string{
-			"FROM busybox",
+			"FROM mirror.gcr.io/busybox",
 			"USER daemon",
 			"WORKDIR /tmp",
 		}, "\n"),
@@ -3229,7 +3229,7 @@ var internalTestCases = []testCase{
 		name:              "builtins",
 		contextDir:        "builtins",
 		dockerUseBuildKit: true,
-		buildArgs:         map[string]string{"SOURCE": "source", "BUSYBOX": "busybox", "ALPINE": "alpine", "OWNERID": "0", "       SECONDBASE": "localhost/no-such-image"},
+		buildArgs:         map[string]string{"SOURCE": "source", "BUSYBOX": "mirror.gcr.io/busybox", "ALPINE": "mirror.gcr.io/alpine", "OWNERID": "0", "SECONDBASE": "localhost/no-such-image"},
 	},
 
 	{
@@ -3248,33 +3248,33 @@ func TestCommit(t *testing.T) {
 	}{
 		{
 			description: "defaults",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 		},
 		{
 			description: "empty change",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{""},
 		},
 		{
 			description: "empty config",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config:      &docker.Config{},
 		},
 		{
 			description: "cmd just changes",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"CMD /bin/imaginarySh"},
 		},
 		{
 			description: "cmd just config",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				Cmd: []string{"/usr/bin/imaginarySh"},
 			},
 		},
 		{
 			description: "cmd conflict",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"CMD /bin/imaginarySh"},
 			config: &docker.Config{
 				Cmd: []string{"/usr/bin/imaginarySh"},
@@ -3282,19 +3282,19 @@ func TestCommit(t *testing.T) {
 		},
 		{
 			description: "entrypoint just changes",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"ENTRYPOINT /bin/imaginarySh"},
 		},
 		{
 			description: "entrypoint just config",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				Entrypoint: []string{"/usr/bin/imaginarySh"},
 			},
 		},
 		{
 			description: "entrypoint conflict",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"ENTRYPOINT /bin/imaginarySh"},
 			config: &docker.Config{
 				Entrypoint: []string{"/usr/bin/imaginarySh"},
@@ -3302,19 +3302,19 @@ func TestCommit(t *testing.T) {
 		},
 		{
 			description: "environment just changes",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"ENV A=1", "ENV C=2"},
 		},
 		{
 			description: "environment just config",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				Env: []string{"A=B"},
 			},
 		},
 		{
 			description: "environment with conflict union",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"ENV A=1", "ENV C=2"},
 			config: &docker.Config{
 				Env: []string{"A=B"},
@@ -3322,19 +3322,19 @@ func TestCommit(t *testing.T) {
 		},
 		{
 			description: "expose just changes",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"EXPOSE 12345"},
 		},
 		{
 			description: "expose just config",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				ExposedPorts: map[docker.Port]struct{}{"23456": struct{}{}},
 			},
 		},
 		{
 			description: "expose union",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"EXPOSE 12345"},
 			config: &docker.Config{
 				ExposedPorts: map[docker.Port]struct{}{"23456": struct{}{}},
@@ -3342,12 +3342,12 @@ func TestCommit(t *testing.T) {
 		},
 		{
 			description: "healthcheck just changes",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{`HEALTHCHECK --interval=1s --timeout=1s --start-period=1s --retries=1 CMD ["/bin/false"]`},
 		},
 		{
 			description: "healthcheck just config",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				Healthcheck: &docker.HealthConfig{
 					Test:        []string{"/bin/true"},
@@ -3360,7 +3360,7 @@ func TestCommit(t *testing.T) {
 		},
 		{
 			description: "healthcheck conflict",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{`HEALTHCHECK --interval=1s --timeout=1s --start-period=1s --retries=1 CMD ["/bin/false"]`},
 			config: &docker.Config{
 				Healthcheck: &docker.HealthConfig{
@@ -3374,19 +3374,19 @@ func TestCommit(t *testing.T) {
 		},
 		{
 			description: "label just changes",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"LABEL A=1 C=2"},
 		},
 		{
 			description: "label just config",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				Labels: map[string]string{"A": "B"},
 			},
 		},
 		{
 			description: "label with conflict union",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"LABEL A=1 C=2"},
 			config: &docker.Config{
 				Labels: map[string]string{"A": "B"},
@@ -3395,13 +3395,13 @@ func TestCommit(t *testing.T) {
 		// n.b. dockerd didn't like a MAINTAINER change, so no test for it, and it's not in a config blob
 		{
 			description:    "onbuild just changes",
-			baseImage:      "docker.io/library/busybox",
+			baseImage:      "mirror.gcr.io/busybox",
 			changes:        []string{"ONBUILD USER alice", "ONBUILD LABEL A=1"},
 			derivedChanges: []string{"LABEL C=3"},
 		},
 		{
 			description: "onbuild just config",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				OnBuild: []string{"USER bob", `CMD ["/bin/smash"]`, "LABEL B=2"},
 			},
@@ -3409,7 +3409,7 @@ func TestCommit(t *testing.T) {
 		},
 		{
 			description: "onbuild conflict",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"ONBUILD USER alice", "ONBUILD LABEL A=1"},
 			config: &docker.Config{
 				OnBuild: []string{"USER bob", `CMD ["/bin/smash"]`, "LABEL B=2"},
@@ -3419,14 +3419,14 @@ func TestCommit(t *testing.T) {
 		// n.b. dockerd didn't like a SHELL change, so no test for it or a conflict with a config blob
 		{
 			description: "shell just config",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				Shell: []string{"/usr/bin/imaginarySh"},
 			},
 		},
 		{
 			description: "stop signal conflict",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"STOPSIGNAL SIGTERM"},
 			config: &docker.Config{
 				StopSignal: "SIGKILL",
@@ -3434,21 +3434,21 @@ func TestCommit(t *testing.T) {
 		},
 		{
 			description: "stop timeout=0",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				StopTimeout: 0,
 			},
 		},
 		{
 			description: "stop timeout=15",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				StopTimeout: 15,
 			},
 		},
 		{
 			description: "stop timeout=15, then 0",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				StopTimeout: 15,
 			},
@@ -3458,7 +3458,7 @@ func TestCommit(t *testing.T) {
 		},
 		{
 			description: "stop timeout=0, then 15",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				StopTimeout: 0,
 			},
@@ -3468,19 +3468,19 @@ func TestCommit(t *testing.T) {
 		},
 		{
 			description: "user just changes",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"USER 1001:1001"},
 		},
 		{
 			description: "user just config",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				User: "1000:1000",
 			},
 		},
 		{
 			description: "user with conflict",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"USER 1001:1001"},
 			config: &docker.Config{
 				User: "1000:1000",
@@ -3488,19 +3488,19 @@ func TestCommit(t *testing.T) {
 		},
 		{
 			description: "volume just changes",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"VOLUME /a-volume"},
 		},
 		{
 			description: "volume just config",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				Volumes: map[string]struct{}{"/b-volume": struct{}{}},
 			},
 		},
 		{
 			description: "volume union",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"VOLUME /a-volume"},
 			config: &docker.Config{
 				Volumes: map[string]struct{}{"/b-volume": struct{}{}},
@@ -3508,19 +3508,19 @@ func TestCommit(t *testing.T) {
 		},
 		{
 			description: "workdir just changes",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"WORKDIR /yeah"},
 		},
 		{
 			description: "workdir just config",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			config: &docker.Config{
 				WorkingDir: "/naw",
 			},
 		},
 		{
 			description: "workdir with conflict",
-			baseImage:   "docker.io/library/busybox",
+			baseImage:   "mirror.gcr.io/busybox",
 			changes:     []string{"WORKDIR /yeah"},
 			config: &docker.Config{
 				WorkingDir: "/naw",

--- a/tests/conformance/testdata/Dockerfile.add
+++ b/tests/conformance/testdata/Dockerfile.add
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 ADD https://github.com/openshift/origin/raw/master/README.md README.md
 USER 1001
 ADD https://github.com/openshift/origin/raw/master/LICENSE .

--- a/tests/conformance/testdata/Dockerfile.copyfrom_1
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_1
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN touch -t @1485449953 /a /b
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a /
 RUN ls -al /a

--- a/tests/conformance/testdata/Dockerfile.copyfrom_10
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_10
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a && touch -t @1485449953 /a/1
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a/1 /a/b/c
 RUN ls -al /a/b/c && ! ls -al /a/b/1

--- a/tests/conformance/testdata/Dockerfile.copyfrom_11
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_11
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a && touch -t @1485449953 /a/1
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a /a/b/c
 RUN ls -al /a/b/c/1 && ! ls -al /a/b/1

--- a/tests/conformance/testdata/Dockerfile.copyfrom_12
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_12
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a && touch -t @1485449953 /a/1
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base a /a
 RUN ls -al /a/1 && ! ls -al /a/a

--- a/tests/conformance/testdata/Dockerfile.copyfrom_13
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_13
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a && touch -t @1485449953 /a/1
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base a/. /a
 RUN ls -al /a/1 && ! ls -al /a/a

--- a/tests/conformance/testdata/Dockerfile.copyfrom_2
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_2
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN touch -t @1485449953 /a
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a /a
 RUN ls -al /a

--- a/tests/conformance/testdata/Dockerfile.copyfrom_3
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_3
@@ -1,6 +1,6 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN touch -t @1485449953 /a
-FROM busybox
+FROM mirror.gcr.io/busybox
 WORKDIR /b
 COPY --from=base /a .
 RUN ls -al /b/a

--- a/tests/conformance/testdata/Dockerfile.copyfrom_3_1
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_3_1
@@ -1,6 +1,6 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN touch -t @1485449953 /a
-FROM busybox
+FROM mirror.gcr.io/busybox
 WORKDIR /b
 COPY --from=base /a ./b
 RUN ls -al /b/b

--- a/tests/conformance/testdata/Dockerfile.copyfrom_4
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_4
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a/b && touch -t @1485449953 /a/b/1 /a/b/2
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a/b/ /b/
 RUN ls -al /b/1 /b/2 /b && ! ls -al /a

--- a/tests/conformance/testdata/Dockerfile.copyfrom_5
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_5
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a/b && touch -t @1485449953 /a/b/1 /a/b/2
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a/b/* /b/
 RUN ls -al /b/1 /b/2 /b && ! ls -al /a /b/a /b/b

--- a/tests/conformance/testdata/Dockerfile.copyfrom_6
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_6
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a/b && touch -t @1485449953 /a/b/1 /a/b/2
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a/b/. /b/
 RUN ls -al /b/1 /b/2 /b && ! ls -al /a /b/a /b/b

--- a/tests/conformance/testdata/Dockerfile.copyfrom_7
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_7
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN touch -t @1485449953 /b
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /b /a
 RUN ls -al /a && ! ls -al /b

--- a/tests/conformance/testdata/Dockerfile.copyfrom_8
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_8
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a && touch -t @1485449953 /a/b
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a/b /a
 RUN ls -al /a && ! ls -al /b

--- a/tests/conformance/testdata/Dockerfile.copyfrom_9
+++ b/tests/conformance/testdata/Dockerfile.copyfrom_9
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a && touch -t @1485449953 /a/1
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a/1 /a/b/c/
 RUN ls -al /a/b/c/1 && ! ls -al /a/b/1

--- a/tests/conformance/testdata/Dockerfile.edgecases
+++ b/tests/conformance/testdata/Dockerfile.edgecases
@@ -1,5 +1,5 @@
-# Note: Hopefully a registries.conf alias redirects this to quay.io/libpod/busybox
-FROM busybox
+# Note: Hopefully a registries.conf alias redirects this to quay.io/libpod/mirror.gcr.io/busybox
+FROM mirror.gcr.io/busybox
 
 MAINTAINER docker <docker@docker.io>
 

--- a/tests/conformance/testdata/Dockerfile.env
+++ b/tests/conformance/testdata/Dockerfile.env
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 ENV name value
 ENV name=value
 ENV name=value name2=value2

--- a/tests/conformance/testdata/Dockerfile.exposedefault
+++ b/tests/conformance/testdata/Dockerfile.exposedefault
@@ -1,2 +1,2 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 EXPOSE 3469

--- a/tests/conformance/testdata/Dockerfile.heredoc-quoting
+++ b/tests/conformance/testdata/Dockerfile.heredoc-quoting
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 ARG argA=argvA
 ENV varA=valueA
 

--- a/tests/conformance/testdata/Dockerfile.margs
+++ b/tests/conformance/testdata/Dockerfile.margs
@@ -1,4 +1,4 @@
-FROM alpine
+FROM mirror.gcr.io/alpine
 ARG BUILDPLATFORM
 ARG BUILDOS
 ARG BUILDARCH
@@ -17,7 +17,7 @@ RUN echo ${TARGETOS}       > first/targetos=`echo ${TARGETOS} | sed s,/,_,g`
 RUN echo ${TARGETARCH}     > first/targetarch=`echo ${TARGETARCH} | sed s,/,_,g`
 RUN echo ${TARGETVARIANT}  > first/targetvariant=`echo ${TARGETVARIANT} | sed s,/,_,g`
 
-FROM alpine
+FROM mirror.gcr.io/alpine
 ARG BUILDPLATFORM
 ARG BUILDOS
 ARG BUILDARCH

--- a/tests/conformance/testdata/Dockerfile.run.args
+++ b/tests/conformance/testdata/Dockerfile.run.args
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN echo first second
 RUN /bin/echo third fourth
 RUN ["/bin/echo", "fifth", "sixth"]

--- a/tests/conformance/testdata/add/dir-not-dir/Dockerfile
+++ b/tests/conformance/testdata/add/dir-not-dir/Dockerfile
@@ -1,3 +1,3 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN mkdir fileone
 ADD test.tar /

--- a/tests/conformance/testdata/add/not-dir-dir/Dockerfile
+++ b/tests/conformance/testdata/add/not-dir-dir/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN touch /new-directory
 ADD test.tar /
 RUN ls -ld /new-directory

--- a/tests/conformance/testdata/add/parent-clean/Dockerfile
+++ b/tests/conformance/testdata/add/parent-clean/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN ln -s /symlink-target/subdirectory /symlink
 ADD . /symlink/..
 RUN find /symlink* -print

--- a/tests/conformance/testdata/add/parent-dangling/Dockerfile
+++ b/tests/conformance/testdata/add/parent-dangling/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN ln -s symlink-target /symlink
 ADD . /symlink/subdirectory/
 RUN find /symlink* -print

--- a/tests/conformance/testdata/add/populated-dir-not-dir/Dockerfile
+++ b/tests/conformance/testdata/add/populated-dir-not-dir/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN mkdir dirone
 RUN echo one > dirone/onefile.txt
 RUN echo two > dirone/twofile.txt

--- a/tests/conformance/testdata/builtins/Dockerfile
+++ b/tests/conformance/testdata/builtins/Dockerfile
@@ -1,23 +1,23 @@
 ARG ALPINE
 
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN echo TARGETPLATFORM=$TARGETPLATFORM | tee 0.txt
 ARG TARGETPLATFORM
 RUN echo TARGETPLATFORM=$TARGETPLATFORM | tee -a 0.txt
 RUN touch -d @0 0.txt
 
-FROM ${SECONDBASE:-busybox}
+FROM ${SECONDBASE:-mirror.gcr.io/busybox}
 COPY --from=0 /*.txt /
 COPY --chown=${OWNERID:-1}:${OWNERID:-1} ${SOURCE:-other}file.txt /1a.txt
 ARG OWNERID=1
 ARG SOURCE=
 COPY --chown=${OWNERID:-1}:${OWNERID:-1} ${SOURCE:-other}file.txt /1b.txt
 
-FROM ${ALPINE:-busybox}
+FROM ${ALPINE:-mirror.gcr.io/busybox}
 ARG SECONDBASE=localhost/no-such-image
 COPY --from=1 /*.txt /
 RUN cp -p /etc/nsswitch.conf /2.txt
 
-FROM ${BUSYBOX:-alpine}
+FROM ${BUSYBOX:-mirror.gcr.io/alpine}
 COPY --from=2 /*.txt /
 RUN cp -p /etc/nsswitch.conf /3.txt

--- a/tests/conformance/testdata/chown-volume/Dockerfile
+++ b/tests/conformance/testdata/chown-volume/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox AS first
+FROM mirror.gcr.io/busybox AS first
 RUN mkdir /volumea /volumeb /volumec
 # This next change will be omitted from naive diff output without
 # both https://github.com/containers/storage/pull/1962 and

--- a/tests/conformance/testdata/copyblahblub/Dockerfile
+++ b/tests/conformance/testdata/copyblahblub/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY firstdir/seconddir /var
 RUN ls -la /var
 RUN ls -la /var/dir-a

--- a/tests/conformance/testdata/copyblahblub/Dockerfile2
+++ b/tests/conformance/testdata/copyblahblub/Dockerfile2
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY /firstdir/seconddir /var
 RUN ls -la /var
 RUN ls -la /var/dir-a

--- a/tests/conformance/testdata/copyblahblub/Dockerfile3
+++ b/tests/conformance/testdata/copyblahblub/Dockerfile3
@@ -1,8 +1,8 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY /firstdir/seconddir /var
 RUN ls -la /var
 RUN ls -la /var/dir-a
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=0 /var/dir-a /var
 RUN ls -la /var
 RUN ls -la /var/file-a

--- a/tests/conformance/testdata/dir/Dockerfile
+++ b/tests/conformance/testdata/dir/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY . /
 COPY . dir
 COPY subdir/ test/

--- a/tests/conformance/testdata/dockerignore/allowlist/nothing-dot/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/allowlist/nothing-dot/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN touch -t @1485449953 /file
 FROM scratch
 COPY --from=0 /file /

--- a/tests/conformance/testdata/dockerignore/allowlist/nothing-slash/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/allowlist/nothing-slash/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN touch -t @1485449953 /file
 FROM scratch
 COPY --from=0 /file /

--- a/tests/conformance/testdata/dockerignore/allowlist/subsubdir-file/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/allowlist/subsubdir-file/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN touch -t @1485449953 /file
 FROM scratch
 COPY --from=0 /file /

--- a/tests/conformance/testdata/dockerignore/allowlist/subsubdir-nofile/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/allowlist/subsubdir-nofile/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN touch -t @1485449953 /file
 FROM scratch
 COPY --from=0 /file /

--- a/tests/conformance/testdata/dockerignore/allowlist/subsubdir-nosubdir/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/allowlist/subsubdir-nosubdir/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN touch -t @1485449953 /file
 FROM scratch
 COPY --from=0 /file /

--- a/tests/conformance/testdata/dockerignore/exceptions-skip/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/exceptions-skip/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine
+FROM mirror.gcr.io/alpine
 COPY ./ ./

--- a/tests/conformance/testdata/dockerignore/exceptions-weirdness-1/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/exceptions-weirdness-1/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine
+FROM mirror.gcr.io/alpine
 COPY ./ /newdir

--- a/tests/conformance/testdata/dockerignore/exceptions-weirdness-2/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/exceptions-weirdness-2/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine
+FROM mirror.gcr.io/alpine
 COPY ./ /newdir

--- a/tests/conformance/testdata/dockerignore/integration1/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/integration1/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM mirror.gcr.io/alpine
 
 COPY ./ ./
 COPY subdir ./

--- a/tests/conformance/testdata/dockerignore/integration3/Dockerfile
+++ b/tests/conformance/testdata/dockerignore/integration3/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY . /upload/
 COPY src /upload/src2/
 COPY test1.txt /upload/test1.txt

--- a/tests/conformance/testdata/env/precedence/Dockerfile
+++ b/tests/conformance/testdata/env/precedence/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM busybox
+FROM mirror.gcr.io/busybox
 ENV a=b
 ENV c=d
 RUN echo E=$E G=$G

--- a/tests/conformance/testdata/heredoc/Dockerfile.heredoc_copy
+++ b/tests/conformance/testdata/heredoc/Dockerfile.heredoc_copy
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3-labs
-FROM busybox as one
+FROM mirror.gcr.io/busybox as one
 RUN echo helloworld > image_file
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN echo hello
 # copy two heredoc and one from context
 COPY <<robots.txt <<humans.txt file /test/

--- a/tests/conformance/testdata/mount/Dockerfile
+++ b/tests/conformance/testdata/mount/Dockerfile
@@ -1,2 +1,2 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN stat -c "%s %n %a %F %g %u" /tmp/test/*

--- a/tests/conformance/testdata/multistage/copyback/Dockerfile
+++ b/tests/conformance/testdata/multistage/copyback/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine AS base
+FROM mirror.gcr.io/alpine AS base
 RUN touch -r /etc/os-release /1.txt
-FROM alpine AS interloper
+FROM mirror.gcr.io/alpine AS interloper
 RUN --mount=type=bind,from=base,source=/,destination=/base,rw touch -r /etc/os-release /base/2.txt
 FROM base
 RUN --mount=type=bind,from=interloper,source=/etc,destination=/etc2 touch -r /etc2/os-release /3.txt

--- a/tests/conformance/testdata/overlapdirwithoutslash/Dockerfile
+++ b/tests/conformance/testdata/overlapdirwithoutslash/Dockerfile
@@ -1,2 +1,2 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY existing .

--- a/tests/conformance/testdata/overlapdirwithslash/Dockerfile
+++ b/tests/conformance/testdata/overlapdirwithslash/Dockerfile
@@ -1,2 +1,2 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY existing/ .

--- a/tests/conformance/testdata/transientmount/Dockerfile
+++ b/tests/conformance/testdata/transientmount/Dockerfile
@@ -1,3 +1,3 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN ls /mountdir/subdir
 RUN cat /mountfile

--- a/tests/conformance/testdata/transientmount/Dockerfile.env
+++ b/tests/conformance/testdata/transientmount/Dockerfile.env
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 ENV name value
 ENV name=value
 ENV name=value name2=value2

--- a/tests/conformance/testdata/volume/Dockerfile
+++ b/tests/conformance/testdata/volume/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 
 ADD file /var/www/
 VOLUME /var/www

--- a/tests/conformance/testdata/volumerun/Dockerfile
+++ b/tests/conformance/testdata/volumerun/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 
 ADD file /var/www/
 VOLUME /var/www

--- a/tests/conformance/testdata/wildcard/Dockerfile
+++ b/tests/conformance/testdata/wildcard/Dockerfile
@@ -1,3 +1,3 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 ENV DIR=/usr
 ADD dir2/*.b dir2/*.c $DIR/test/


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Use busybox and alpine images from mirror.gcr.io, where possible, to avoid tripping pull limits in CI.

#### How to verify it

So many updated conformance tests!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```