### PR TITLE
[release-1.37] Bump Buildah to v1.37.2, c/common v0.60.2, c/image v5.32.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Changelog
 
+## v1.37.2 (2024-08-20)
+
+    [release-1.37] Bump c/common to v0.60.2, c/image to v5.32.2
+
 ## v1.37.1 (2024-08-12)
 
     [release-1.37] Bump c/common v0.60.1, c/image v5.32.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+- Changelog for v1.37.2 (2024-08-20)
+  * [release-1.37] Bump c/common to v0.60.2, c/image to v5.32.2
+
 - Changelog for v1.37.1 (2024-08-12)
   * [release-1.37] Bump c/common v0.60.1, c/image v5.32.1
 

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.37.1"
+	Version = "1.37.2"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ go 1.21.0 // *****  ATTENTION  WARNING  CAUTION  DANGER  ******
 require (
 	github.com/containerd/containerd v1.7.18
 	github.com/containernetworking/cni v1.2.3
-	github.com/containers/common v0.60.1
-	github.com/containers/image/v5 v5.32.1
+	github.com/containers/common v0.60.2
+	github.com/containers/image/v5 v5.32.2
 	github.com/containers/luksy v0.0.0-20240618143119-a8846e21c08c
 	github.com/containers/ocicrypt v1.2.0
 	github.com/containers/storage v1.55.0

--- a/go.sum
+++ b/go.sum
@@ -61,10 +61,10 @@ github.com/containernetworking/cni v1.2.3 h1:hhOcjNVUQTnzdRJ6alC5XF+wd9mfGIUaj8F
 github.com/containernetworking/cni v1.2.3/go.mod h1:DuLgF+aPd3DzcTQTtp/Nvl1Kim23oFKdm2okJzBQA5M=
 github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+E5J/EcKOE4gQ=
 github.com/containernetworking/plugins v1.5.1/go.mod h1:MIQfgMayGuHYs0XdNudf31cLLAC+i242hNm6KuDGqCM=
-github.com/containers/common v0.60.1 h1:hMJNKfDxfXY91zD7mr4t/Ybe8JbAsTq5nkrUaCqTKsA=
-github.com/containers/common v0.60.1/go.mod h1:tB0DRxznmHviECVHnqgWbl+8AVCSMZLA8qe7+U7KD6k=
-github.com/containers/image/v5 v5.32.1 h1:fVa7GxRC4BCPGsfSRs4JY12WyeY26SUYQ0NuANaCFrI=
-github.com/containers/image/v5 v5.32.1/go.mod h1:v1l73VeMugfj/QtKI+jhYbwnwFCFnNGckvbST3rQ5Hk=
+github.com/containers/common v0.60.2 h1:utcwp2YkO8c0mNlwRxsxfOiqfj157FRrBjxgjR6f+7o=
+github.com/containers/common v0.60.2/go.mod h1:I0upBi1qJX3QmzGbUOBN1LVP6RvkKhd3qQpZbQT+Q54=
+github.com/containers/image/v5 v5.32.2 h1:SzNE2Y6sf9b1GJoC8qjCuMBXwQrACFp4p0RK15+4gmQ=
+github.com/containers/image/v5 v5.32.2/go.mod h1:v1l73VeMugfj/QtKI+jhYbwnwFCFnNGckvbST3rQ5Hk=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/luksy v0.0.0-20240618143119-a8846e21c08c h1:gJDiBJYc8JFD46IJmr8SqGOcueGSRGnuhW6wgXiAjr0=

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.60.1"
+const Version = "0.60.2"

--- a/vendor/github.com/containers/image/v5/signature/fulcio_cert.go
+++ b/vendor/github.com/containers/image/v5/signature/fulcio_cert.go
@@ -195,10 +195,10 @@ func (f *fulcioTrustRoot) verifyFulcioCertificateAtTime(relevantTime time.Time, 
 	return untrustedCertificate.PublicKey, nil
 }
 
-func verifyRekorFulcio(rekorPublicKey *ecdsa.PublicKey, fulcioTrustRoot *fulcioTrustRoot, untrustedRekorSET []byte,
+func verifyRekorFulcio(rekorPublicKeys []*ecdsa.PublicKey, fulcioTrustRoot *fulcioTrustRoot, untrustedRekorSET []byte,
 	untrustedCertificateBytes []byte, untrustedIntermediateChainBytes []byte, untrustedBase64Signature string,
 	untrustedPayloadBytes []byte) (crypto.PublicKey, error) {
-	rekorSETTime, err := internal.VerifyRekorSET(rekorPublicKey, untrustedRekorSET, untrustedCertificateBytes,
+	rekorSETTime, err := internal.VerifyRekorSET(rekorPublicKeys, untrustedRekorSET, untrustedCertificateBytes,
 		untrustedBase64Signature, untrustedPayloadBytes)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/containers/image/v5/signature/internal/rekor_set.go
+++ b/vendor/github.com/containers/image/v5/signature/internal/rekor_set.go
@@ -113,7 +113,7 @@ func (p UntrustedRekorPayload) MarshalJSON() ([]byte, error) {
 
 // VerifyRekorSET verifies that unverifiedRekorSET is correctly signed by publicKey and matches the rest of the data.
 // Returns bundle upload time on success.
-func VerifyRekorSET(publicKey *ecdsa.PublicKey, unverifiedRekorSET []byte, unverifiedKeyOrCertBytes []byte, unverifiedBase64Signature string, unverifiedPayloadBytes []byte) (time.Time, error) {
+func VerifyRekorSET(publicKeys []*ecdsa.PublicKey, unverifiedRekorSET []byte, unverifiedKeyOrCertBytes []byte, unverifiedBase64Signature string, unverifiedPayloadBytes []byte) (time.Time, error) {
 	// FIXME: Should the publicKey parameter hard-code ecdsa?
 
 	// == Parse SET bytes
@@ -130,7 +130,14 @@ func VerifyRekorSET(publicKey *ecdsa.PublicKey, unverifiedRekorSET []byte, unver
 		return time.Time{}, NewInvalidSignatureError(fmt.Sprintf("canonicalizing Rekor SET JSON: %v", err))
 	}
 	untrustedSETPayloadHash := sha256.Sum256(untrustedSETPayloadCanonicalBytes)
-	if !ecdsa.VerifyASN1(publicKey, untrustedSETPayloadHash[:], untrustedSET.UntrustedSignedEntryTimestamp) {
+	publicKeymatched := false
+	for _, pk := range publicKeys {
+		if ecdsa.VerifyASN1(pk, untrustedSETPayloadHash[:], untrustedSET.UntrustedSignedEntryTimestamp) {
+			publicKeymatched = true
+			break
+		}
+	}
+	if !publicKeymatched {
 		return time.Time{}, NewInvalidSignatureError("cryptographic signature verification of Rekor SET failed")
 	}
 

--- a/vendor/github.com/containers/image/v5/signature/policy_eval_sigstore.go
+++ b/vendor/github.com/containers/image/v5/signature/policy_eval_sigstore.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/containers/image/v5/internal/multierr"
 	"github.com/containers/image/v5/internal/private"
@@ -20,37 +21,69 @@ import (
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
 
-// loadBytesFromDataOrPath ensures there is at most one of ${prefix}Data and ${prefix}Path set,
+// configBytesSources contains configuration fields which may result in one or more []byte values
+type configBytesSources struct {
+	inconsistencyErrorMessage string   // Error to return if more than one source is set
+	path                      string   // …Path: a path to a file containing the data, or ""
+	paths                     []string // …Paths: paths to files containing the data, or nil
+	data                      []byte   // …Data: a single instance ofhe raw data, or nil
+	datas                     [][]byte // …Datas: the raw data, or nil // codespell:ignore datas
+}
+
+// loadBytesFromConfigSources ensures at most one of the sources in src is set,
 // and returns the referenced data, or nil if neither is set.
-func loadBytesFromDataOrPath(prefix string, data []byte, path string) ([]byte, error) {
-	switch {
-	case data != nil && path != "":
-		return nil, fmt.Errorf(`Internal inconsistency: both "%sPath" and "%sData" specified`, prefix, prefix)
-	case path != "":
-		d, err := os.ReadFile(path)
+func loadBytesFromConfigSources(src configBytesSources) ([][]byte, error) {
+	sources := 0
+	var data [][]byte // = nil
+	if src.path != "" {
+		sources++
+		d, err := os.ReadFile(src.path)
 		if err != nil {
 			return nil, err
 		}
-		return d, nil
-	case data != nil:
-		return data, nil
-	default: // Nothing
-		return nil, nil
+		data = [][]byte{d}
 	}
+	if src.paths != nil {
+		sources++
+		data = [][]byte{}
+		for _, path := range src.paths {
+			d, err := os.ReadFile(path)
+			if err != nil {
+				return nil, err
+			}
+			data = append(data, d)
+		}
+	}
+	if src.data != nil {
+		sources++
+		data = [][]byte{src.data}
+	}
+	if src.datas != nil { // codespell:ignore datas
+		sources++
+		data = src.datas // codespell:ignore datas
+	}
+	if sources > 1 {
+		return nil, errors.New(src.inconsistencyErrorMessage)
+	}
+	return data, nil
 }
 
 // prepareTrustRoot creates a fulcioTrustRoot from the input data.
 // (This also prevents external implementations of this interface, ensuring that prSigstoreSignedFulcio is the only one.)
 func (f *prSigstoreSignedFulcio) prepareTrustRoot() (*fulcioTrustRoot, error) {
-	caCertBytes, err := loadBytesFromDataOrPath("fulcioCA", f.CAData, f.CAPath)
+	caCertPEMs, err := loadBytesFromConfigSources(configBytesSources{
+		inconsistencyErrorMessage: `Internal inconsistency: both "caPath" and "caData" specified`,
+		path:                      f.CAPath,
+		data:                      f.CAData,
+	})
 	if err != nil {
 		return nil, err
 	}
-	if caCertBytes == nil {
-		return nil, errors.New(`Internal inconsistency: Fulcio specified with neither "caPath" nor "caData"`)
+	if len(caCertPEMs) != 1 {
+		return nil, errors.New(`Internal inconsistency: Fulcio specified with not exactly one of "caPath" nor "caData"`)
 	}
 	certs := x509.NewCertPool()
-	if ok := certs.AppendCertsFromPEM(caCertBytes); !ok {
+	if ok := certs.AppendCertsFromPEM(caCertPEMs[0]); !ok {
 		return nil, errors.New("error loading Fulcio CA certificates")
 	}
 	fulcio := fulcioTrustRoot{
@@ -66,24 +99,35 @@ func (f *prSigstoreSignedFulcio) prepareTrustRoot() (*fulcioTrustRoot, error) {
 
 // sigstoreSignedTrustRoot contains an already parsed version of the prSigstoreSigned policy
 type sigstoreSignedTrustRoot struct {
-	publicKey      crypto.PublicKey
-	fulcio         *fulcioTrustRoot
-	rekorPublicKey *ecdsa.PublicKey
+	publicKeys      []crypto.PublicKey
+	fulcio          *fulcioTrustRoot
+	rekorPublicKeys []*ecdsa.PublicKey
 }
 
 func (pr *prSigstoreSigned) prepareTrustRoot() (*sigstoreSignedTrustRoot, error) {
 	res := sigstoreSignedTrustRoot{}
 
-	publicKeyPEM, err := loadBytesFromDataOrPath("key", pr.KeyData, pr.KeyPath)
+	publicKeyPEMs, err := loadBytesFromConfigSources(configBytesSources{
+		inconsistencyErrorMessage: `Internal inconsistency: more than one of "keyPath", "keyPaths", "keyData", "keyDatas" specified`,
+		path:                      pr.KeyPath,
+		paths:                     pr.KeyPaths,
+		data:                      pr.KeyData,
+		datas:                     pr.KeyDatas, // codespell:ignore datas
+	})
 	if err != nil {
 		return nil, err
 	}
-	if publicKeyPEM != nil {
-		pk, err := cryptoutils.UnmarshalPEMToPublicKey(publicKeyPEM)
-		if err != nil {
-			return nil, fmt.Errorf("parsing public key: %w", err)
+	if publicKeyPEMs != nil {
+		for index, keyData := range publicKeyPEMs {
+			pk, err := cryptoutils.UnmarshalPEMToPublicKey(keyData)
+			if err != nil {
+				return nil, fmt.Errorf("parsing public key %d: %w", index+1, err)
+			}
+			res.publicKeys = append(res.publicKeys, pk)
 		}
-		res.publicKey = pk
+		if len(res.publicKeys) == 0 {
+			return nil, errors.New(`Internal inconsistency: "keyPath", "keyPaths", "keyData" and "keyDatas" produced no public keys`)
+		}
 	}
 
 	if pr.Fulcio != nil {
@@ -94,21 +138,32 @@ func (pr *prSigstoreSigned) prepareTrustRoot() (*sigstoreSignedTrustRoot, error)
 		res.fulcio = f
 	}
 
-	rekorPublicKeyPEM, err := loadBytesFromDataOrPath("rekorPublicKey", pr.RekorPublicKeyData, pr.RekorPublicKeyPath)
+	rekorPublicKeyPEMs, err := loadBytesFromConfigSources(configBytesSources{
+		inconsistencyErrorMessage: `Internal inconsistency: both "rekorPublicKeyPath" and "rekorPublicKeyData" specified`,
+		path:                      pr.RekorPublicKeyPath,
+		paths:                     pr.RekorPublicKeyPaths,
+		data:                      pr.RekorPublicKeyData,
+		datas:                     pr.RekorPublicKeyDatas, // codespell:ignore datas
+	})
 	if err != nil {
 		return nil, err
 	}
-	if rekorPublicKeyPEM != nil {
-		pk, err := cryptoutils.UnmarshalPEMToPublicKey(rekorPublicKeyPEM)
-		if err != nil {
-			return nil, fmt.Errorf("parsing Rekor public key: %w", err)
-		}
-		pkECDSA, ok := pk.(*ecdsa.PublicKey)
-		if !ok {
-			return nil, fmt.Errorf("Rekor public key is not using ECDSA")
+	if rekorPublicKeyPEMs != nil {
+		for index, pem := range rekorPublicKeyPEMs {
+			pk, err := cryptoutils.UnmarshalPEMToPublicKey(pem)
+			if err != nil {
+				return nil, fmt.Errorf("parsing Rekor public key %d: %w", index+1, err)
+			}
+			pkECDSA, ok := pk.(*ecdsa.PublicKey)
+			if !ok {
+				return nil, fmt.Errorf("Rekor public key %d is not using ECDSA", index+1)
 
+			}
+			res.rekorPublicKeys = append(res.rekorPublicKeys, pkECDSA)
 		}
-		res.rekorPublicKey = pkECDSA
+		if len(res.rekorPublicKeys) == 0 {
+			return nil, errors.New(`Internal inconsistency: "rekorPublicKeyPath", "rekorPublicKeyPaths", "rekorPublicKeyData" and "rekorPublicKeyDatas" produced no public keys`)
+		}
 	}
 
 	return &res, nil
@@ -134,37 +189,51 @@ func (pr *prSigstoreSigned) isSignatureAccepted(ctx context.Context, image priva
 	}
 	untrustedPayload := sig.UntrustedPayload()
 
-	var publicKey crypto.PublicKey
+	var publicKeys []crypto.PublicKey
 	switch {
-	case trustRoot.publicKey != nil && trustRoot.fulcio != nil: // newPRSigstoreSigned rejects such combinations.
+	case trustRoot.publicKeys != nil && trustRoot.fulcio != nil: // newPRSigstoreSigned rejects such combinations.
 		return sarRejected, errors.New("Internal inconsistency: Both a public key and Fulcio CA specified")
-	case trustRoot.publicKey == nil && trustRoot.fulcio == nil: // newPRSigstoreSigned rejects such combinations.
+	case trustRoot.publicKeys == nil && trustRoot.fulcio == nil: // newPRSigstoreSigned rejects such combinations.
 		return sarRejected, errors.New("Internal inconsistency: Neither a public key nor a Fulcio CA specified")
 
-	case trustRoot.publicKey != nil:
-		if trustRoot.rekorPublicKey != nil {
+	case trustRoot.publicKeys != nil:
+		if trustRoot.rekorPublicKeys != nil {
 			untrustedSET, ok := untrustedAnnotations[signature.SigstoreSETAnnotationKey]
 			if !ok { // For user convenience; passing an empty []byte to VerifyRekorSet should work.
 				return sarRejected, fmt.Errorf("missing %s annotation", signature.SigstoreSETAnnotationKey)
 			}
-			// We could use publicKeyPEM directly, but let’s re-marshal to avoid inconsistencies.
-			// FIXME: We could just generate DER instead of the full PEM text
-			recreatedPublicKeyPEM, err := cryptoutils.MarshalPublicKeyToPEM(trustRoot.publicKey)
-			if err != nil {
-				// Coverage: The key was loaded from a PEM format, so it’s unclear how this could fail.
-				// (PEM is not essential, MarshalPublicKeyToPEM can only fail if marshaling to ASN1.DER fails.)
-				return sarRejected, fmt.Errorf("re-marshaling public key to PEM: %w", err)
 
+			var rekorFailures []string
+			for _, candidatePublicKey := range trustRoot.publicKeys {
+				// We could use publicKeyPEM directly, but let’s re-marshal to avoid inconsistencies.
+				// FIXME: We could just generate DER instead of the full PEM text
+				recreatedPublicKeyPEM, err := cryptoutils.MarshalPublicKeyToPEM(candidatePublicKey)
+				if err != nil {
+					// Coverage: The key was loaded from a PEM format, so it’s unclear how this could fail.
+					// (PEM is not essential, MarshalPublicKeyToPEM can only fail if marshaling to ASN1.DER fails.)
+					return sarRejected, fmt.Errorf("re-marshaling public key to PEM: %w", err)
+				}
+				// We don’t care about the Rekor timestamp, just about log presence.
+				_, err = internal.VerifyRekorSET(trustRoot.rekorPublicKeys, []byte(untrustedSET), recreatedPublicKeyPEM, untrustedBase64Signature, untrustedPayload)
+				if err == nil {
+					publicKeys = append(publicKeys, candidatePublicKey)
+					break // The SET can only accept one public key entry, so if we found one, the rest either doesn’t match or is a duplicate
+				}
+				rekorFailures = append(rekorFailures, err.Error())
 			}
-			// We don’t care about the Rekor timestamp, just about log presence.
-			if _, err := internal.VerifyRekorSET(trustRoot.rekorPublicKey, []byte(untrustedSET), recreatedPublicKeyPEM, untrustedBase64Signature, untrustedPayload); err != nil {
-				return sarRejected, err
+			if len(publicKeys) == 0 {
+				if len(rekorFailures) == 0 {
+					// Coverage: We have ensured that len(trustRoot.publicKeys) != 0, when nothing succeeds, there must be at least one failure.
+					return sarRejected, errors.New(`Internal inconsistency: Rekor SET did not match any key but we have no failures.`)
+				}
+				return sarRejected, internal.NewInvalidSignatureError(fmt.Sprintf("No public key verified against the RekorSET: %s", strings.Join(rekorFailures, ", ")))
 			}
+		} else {
+			publicKeys = trustRoot.publicKeys
 		}
-		publicKey = trustRoot.publicKey
 
 	case trustRoot.fulcio != nil:
-		if trustRoot.rekorPublicKey == nil { // newPRSigstoreSigned rejects such combinations.
+		if trustRoot.rekorPublicKeys == nil { // newPRSigstoreSigned rejects such combinations.
 			return sarRejected, errors.New("Internal inconsistency: Fulcio CA specified without a Rekor public key")
 		}
 		untrustedSET, ok := untrustedAnnotations[signature.SigstoreSETAnnotationKey]
@@ -179,19 +248,20 @@ func (pr *prSigstoreSigned) isSignatureAccepted(ctx context.Context, image priva
 		if untrustedIntermediateChain, ok := untrustedAnnotations[signature.SigstoreIntermediateCertificateChainAnnotationKey]; ok {
 			untrustedIntermediateChainBytes = []byte(untrustedIntermediateChain)
 		}
-		pk, err := verifyRekorFulcio(trustRoot.rekorPublicKey, trustRoot.fulcio,
+		pk, err := verifyRekorFulcio(trustRoot.rekorPublicKeys, trustRoot.fulcio,
 			[]byte(untrustedSET), []byte(untrustedCert), untrustedIntermediateChainBytes, untrustedBase64Signature, untrustedPayload)
 		if err != nil {
 			return sarRejected, err
 		}
-		publicKey = pk
+		publicKeys = []crypto.PublicKey{pk}
 	}
 
-	if publicKey == nil {
-		// Coverage: This should never happen, we have already excluded the possibility in the switch above.
+	if len(publicKeys) == 0 {
+		// Coverage: This should never happen, we ensured that trustRoot.publicKeys is non-empty if set,
+		// and we have already excluded the possibility in the switch above.
 		return sarRejected, fmt.Errorf("Internal inconsistency: publicKey not set before verifying sigstore payload")
 	}
-	signature, err := internal.VerifySigstorePayload(publicKey, untrustedPayload, untrustedBase64Signature, internal.SigstorePayloadAcceptanceRules{
+	signature, err := internal.VerifySigstorePayload(publicKeys, untrustedPayload, untrustedBase64Signature, internal.SigstorePayloadAcceptanceRules{
 		ValidateSignedDockerReference: func(ref string) error {
 			if !pr.SignedIdentity.matchesDockerReference(image, ref) {
 				return PolicyRequirementError(fmt.Sprintf("Signature for identity %q is not accepted", ref))

--- a/vendor/github.com/containers/image/v5/signature/policy_types.go
+++ b/vendor/github.com/containers/image/v5/signature/policy_types.go
@@ -74,7 +74,7 @@ type prSignedBy struct {
 
 	// KeyPath is a pathname to a local file containing the trusted key(s). Exactly one of KeyPath, KeyPaths and KeyData must be specified.
 	KeyPath string `json:"keyPath,omitempty"`
-	// KeyPaths if a set of pathnames to local files containing the trusted key(s). Exactly one of KeyPath, KeyPaths and KeyData must be specified.
+	// KeyPaths is a set of pathnames to local files containing the trusted key(s). Exactly one of KeyPath, KeyPaths and KeyData must be specified.
 	KeyPaths []string `json:"keyPaths,omitempty"`
 	// KeyData contains the trusted key(s), base64-encoded. Exactly one of KeyPath, KeyPaths and KeyData must be specified.
 	KeyData []byte `json:"keyData,omitempty"`
@@ -111,24 +111,35 @@ type prSignedBaseLayer struct {
 type prSigstoreSigned struct {
 	prCommon
 
-	// KeyPath is a pathname to a local file containing the trusted key. Exactly one of KeyPath, KeyData, Fulcio must be specified.
+	// KeyPath is a pathname to a local file containing the trusted key. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
 	KeyPath string `json:"keyPath,omitempty"`
-	// KeyData contains the trusted key, base64-encoded. Exactly one of KeyPath, KeyData, Fulcio must be specified.
+	// KeyPaths is a set of pathnames to local files containing the trusted key(s). Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
+	KeyPaths []string `json:"keyPaths,omitempty"`
+	// KeyData contains the trusted key, base64-encoded. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
 	KeyData []byte `json:"keyData,omitempty"`
-	// FIXME: Multiple public keys?
+	// KeyDatas is a set of trusted keys, base64-encoded. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
+	KeyDatas [][]byte `json:"keyDatas,omitempty"`
 
-	// Fulcio specifies which Fulcio-generated certificates are accepted. Exactly one of KeyPath, KeyData, Fulcio must be specified.
+	// Fulcio specifies which Fulcio-generated certificates are accepted. Exactly one of KeyPath, KeyPaths, KeyData, KeyDatas and Fulcio must be specified.
 	// If Fulcio is specified, one of RekorPublicKeyPath or RekorPublicKeyData must be specified as well.
 	Fulcio PRSigstoreSignedFulcio `json:"fulcio,omitempty"`
 
 	// RekorPublicKeyPath is a pathname to local file containing a public key of a Rekor server which must record acceptable signatures.
-	// If Fulcio is used, one of RekorPublicKeyPath or RekorPublicKeyData must be specified as well; otherwise it is optional
-	// (and Rekor inclusion is not required if a Rekor public key is not specified).
+	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
+	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
 	RekorPublicKeyPath string `json:"rekorPublicKeyPath,omitempty"`
+	// RekorPublicKeyPaths is a set of pathnames to local files, each containing a public key of a Rekor server. One of the keys must record acceptable signatures.
+	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
+	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
+	RekorPublicKeyPaths []string `json:"rekorPublicKeyPaths,omitempty"`
 	// RekorPublicKeyPath contain a base64-encoded public key of a Rekor server which must record acceptable signatures.
-	// If Fulcio is used, one of RekorPublicKeyPath or RekorPublicKeyData must be specified as well; otherwise it is optional
-	// (and Rekor inclusion is not required if a Rekor public key is not specified).
+	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
+	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
 	RekorPublicKeyData []byte `json:"rekorPublicKeyData,omitempty"`
+	// RekorPublicKeyDatas each contain a base64-encoded public key of a Rekor server. One of the keys must record acceptable signatures.
+	// If Fulcio is used, one of RekorPublicKeyPath, RekorPublicKeyPaths, RekorPublicKeyData and RekorPublicKeyDatas must be specified as well;
+	// otherwise it is optional (and Rekor inclusion is not required if a Rekor public key is not specified).
+	RekorPublicKeyDatas [][]byte `json:"rekorPublicKeyDatas,omitempty"`
 
 	// SignedIdentity specifies what image identity the signature must be claiming about the image.
 	// Defaults to "matchRepoDigestOrExact" if not specified.

--- a/vendor/github.com/containers/image/v5/version/version.go
+++ b/vendor/github.com/containers/image/v5/version/version.go
@@ -6,9 +6,9 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 5
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 33
+	VersionMinor = 32
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,7 +107,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.5.1
 ## explicit; go 1.20
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/common v0.60.1
+# github.com/containers/common v0.60.2
 ## explicit; go 1.21.0
 github.com/containers/common/internal
 github.com/containers/common/internal/attributedstring
@@ -160,7 +160,7 @@ github.com/containers/common/pkg/umask
 github.com/containers/common/pkg/util
 github.com/containers/common/pkg/version
 github.com/containers/common/version
-# github.com/containers/image/v5 v5.32.1
+# github.com/containers/image/v5 v5.32.2
 ## explicit; go 1.21.0
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory


### PR DESCRIPTION
As the title says.  Bumping in prepartion for Podman v5.2.2

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

