### PR TITLE
CI: enable the gofumpt and whitespace linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ run:
 linters:
   enable:
     - gofmt
+    - gofumpt
     - revive
     - unconvert
     - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,3 +13,4 @@ linters:
     - revive
     - unconvert
     - unparam
+    - whitespace

--- a/add.go
+++ b/add.go
@@ -689,7 +689,6 @@ func (b *Builder) userForRun(mountPoint string, userspec string) (specs.User, st
 		} else {
 			u.AdditionalGids = groups
 		}
-
 	}
 	return u, homeDir, err
 }

--- a/add.go
+++ b/add.go
@@ -35,7 +35,7 @@ import (
 
 // AddAndCopyOptions holds options for add and copy commands.
 type AddAndCopyOptions struct {
-	//Chmod sets the access permissions of the destination content.
+	// Chmod sets the access permissions of the destination content.
 	Chmod string
 	// Chown is a spec for the user who should be given ownership over the
 	// newly-added content, potentially overriding permissions which would
@@ -176,7 +176,7 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 		uid = chown.UID
 		gid = chown.GID
 	}
-	var mode int64 = 0600
+	var mode int64 = 0o600
 	if chmod != nil {
 		mode = int64(*chmod)
 	}

--- a/bind/mount.go
+++ b/bind/mount.go
@@ -48,7 +48,7 @@ func SetupIntermediateMountNamespace(spec *specs.Spec, bundlePath string) (unmou
 	if err != nil {
 		return nil, fmt.Errorf("checking permissions on %q: %w", bundlePath, err)
 	}
-	if err = os.Chmod(bundlePath, info.Mode()|0111); err != nil {
+	if err = os.Chmod(bundlePath, info.Mode()|0o111); err != nil {
 		return nil, fmt.Errorf("loosening permissions on %q: %w", bundlePath, err)
 	}
 
@@ -115,7 +115,7 @@ func SetupIntermediateMountNamespace(spec *specs.Spec, bundlePath string) (unmou
 	// other unprivileged users outside of containers, shouldn't be able to
 	// access.
 	mnt := filepath.Join(bundlePath, "mnt")
-	if err = idtools.MkdirAndChown(mnt, 0100, idtools.IDPair{UID: int(rootUID), GID: int(rootGID)}); err != nil {
+	if err = idtools.MkdirAndChown(mnt, 0o100, idtools.IDPair{UID: int(rootUID), GID: int(rootGID)}); err != nil {
 		return unmountAll, fmt.Errorf("creating %q owned by the container's root user: %w", mnt, err)
 	}
 
@@ -128,7 +128,7 @@ func SetupIntermediateMountNamespace(spec *specs.Spec, bundlePath string) (unmou
 
 	// Create a bind mount for the root filesystem and add it to the list.
 	rootfs := filepath.Join(mnt, "rootfs")
-	if err = os.Mkdir(rootfs, 0000); err != nil {
+	if err = os.Mkdir(rootfs, 0o000); err != nil {
 		return unmountAll, fmt.Errorf("creating directory %q: %w", rootfs, err)
 	}
 	if err = unix.Mount(rootPath, rootfs, "", unix.MS_BIND|unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
@@ -159,13 +159,13 @@ func SetupIntermediateMountNamespace(spec *specs.Spec, bundlePath string) (unmou
 		if info.IsDir() {
 			// If the source is a directory, make one to use as the
 			// mount target.
-			if err = os.Mkdir(stage, 0000); err != nil {
+			if err = os.Mkdir(stage, 0o000); err != nil {
 				return unmountAll, fmt.Errorf("creating directory %q: %w", stage, err)
 			}
 		} else {
 			// If the source is not a directory, create an empty
 			// file to use as the mount target.
-			file, err := os.OpenFile(stage, os.O_WRONLY|os.O_CREATE, 0000)
+			file, err := os.OpenFile(stage, os.O_WRONLY|os.O_CREATE, 0o000)
 			if err != nil {
 				return unmountAll, fmt.Errorf("creating file %q: %w", stage, err)
 			}

--- a/buildah.go
+++ b/buildah.go
@@ -570,7 +570,7 @@ func (b *Builder) Save() error {
 	if err != nil {
 		return err
 	}
-	if err = ioutils.AtomicWriteFile(filepath.Join(cdir, stateFile), buildstate, 0600); err != nil {
+	if err = ioutils.AtomicWriteFile(filepath.Join(cdir, stateFile), buildstate, 0o600); err != nil {
 		return fmt.Errorf("saving builder state to %q: %w", filepath.Join(cdir, stateFile), err)
 	}
 	return nil

--- a/buildah_test.go
+++ b/buildah_test.go
@@ -14,12 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	testSystemContext = imagetypes.SystemContext{
-		SignaturePolicyPath:      "tests/policy.json",
-		SystemRegistriesConfPath: "tests/registries.conf",
-	}
-)
+var testSystemContext = imagetypes.SystemContext{
+	SignaturePolicyPath:      "tests/policy.json",
+	SystemRegistriesConfPath: "tests/registries.conf",
+}
 
 func TestMain(m *testing.M) {
 	var logLevel string

--- a/chroot/pty_ptmx.go
+++ b/chroot/pty_ptmx.go
@@ -15,7 +15,7 @@ import (
 // this instead of posix_openpt is that it avoids cgo.
 func getPtyDescriptors() (int, int, error) {
 	// Create a pseudo-terminal -- open a copy of the master side.
-	controlFd, err := unix.Open("/dev/ptmx", os.O_RDWR, 0600)
+	controlFd, err := unix.Open("/dev/ptmx", os.O_RDWR, 0o600)
 	if err != nil {
 		return -1, -1, fmt.Errorf("opening PTY master using /dev/ptmx: %v", err)
 	}
@@ -36,7 +36,7 @@ func getPtyDescriptors() (int, int, error) {
 			return -1, -1, fmt.Errorf("getting PTY number: %v", err)
 		}
 		ptyName := fmt.Sprintf("/dev/pts/%d", ptyN)
-		fd, err := unix.Open(ptyName, unix.O_RDWR|unix.O_NOCTTY, 0620)
+		fd, err := unix.Open(ptyName, unix.O_RDWR|unix.O_NOCTTY, 0o620)
 		if err != nil {
 			return -1, -1, fmt.Errorf("opening PTY %q: %v", ptyName, err)
 		}

--- a/chroot/run_common.go
+++ b/chroot/run_common.go
@@ -73,7 +73,7 @@ func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reade
 	if err != nil {
 		return err
 	}
-	if err = ioutils.AtomicWriteFile(filepath.Join(bundlePath, "config.json"), specbytes, 0600); err != nil {
+	if err = ioutils.AtomicWriteFile(filepath.Join(bundlePath, "config.json"), specbytes, 0o600); err != nil {
 		return fmt.Errorf("storing runtime configuration: %w", err)
 	}
 	logrus.Debugf("config = %v", string(specbytes))
@@ -265,7 +265,7 @@ func runUsingChrootMain() {
 			logrus.Warnf("error %s ownership of container PTY %sto %d/%d: %v", op, from, rootUID, rootGID, err)
 		}
 		// Set permissions on the PTY.
-		if err = ctty.Chmod(0620); err != nil {
+		if err = ctty.Chmod(0o620); err != nil {
 			logrus.Errorf("error setting permissions of container PTY: %v", err)
 			os.Exit(1)
 		}
@@ -525,7 +525,6 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 	cmd.ExtraFiles = append([]*os.File{preader}, cmd.ExtraFiles...)
 	if err := setPlatformUnshareOptions(spec, cmd); err != nil {
 		return 1, fmt.Errorf("setting platform unshare options: %w", err)
-
 	}
 	interrupted := make(chan os.Signal, 100)
 	cmd.Hook = func(int) error {

--- a/chroot/run_freebsd.go
+++ b/chroot/run_freebsd.go
@@ -190,12 +190,12 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			// XXX: This was copied from the linux version which supports bind mounting files.
 			// Leaving it here since I plan to add this to FreeBSD's nullfs.
 			if m.Type != "nullfs" || srcinfo.IsDir() {
-				if err = os.MkdirAll(target, 0111); err != nil {
+				if err = os.MkdirAll(target, 0o111); err != nil {
 					return undoBinds, fmt.Errorf("creating mountpoint %q in mount namespace: %w", target, err)
 				}
 				removes = append(removes, target)
 			} else {
-				if err = os.MkdirAll(filepath.Dir(target), 0111); err != nil {
+				if err = os.MkdirAll(filepath.Dir(target), 0o111); err != nil {
 					return undoBinds, fmt.Errorf("ensuring parent of mountpoint %q (%q) is present in mount namespace: %w", target, filepath.Dir(target), err)
 				}
 				// Don't do this until we can support file mounts in nullfs
@@ -218,7 +218,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 					save := saveDir(spec, target)
 					if err := fileutils.Exists(save); err != nil {
 						if errors.Is(err, fs.ErrNotExist) {
-							err = os.MkdirAll(save, 0111)
+							err = os.MkdirAll(save, 0o111)
 						}
 						if err != nil {
 							return undoBinds, fmt.Errorf("creating file mount save directory %q: %w", save, err)

--- a/chroot/run_linux.go
+++ b/chroot/run_linux.go
@@ -363,9 +363,9 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 		if err := unix.Mount(m.Mountpoint, subSys, "bind", sysFlags, ""); err != nil {
 			msg := fmt.Sprintf("could not bind mount %q, skipping: %v", m.Mountpoint, err)
 			if strings.HasPrefix(m.Mountpoint, "/sys") {
-				logrus.Infof(msg)
+				logrus.Info(msg)
 			} else {
-				logrus.Warningf(msg)
+				logrus.Warning(msg)
 			}
 			continue
 		}

--- a/chroot/run_linux.go
+++ b/chroot/run_linux.go
@@ -301,7 +301,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	subDev := filepath.Join(spec.Root.Path, "/dev")
 	if err := unix.Mount("/dev", subDev, "bind", devFlags, ""); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			err = os.Mkdir(subDev, 0755)
+			err = os.Mkdir(subDev, 0o755)
 			if err == nil {
 				err = unix.Mount("/dev", subDev, "bind", devFlags, "")
 			}
@@ -325,7 +325,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	subProc := filepath.Join(spec.Root.Path, "/proc")
 	if err := unix.Mount("/proc", subProc, "bind", procFlags, ""); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			err = os.Mkdir(subProc, 0755)
+			err = os.Mkdir(subProc, 0o755)
 			if err == nil {
 				err = unix.Mount("/proc", subProc, "bind", procFlags, "")
 			}
@@ -340,7 +340,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	subSys := filepath.Join(spec.Root.Path, "/sys")
 	if err := unix.Mount("/sys", subSys, "bind", sysFlags, ""); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			err = os.Mkdir(subSys, 0755)
+			err = os.Mkdir(subSys, 0o755)
 			if err == nil {
 				err = unix.Mount("/sys", subSys, "bind", sysFlags, "")
 			}
@@ -432,15 +432,15 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 			// The target isn't there yet, so create it.  If the source is a directory,
 			// we need a directory, otherwise we need a non-directory (i.e., a file).
 			if srcinfo.IsDir() {
-				if err = os.MkdirAll(target, 0755); err != nil {
+				if err = os.MkdirAll(target, 0o755); err != nil {
 					return undoBinds, fmt.Errorf("creating mountpoint %q in mount namespace: %w", target, err)
 				}
 			} else {
-				if err = os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				if err = os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 					return undoBinds, fmt.Errorf("ensuring parent of mountpoint %q (%q) is present in mount namespace: %w", target, filepath.Dir(target), err)
 				}
 				var file *os.File
-				if file, err = os.OpenFile(target, os.O_WRONLY|os.O_CREATE, 0755); err != nil {
+				if file, err = os.OpenFile(target, os.O_WRONLY|os.O_CREATE, 0o755); err != nil {
 					return undoBinds, fmt.Errorf("creating mountpoint %q in mount namespace: %w", target, err)
 				}
 				file.Close()
@@ -593,7 +593,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 	// Create an empty directory for to use for masking directories.
 	roEmptyDir := filepath.Join(bundlePath, "empty")
 	if len(spec.Linux.MaskedPaths) > 0 {
-		if err := os.Mkdir(roEmptyDir, 0700); err != nil {
+		if err := os.Mkdir(roEmptyDir, 0o700); err != nil {
 			return undoBinds, fmt.Errorf("creating empty directory %q: %w", roEmptyDir, err)
 		}
 	}

--- a/chroot/run_test.go
+++ b/chroot/run_test.go
@@ -49,17 +49,17 @@ func testMinimal(t *testing.T, modify func(g *generate.Generator, rootDir, bundl
 	// t.TempDir returns /tmp/TestName/001.
 	// /tmp/TestName/001 has permission 0777, but /tmp/TestName is 0700
 	tempDir := t.TempDir()
-	if err = os.Chmod(filepath.Dir(tempDir), 0711); err != nil {
+	if err = os.Chmod(filepath.Dir(tempDir), 0o711); err != nil {
 		t.Fatalf("error loosening permissions on %q: %v", tempDir, err)
 	}
 
 	rootDir := filepath.Join(tempDir, "root")
-	if err := os.Mkdir(rootDir, 0711); err != nil {
+	if err := os.Mkdir(rootDir, 0o711); err != nil {
 		t.Fatalf("os.Mkdir(%q): %v", rootDir, err)
 	}
 
 	rootTmpDir := filepath.Join(rootDir, "tmp")
-	if err := os.Mkdir(rootTmpDir, 01777); err != nil {
+	if err := os.Mkdir(rootTmpDir, 0o1777); err != nil {
 		t.Fatalf("os.Mkdir(%q): %v", rootTmpDir, err)
 	}
 
@@ -69,7 +69,7 @@ func testMinimal(t *testing.T, modify func(g *generate.Generator, rootDir, bundl
 		t.Fatalf("open(%q): %v", specPath, err)
 	}
 	defer specBinarySource.Close()
-	specBinary, err := os.OpenFile(filepath.Join(rootDir, reportCommand), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0711)
+	specBinary, err := os.OpenFile(filepath.Join(rootDir, reportCommand), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o711)
 	if err != nil {
 		t.Fatalf("open(%q): %v", filepath.Join(rootDir, reportCommand), err)
 	}
@@ -83,7 +83,7 @@ func testMinimal(t *testing.T, modify func(g *generate.Generator, rootDir, bundl
 	g.SetProcessArgs([]string{"/" + reportCommand})
 
 	bundleDir := filepath.Join(tempDir, "bundle")
-	if err := os.Mkdir(bundleDir, 0700); err != nil {
+	if err := os.Mkdir(bundleDir, 0o700); err != nil {
 		t.Fatalf("os.Mkdir(%q): %v", bundleDir, err)
 	}
 
@@ -223,7 +223,7 @@ func TestProcessCwd(t *testing.T) {
 	}
 	testMinimal(t,
 		func(g *generate.Generator, rootDir, _ string) {
-			if err := os.Mkdir(filepath.Join(rootDir, "/no-such-directory"), 0700); err != nil {
+			if err := os.Mkdir(filepath.Join(rootDir, "/no-such-directory"), 0o700); err != nil {
 				t.Fatalf("mkdir(%q): %v", filepath.Join(rootDir, "/no-such-directory"), err)
 			}
 			g.SetProcessCwd("/no-such-directory")
@@ -431,7 +431,8 @@ func TestMounts(t *testing.T) {
 			name:        "nosuid",
 			destination: "/nosuid",
 			options:     []string{"nosuid"},
-			reject:      []string{"suid"}},
+			reject:      []string{"suid"},
+		},
 		{
 			name:        "nodev,noexec",
 			destination: "/nodev,noexec",

--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -71,7 +71,7 @@ func init() {
 
 func buildCmd(c *cobra.Command, inputArgs []string, iopts buildahcli.BuildOptions) error {
 	if c.Flag("logfile").Changed {
-		logfile, err := os.OpenFile(iopts.Logfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+		logfile, err := os.OpenFile(iopts.Logfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 		if err != nil {
 			return err
 		}

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -83,7 +83,6 @@ func init() {
 	commitCommand.SetUsageTemplate(UsageTemplate())
 	commitListFlagSet(commitCommand, &opts)
 	rootCmd.AddCommand(commitCommand)
-
 }
 
 func commitListFlagSet(cmd *cobra.Command, opts *commitInputOptions) {
@@ -125,7 +124,7 @@ func commitListFlagSet(cmd *cobra.Command, opts *commitInputOptions) {
 	_ = cmd.RegisterFlagCompletionFunc("reference-time", completion.AutocompleteNone)
 
 	flags.StringVar(&opts.pull, "pull", "true", "pull SBOM scanner images from the registry if newer or not present in store, if false, only pull SBOM scanner images if not present, if always, pull SBOM scanner images even if the named images are present in store, if never, only use images present in store if available")
-	flags.Lookup("pull").NoOptDefVal = "true" //allow `--pull ` to be set to `true` as expected.
+	flags.Lookup("pull").NoOptDefVal = "true" // allow `--pull ` to be set to `true` as expected.
 
 	flags.BoolVar(&opts.pullAlways, "pull-always", false, "pull the image even if the named image is present in store")
 	if err := flags.MarkHidden("pull-always"); err != nil {

--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -20,10 +20,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
-var (
-	// configuration, including customizations made in containers.conf
-	needToShutdownStore = false
-)
+// configuration, including customizations made in containers.conf
+var needToShutdownStore = false
 
 func getStore(c *cobra.Command) (storage.Store, error) {
 	if err := setXDGRuntimeDir(); err != nil {

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -104,7 +104,6 @@ func init() {
 	flags.StringSliceVar(&opts.unsetLabels, "unsetlabel", nil, "remove image configuration label")
 
 	rootCmd.AddCommand(configCommand)
-
 }
 
 func updateCmd(builder *buildah.Builder, cmd string) error {
@@ -386,7 +385,7 @@ func updateHealthcheck(builder *buildah.Builder, c *cobra.Command, iopts configR
 		if c.Flag("healthcheck-retries").Changed {
 			healthcheck.Retries = iopts.healthcheckRetries
 			args = args + "--retries=" + strconv.Itoa(iopts.healthcheckRetries) + " "
-			//args = fmt.Sprintf("%s --retries=%d ", args, iopts.healthcheckRetries)
+			// args = fmt.Sprintf("%s --retries=%d ", args, iopts.healthcheckRetries)
 
 		}
 		if c.Flag("healthcheck-start-period").Changed {

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -386,7 +386,6 @@ func updateHealthcheck(builder *buildah.Builder, c *cobra.Command, iopts configR
 			healthcheck.Retries = iopts.healthcheckRetries
 			args = args + "--retries=" + strconv.Itoa(iopts.healthcheckRetries) + " "
 			// args = fmt.Sprintf("%s --retries=%d ", args, iopts.healthcheckRetries)
-
 		}
 		if c.Flag("healthcheck-start-period").Changed {
 			duration, err := time.ParseDuration(iopts.healthcheckStartPeriod)

--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -76,7 +76,7 @@ func init() {
 		Aliases: []string{"list", "ls", "ps"},
 		Short:   "List working containers and their base images",
 		Long:    containersDescription,
-		//Flags:                  sortFlags(containersFlags),
+		// Flags:                  sortFlags(containersFlags),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return containersCmd(cmd, args, opts)
 		},
@@ -168,11 +168,13 @@ func outputContainers(store storage.Store, opts containerOptions, params *contai
 				continue
 			}
 			if opts.json {
-				JSONContainers = append(JSONContainers, jsonContainer{ID: builder.ContainerID,
+				JSONContainers = append(JSONContainers, jsonContainer{
+					ID:            builder.ContainerID,
 					Builder:       true,
 					ImageID:       builder.FromImageID,
 					ImageName:     image,
-					ContainerName: builder.Container})
+					ContainerName: builder.Container,
+				})
 				continue
 			}
 			output := containerOutputParams{
@@ -208,11 +210,13 @@ func outputContainers(store storage.Store, opts containerOptions, params *contai
 				continue
 			}
 			if opts.json {
-				JSONContainers = append(JSONContainers, jsonContainer{ID: container.ID,
+				JSONContainers = append(JSONContainers, jsonContainer{
+					ID:            container.ID,
 					Builder:       ours,
 					ImageID:       container.ImageID,
 					ImageName:     imageNameForID(container.ImageID),
-					ContainerName: name})
+					ContainerName: name,
+				})
 				continue
 			}
 			output := containerOutputParams{

--- a/cmd/buildah/dumpbolt.go
+++ b/cmd/buildah/dumpbolt.go
@@ -22,7 +22,7 @@ var (
 )
 
 func dumpBoltCmd(_ *cobra.Command, args []string) error {
-	db, err := bolt.Open(args[0], 0600, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(args[0], 0o600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return fmt.Errorf("opening database %q: %w", args[0], err)
 	}

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -75,7 +75,7 @@ missing: pull images if the named images are not present in store,
 never: only use images present in store if available,
 newer: only pull images when newer images exist on the registry than those in the store.`)
 
-	flags.Lookup("pull").NoOptDefVal = "true" //allow `--pull ` to be set to `true` as expected.
+	flags.Lookup("pull").NoOptDefVal = "true" // allow `--pull ` to be set to `true` as expected.
 
 	flags.BoolVar(&opts.pullAlways, "pull-always", false, "pull the image even if the named image is present in store")
 	if err := flags.MarkHidden("pull-always"); err != nil {
@@ -312,7 +312,7 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 
 	if iopts.cidfile != "" {
 		filePath := iopts.cidfile
-		if err := os.WriteFile(filePath, []byte(builder.ContainerID), 0644); err != nil {
+		if err := os.WriteFile(filePath, []byte(builder.ContainerID), 0o644); err != nil {
 			return fmt.Errorf("failed to write container ID file %q: %w", filePath, err)
 		}
 	}

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -70,7 +70,6 @@ func init() {
 	if err != nil {
 		logrus.Error(err.Error())
 		os.Exit(1)
-
 	}
 
 	if len(storageOptions.GraphDriverOptions) > 0 {

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -68,7 +68,7 @@ func init() {
 	var defaultStoreDriverOptions []string
 	storageOptions, err := storage.DefaultStoreOptions()
 	if err != nil {
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		os.Exit(1)
 
 	}
@@ -80,7 +80,7 @@ func init() {
 
 	defaultContainerConfig, err = config.Default()
 	if err != nil {
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		os.Exit(1)
 	}
 	defaultContainerConfig.CheckCgroupsAndAdjustConfig()

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -65,9 +65,7 @@ var (
 )
 
 func init() {
-	var (
-		defaultStoreDriverOptions []string
-	)
+	var defaultStoreDriverOptions []string
 	storageOptions, err := storage.DefaultStoreOptions()
 	if err != nil {
 		logrus.Errorf(err.Error())
@@ -90,7 +88,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	// Disable the implicit `completion` command in cobra.
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
-	//rootCmd.TraverseChildren = true
+	// rootCmd.TraverseChildren = true
 	rootCmd.Version = fmt.Sprintf("%s (image-spec %s, runtime-spec %s)", define.Version, ispecs.Version, rspecs.Version)
 	rootCmd.PersistentFlags().BoolVar(&globalFlagResults.Debug, "debug", false, "print debugging information")
 	// TODO Need to allow for environment variable

--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -1207,7 +1207,7 @@ func manifestPush(systemContext *types.SystemContext, store storage.Store, listI
 	}
 
 	if opts.digestfile != "" {
-		if err = os.WriteFile(opts.digestfile, []byte(digest.String()), 0644); err != nil {
+		if err = os.WriteFile(opts.digestfile, []byte(digest.String()), 0o644); err != nil {
 			return util.GetFailureCause(err, fmt.Errorf("failed to write digest to file %q: %w", opts.digestfile, err))
 		}
 	}

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -1,12 +1,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
-
-	"errors"
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
@@ -255,7 +254,7 @@ func pushCmd(c *cobra.Command, args []string, iopts pushOptions) error {
 	logrus.Debugf("Successfully pushed %s with digest %s", transports.ImageName(dest), digest.String())
 
 	if iopts.digestfile != "" {
-		if err = os.WriteFile(iopts.digestfile, []byte(digest.String()), 0644); err != nil {
+		if err = os.WriteFile(iopts.digestfile, []byte(digest.String()), 0o644); err != nil {
 			return util.GetFailureCause(err, fmt.Errorf("failed to write digest to file %q: %w", iopts.digestfile, err))
 		}
 	}

--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -86,7 +86,6 @@ func rmCmd(c *cobra.Command, args []string, iopts rmResults) error {
 			}
 			fmt.Printf("%s\n", id)
 		}
-
 	}
 	return lastError
 }

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -53,7 +53,6 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.NameSpaceResults = &namespaceResults
 			return runCmd(cmd, args, opts)
-
 		},
 		Example: `buildah run containerID -- ps -auxw
   buildah run --terminal containerID /bin/bash

--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -44,7 +44,7 @@ type versionOptions struct {
 func init() {
 	var opts versionOptions
 
-	//cli command to print out the version info of buildah
+	// cli command to print out the version info of buildah
 	versionCommand := &cobra.Command{
 		Use:   "version",
 		Short: "Display the Buildah version information",
@@ -67,7 +67,7 @@ func versionCmd(opts versionOptions) error {
 	var err error
 	buildTime := int64(0)
 	if buildInfo != "" {
-		//converting unix time from string to int64
+		// converting unix time from string to int64
 		buildTime, err = strconv.ParseInt(buildInfo, 10, 64)
 		if err != nil {
 			return err
@@ -106,7 +106,7 @@ func versionCmd(opts versionOptions) error {
 	fmt.Println("image Version:  ", version.ImageVersion)
 	fmt.Println("Git Commit:     ", version.GitCommit)
 
-	//Prints out the build time in readable format
+	// Prints out the build time in readable format
 	fmt.Println("Built:          ", version.Built)
 	fmt.Println("OS/Arch:        ", version.OsArch)
 	fmt.Println("BuildPlatform:  ", version.BuildPlatform)

--- a/commit.go
+++ b/commit.go
@@ -153,15 +153,13 @@ type LinkedLayer struct {
 	BlobPath string     // corresponding uncompressed blob file (layer as a tar archive), or directory tree to archive
 }
 
-var (
-	// storageAllowedPolicyScopes overrides the policy for local storage
-	// to ensure that we can read images from it.
-	storageAllowedPolicyScopes = signature.PolicyTransportScopes{
-		"": []signature.PolicyRequirement{
-			signature.NewPRInsecureAcceptAnything(),
-		},
-	}
-)
+// storageAllowedPolicyScopes overrides the policy for local storage
+// to ensure that we can read images from it.
+var storageAllowedPolicyScopes = signature.PolicyTransportScopes{
+	"": []signature.PolicyRequirement{
+		signature.NewPRInsecureAcceptAnything(),
+	},
+}
 
 // checkRegistrySourcesAllows checks the $BUILD_REGISTRY_SOURCES environment
 // variable, if it's set.  The contents are expected to be a JSON-encoded
@@ -458,7 +456,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 			logrus.Debugf("removing %v from assigned names to image %q", nameToRemove, img.ID)
 		}
 		if options.IIDFile != "" {
-			if err = os.WriteFile(options.IIDFile, []byte("sha256:"+img.ID), 0644); err != nil {
+			if err = os.WriteFile(options.IIDFile, []byte("sha256:"+img.ID), 0o644); err != nil {
 				return imgID, nil, "", err
 			}
 		}

--- a/commit.go
+++ b/commit.go
@@ -505,7 +505,6 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 			return imgID, nil, "", err
 		}
 		logrus.Debugf("added imgID %s to manifestID %s", imgID, manifestID)
-
 	}
 	return imgID, ref, manifestDigest, nil
 }

--- a/copier/copier_linux_test.go
+++ b/copier/copier_linux_test.go
@@ -117,17 +117,17 @@ func TestGetPermissionErrorChroot(t *testing.T) {
 func testGetPermissionError(t *testing.T) {
 	dropCaps := []capability.Cap{capability.CAP_DAC_OVERRIDE, capability.CAP_DAC_READ_SEARCH}
 	tmp := t.TempDir()
-	err := os.Mkdir(filepath.Join(tmp, "unreadable-directory"), 0000)
+	err := os.Mkdir(filepath.Join(tmp, "unreadable-directory"), 0o000)
 	require.NoError(t, err, "error creating an unreadable directory")
-	err = os.Mkdir(filepath.Join(tmp, "readable-directory"), 0755)
+	err = os.Mkdir(filepath.Join(tmp, "readable-directory"), 0o755)
 	require.NoError(t, err, "error creating a readable directory")
-	err = os.Mkdir(filepath.Join(tmp, "readable-directory", "unreadable-subdirectory"), 0000)
+	err = os.Mkdir(filepath.Join(tmp, "readable-directory", "unreadable-subdirectory"), 0o000)
 	require.NoError(t, err, "error creating an unreadable subdirectory")
-	err = os.WriteFile(filepath.Join(tmp, "unreadable-file"), []byte("hi, i'm a file that you can't read"), 0000)
+	err = os.WriteFile(filepath.Join(tmp, "unreadable-file"), []byte("hi, i'm a file that you can't read"), 0o000)
 	require.NoError(t, err, "error creating an unreadable file")
-	err = os.WriteFile(filepath.Join(tmp, "readable-file"), []byte("hi, i'm also a file, and you can read me"), 0644)
+	err = os.WriteFile(filepath.Join(tmp, "readable-file"), []byte("hi, i'm also a file, and you can read me"), 0o644)
 	require.NoError(t, err, "error creating a readable file")
-	err = os.WriteFile(filepath.Join(tmp, "readable-directory", "unreadable-file"), []byte("hi, i'm also a file that you can't read"), 0000)
+	err = os.WriteFile(filepath.Join(tmp, "readable-directory", "unreadable-file"), []byte("hi, i'm also a file that you can't read"), 0o000)
 	require.NoError(t, err, "error creating an unreadable file in a readable directory")
 	for _, ignore := range []bool{false, true} {
 		t.Run(fmt.Sprintf("ignore=%v", ignore), func(t *testing.T) {
@@ -163,7 +163,7 @@ func TestGetNoCrossDevice(t *testing.T) {
 	require.NoError(t, err, "error creating new mount namespace")
 
 	subdir := filepath.Join(tmpdir, "subdir")
-	err = os.Mkdir(subdir, 0755)
+	err = os.Mkdir(subdir, 0o755)
 	require.NoErrorf(t, err, "error creating %q", subdir)
 
 	err = mount.Mount("tmpfs", subdir, "tmpfs", "rw")
@@ -174,7 +174,7 @@ func TestGetNoCrossDevice(t *testing.T) {
 	}()
 
 	skipped := filepath.Join(subdir, "skipped.txt")
-	err = os.WriteFile(skipped, []byte("this file should have been skipped\n"), 0644)
+	err = os.WriteFile(skipped, []byte("this file should have been skipped\n"), 0o644)
 	require.NoErrorf(t, err, "error writing file at %q", skipped)
 
 	var buf bytes.Buffer

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -181,9 +181,9 @@ var (
 	uid = os.Getuid()
 
 	testArchiveSlice = makeArchiveSlice([]tar.Header{
-		{Name: "item-0", Typeflag: tar.TypeReg, Size: 123, Mode: 0600, ModTime: testDate},
-		{Name: "item-1", Typeflag: tar.TypeReg, Size: 456, Mode: 0600, ModTime: testDate},
-		{Name: "item-2", Typeflag: tar.TypeReg, Size: 789, Mode: 0600, ModTime: testDate},
+		{Name: "item-0", Typeflag: tar.TypeReg, Size: 123, Mode: 0o600, ModTime: testDate},
+		{Name: "item-1", Typeflag: tar.TypeReg, Size: 456, Mode: 0o600, ModTime: testDate},
+		{Name: "item-2", Typeflag: tar.TypeReg, Size: 789, Mode: 0o600, ModTime: testDate},
 	})
 
 	testArchives = []struct {
@@ -204,38 +204,38 @@ var (
 			name:     "regular",
 			rootOnly: false,
 			headers: []tar.Header{
-				{Name: "file-0", Typeflag: tar.TypeReg, Size: 123456789, Mode: 0600, ModTime: testDate},
-				{Name: "file-a", Typeflag: tar.TypeReg, Size: 23, Mode: 0600, ModTime: testDate},
-				{Name: "file-b", Typeflag: tar.TypeReg, Size: 23, Mode: 0600, ModTime: testDate},
-				{Name: "file-c", Typeflag: tar.TypeLink, Linkname: "file-a", Mode: 0600, ModTime: testDate},
-				{Name: "file-u", Typeflag: tar.TypeReg, Size: 23, Mode: cISUID | 0755, ModTime: testDate},
-				{Name: "file-g", Typeflag: tar.TypeReg, Size: 23, Mode: cISGID | 0755, ModTime: testDate},
-				{Name: "file-t", Typeflag: tar.TypeReg, Size: 23, Mode: cISVTX | 0755, ModTime: testDate},
-				{Name: "link-0", Typeflag: tar.TypeSymlink, Linkname: "../file-0", Size: 123456789, Mode: 0777, ModTime: testDate},
-				{Name: "link-a", Typeflag: tar.TypeSymlink, Linkname: "file-a", Size: 23, Mode: 0777, ModTime: testDate},
-				{Name: "link-b", Typeflag: tar.TypeSymlink, Linkname: "../file-a", Size: 23, Mode: 0777, ModTime: testDate},
-				{Name: "hlink-0", Typeflag: tar.TypeLink, Linkname: "file-0", Size: 123456789, Mode: 0600, ModTime: testDate},
-				{Name: "hlink-a", Typeflag: tar.TypeLink, Linkname: "/file-a", Size: 23, Mode: 0600, ModTime: testDate},
-				{Name: "hlink-b", Typeflag: tar.TypeLink, Linkname: "../file-b", Size: 23, Mode: 0600, ModTime: testDate},
-				{Name: "subdir-a", Typeflag: tar.TypeDir, Mode: 0700, ModTime: testDate},
-				{Name: "subdir-a/file-n", Typeflag: tar.TypeReg, Size: 108, Mode: 0660, ModTime: testDate},
-				{Name: "subdir-a/file-o", Typeflag: tar.TypeReg, Size: 34, Mode: 0660, ModTime: testDate},
-				{Name: "subdir-a/file-a", Typeflag: tar.TypeSymlink, Linkname: "../file-a", Size: 23, Mode: 0777, ModTime: testDate},
-				{Name: "subdir-a/file-b", Typeflag: tar.TypeSymlink, Linkname: "../../file-b", Size: 23, Mode: 0777, ModTime: testDate},
-				{Name: "subdir-a/file-c", Typeflag: tar.TypeSymlink, Linkname: "/file-c", Size: 23, Mode: 0777, ModTime: testDate},
-				{Name: "subdir-b", Typeflag: tar.TypeDir, Mode: 0700, ModTime: testDate},
-				{Name: "subdir-b/file-n", Typeflag: tar.TypeReg, Size: 216, Mode: 0660, ModTime: testDate},
-				{Name: "subdir-b/file-o", Typeflag: tar.TypeReg, Size: 45, Mode: 0660, ModTime: testDate},
-				{Name: "subdir-c", Typeflag: tar.TypeDir, Mode: 0700, ModTime: testDate},
-				{Name: "subdir-c/file-n", Typeflag: tar.TypeReg, Size: 432, Mode: 0666, ModTime: testDate},
-				{Name: "subdir-c/file-o", Typeflag: tar.TypeReg, Size: 56, Mode: 0666, ModTime: testDate},
-				{Name: "subdir-d", Typeflag: tar.TypeDir, Mode: 0700, ModTime: testDate},
-				{Name: "subdir-d/hlink-0", Typeflag: tar.TypeLink, Linkname: "../file-0", Size: 123456789, Mode: 0600, ModTime: testDate},
-				{Name: "subdir-d/hlink-a", Typeflag: tar.TypeLink, Linkname: "/file-a", Size: 23, Mode: 0600, ModTime: testDate},
-				{Name: "subdir-d/hlink-b", Typeflag: tar.TypeLink, Linkname: "../../file-b", Size: 23, Mode: 0600, ModTime: testDate},
-				{Name: "archive-a", Typeflag: tar.TypeReg, Size: 0, Mode: 0600, ModTime: testDate},
-				{Name: "subdir-e", Typeflag: tar.TypeDir, Mode: 0500, ModTime: testDate},
-				{Name: "subdir-e/file-p", Typeflag: tar.TypeReg, Size: 890, Mode: 0600, ModTime: testDate},
+				{Name: "file-0", Typeflag: tar.TypeReg, Size: 123456789, Mode: 0o600, ModTime: testDate},
+				{Name: "file-a", Typeflag: tar.TypeReg, Size: 23, Mode: 0o600, ModTime: testDate},
+				{Name: "file-b", Typeflag: tar.TypeReg, Size: 23, Mode: 0o600, ModTime: testDate},
+				{Name: "file-c", Typeflag: tar.TypeLink, Linkname: "file-a", Mode: 0o600, ModTime: testDate},
+				{Name: "file-u", Typeflag: tar.TypeReg, Size: 23, Mode: cISUID | 0o755, ModTime: testDate},
+				{Name: "file-g", Typeflag: tar.TypeReg, Size: 23, Mode: cISGID | 0o755, ModTime: testDate},
+				{Name: "file-t", Typeflag: tar.TypeReg, Size: 23, Mode: cISVTX | 0o755, ModTime: testDate},
+				{Name: "link-0", Typeflag: tar.TypeSymlink, Linkname: "../file-0", Size: 123456789, Mode: 0o777, ModTime: testDate},
+				{Name: "link-a", Typeflag: tar.TypeSymlink, Linkname: "file-a", Size: 23, Mode: 0o777, ModTime: testDate},
+				{Name: "link-b", Typeflag: tar.TypeSymlink, Linkname: "../file-a", Size: 23, Mode: 0o777, ModTime: testDate},
+				{Name: "hlink-0", Typeflag: tar.TypeLink, Linkname: "file-0", Size: 123456789, Mode: 0o600, ModTime: testDate},
+				{Name: "hlink-a", Typeflag: tar.TypeLink, Linkname: "/file-a", Size: 23, Mode: 0o600, ModTime: testDate},
+				{Name: "hlink-b", Typeflag: tar.TypeLink, Linkname: "../file-b", Size: 23, Mode: 0o600, ModTime: testDate},
+				{Name: "subdir-a", Typeflag: tar.TypeDir, Mode: 0o700, ModTime: testDate},
+				{Name: "subdir-a/file-n", Typeflag: tar.TypeReg, Size: 108, Mode: 0o660, ModTime: testDate},
+				{Name: "subdir-a/file-o", Typeflag: tar.TypeReg, Size: 34, Mode: 0o660, ModTime: testDate},
+				{Name: "subdir-a/file-a", Typeflag: tar.TypeSymlink, Linkname: "../file-a", Size: 23, Mode: 0o777, ModTime: testDate},
+				{Name: "subdir-a/file-b", Typeflag: tar.TypeSymlink, Linkname: "../../file-b", Size: 23, Mode: 0o777, ModTime: testDate},
+				{Name: "subdir-a/file-c", Typeflag: tar.TypeSymlink, Linkname: "/file-c", Size: 23, Mode: 0o777, ModTime: testDate},
+				{Name: "subdir-b", Typeflag: tar.TypeDir, Mode: 0o700, ModTime: testDate},
+				{Name: "subdir-b/file-n", Typeflag: tar.TypeReg, Size: 216, Mode: 0o660, ModTime: testDate},
+				{Name: "subdir-b/file-o", Typeflag: tar.TypeReg, Size: 45, Mode: 0o660, ModTime: testDate},
+				{Name: "subdir-c", Typeflag: tar.TypeDir, Mode: 0o700, ModTime: testDate},
+				{Name: "subdir-c/file-n", Typeflag: tar.TypeReg, Size: 432, Mode: 0o666, ModTime: testDate},
+				{Name: "subdir-c/file-o", Typeflag: tar.TypeReg, Size: 56, Mode: 0o666, ModTime: testDate},
+				{Name: "subdir-d", Typeflag: tar.TypeDir, Mode: 0o700, ModTime: testDate},
+				{Name: "subdir-d/hlink-0", Typeflag: tar.TypeLink, Linkname: "../file-0", Size: 123456789, Mode: 0o600, ModTime: testDate},
+				{Name: "subdir-d/hlink-a", Typeflag: tar.TypeLink, Linkname: "/file-a", Size: 23, Mode: 0o600, ModTime: testDate},
+				{Name: "subdir-d/hlink-b", Typeflag: tar.TypeLink, Linkname: "../../file-b", Size: 23, Mode: 0o600, ModTime: testDate},
+				{Name: "archive-a", Typeflag: tar.TypeReg, Size: 0, Mode: 0o600, ModTime: testDate},
+				{Name: "subdir-e", Typeflag: tar.TypeDir, Mode: 0o500, ModTime: testDate},
+				{Name: "subdir-e/file-p", Typeflag: tar.TypeReg, Size: 890, Mode: 0o600, ModTime: testDate},
 			},
 			contents: map[string][]byte{
 				"archive-a": testArchiveSlice,
@@ -412,8 +412,8 @@ var (
 			name:     "devices",
 			rootOnly: true,
 			headers: []tar.Header{
-				{Name: "char-dev", Typeflag: tar.TypeChar, Devmajor: 0, Devminor: 0, Mode: 0600, ModTime: testDate},
-				{Name: "blk-dev", Typeflag: tar.TypeBlock, Devmajor: 0, Devminor: 0, Mode: 0600, ModTime: testDate},
+				{Name: "char-dev", Typeflag: tar.TypeChar, Devmajor: 0, Devminor: 0, Mode: 0o600, ModTime: testDate},
+				{Name: "blk-dev", Typeflag: tar.TypeBlock, Devmajor: 0, Devminor: 0, Mode: 0o600, ModTime: testDate},
 			},
 		},
 	}
@@ -534,13 +534,13 @@ func testPut(t *testing.T) {
 		for _, typeFlag := range []byte{tar.TypeReg, tar.TypeLink, tar.TypeSymlink, tar.TypeChar, tar.TypeBlock, tar.TypeFifo} {
 			t.Run(fmt.Sprintf("overwrite (dir)=%v,type=%c", overwrite, typeFlag), func(t *testing.T) {
 				archive := makeArchiveSlice([]tar.Header{
-					{Name: "target", Typeflag: tar.TypeSymlink, Mode: 0755, Linkname: "target", ModTime: testDate},
-					{Name: "target", Typeflag: tar.TypeDir, Mode: 0755, ModTime: testDate},
-					{Name: "target", Typeflag: tar.TypeSymlink, Mode: 0755, Linkname: "target", ModTime: testDate},
-					{Name: "target", Typeflag: tar.TypeReg, Size: 123, Mode: 0755, ModTime: testDate},
-					{Name: "test", Typeflag: tar.TypeDir, Size: 0, Mode: 0755, ModTime: testDate},
-					{Name: "test/content", Typeflag: tar.TypeReg, Size: 0, Mode: 0755, ModTime: testDate},
-					{Name: "test", Typeflag: typeFlag, Size: 0, Mode: 0755, Linkname: "target", ModTime: testDate},
+					{Name: "target", Typeflag: tar.TypeSymlink, Mode: 0o755, Linkname: "target", ModTime: testDate},
+					{Name: "target", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
+					{Name: "target", Typeflag: tar.TypeSymlink, Mode: 0o755, Linkname: "target", ModTime: testDate},
+					{Name: "target", Typeflag: tar.TypeReg, Size: 123, Mode: 0o755, ModTime: testDate},
+					{Name: "test", Typeflag: tar.TypeDir, Size: 0, Mode: 0o755, ModTime: testDate},
+					{Name: "test/content", Typeflag: tar.TypeReg, Size: 0, Mode: 0o755, ModTime: testDate},
+					{Name: "test", Typeflag: typeFlag, Size: 0, Mode: 0o755, Linkname: "target", ModTime: testDate},
 				})
 				tmp := t.TempDir()
 				err := Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, NoOverwriteDirNonDir: !overwrite}, bytes.NewReader(archive))
@@ -560,13 +560,13 @@ func testPut(t *testing.T) {
 		for _, typeFlag := range []byte{tar.TypeReg, tar.TypeLink, tar.TypeSymlink, tar.TypeChar, tar.TypeBlock, tar.TypeFifo} {
 			t.Run(fmt.Sprintf("overwrite (non-dir)=%v,type=%c", overwrite, typeFlag), func(t *testing.T) {
 				archive := makeArchiveSlice([]tar.Header{
-					{Name: "target", Typeflag: tar.TypeSymlink, Mode: 0755, Linkname: "target", ModTime: testDate},
-					{Name: "target", Typeflag: tar.TypeReg, Mode: 0755, ModTime: testDate},
-					{Name: "target", Typeflag: tar.TypeSymlink, Mode: 0755, Linkname: "target", ModTime: testDate},
-					{Name: "target", Typeflag: tar.TypeReg, Size: 123, Mode: 0755, ModTime: testDate},
-					{Name: "test", Typeflag: typeFlag, Size: 0, Mode: 0755, Linkname: "target", ModTime: testDate},
-					{Name: "test", Typeflag: tar.TypeDir, Size: 0, Mode: 0755, ModTime: testDate},
-					{Name: "test/content", Typeflag: tar.TypeReg, Size: 0, Mode: 0755, ModTime: testDate},
+					{Name: "target", Typeflag: tar.TypeSymlink, Mode: 0o755, Linkname: "target", ModTime: testDate},
+					{Name: "target", Typeflag: tar.TypeReg, Mode: 0o755, ModTime: testDate},
+					{Name: "target", Typeflag: tar.TypeSymlink, Mode: 0o755, Linkname: "target", ModTime: testDate},
+					{Name: "target", Typeflag: tar.TypeReg, Size: 123, Mode: 0o755, ModTime: testDate},
+					{Name: "test", Typeflag: typeFlag, Size: 0, Mode: 0o755, Linkname: "target", ModTime: testDate},
+					{Name: "test", Typeflag: tar.TypeDir, Size: 0, Mode: 0o755, ModTime: testDate},
+					{Name: "test/content", Typeflag: tar.TypeReg, Size: 0, Mode: 0o755, ModTime: testDate},
 				})
 				tmp := t.TempDir()
 				err := Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, NoOverwriteNonDirDir: !overwrite}, bytes.NewReader(archive))
@@ -587,9 +587,9 @@ func testPut(t *testing.T) {
 					t.Skip("can only test !IgnoreDevices with root privileges, skipping")
 				}
 				archive := makeArchiveSlice([]tar.Header{
-					{Name: "test", Typeflag: typeFlag, Size: 0, Mode: 0600, ModTime: testDate, Devmajor: 0, Devminor: 0},
-					{Name: "link", Typeflag: tar.TypeLink, Size: 0, Mode: 0600, ModTime: testDate, Linkname: "test"},
-					{Name: "unrelated", Typeflag: tar.TypeReg, Size: 0, Mode: 0600, ModTime: testDate},
+					{Name: "test", Typeflag: typeFlag, Size: 0, Mode: 0o600, ModTime: testDate, Devmajor: 0, Devminor: 0},
+					{Name: "link", Typeflag: tar.TypeLink, Size: 0, Mode: 0o600, ModTime: testDate, Linkname: "test"},
+					{Name: "unrelated", Typeflag: tar.TypeReg, Size: 0, Mode: 0o600, ModTime: testDate},
 				})
 				tmp := t.TempDir()
 				err := Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, IgnoreDevices: ignoreDevices}, bytes.NewReader(archive))
@@ -889,7 +889,7 @@ func testGetMultiple(t *testing.T) {
 		renames            map[string]string
 		noDerefSymlinks    bool
 	}
-	var getTestArchives = []struct {
+	getTestArchives := []struct {
 		name              string
 		headers           []tar.Header
 		contents          map[string][]byte
@@ -899,32 +899,32 @@ func testGetMultiple(t *testing.T) {
 		{
 			name: "regular",
 			headers: []tar.Header{
-				{Name: "file-0", Typeflag: tar.TypeReg, Size: 123456789, Mode: 0600},
-				{Name: "file-a", Typeflag: tar.TypeReg, Size: 23, Mode: 0600},
-				{Name: "file-b", Typeflag: tar.TypeReg, Size: 23, Mode: 0600},
-				{Name: "link-a", Typeflag: tar.TypeSymlink, Linkname: "file-a", Size: 23, Mode: 0600},
-				{Name: "link-c", Typeflag: tar.TypeSymlink, Linkname: "subdir-c", Mode: 0700, ModTime: testDate},
-				{Name: "archive-a", Typeflag: tar.TypeReg, Size: 0, Mode: 0600},
-				{Name: "non-archive-a", Typeflag: tar.TypeReg, Size: 1199, Mode: 0600},
-				{Name: "hlink-0", Typeflag: tar.TypeLink, Linkname: "file-0", Size: 123456789, Mode: 0600},
-				{Name: "something-a", Typeflag: tar.TypeReg, Size: 34, Mode: 0600},
-				{Name: "subdir-a", Typeflag: tar.TypeDir, Mode: 0700},
-				{Name: "subdir-a/file-n", Typeflag: tar.TypeReg, Size: 108, Mode: 0660},
-				{Name: "subdir-a/file-o", Typeflag: tar.TypeReg, Size: 45, Mode: 0660},
-				{Name: "subdir-a/file-a", Typeflag: tar.TypeSymlink, Linkname: "../file-a", Size: 23, Mode: 0600},
-				{Name: "subdir-a/file-b", Typeflag: tar.TypeSymlink, Linkname: "../../file-b", Size: 23, Mode: 0600},
-				{Name: "subdir-a/file-c", Typeflag: tar.TypeReg, Size: 56, Mode: 0600},
-				{Name: "subdir-b", Typeflag: tar.TypeDir, Mode: 0700},
-				{Name: "subdir-b/file-n", Typeflag: tar.TypeReg, Size: 216, Mode: 0660},
-				{Name: "subdir-b/file-o", Typeflag: tar.TypeReg, Size: 67, Mode: 0660},
-				{Name: "subdir-c", Typeflag: tar.TypeDir, Mode: 0700},
-				{Name: "subdir-c/file-p", Typeflag: tar.TypeReg, Size: 432, Mode: 0666},
-				{Name: "subdir-c/file-q", Typeflag: tar.TypeReg, Size: 78, Mode: 0666},
-				{Name: "subdir-d", Typeflag: tar.TypeDir, Mode: 0700},
-				{Name: "subdir-d/hlink-0", Typeflag: tar.TypeLink, Linkname: "../file-0", Size: 123456789, Mode: 0600},
-				{Name: "subdir-e", Typeflag: tar.TypeDir, Mode: 0700},
-				{Name: "subdir-e/subdir-f", Typeflag: tar.TypeDir, Mode: 0700},
-				{Name: "subdir-e/subdir-f/hlink-b", Typeflag: tar.TypeLink, Linkname: "../../file-b", Size: 23, Mode: 0600},
+				{Name: "file-0", Typeflag: tar.TypeReg, Size: 123456789, Mode: 0o600},
+				{Name: "file-a", Typeflag: tar.TypeReg, Size: 23, Mode: 0o600},
+				{Name: "file-b", Typeflag: tar.TypeReg, Size: 23, Mode: 0o600},
+				{Name: "link-a", Typeflag: tar.TypeSymlink, Linkname: "file-a", Size: 23, Mode: 0o600},
+				{Name: "link-c", Typeflag: tar.TypeSymlink, Linkname: "subdir-c", Mode: 0o700, ModTime: testDate},
+				{Name: "archive-a", Typeflag: tar.TypeReg, Size: 0, Mode: 0o600},
+				{Name: "non-archive-a", Typeflag: tar.TypeReg, Size: 1199, Mode: 0o600},
+				{Name: "hlink-0", Typeflag: tar.TypeLink, Linkname: "file-0", Size: 123456789, Mode: 0o600},
+				{Name: "something-a", Typeflag: tar.TypeReg, Size: 34, Mode: 0o600},
+				{Name: "subdir-a", Typeflag: tar.TypeDir, Mode: 0o700},
+				{Name: "subdir-a/file-n", Typeflag: tar.TypeReg, Size: 108, Mode: 0o660},
+				{Name: "subdir-a/file-o", Typeflag: tar.TypeReg, Size: 45, Mode: 0o660},
+				{Name: "subdir-a/file-a", Typeflag: tar.TypeSymlink, Linkname: "../file-a", Size: 23, Mode: 0o600},
+				{Name: "subdir-a/file-b", Typeflag: tar.TypeSymlink, Linkname: "../../file-b", Size: 23, Mode: 0o600},
+				{Name: "subdir-a/file-c", Typeflag: tar.TypeReg, Size: 56, Mode: 0o600},
+				{Name: "subdir-b", Typeflag: tar.TypeDir, Mode: 0o700},
+				{Name: "subdir-b/file-n", Typeflag: tar.TypeReg, Size: 216, Mode: 0o660},
+				{Name: "subdir-b/file-o", Typeflag: tar.TypeReg, Size: 67, Mode: 0o660},
+				{Name: "subdir-c", Typeflag: tar.TypeDir, Mode: 0o700},
+				{Name: "subdir-c/file-p", Typeflag: tar.TypeReg, Size: 432, Mode: 0o666},
+				{Name: "subdir-c/file-q", Typeflag: tar.TypeReg, Size: 78, Mode: 0o666},
+				{Name: "subdir-d", Typeflag: tar.TypeDir, Mode: 0o700},
+				{Name: "subdir-d/hlink-0", Typeflag: tar.TypeLink, Linkname: "../file-0", Size: 123456789, Mode: 0o600},
+				{Name: "subdir-e", Typeflag: tar.TypeDir, Mode: 0o700},
+				{Name: "subdir-e/subdir-f", Typeflag: tar.TypeDir, Mode: 0o700},
+				{Name: "subdir-e/subdir-f/hlink-b", Typeflag: tar.TypeLink, Linkname: "../../file-b", Size: 23, Mode: 0o600},
 			},
 			contents: map[string][]byte{
 				"archive-a": testArchiveSlice,
@@ -1518,9 +1518,9 @@ func testMkdir(t *testing.T) {
 		{
 			name: "regular",
 			headers: []tar.Header{
-				{Name: "subdir-a", Typeflag: tar.TypeDir, Mode: 0755, ModTime: testDate},
-				{Name: "subdir-a/subdir-b", Typeflag: tar.TypeDir, Mode: 0755, ModTime: testDate},
-				{Name: "subdir-a/subdir-b/subdir-c", Typeflag: tar.TypeDir, Mode: 0755, ModTime: testDate},
+				{Name: "subdir-a", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
+				{Name: "subdir-a/subdir-b", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
+				{Name: "subdir-a/subdir-b/subdir-c", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
 				{Name: "subdir-a/subdir-b/dangle1", Typeflag: tar.TypeSymlink, Linkname: "dangle1-target", ModTime: testDate},
 				{Name: "subdir-a/subdir-b/dangle2", Typeflag: tar.TypeSymlink, Linkname: "../dangle2-target", ModTime: testDate},
 				{Name: "subdir-a/subdir-b/dangle3", Typeflag: tar.TypeSymlink, Linkname: "../../dangle3-target", ModTime: testDate},
@@ -1713,17 +1713,17 @@ func testRemove(t *testing.T) {
 		{
 			name: "regular",
 			headers: []tar.Header{
-				{Name: "subdir-a", Typeflag: tar.TypeDir, Mode: 0755, ModTime: testDate},
-				{Name: "subdir-a/file-a", Typeflag: tar.TypeReg, Mode: 0755, ModTime: testDate},
-				{Name: "subdir-a/file-b", Typeflag: tar.TypeReg, Mode: 0755, ModTime: testDate},
-				{Name: "subdir-a/subdir-b", Typeflag: tar.TypeDir, Mode: 0755, ModTime: testDate},
-				{Name: "subdir-a/subdir-b/subdir-c", Typeflag: tar.TypeDir, Mode: 0755, ModTime: testDate},
+				{Name: "subdir-a", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
+				{Name: "subdir-a/file-a", Typeflag: tar.TypeReg, Mode: 0o755, ModTime: testDate},
+				{Name: "subdir-a/file-b", Typeflag: tar.TypeReg, Mode: 0o755, ModTime: testDate},
+				{Name: "subdir-a/subdir-b", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
+				{Name: "subdir-a/subdir-b/subdir-c", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
 				{Name: "subdir-a/subdir-b/subdir-c/parent", Typeflag: tar.TypeSymlink, Linkname: "..", ModTime: testDate},
 				{Name: "subdir-a/subdir-b/subdir-c/link-b", Typeflag: tar.TypeSymlink, Linkname: "../../file-b", ModTime: testDate},
 				{Name: "subdir-a/subdir-b/subdir-c/root", Typeflag: tar.TypeSymlink, Linkname: "/", ModTime: testDate},
-				{Name: "subdir-a/subdir-d", Typeflag: tar.TypeDir, Mode: 0755, ModTime: testDate},
-				{Name: "subdir-a/subdir-e", Typeflag: tar.TypeDir, Mode: 0755, ModTime: testDate},
-				{Name: "subdir-a/subdir-e/subdir-f", Typeflag: tar.TypeDir, Mode: 0755, ModTime: testDate},
+				{Name: "subdir-a/subdir-d", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
+				{Name: "subdir-a/subdir-e", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
+				{Name: "subdir-a/subdir-e/subdir-f", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
 			},
 			testCases: []testCase{
 				{

--- a/copier/hardlink_unix.go
+++ b/copier/hardlink_unix.go
@@ -24,6 +24,7 @@ func (h *hardlinkChecker) Check(fi os.FileInfo) string {
 	}
 	return ""
 }
+
 func (h *hardlinkChecker) Add(fi os.FileInfo, name string) {
 	if st, ok := fi.Sys().(*syscall.Stat_t); ok && fi.Mode().IsRegular() && st.Nlink > 1 {
 		h.hardlinks.Store(makeHardlinkDeviceAndInode(st), name)

--- a/copier/hardlink_windows.go
+++ b/copier/hardlink_windows.go
@@ -6,11 +6,11 @@ import (
 	"os"
 )
 
-type hardlinkChecker struct {
-}
+type hardlinkChecker struct{}
 
 func (h *hardlinkChecker) Check(fi os.FileInfo) string {
 	return ""
 }
+
 func (h *hardlinkChecker) Add(fi os.FileInfo, name string) {
 }

--- a/copier/syscall_windows.go
+++ b/copier/syscall_windows.go
@@ -83,6 +83,6 @@ func sameDevice(a, b os.FileInfo) bool {
 }
 
 const (
-	testModeMask           = int64(0600)
+	testModeMask           = int64(0o600)
 	testIgnoreSymlinkDates = true
 )

--- a/define/mount_freebsd.go
+++ b/define/mount_freebsd.go
@@ -10,7 +10,5 @@ const (
 	TempDir = "/var/tmp"
 )
 
-var (
-	// Mount potions for bind
-	BindOptions = []string{}
-)
+// Mount potions for bind
+var BindOptions = []string{}

--- a/define/mount_linux.go
+++ b/define/mount_linux.go
@@ -10,7 +10,5 @@ const (
 	TempDir = "/dev/shm"
 )
 
-var (
-	// Mount potions for bind
-	BindOptions = []string{"bind"}
-)
+// Mount potions for bind
+var BindOptions = []string{"bind"}

--- a/define/mount_unsupported.go
+++ b/define/mount_unsupported.go
@@ -10,7 +10,5 @@ const (
 	TempDir = "/var/tmp"
 )
 
-var (
-	// Mount potions for bind
-	BindOptions = []string{""}
-)
+// Mount potions for bind
+var BindOptions = []string{""}

--- a/define/types.go
+++ b/define/types.go
@@ -324,7 +324,7 @@ func downloadToDirectory(url, dir string) error {
 		}
 		dockerfile := filepath.Join(dir, "Dockerfile")
 		// Assume this is a Dockerfile
-		if err := ioutils.AtomicWriteFile(dockerfile, body, 0600); err != nil {
+		if err := ioutils.AtomicWriteFile(dockerfile, body, 0o600); err != nil {
 			return fmt.Errorf("failed to write %q to %q: %w", url, dockerfile, err)
 		}
 	}
@@ -342,7 +342,7 @@ func stdinToDirectory(dir string) error {
 	if err := chrootarchive.Untar(reader, dir, nil); err != nil {
 		dockerfile := filepath.Join(dir, "Dockerfile")
 		// Assume this is a Dockerfile
-		if err := ioutils.AtomicWriteFile(dockerfile, b, 0600); err != nil {
+		if err := ioutils.AtomicWriteFile(dockerfile, b, 0o600); err != nil {
 			return fmt.Errorf("failed to write bytes to %q: %w", dockerfile, err)
 		}
 	}

--- a/define/types_test.go
+++ b/define/types_test.go
@@ -1,8 +1,9 @@
 package define
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseGitBuildContext(t *testing.T) {

--- a/digester_test.go
+++ b/digester_test.go
@@ -133,7 +133,7 @@ func TestCompositeDigester(t *testing.T) {
 						hdr := &tar.Header{
 							Name:     "content",
 							Size:     size,
-							Mode:     0640,
+							Mode:     0o640,
 							ModTime:  time.Now(),
 							Typeflag: tar.TypeReg,
 						}

--- a/image.go
+++ b/image.go
@@ -289,7 +289,6 @@ func (i *containerImageRef) extractRootfs(opts ExtractRootfsOptions) (io.ReadClo
 		err := copier.Get(mountPoint, mountPoint, copierOptions, []string{"."}, pipeWriter)
 		errChan <- err
 		pipeWriter.Close()
-
 	}()
 	return ioutils.NewReadCloserWrapper(pipeReader, func() error {
 		if err = pipeReader.Close(); err != nil {
@@ -627,7 +626,7 @@ func (i *containerImageRef) NewImageSource(_ context.Context, _ *types.SystemCon
 		}
 		srcHasher := digest.Canonical.Digester()
 		// Set up to write the possibly-recompressed blob.
-		layerFile, err := os.OpenFile(filepath.Join(path, "layer"), os.O_CREATE|os.O_WRONLY, 0600)
+		layerFile, err := os.OpenFile(filepath.Join(path, "layer"), os.O_CREATE|os.O_WRONLY, 0o600)
 		if err != nil {
 			rc.Close()
 			return nil, fmt.Errorf("opening file for %s: %w", what, err)
@@ -1004,7 +1003,7 @@ func (i *containerImageSource) GetBlob(_ context.Context, blob types.BlobInfo, _
 	} else {
 		for _, blobDir := range []string{i.blobDirectory, i.path} {
 			var layerFile *os.File
-			layerFile, err = os.OpenFile(filepath.Join(blobDir, blob.Digest.String()), os.O_RDONLY, 0600)
+			layerFile, err = os.OpenFile(filepath.Join(blobDir, blob.Digest.String()), os.O_RDONLY, 0o600)
 			if err == nil {
 				st, err := layerFile.Stat()
 				if err != nil {

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -220,7 +220,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		if options.RusageLogFile == "" {
 			rusageLogFile = options.Out
 		} else {
-			rusageLogFile, err = os.OpenFile(options.RusageLogFile, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+			rusageLogFile, err = os.OpenFile(options.RusageLogFile, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0o644)
 			if err != nil {
 				return nil, err
 			}
@@ -1050,7 +1050,7 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 	}
 	logrus.Debugf("printing final image id %q", imageID)
 	if b.iidfile != "" {
-		if err = os.WriteFile(b.iidfile, []byte("sha256:"+imageID), 0644); err != nil {
+		if err = os.WriteFile(b.iidfile, []byte("sha256:"+imageID), 0o644); err != nil {
 			return imageID, ref, fmt.Errorf("failed to write image ID to file %q: %w", b.iidfile, err)
 		}
 	} else {

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -904,20 +904,20 @@ func (s *StageExecutor) UnrecognizedInstruction(step *imagebuilder.Step) error {
 	errStr := fmt.Sprintf("Build error: Unknown instruction: %q ", strings.ToUpper(step.Command))
 	err := fmt.Sprintf(errStr+"%#v", step)
 	if s.executor.ignoreUnrecognizedInstructions {
-		logrus.Debugf(err)
+		logrus.Debug(err)
 		return nil
 	}
 
 	switch logrus.GetLevel() {
 	case logrus.ErrorLevel:
-		s.executor.logger.Errorf(errStr)
+		s.executor.logger.Error(errStr)
 	case logrus.DebugLevel:
-		logrus.Debugf(err)
+		logrus.Debug(err)
 	default:
 		s.executor.logger.Errorf("+(UNHANDLED LOGLEVEL) %#v", step)
 	}
 
-	return fmt.Errorf(err)
+	return errors.New(err)
 }
 
 // prepare creates a working container based on the specified image, or if one
@@ -1223,7 +1223,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 		if output != "" {
 			commitMessage = fmt.Sprintf("%s %s", commitMessage, output)
 		}
-		logrus.Debugf(commitMessage)
+		logrus.Debug(commitMessage)
 		if !s.executor.quiet {
 			s.log(commitMessage)
 		}

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -258,7 +258,7 @@ func (s *StageExecutor) volumeCacheSaveVFS() (mounts []specs.Mount, err error) {
 		if !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}
-		createdDirPerms := os.FileMode(0755)
+		createdDirPerms := os.FileMode(0o755)
 		if err := copier.Mkdir(s.mountPoint, archivedPath, copier.MkdirOptions{ChmodNew: &createdDirPerms}); err != nil {
 			return nil, fmt.Errorf("ensuring volume path exists: %w", err)
 		}
@@ -455,7 +455,7 @@ func (s *StageExecutor) performCopy(excludes []string, copies ...imagebuilder.Co
 				if err != nil {
 					return fmt.Errorf("unable to create tmp file for COPY instruction at %q: %w", parse.GetTempDir(), err)
 				}
-				err = tmpFile.Chmod(0644) // 644 is consistent with buildkit
+				err = tmpFile.Chmod(0o644) // 644 is consistent with buildkit
 				if err != nil {
 					tmpFile.Close()
 					return fmt.Errorf("unable to chmod tmp file created for COPY instruction at %q: %w", tmpFile.Name(), err)
@@ -734,7 +734,7 @@ func (s *StageExecutor) createNeededHeredocMountsForRun(files []imagebuilder.Fil
 			f.Close()
 			return nil, err
 		}
-		err = f.Chmod(0755)
+		err = f.Chmod(0o755)
 		if err != nil {
 			f.Close()
 			return nil, err
@@ -2129,7 +2129,7 @@ func (s *StageExecutor) pullCache(ctx context.Context, cacheKey string) (referen
 		if err != nil {
 			logrus.Debugf("failed pulling cache from source %s: %v", src, err)
 			continue // failed pulling this one try next
-			//return "", fmt.Errorf("failed while pulling cache from %q: %w", src, err)
+			// return "", fmt.Errorf("failed while pulling cache from %q: %w", src, err)
 		}
 		logrus.Debugf("successfully pulled cache from repo %s: %s", src, id)
 		return src.DockerReference(), id, nil

--- a/internal/source/add.go
+++ b/internal/source/add.go
@@ -130,5 +130,5 @@ func updateIndexWithNewManifestDescriptor(manifest *specV1.Descriptor, sourcePat
 		return err
 	}
 
-	return os.WriteFile(indexPath, rawData, 0644)
+	return os.WriteFile(indexPath, rawData, 0o644)
 }

--- a/internal/source/push.go
+++ b/internal/source/push.go
@@ -74,7 +74,7 @@ func Push(ctx context.Context, sourcePath string, imageInput string, options Pus
 		if err != nil {
 			return fmt.Errorf("computing digest of manifest of source: %w", err)
 		}
-		if err = os.WriteFile(options.DigestFile, []byte(manifestDigest.String()), 0644); err != nil {
+		if err = os.WriteFile(options.DigestFile, []byte(manifestDigest.String()), 0o644); err != nil {
 			return fmt.Errorf("failed to write digest to file %q: %w", options.DigestFile, err)
 		}
 	}

--- a/internal/tmpdir/tmpdir_test.go
+++ b/internal/tmpdir/tmpdir_test.go
@@ -54,5 +54,4 @@ func TestGetTempDir(t *testing.T) {
 	require.NoError(t, err)
 	tmpdir = GetTempDir()
 	assert.Equal(t, "/mnt", tmpdir)
-
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -72,7 +72,7 @@ func ExportFromReader(input io.Reader, opts define.BuildOutputOption) error {
 			noLChown = true
 		}
 
-		err = os.MkdirAll(opts.Path, 0700)
+		err = os.MkdirAll(opts.Path, 0o700)
 		if err != nil {
 			return fmt.Errorf("failed while creating the destination path %q: %w", opts.Path, err)
 		}

--- a/internal/volumes/volumes.go
+++ b/internal/volumes/volumes.go
@@ -2,14 +2,13 @@ package volumes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
-
-	"errors"
 
 	"github.com/containers/buildah/copier"
 	"github.com/containers/buildah/define"
@@ -373,7 +372,7 @@ func GetCacheMount(args []string, _ storage.Store, _ string, additionalMountPoin
 		// cache parent directory: creates separate cache parent for each user.
 		cacheParent := CacheParent()
 		// create cache on host if not present
-		err = os.MkdirAll(cacheParent, os.FileMode(0755))
+		err = os.MkdirAll(cacheParent, os.FileMode(0o755))
 		if err != nil {
 			return newMount, nil, fmt.Errorf("unable to create build cache directory: %w", err)
 		}
@@ -397,7 +396,7 @@ func GetCacheMount(args []string, _ storage.Store, _ string, additionalMountPoin
 
 		// create a subdirectory inside `cacheParent` just to store lockfiles
 		buildahLockFilesDir = filepath.Join(cacheParent, buildahLockFilesDir)
-		err = os.MkdirAll(buildahLockFilesDir, os.FileMode(0700))
+		err = os.MkdirAll(buildahLockFilesDir, os.FileMode(0o700))
 		if err != nil {
 			return newMount, nil, fmt.Errorf("unable to create build cache lockfiles directory: %w", err)
 		}

--- a/manifests/compat.go
+++ b/manifests/compat.go
@@ -17,10 +17,8 @@ type (
 	PushOptions = manifests.PushOptions
 )
 
-var (
-	// ErrListImageUnknown is an alias for github.com/containers/common/libimage/manifests.ErrListImageUnknown
-	ErrListImageUnknown = manifests.ErrListImageUnknown
-)
+// ErrListImageUnknown is an alias for github.com/containers/common/libimage/manifests.ErrListImageUnknown
+var ErrListImageUnknown = manifests.ErrListImageUnknown
 
 // Create wraps github.com/containers/common/libimage/manifests.Create().
 func Create() List {

--- a/new.go
+++ b/new.go
@@ -243,7 +243,6 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 
 	suffixDigitsModulo := 100
 	for {
-
 		var flags map[string]interface{}
 		// check if we have predefined ProcessLabel and MountLabel
 		// this could be true if this is another stage in a build

--- a/pkg/chrootuser/user.go
+++ b/pkg/chrootuser/user.go
@@ -8,11 +8,9 @@ import (
 	"strings"
 )
 
-var (
-	// ErrNoSuchUser indicates that the user provided by the caller does not
-	// exist in /etc/passws
-	ErrNoSuchUser = errors.New("user does not exist in /etc/passwd")
-)
+// ErrNoSuchUser indicates that the user provided by the caller does not
+// exist in /etc/passws
+var ErrNoSuchUser = errors.New("user does not exist in /etc/passwd")
 
 // GetUser will return the uid, gid of the user specified in the userspec
 // it will use the /etc/passwd and /etc/group files inside of the rootdir

--- a/pkg/chrootuser/user_unix.go
+++ b/pkg/chrootuser/user_unix.go
@@ -75,9 +75,7 @@ func openChrootedFile(rootdir, filename string) (*exec.Cmd, io.ReadCloser, error
 	return cmd, stdout, nil
 }
 
-var (
-	lookupUser, lookupGroup sync.Mutex
-)
+var lookupUser, lookupGroup sync.Mutex
 
 type lookupPasswdEntry struct {
 	name string

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -60,7 +60,6 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		if c.Flag("dns-search").Changed {
 			return options, nil, nil, errors.New("the --dns-search option cannot be used with --network=none")
 		}
-
 	}
 	if c.Flag("tag").Changed {
 		tags = iopts.Tag

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -270,7 +270,7 @@ always:  pull base and SBOM scanner images even if the named images are present 
 missing: pull base and SBOM scanner images if the named images are not present in store.
 never:   only use images present in store if available.
 newer:   only pull base and SBOM scanner images when newer images exist on the registry than those in the store.`)
-	fs.Lookup("pull").NoOptDefVal = "missing" //treat a --pull with no argument like --pull=missing
+	fs.Lookup("pull").NoOptDefVal = "missing" // treat a --pull with no argument like --pull=missing
 	fs.BoolVar(&flags.PullAlways, "pull-always", false, "pull the image even if the named image is present in store")
 	if err := fs.MarkHidden("pull-always"); err != nil {
 		panic(fmt.Sprintf("error marking the pull-always flag as hidden: %v", err))
@@ -550,10 +550,8 @@ func LookupEnvVarReferences(specs, environ []string) []string {
 	for _, spec := range specs {
 		if key, _, ok := strings.Cut(spec, "="); ok {
 			result = append(result, spec)
-
 		} else if key == "*" {
 			result = append(result, environ...)
-
 		} else {
 			prefix := key + "="
 			if strings.HasSuffix(key, "*") {

--- a/pkg/cli/common_test.go
+++ b/pkg/cli/common_test.go
@@ -23,7 +23,6 @@ func testFlagCompletion(t *testing.T, flags pflag.FlagSet, flagCompletions compl
 			t.Errorf(`Flag %q is a bool flag but has a shell completion function set.
 	You have to remove this shell completion function.`, f.Name)
 			return
-
 		}
 	})
 

--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -1,14 +1,13 @@
 package overlay
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
-
-	"errors"
 
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/system"
@@ -54,7 +53,7 @@ type Options struct {
 // TempDir generates an overlay Temp directory in the container content
 func TempDir(containerDir string, rootUID, rootGID int) (string, error) {
 	contentDir := filepath.Join(containerDir, "overlay")
-	if err := idtools.MkdirAllAs(contentDir, 0700, rootUID, rootGID); err != nil {
+	if err := idtools.MkdirAllAs(contentDir, 0o700, rootUID, rootGID); err != nil {
 		return "", fmt.Errorf("failed to create the overlay %s directory: %w", contentDir, err)
 	}
 
@@ -69,7 +68,7 @@ func TempDir(containerDir string, rootUID, rootGID int) (string, error) {
 // GenerateStructure generates an overlay directory structure for container content
 func GenerateStructure(containerDir, containerID, name string, rootUID, rootGID int) (string, error) {
 	contentDir := filepath.Join(containerDir, "overlay-containers", containerID, name)
-	if err := idtools.MkdirAllAs(contentDir, 0700, rootUID, rootGID); err != nil {
+	if err := idtools.MkdirAllAs(contentDir, 0o700, rootUID, rootGID); err != nil {
 		return "", fmt.Errorf("failed to create the overlay %s directory: %w", contentDir, err)
 	}
 
@@ -80,14 +79,14 @@ func GenerateStructure(containerDir, containerID, name string, rootUID, rootGID 
 func generateOverlayStructure(containerDir string, rootUID, rootGID int) (string, error) {
 	upperDir := filepath.Join(containerDir, "upper")
 	workDir := filepath.Join(containerDir, "work")
-	if err := idtools.MkdirAllAs(upperDir, 0700, rootUID, rootGID); err != nil {
+	if err := idtools.MkdirAllAs(upperDir, 0o700, rootUID, rootGID); err != nil {
 		return "", fmt.Errorf("failed to create the overlay %s directory: %w", upperDir, err)
 	}
-	if err := idtools.MkdirAllAs(workDir, 0700, rootUID, rootGID); err != nil {
+	if err := idtools.MkdirAllAs(workDir, 0o700, rootUID, rootGID); err != nil {
 		return "", fmt.Errorf("failed to create the overlay %s directory: %w", workDir, err)
 	}
 	mergeDir := filepath.Join(containerDir, "merge")
-	if err := idtools.MkdirAllAs(mergeDir, 0700, rootUID, rootGID); err != nil {
+	if err := idtools.MkdirAllAs(mergeDir, 0o700, rootUID, rootGID); err != nil {
 		return "", fmt.Errorf("failed to create the overlay %s directory: %w", mergeDir, err)
 	}
 

--- a/pkg/overlay/overlay_linux.go
+++ b/pkg/overlay/overlay_linux.go
@@ -27,7 +27,7 @@ func MountWithOptions(contentDir, source, dest string, opts *Options) (mount spe
 	if opts.ReadOnly {
 		// Read-only overlay mounts require two lower layer.
 		lowerTwo := filepath.Join(contentDir, "lower")
-		if err := os.Mkdir(lowerTwo, 0755); err != nil {
+		if err := os.Mkdir(lowerTwo, 0o755); err != nil {
 			return mount, err
 		}
 		overlayOptions = fmt.Sprintf("lowerdir=%s:%s,private", escapeColon(source), lowerTwo)

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -328,7 +328,7 @@ func validateExtraHost(val string) error {
 // validateIPAddress validates an Ip address.
 // for dns, ip, and ip6 flags also
 func validateIPAddress(val string) (string, error) {
-	var ip = net.ParseIP(strings.TrimSpace(val))
+	ip := net.ParseIP(strings.TrimSpace(val))
 	if ip != nil {
 		return ip.String(), nil
 	}
@@ -661,15 +661,19 @@ func GetBuildOutput(buildOutput string) (define.BuildOutputOption, error) {
 	if len(buildOutput) == 1 && buildOutput == "-" {
 		// Feature parity with buildkit, output tar to stdout
 		// Read more here: https://docs.docker.com/engine/reference/commandline/build/#custom-build-outputs
-		return define.BuildOutputOption{Path: "",
+		return define.BuildOutputOption{
+			Path:     "",
 			IsDir:    false,
-			IsStdout: true}, nil
+			IsStdout: true,
+		}, nil
 	}
 	if !strings.Contains(buildOutput, ",") {
 		// expect default --output <dirname>
-		return define.BuildOutputOption{Path: buildOutput,
+		return define.BuildOutputOption{
+			Path:     buildOutput,
 			IsDir:    true,
-			IsStdout: false}, nil
+			IsStdout: false,
+		}, nil
 	}
 	isDir := true
 	isStdout := false
@@ -714,9 +718,11 @@ func GetBuildOutput(buildOutput string) (define.BuildOutputOption, error) {
 		if isDir {
 			return define.BuildOutputOption{}, fmt.Errorf("invalid build output option %q, type=local and dest=- is not supported", buildOutput)
 		}
-		return define.BuildOutputOption{Path: "",
+		return define.BuildOutputOption{
+			Path:     "",
 			IsDir:    false,
-			IsStdout: true}, nil
+			IsStdout: true,
+		}, nil
 	}
 
 	return define.BuildOutputOption{Path: path, IsDir: isDir, IsStdout: isStdout}, nil
@@ -1211,7 +1217,7 @@ func Device(device string) (string, string, string, error) {
 // isValidDeviceMode checks if the mode for device is valid or not.
 // isValid mode is a composition of r (read), w (write), and m (mknod).
 func isValidDeviceMode(mode string) bool {
-	var legalDeviceMode = map[rune]struct{}{
+	legalDeviceMode := map[rune]struct{}{
 		'r': {},
 		'w': {},
 		'm': {},

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -250,7 +250,6 @@ func parseSecurityOpts(securityOpts []string, commonOpts *define.CommonBuildOpti
 		default:
 			return fmt.Errorf("invalid --security-opt 2: %q", opt)
 		}
-
 	}
 
 	if commonOpts.SeccompProfilePath == "" {
@@ -1293,7 +1292,6 @@ func Secrets(secrets []string) (map[string]define.Secret, error) {
 			SourceType: typ,
 		}
 		parsed[id] = newSecret
-
 	}
 	return parsed, nil
 }

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -61,7 +61,7 @@ func TestDeviceParser(t *testing.T) {
 	assert.Equal(t, dest, "/dev/foo")
 	assert.Equal(t, permissions, "rm")
 
-	//test bogus permissions
+	// test bogus permissions
 	_, _, _, err = Device("/dev/fuse1:BOGUS")
 	assert.Error(t, err)
 

--- a/pkg/sshagent/sshagent.go
+++ b/pkg/sshagent/sshagent.go
@@ -64,7 +64,6 @@ func newAgentServerSocket(socketPath string) (*AgentServer, error) {
 		conn:     &conn,
 		shutdown: make(chan bool, 1),
 	}, nil
-
 }
 
 // Serve starts the SSH agent on the host and returns the path of the socket where the agent is serving
@@ -104,7 +103,7 @@ func (a *AgentServer) Serve(processLabel string) (string, error) {
 
 	go func() {
 		for {
-			//listener.Accept blocks
+			// listener.Accept blocks
 			c, err := listener.Accept()
 			if err != nil {
 				select {

--- a/pkg/sshagent/sshagent_test.go
+++ b/pkg/sshagent/sshagent_test.go
@@ -31,7 +31,6 @@ func testClient(path string) ([]*agent.Key, error) {
 		return nil, err
 	}
 	return keys, nil
-
 }
 
 func TestAgentServer(t *testing.T) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -28,5 +28,4 @@ func TestDiscoverContainerfile(t *testing.T) {
 	name, err = DiscoverContainerfile("test/test2")
 	assert.Nil(t, err)
 	assert.Equal(t, name, "test/test2/Dockerfile")
-
 }

--- a/pkg/util/version_windows.go
+++ b/pkg/util/version_windows.go
@@ -6,5 +6,4 @@ import (
 
 func ReadKernelVersion() (string, error) {
 	return "", errors.New("readKernelVersion not supported on windows")
-
 }

--- a/run_common.go
+++ b/run_common.go
@@ -84,7 +84,8 @@ func (b *Builder) createResolvConf(rdir string, chownOpts *idtools.IDPair) (stri
 
 // addResolvConf copies files from host and sets them up to bind mount into container
 func (b *Builder) addResolvConfEntries(file string, networkNameServer []string,
-	spec *specs.Spec, keepHostServers, ipv6 bool) error {
+	spec *specs.Spec, keepHostServers, ipv6 bool,
+) error {
 	defaultConfig, err := config.Default()
 	if err != nil {
 		return fmt.Errorf("failed to get config: %w", err)
@@ -179,7 +180,7 @@ func (b *Builder) generateHostname(rdir, hostname string, chownOpts *idtools.IDP
 	hostnameBuffer.Write([]byte(fmt.Sprintf("%s\n", hostname)))
 
 	cfile := filepath.Join(rdir, filepath.Base(hostnamePath))
-	if err = ioutils.AtomicWriteFile(cfile, hostnameBuffer.Bytes(), 0644); err != nil {
+	if err = ioutils.AtomicWriteFile(cfile, hostnameBuffer.Bytes(), 0o644); err != nil {
 		return "", fmt.Errorf("writing /etc/hostname into the container: %w", err)
 	}
 
@@ -257,7 +258,7 @@ func runLookupPath(g *generate.Generator, command []string) []string {
 		// check if it's there,
 		if fi, err := os.Lstat(filepath.Join(spec.Root.Path, candidate)); fi != nil && err == nil {
 			// and if it's not a directory, and either a symlink or executable,
-			if !fi.IsDir() && ((fi.Mode()&os.ModeSymlink != 0) || (fi.Mode()&0111 != 0)) {
+			if !fi.IsDir() && ((fi.Mode()&os.ModeSymlink != 0) || (fi.Mode()&0o111 != 0)) {
 				// use that.
 				return append([]string{candidate}, command[1:]...)
 			}
@@ -439,7 +440,8 @@ func waitForSync(pipeR *os.File) error {
 }
 
 func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs []string, spec *specs.Spec, bundlePath, containerName string,
-	containerCreateW io.WriteCloser, containerStartR io.ReadCloser) (wstatus unix.WaitStatus, err error) {
+	containerCreateW io.WriteCloser, containerStartR io.ReadCloser,
+) (wstatus unix.WaitStatus, err error) {
 	if options.Logger == nil {
 		options.Logger = logrus.StandardLogger()
 	}
@@ -465,7 +467,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 	if err != nil {
 		return 1, fmt.Errorf("encoding configuration %#v as json: %w", spec, err)
 	}
-	if err = ioutils.AtomicWriteFile(filepath.Join(bundlePath, "config.json"), specbytes, 0600); err != nil {
+	if err = ioutils.AtomicWriteFile(filepath.Join(bundlePath, "config.json"), specbytes, 0o600); err != nil {
 		return 1, fmt.Errorf("storing runtime configuration: %w", err)
 	}
 
@@ -1137,7 +1139,8 @@ func runUsingRuntimeMain() {
 }
 
 func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options RunOptions, configureNetwork bool, networkString string,
-	moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName, buildContainerName, hostsFile, resolvFile string) (err error) {
+	moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName, buildContainerName, hostsFile, resolvFile string,
+) (err error) {
 	// Lock the caller to a single OS-level thread.
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -1339,8 +1342,8 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 	}
 
 	// Get host UID and GID of the container process.
-	var uidMap = []specs.LinuxIDMapping{}
-	var gidMap = []specs.LinuxIDMapping{}
+	uidMap := []specs.LinuxIDMapping{}
+	gidMap := []specs.LinuxIDMapping{}
 	if spec.Linux != nil {
 		uidMap = spec.Linux.UIDMappings
 		gidMap = spec.Linux.GIDMappings
@@ -1380,7 +1383,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 	}
 
 	// Get the list of explicitly-specified volume mounts.
-	var mountLabel = ""
+	mountLabel := ""
 	if spec.Linux != nil {
 		mountLabel = spec.Linux.MountLabel
 	}
@@ -1441,7 +1444,7 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, builtin
 				return nil, err
 			}
 			logrus.Debugf("setting up built-in volume path at %q for %q", volumePath, volume)
-			if err = os.MkdirAll(volumePath, 0755); err != nil {
+			if err = os.MkdirAll(volumePath, 0o755); err != nil {
 				return nil, err
 			}
 			if err = relabel(volumePath, mountLabel, false); err != nil {
@@ -1680,7 +1683,7 @@ func (b *Builder) getSecretMount(tokens []string, secrets map[string]define.Secr
 	var id, target string
 	var required bool
 	var uid, gid uint32
-	var mode uint32 = 0400
+	var mode uint32 = 0o400
 	for _, val := range tokens {
 		kv := strings.SplitN(val, "=", 2)
 		switch kv[0] {
@@ -1774,10 +1777,10 @@ func (b *Builder) getSecretMount(tokens []string, secrets map[string]define.Secr
 
 	// Copy secrets to container working dir (or tmp dir if it's an env), since we need to chmod,
 	// chown and relabel it for the container user and we don't want to mess with the original file
-	if err := os.MkdirAll(filepath.Dir(ctrFileOnHost), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(ctrFileOnHost), 0o755); err != nil {
 		return nil, "", err
 	}
-	if err := os.WriteFile(ctrFileOnHost, data, 0644); err != nil {
+	if err := os.WriteFile(ctrFileOnHost, data, 0o644); err != nil {
 		return nil, "", err
 	}
 
@@ -1939,7 +1942,7 @@ func (b *Builder) cleanupRunMounts(context *imageTypes.SystemContext, mountpoint
 		}
 	}
 
-	//cleanup any mounted images for this run
+	// cleanup any mounted images for this run
 	for _, image := range artifacts.MountedImages {
 		if image != "" {
 			// if flow hits here some image was mounted for this run

--- a/run_common.go
+++ b/run_common.go
@@ -1926,7 +1926,7 @@ func (b *Builder) cleanupTempVolumes() {
 	for tempVolume, val := range b.TempVolumes {
 		if val {
 			if err := overlay.RemoveTemp(tempVolume); err != nil {
-				b.Logger.Errorf(err.Error())
+				b.Logger.Error(err.Error())
 			}
 			b.TempVolumes[tempVolume] = false
 		}

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -45,16 +45,14 @@ const (
 	PROC_REAP_RELEASE = 3
 )
 
-var (
-	// We dont want to remove destinations with /etc, /dev as
-	// rootfs already contains these files and unionfs will create
-	// a `whiteout` i.e `.wh` files on removal of overlapping
-	// files from these directories.  everything other than these
-	// will be cleaned up
-	nonCleanablePrefixes = []string{
-		"/etc", "/dev",
-	}
-)
+// We dont want to remove destinations with /etc, /dev as
+// rootfs already contains these files and unionfs will create
+// a `whiteout` i.e `.wh` files on removal of overlapping
+// files from these directories.  everything other than these
+// will be cleaned up
+var nonCleanablePrefixes = []string{
+	"/etc", "/dev",
+}
 
 func procctl(idtype int, id int, cmd int, arg *byte) error {
 	_, _, e1 := unix.Syscall6(
@@ -184,7 +182,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	uid, gid := spec.Process.User.UID, spec.Process.User.GID
 	idPair := &idtools.IDPair{UID: int(uid), GID: int(gid)}
 
-	mode := os.FileMode(0755)
+	mode := os.FileMode(0o755)
 	coptions := copier.MkdirOptions{
 		ChownNew: idPair,
 		ChmodNew: &mode,
@@ -535,7 +533,7 @@ func (b *Builder) configureNamespaces(g *generate.Generator, options *RunOptions
 	namespaceOptions.AddOrReplace(options.NamespaceOptions...)
 
 	networkPolicy := options.ConfigureNetwork
-	//Nothing was specified explicitly so network policy should be inherited from builder
+	// Nothing was specified explicitly so network policy should be inherited from builder
 	if networkPolicy == NetworkDefault {
 		networkPolicy = b.ConfigureNetwork
 

--- a/run_unix.go
+++ b/run_unix.go
@@ -23,6 +23,7 @@ func runUsingRuntimeMain() {}
 func (b *Builder) Run(command []string, options RunOptions) error {
 	return errors.New("function not supported on non-linux systems")
 }
+
 func DefaultNamespaceOptions() (NamespaceOptions, error) {
 	options := NamespaceOptions{
 		{Name: string(specs.CgroupNamespace), Host: false},

--- a/run_unsupported.go
+++ b/run_unsupported.go
@@ -18,6 +18,7 @@ func runUsingRuntimeMain() {}
 func (b *Builder) Run(command []string, options RunOptions) error {
 	return errors.New("function not supported on non-linux systems")
 }
+
 func DefaultNamespaceOptions() (NamespaceOptions, error) {
 	return NamespaceOptions{}, errors.New("function not supported on non-linux systems")
 }

--- a/util/util.go
+++ b/util/util.go
@@ -35,14 +35,12 @@ const (
 	DefaultTransport = "docker://"
 )
 
-var (
-	// RegistryDefaultPathPrefix contains a per-registry listing of default prefixes
-	// to prepend to image names that only contain a single path component.
-	RegistryDefaultPathPrefix = map[string]string{
-		"index.docker.io": "library",
-		"docker.io":       "library",
-	}
-)
+// RegistryDefaultPathPrefix contains a per-registry listing of default prefixes
+// to prepend to image names that only contain a single path component.
+var RegistryDefaultPathPrefix = map[string]string{
+	"index.docker.io": "library",
+	"docker.io":       "library",
+}
 
 // StringInSlice is deprecated, use golang.org/x/exp/slices.Contains
 func StringInSlice(s string, slice []string) bool {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Enables the gofumpt and whitespace linters and patches the things they warn about.  Preemptively patch some things a newer version of golangci-lint warns about from its "govet" linter.

#### How to verify it

No new breakage.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```