### PR TITLE
build, run: record hash or digest in image history for sources used in `--mount`

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1279,7 +1279,11 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// No base image means there's nothing to put in a
 			// layer, so don't create one.
 			emptyLayer := (s.builder.FromImageID == "")
-			if imgID, ref, err = s.commit(ctx, s.getCreatedBy(nil, ""), emptyLayer, s.output, s.executor.squash || s.executor.confidentialWorkload.Convert, lastStage); err != nil {
+			createdBy, err := s.getCreatedBy(nil, "")
+			if err != nil {
+				return "", nil, false, fmt.Errorf("unable to get createdBy for the node: %w", err)
+			}
+			if imgID, ref, err = s.commit(ctx, createdBy, emptyLayer, s.output, s.executor.squash || s.executor.confidentialWorkload.Convert, lastStage); err != nil {
 				return "", nil, false, fmt.Errorf("committing base container: %w", err)
 			}
 		} else {
@@ -1426,7 +1430,11 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 				if s.executor.timestamp != nil {
 					timestamp = *s.executor.timestamp
 				}
-				s.builder.AddPrependedEmptyLayer(&timestamp, s.getCreatedBy(node, addedContentSummary), "", "")
+				createdBy, err := s.getCreatedBy(node, addedContentSummary)
+				if err != nil {
+					return "", nil, false, fmt.Errorf("unable to get createdBy for the node: %w", err)
+				}
+				s.builder.AddPrependedEmptyLayer(&timestamp, createdBy, "", "")
 				continue
 			}
 			// This is the last instruction for this stage,
@@ -1436,7 +1444,11 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// stage.
 			if lastStage || imageIsUsedLater {
 				logCommit(s.output, i)
-				imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), false, s.output, s.executor.squash, lastStage && lastInstruction)
+				createdBy, err := s.getCreatedBy(node, addedContentSummary)
+				if err != nil {
+					return "", nil, false, fmt.Errorf("unable to get createdBy for the node: %w", err)
+				}
+				imgID, ref, err = s.commit(ctx, createdBy, false, s.output, s.executor.squash, lastStage && lastInstruction)
 				if err != nil {
 					return "", nil, false, fmt.Errorf("committing container for step %+v: %w", *step, err)
 				}
@@ -1657,6 +1669,10 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// We're not going to find any more cache hits, so we
 			// can stop looking for them.
 			checkForLayers = false
+			createdBy, err := s.getCreatedBy(node, addedContentSummary)
+			if err != nil {
+				return "", nil, false, fmt.Errorf("unable to get createdBy for the node: %w", err)
+			}
 			// Create a new image, maybe with a new layer, with the
 			// name for this stage if it's the last instruction.
 			logCommit(s.output, i)
@@ -1664,7 +1680,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			// because at this point we want to save history for
 			// layers even if its a squashed build so that they
 			// can be part of the build cache.
-			imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), !s.stepRequiresLayer(step), commitName, false, lastStage && lastInstruction)
+			imgID, ref, err = s.commit(ctx, createdBy, !s.stepRequiresLayer(step), commitName, false, lastStage && lastInstruction)
 			if err != nil {
 				return "", nil, false, fmt.Errorf("committing container for step %+v: %w", *step, err)
 			}
