### PR TITLE
build: fall back to parsing a TARGETPLATFORM build-arg

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -229,6 +229,17 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 		if platform.OS == "" && platform.Arch != "" {
 			platform.OS = runtime.GOOS
 		}
+		if platform.OS == "" && platform.Arch == "" {
+			if targetPlatform, ok := options.Args["TARGETPLATFORM"]; ok {
+				targetPlatform, err := platforms.Parse(targetPlatform)
+				if err != nil {
+					return "", nil, fmt.Errorf("parsing TARGETPLATFORM value %q: %w", targetPlatform, err)
+				}
+				platform.OS = targetPlatform.OS
+				platform.Arch = targetPlatform.Architecture
+				platform.Variant = targetPlatform.Variant
+			}
+		}
 		platformSpec := internalUtil.NormalizePlatform(v1.Platform{
 			OS:           platform.OS,
 			Architecture: platform.Arch,

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6157,6 +6157,18 @@ _EOF
   assert "$manifests" = "amd64 arm64 ppc64le s390x" "arch list in manifest"
 }
 
+@test "bud-targetplatform-as-build-arg" {
+  outputlist=localhost/testlist
+  for targetplatform in linux/arm64 linux/amd64 ; do
+    run_buildah build $WITH_POLICY_JSON \
+              --build-arg SAFEIMAGE=$SAFEIMAGE \
+              --build-arg TARGETPLATFORM=$targetplatform \
+              -f $BUDFILES/multiarch/Dockerfile.built-in-args \
+              $BUDFILES/multiarch
+    expect_output --substring "I'm compiling for $targetplatform"
+  done
+}
+
 # * Performs multi-stage build with label1=value1 and verifies
 # * Relabels build with label1=value2 and verifies
 # * Rebuild with label1=value1 and makes sure everything is used from cache


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

If we're not given an explicit platform or arch or os to target for a build, but someone defined TARGETPLATFORM as a build argument, parse it.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

This should fix the last thing in https://github.com/containers/podman/issues/23046.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
If a target platform for `buildah build` is not specified with one of the `--platform`, `--os`, or `--arch` flags, but a `TARGETPLATFORM` build argument has been set with `--build-arg`, its value will be used as though it had been specified to `--platform`.
```