### PR TITLE
run: fix a nil pointer dereference on FreeBSD

### DIFF
--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -243,7 +243,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		// Only add entries here if we do not have to do setup network,
 		// if we do we have to do it much later after the network setup.
 		if !configureNetwork {
-			err = b.addResolvConfEntries(resolvFile, nil, nil, false, true)
+			err = b.addResolvConfEntries(resolvFile, nil, spec, false, true)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Attempting to use 'buildah run --network=host' caused a nil pointer dereference while setting up the container's resolv.conf file - (*Builder).addResolvConfEntries expects a non-nil value for its specs parameter.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This makes buildah usable on FreeBSD with networking set to host.

#### How to verify it

On a FreeBSD host, running these commands should print the OS version instead of failing with a nil pointer dereference:
```
c=$(sudo buildah from quay.io/dougrabson/freebsd14.0-minimal)
sudo buildah run --network=host $c freebsd-version
```

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