@@ -1695,12 +1711,16 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 
 		if lastInstruction && lastStage {
 			if s.executor.squash || s.executor.confidentialWorkload.Convert || len(s.executor.sbomScanOptions) != 0 {
+				createdBy, err := s.getCreatedBy(node, addedContentSummary)
+				if err != nil {
+					return "", nil, false, fmt.Errorf("unable to get createdBy for the node: %w", err)
+				}
 				// If this is the last instruction of the last stage,
 				// create a squashed or confidential workload
 				// version of the image if that's what we're after,
 				// or a normal one if we need to scan the image while
 				// committing it.
-				imgID, ref, err = s.commit(ctx, s.getCreatedBy(node, addedContentSummary), !s.stepRequiresLayer(step), commitName, s.executor.squash || s.executor.confidentialWorkload.Convert, lastStage && lastInstruction)
+				imgID, ref, err = s.commit(ctx, createdBy, !s.stepRequiresLayer(step), commitName, s.executor.squash || s.executor.confidentialWorkload.Convert, lastStage && lastInstruction)
 				if err != nil {
 					return "", nil, false, fmt.Errorf("committing final squash step %+v: %w", *step, err)
 				}
@@ -1792,54 +1812,58 @@ func historyEntriesEqual(base, derived v1.History) bool {
 // that we're comparing.
 // Used to verify whether a cache of the intermediate image exists and whether
 // to run the build again.
-func (s *StageExecutor) historyAndDiffIDsMatch(baseHistory []v1.History, baseDiffIDs []digest.Digest, child *parser.Node, history []v1.History, diffIDs []digest.Digest, addedContentSummary string, buildAddsLayer bool) bool {
+func (s *StageExecutor) historyAndDiffIDsMatch(baseHistory []v1.History, baseDiffIDs []digest.Digest, child *parser.Node, history []v1.History, diffIDs []digest.Digest, addedContentSummary string, buildAddsLayer bool) (bool, error) {
 	// our history should be as long as the base's, plus one entry for what
 	// we're doing
 	if len(history) != len(baseHistory)+1 {
-		return false
+		return false, nil
 	}
 	// check that each entry in the base history corresponds to an entry in
 	// our history, and count how many of them add a layer diff
 	expectedDiffIDs := 0
 	for i := range baseHistory {
 		if !historyEntriesEqual(baseHistory[i], history[i]) {
-			return false
+			return false, nil
 		}
 		if !baseHistory[i].EmptyLayer {
 			expectedDiffIDs++
 		}
 	}
 	if len(baseDiffIDs) != expectedDiffIDs {
-		return false
+		return false, nil
 	}
 	if buildAddsLayer {
 		// we're adding a layer, so we should have exactly one more
 		// layer than the base image
 		if len(diffIDs) != expectedDiffIDs+1 {
-			return false
+			return false, nil
 		}
 	} else {
 		// we're not adding a layer, so we should have exactly the same
 		// layers as the base image
 		if len(diffIDs) != expectedDiffIDs {
-			return false
+			return false, nil
 		}
 	}
 	// compare the diffs for the layers that we should have in common
 	for i := range baseDiffIDs {
 		if diffIDs[i] != baseDiffIDs[i] {
-			return false
+			return false, nil
 		}
 	}
-	return history[len(baseHistory)].CreatedBy == s.getCreatedBy(child, addedContentSummary)
+	createdBy, err := s.getCreatedBy(child, addedContentSummary)
+	if err != nil {
+		return false, fmt.Errorf("unable to get createdBy for the node: %w", err)
+	}
+	return history[len(baseHistory)].CreatedBy == createdBy, nil
 }
 
 // getCreatedBy returns the command the image at node will be created by.  If
 // the passed-in CompositeDigester is not nil, it is assumed to have the digest
 // information for the content if the node is ADD or COPY.
-func (s *StageExecutor) getCreatedBy(node *parser.Node, addedContentSummary string) string {
+func (s *StageExecutor) getCreatedBy(node *parser.Node, addedContentSummary string) (string, error) {
 	if node == nil {
-		return "/bin/sh"
+		return "/bin/sh", nil
 	}
 	switch strings.ToUpper(node.Value) {
 	case "ARG":
@@ -1849,15 +1873,72 @@ func (s *StageExecutor) getCreatedBy(node *parser.Node, addedContentSummary stri
 			}
 		}
 		buildArgs := s.getBuildArgsKey()
-		return "/bin/sh -c #(nop) ARG " + buildArgs
+		return "/bin/sh -c #(nop) ARG " + buildArgs, nil
 	case "RUN":
 		shArg := ""
 		buildArgs := s.getBuildArgsResolvedForRun()
+		appendCheckSum := ""
+		for _, flag := range node.Flags {
+			var err error
+			mountOptionSource := ""
+			mountOptionFrom := ""
+			mountCheckSum := ""
+			if strings.HasPrefix(flag, "--mount=") {
+				mountInfo := getFromAndSourceKeysFromMountFlag(flag)
+				if mountInfo.Type != "bind" {
+					continue
+				}
+				mountOptionSource = mountInfo.Source
+				mountOptionFrom = mountInfo.From
+				// If source is not specified then default is '.'
+				if mountOptionSource == "" {
+					mountOptionSource = "."
+				}
+			}
+			// Source specificed is part of stage, image or additional-build-context.
+			if mountOptionFrom != "" {
+				// If this is not a stage then get digest of image or additional build context
+				if _, ok := s.executor.stages[mountOptionFrom]; !ok {
+					if builder, ok := s.executor.containerMap[mountOptionFrom]; ok {
+						// Found valid image, get image digest.
+						mountCheckSum = builder.FromImageDigest
+					} else {
+						if s.executor.additionalBuildContexts[mountOptionFrom].IsImage {
+							if builder, ok := s.executor.containerMap[s.executor.additionalBuildContexts[mountOptionFrom].Value]; ok {
+								// Found valid image, get image digest.
+								mountCheckSum = builder.FromImageDigest
+							}
+						} else {
+							// Found additional build context, get directory sha.
+							basePath := s.executor.additionalBuildContexts[mountOptionFrom].Value
+							if s.executor.additionalBuildContexts[mountOptionFrom].IsURL {
+								basePath = s.executor.additionalBuildContexts[mountOptionFrom].DownloadedCache
+							}
+							mountCheckSum, err = generatePathChecksum(filepath.Join(basePath, mountOptionSource))
+							if err != nil {
+								return "", fmt.Errorf("generating checksum for directory %q in %q: %w", mountOptionSource, basePath, err)
+							}
+						}
+					}
+				}
+			} else {
+				if mountOptionSource != "" {
+					mountCheckSum, err = generatePathChecksum(filepath.Join(s.executor.contextDir, mountOptionSource))
+					if err != nil {
+						return "", fmt.Errorf("generating checksum for directory %q in %q: %w", mountOptionSource, s.executor.contextDir, err)
+					}
+				}
+			}
+			if mountCheckSum != "" {
+				// add a separator to appendCheckSum
+				appendCheckSum += ":" + mountCheckSum
+			}
+		}
 		if len(node.Original) > 4 {
 			shArg = node.Original[4:]
 		}
 		if buildArgs != "" {
-			return "|" + strconv.Itoa(len(strings.Split(buildArgs, " "))) + " " + buildArgs + " /bin/sh -c " + shArg
+			return "|" + strconv.Itoa(len(strings.Split(buildArgs, " "))) + " " + buildArgs + " /bin/sh -c " + shArg + appendCheckSum, nil
 		}
 		result := "/bin/sh -c " + shArg
 		if len(node.Heredocs) > 0 {
@@ -1866,15 +1947,15 @@ func (s *StageExecutor) getCreatedBy(node *parser.Node, addedContentSummary stri
 				result = result + "\n" + heredocContent
 			}
 		}
-		return result
+		return result + appendCheckSum, nil
 	case "ADD", "COPY":
 		destination := node
 		for destination.Next != nil {
 			destination = destination.Next
 		}
-		return "/bin/sh -c #(nop) " + strings.ToUpper(node.Value) + " " + addedContentSummary + " in " + destination.Value + " "
+		return "/bin/sh -c #(nop) " + strings.ToUpper(node.Value) + " " + addedContentSummary + " in " + destination.Value + " ", nil
 	default:
-		return "/bin/sh -c #(nop) " + node.Original
+		return "/bin/sh -c #(nop) " + node.Original, nil
 	}
 }
 
@@ -2023,7 +2104,10 @@ func (s *StageExecutor) generateCacheKey(ctx context.Context, currNode *parser.N
 			fmt.Fprintln(hash, diffIDs[i].String())
 		}
 	}
-	createdBy := s.getCreatedBy(currNode, addedContentDigest)
+	createdBy, err := s.getCreatedBy(currNode, addedContentDigest)
+	if err != nil {
+		return "", err
+	}
 	fmt.Fprintf(hash, "%t", buildAddsLayer)
 	fmt.Fprintln(hash, createdBy)
 	fmt.Fprintln(hash, manifestType)
@@ -2203,7 +2287,11 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 			continue
 		}
 		// children + currNode is the point of the Dockerfile we are currently at.
-		if s.historyAndDiffIDsMatch(baseHistory, baseDiffIDs, currNode, history, diffIDs, addedContentDigest, buildAddsLayer) {
+		foundMatch, err := s.historyAndDiffIDsMatch(baseHistory, baseDiffIDs, currNode, history, diffIDs, addedContentDigest, buildAddsLayer)
+		if err != nil {
+			return "", err
+		}
+		if foundMatch {
 			return image.ID, nil
 		}
 	}

--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -1,8 +1,97 @@
 package imagebuildah
 
 import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/containers/buildah"
+	digest "github.com/opencontainers/go-digest"
 )
+
+type mountInfo struct {
+	Type   string
+	Source string
+	From   string
+}
+
+// Consumes mount flag in format of `--mount=type=bind,src=/path,from=image` and
+// return mountInfo with values, otherwise values are empty if keys are not present in the option.
+func getFromAndSourceKeysFromMountFlag(mount string) mountInfo {
+	tokens := strings.Split(strings.TrimPrefix(mount, "--mount="), ",")
+	source := ""
+	from := ""
+	mountType := ""
+	for _, option := range tokens {
+		if optionSplit := strings.Split(option, "="); len(optionSplit) == 2 {
+			if optionSplit[0] == "src" || optionSplit[0] == "source" {
+				source = optionSplit[1]
+			}
+			if optionSplit[0] == "from" {
+				from = optionSplit[1]
+			}
+			if optionSplit[0] == "type" {
+				mountType = optionSplit[1]
+			}
+		}
+	}
+	return mountInfo{Source: source, From: from, Type: mountType}
+}
+
+// generatePathChecksum generates the SHA-256 checksum for a file or a directory.
+func generatePathChecksum(sourcePath string) (string, error) {
+	digester := digest.SHA256.Digester()
+	tarWriter := tar.NewWriter(digester.Hash())
+
+	err := filepath.Walk(sourcePath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		var linkTarget string
+		if info.Mode()&os.ModeSymlink != 0 {
+			// If the file is a symlink, get the target
+			linkTarget, err = os.Readlink(path)
+			if err != nil {
+				return err
+			}
+		}
+
+		header, err := tar.FileInfoHeader(info, linkTarget)
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(sourcePath, path)
+		if err != nil {
+			return err
+		}
+		header.Name = filepath.ToSlash(relPath)
+
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		_, err = io.Copy(tarWriter, file)
+		return err
+	})
+	tarWriter.Close()
+	if err != nil {
+		return "", err
+	}
+	return digester.Digest().String(), nil
+}
 
 // InitReexec is a wrapper for buildah.InitReexec().  It should be called at
 // the start of main(), and if it returns true, main() should return

