### PR TITLE
`manifest add --artifact`: handle multiple values

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -432,24 +432,21 @@ func manifestAddCmd(c *cobra.Command, args []string, opts manifestAddOpts) error
 	switch len(args) {
 	case 0, 1:
 		return errors.New("At least a list image and an image or artifact to add must be specified")
-	case 2:
+	default:
 		listImageSpec = args[0]
 		if listImageSpec == "" {
-			return fmt.Errorf(`Invalid image name "%s"`, args[0])
+			return fmt.Errorf("Invalid image name %q", args[0])
 		}
 		if opts.artifact {
 			artifactSpec = args[1:]
 		} else {
+			if len(args) > 2 {
+				return errors.New("Too many arguments: expected list and image add to list")
+			}
 			imageSpec = args[1]
 			if imageSpec == "" {
-				return fmt.Errorf(`Invalid image name "%s"`, args[1])
+				return fmt.Errorf("Invalid image name %q", args[1])
 			}
-		}
-	default:
-		if opts.artifact {
-			artifactSpec = args[1:]
-		} else {
-			return errors.New("Too many arguments: expected list and image add to list")
 		}
 	}
 

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -75,6 +75,14 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest rm foo
 }
 
+@test "manifest-add-multiple-artifacts" {
+    run_buildah manifest create foo
+    createrandom $TEST_SCRATCH_DIR/randomfile4
+    createrandom $TEST_SCRATCH_DIR/randomfile3
+    run_buildah manifest add --artifact foo $TEST_SCRATCH_DIR/randomfile3 $TEST_SCRATCH_DIR/randomfile4
+    run_buildah manifest push --all foo oci:$TEST_SCRATCH_DIR/pushed
+}
+
 @test "manifest-add local image" {
     target=scratch-image
     run_buildah bud $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Don't error out when `manifest add --artifact` is given multiple files, and add the test I should have added to check that.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes #5727.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah manifest add --artifact` no longer fails if it's invoked with multiple file arguments.  All of the files should be added to a single artifact manifest which should then be added to the image index being updated.
```