### PR TITLE
Add a validation script for Makefile $(SOURCES)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ LIBSECCOMP_COMMIT := release-2.3
 
 EXTRA_LDFLAGS ?=
 BUILDAH_LDFLAGS := $(GO_LDFLAGS) '-X main.GitCommit=$(GIT_COMMIT) -X main.buildInfo=$(SOURCE_DATE_EPOCH) -X main.cniVersion=$(CNI_COMMIT) $(EXTRA_LDFLAGS)'
-SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go define/*.go docker/*.go internal/config/*.go internal/mkcw/*.go internal/mkcw/types/*.go internal/parse/*.go internal/sbom/*.go internal/source/*.go internal/tmpdir/*.go internal/*.go internal/util/*.go internal/volumes/*.go manifests/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/jail/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go pkg/util/*.go pkg/volumes/*.go util/*.go
+SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go define/*.go docker/*.go internal/config/*.go internal/mkcw/*.go internal/mkcw/types/*.go internal/parse/*.go internal/sbom/*.go internal/source/*.go internal/tmpdir/*.go internal/*.go internal/util/*.go internal/volumes/*.go manifests/*.go pkg/blobcache/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/jail/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go pkg/util/*.go pkg/volumes/*.go util/*.go
 
 LINTFLAGS ?=
 
@@ -133,6 +133,7 @@ validate: install.tools
 	./tests/validate/whitespace.sh
 	./hack/xref-helpmsgs-manpages
 	./tests/validate/pr-should-include-tests
+	./hack/makefile_sources
 
 .PHONY: install.tools
 install.tools:

--- a/hack/makefile_sources
+++ b/hack/makefile_sources
@@ -1,0 +1,20 @@
+#!/bin/bash
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")/.."
+discovered=$(mktemp -t discovered_XXXXXX)
+recorded=$(mktemp -t recorded_XXXXXX)
+addlist=$(mktemp -t need_to_add_XXXXXX)
+# SOURCES in the top-level Makefile is more or less the dependencies of our
+# "imagebuildah" package, so look for things that we depend on that aren't
+# listed therein.
+ls -1 $(go list -deps "${@:-./imagebuildah}" | grep ^github.com/containers/buildah | sed -r -e 's,$,/*.go,' -e 's,^github.com/containers/buildah/?,,') | sort -u > "$discovered"
+ls -1 $(grep ^SOURCES Makefile | sed -e 's,.*=,,' ) | sort -u > "$recorded"
+# Filter for things that are missing, since some of the platform-specific
+# packages are going to be dropped on this particular platform, but we still
+# want to list them as dependencies.
+diff "$recorded" "$discovered" | grep '^>' | cut -c 3- | xargs -r dirname > "$addlist"
+if test -s "$addlist"; then
+    echo The \"SOURCES\" definition in the top-level Makefile is missing these patterns:
+    sed -e 's,$,/*.go,' "$addlist"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Add a validation script that checks that we haven't forgotten to add any new packages to the SOURCES definition in the top-level Makefile.  Heavily based on review comments in #5496.

#### How to verify it

New validation test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

https://github.com/containers/buildah/pull/5496#pullrequestreview-2032386290

#### Does this PR introduce a user-facing change?

```release-note
None
```