### PR TITLE
[skip-ci] Packit: Enable sidetags for bodhi updates

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -89,12 +89,14 @@ jobs:
     dist_git_branches:
       - c10s
 
+  # Fedora Koji build
   - job: koji_build
     trigger: commit
+    sidetag_group: podman-releases
+    # Dependents are not rpm dependencies, but the package whose bodhi update
+    # should include this package.
+    # Ref: https://packit.dev/docs/fedora-releases-guide/releasing-multiple-packages
+    dependents:
+      - podman
     dist_git_branches:
       - fedora-all
-
-  - job: bodhi_update
-    trigger: commit
-    dist_git_branches:
-      - fedora-branched # rawhide updates are created automatically

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,8 @@ packages:
     specfile_path: rpm/buildah.spec
   buildah-rhel:
     specfile_path: rpm/buildah.spec
+  buildah-eln:
+    specfile_path: rpm/buildah.spec
 
 srpm_build_deps:
   - make
@@ -26,12 +28,21 @@ jobs:
       failure_comment:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
     targets:
-      fedora-development-x86_64: {}
-      fedora-development-aarch64: {}
-      fedora-latest-x86_64: {}
-      fedora-latest-aarch64: {}
-      fedora-latest-stable-x86_64: {}
-      fedora-latest-stable-aarch64: {}
+      - fedora-development-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-x86_64
+      - fedora-latest-aarch64
+      - fedora-latest-stable-x86_64
+      - fedora-latest-stable-aarch64
+      - fedora-40-x86_64
+      - fedora-40-aarch64
+    enable_net: true
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [buildah-eln]
+    notifications: *copr_build_failure_notification
+    targets:
       fedora-eln-x86_64:
         additional_repos:
           - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/x86_64/"
@@ -78,7 +89,7 @@ jobs:
     trigger: release
     packages: [buildah-fedora]
     update_release: false
-    dist_git_branches:
+    dist_git_branches: &fedora_targets
       - fedora-all
 
   # Sync to CentOS Stream
@@ -98,5 +109,4 @@ jobs:
     # Ref: https://packit.dev/docs/fedora-releases-guide/releasing-multiple-packages
     dependents:
       - podman
-    dist_git_branches:
-      - fedora-all
+    dist_git_branches: *fedora_targets


### PR DESCRIPTION
Packit now has sidetag support for adding multiple builds into a single bodhi update.
    
Since we release c/ccommon, skopeo, buildah and podman often almoost simultaneously, we should release them to Fedora in a single bodhi update using sidetags so all builds can be tested together.


<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

Makes Fedora package updates easier

#### How to verify it

We can only verify this after the next release which ships this config.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None


#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

