### PR TITLE
stage_executor: set `avoidLookingCache` only if mounting stage and not additional build context

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -694,7 +694,7 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 								mountPoint = additionalBuildContext.DownloadedCache
 							}
 						}
-						stageMountPoints[from] = internal.StageMountDetails{IsStage: true, DidExecute: true, MountPoint: mountPoint}
+						stageMountPoints[from] = internal.StageMountDetails{IsStage: false, DidExecute: true, MountPoint: mountPoint}
 						break
 					}
 					// If the source's name corresponds to the

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1492,7 +1492,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 			return "", nil, false, err
 		}
 		for _, mountPoint := range stageMountPoints {
-			if mountPoint.DidExecute {
+			if mountPoint.DidExecute && mountPoint.IsStage {
 				avoidLookingCache = true
 			}
 		}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -943,6 +943,34 @@ _EOF
 
 }
 
+@test "build-test use image from cache with --mount and burst when image is changed" {
+  _prefetch alpine
+  local contextdir=${TEST_SCRATCH_DIR}/bud/platform
+  mkdir -p $contextdir
+
+  cat > $contextdir/Containerfile << _EOF
+FROM alpine
+RUN touch firstfile
+_EOF
+
+  run_buildah build $WITH_POLICY_JSON --layers -t source -f $contextdir/Containerfile
+
+  cat > $contextdir/Containerfile2 << _EOF
+FROM alpine
+
+RUN --mount=type=bind,source=.,target=/build,from=source ls /build
+
+_EOF
+
+  run_buildah build $WITH_POLICY_JSON --layers -t source2 -f $contextdir/Containerfile2
+  expect_output --substring "firstfile"
+
+  # Building again must use cache
+  run_buildah build $WITH_POLICY_JSON --layers -t source2 -f $contextdir/Containerfile2
+  expect_output --substring "Using cache"
+  assert "$output" !~ "firstfile"
+}
+
 # Verify: https://github.com/containers/buildah/issues/4572
 @test "build-test verify no dangling containers are left" {
   _prefetch alpine busybox
@@ -1513,6 +1541,30 @@ _EOF
   # Additional context for RUN --mount is file on host
   run_buildah build $WITH_POLICY_JSON --build-context some-stage=$contextdir -t test -f $contextdir/Dockerfile2
   expect_output --substring "world"
+}
+
+@test "build-with-additional-build-context must use cache if built with layers" {
+  _prefetch alpine
+  local contextdir=${TEST_SCRATCH_DIR}/bud/platform
+  mkdir -p $contextdir
+  echo world > $contextdir/hello
+
+  cat > $contextdir/Containerfile2 << _EOF
+FROM alpine as some-stage
+RUN echo some_text
+
+# hello should get copied since we are giving priority to additional context
+FROM alpine
+RUN --mount=type=bind,from=some-stage,target=/test,z cat /test/hello
+_EOF
+
+  # Additional context for RUN --mount is file on host
+  run_buildah build $WITH_POLICY_JSON --layers --build-context some-stage=$contextdir -t test -f $contextdir/Containerfile2
+  expect_output --substring "world"
+
+  run_buildah build $WITH_POLICY_JSON --layers --build-context some-stage=$contextdir -t test -f $contextdir/Containerfile2
+  expect_output --substring "Using cache"
+  assert "$output" !~ "world"
 }
 
 # Test usage of RUN --mount=from=<name> with additional context is URL and mount source is relative using src


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it
Newly added integration tests.

#### Which issue(s) this PR fixes:

Closes: https://github.com/containers/buildah/issues/5692

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build: cache now works with when additional build context is used as source of --mount
```

