### PR TITLE
imagebuildah: make scratch config handling toggleable

### DIFF
--- a/buildah.go
+++ b/buildah.go
@@ -377,6 +377,11 @@ type BuilderOptions struct {
 	// CDIConfigDir is the location of CDI configuration files, if the files in
 	// the default configuration locations shouldn't be used.
 	CDIConfigDir string
+	// CompatScratchConfig controls whether a "scratch" image is created
+	// with a truly empty configuration, as would have happened in the past
+	// (when set to true), or with a minimal initial configuration which
+	// has a working directory set in it.
+	CompatScratchConfig types.OptionalBool
 }
 
 // ImportOptions are used to initialize a Builder from an existing container

--- a/config.go
+++ b/config.go
@@ -61,7 +61,7 @@ func unmarshalConvertedConfig(ctx context.Context, dest interface{}, img types.I
 	return nil
 }
 
-func (b *Builder) initConfig(ctx context.Context, img types.Image, sys *types.SystemContext) error {
+func (b *Builder) initConfig(ctx context.Context, sys *types.SystemContext, img types.Image, options *BuilderOptions) error {
 	if img != nil { // A pre-existing image, as opposed to a "FROM scratch" new one.
 		rawManifest, manifestMIMEType, err := img.Manifest(ctx)
 		if err != nil {
@@ -99,6 +99,21 @@ func (b *Builder) initConfig(ctx context.Context, img types.Image, sys *types.Sy
 				for k, v := range v1Manifest.Annotations {
 					b.ImageAnnotations[k] = v
 				}
+			}
+		}
+	} else {
+		if options == nil || options.CompatScratchConfig != types.OptionalBoolTrue {
+			b.Docker = docker.V2Image{
+				V1Image: docker.V1Image{
+					Config: &docker.Config{
+						WorkingDir: "/",
+					},
+				},
+			}
+			b.OCIv1 = ociv1.Image{
+				Config: ociv1.ImageConfig{
+					WorkingDir: "/",
+				},
 			}
 		}
 	}

--- a/define/build.go
+++ b/define/build.go
@@ -373,4 +373,10 @@ type BuildOptions struct {
 	// base images or by a VOLUME instruction to be preserved during RUN
 	// instructions.  Newer BuildKit-based docker build doesn't bother.
 	CompatVolumes types.OptionalBool
+	// CompatScratchConfig causes the image, if it does not have a base
+	// image, to begin with a truly empty default configuration instead of
+	// a minimal default configuration. Newer BuildKit-based docker build
+	// provides a minimal initial configuration with a working directory
+	// set in it.
+	CompatScratchConfig types.OptionalBool
 }

--- a/docs/buildah-copy.1.md
+++ b/docs/buildah-copy.1.md
@@ -115,7 +115,7 @@ Users can specify a series of Unix shell glob patterns in an ignore file to
 identify files/directories to exclude.
 
 Buildah supports a special wildcard string `**` which matches any number of
-directories (including zero). For example, **/*.go will exclude all files that
+directories (including zero). For example, `**/*.go` will exclude all files that
 end with .go that are found in all directories.
 
 Example .containerignore/.dockerignore file:

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -162,6 +162,7 @@ type Executor struct {
 	cdiConfigDir                            string
 	compatSetParent                         types.OptionalBool
 	compatVolumes                           types.OptionalBool
+	compatScratchConfig                     types.OptionalBool
 }
 
 type imageTypeAndHistoryAndDiffIDs struct {
@@ -320,6 +321,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		cdiConfigDir:                            options.CDIConfigDir,
 		compatSetParent:                         options.CompatSetParent,
 		compatVolumes:                           options.CompatVolumes,
+		compatScratchConfig:                     options.CompatScratchConfig,
 	}
 	if exec.err == nil {
 		exec.err = os.Stderr

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1007,6 +1007,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		MountLabel:            s.executor.mountLabel,
 		PreserveBaseImageAnns: preserveBaseImageAnnotations,
 		CDIConfigDir:          s.executor.cdiConfigDir,
+		CompatScratchConfig:   s.executor.compatScratchConfig,
 	}
 
 	builder, err = buildah.NewBuilder(ctx, s.executor.store, builderOptions)

--- a/import.go
+++ b/import.go
@@ -109,7 +109,7 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 		CommonBuildOpts:  &CommonBuildOptions{},
 	}
 
-	if err := builder.initConfig(ctx, image, systemContext); err != nil {
+	if err := builder.initConfig(ctx, systemContext, image, nil); err != nil {
 		return nil, fmt.Errorf("preparing image configuration: %w", err)
 	}
 

--- a/new.go
+++ b/new.go
@@ -334,7 +334,7 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 		}
 	}
 
-	if err := builder.initConfig(ctx, src, systemContext); err != nil {
+	if err := builder.initConfig(ctx, systemContext, src, &options); err != nil {
 		return nil, fmt.Errorf("preparing image configuration: %w", err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

The default configuration that `docker build` applies to images built using "scratch" has changed from classic builds to BuildKit.  Add a toggle for selecting which behavior to mimic.

#### How to verify it

Updated conformance test cases!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```