--- a/imagebuildah/util_test.go
+++ b/imagebuildah/util_test.go
@@ -1,0 +1,81 @@
+package imagebuildah
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGeneratePathChecksum(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tempFile, err := os.CreateTemp(tempDir, "testfile")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer tempFile.Close()
+
+	// Write some data to the file
+	data := []byte("Hello, world!")
+	if _, err := tempFile.Write(data); err != nil {
+		t.Fatalf("Failed to write data to temp file: %v", err)
+	}
+
+	// Generate the checksum for the directory
+	checksum, err := generatePathChecksum(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to generate checksum: %v", err)
+	}
+
+	digester := digest.SHA256.Digester()
+	tarWriter := tar.NewWriter(digester.Hash())
+
+	err = filepath.Walk(tempDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(tempDir, path)
+		if err != nil {
+			return err
+		}
+		header.Name = filepath.ToSlash(relPath)
+
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		_, err = io.Copy(tarWriter, file)
+		return err
+	})
+	if err != nil {
+		tarWriter.Close()
+		t.Fatalf("Failed to manually generate checksum: %v", err)
+	}
+
+	tarWriter.Close()
+	expectedChecksum := digester.Digest().String()
+
+	// Compare the generated checksum to the expected checksum
+	assert.Equal(t, expectedChecksum, checksum, "didn't get expected checksum over a sample directory")
+}


### PR DESCRIPTION
When using `--mount=type=bind` or `--mount=type=cache` the hash or digest of source in these flags should be added to image history so buildah can burst cache if files on host or image which is being used as source is changed.

Closes
* https://github.com/containers/podman/issues/23382
* https://github.com/containers/buildah/issues/5400

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build, run: record hash or digest in image history for sources used in `--mount`
```

