### PR TITLE
In a container, try to register binfmt_misc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ LIBSECCOMP_COMMIT := release-2.3
 
 EXTRA_LDFLAGS ?=
 BUILDAH_LDFLAGS := $(GO_LDFLAGS) '-X main.GitCommit=$(GIT_COMMIT) -X main.buildInfo=$(SOURCE_DATE_EPOCH) -X main.cniVersion=$(CNI_COMMIT) $(EXTRA_LDFLAGS)'
-SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go define/*.go docker/*.go internal/config/*.go internal/mkcw/*.go internal/mkcw/types/*.go internal/parse/*.go internal/sbom/*.go internal/source/*.go internal/tmpdir/*.go internal/*.go internal/util/*.go internal/volumes/*.go manifests/*.go pkg/blobcache/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/jail/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go pkg/util/*.go pkg/volumes/*.go util/*.go
+SOURCES=*.go imagebuildah/*.go bind/*.go chroot/*.go copier/*.go define/*.go docker/*.go internal/config/*.go internal/mkcw/*.go internal/mkcw/types/*.go internal/parse/*.go internal/sbom/*.go internal/source/*.go internal/tmpdir/*.go internal/*.go internal/util/*.go internal/volumes/*.go manifests/*.go pkg/binfmt/*.go pkg/blobcache/*.go pkg/chrootuser/*.go pkg/cli/*.go pkg/completion/*.go pkg/formats/*.go pkg/jail/*.go pkg/overlay/*.go pkg/parse/*.go pkg/rusage/*.go pkg/sshagent/*.go pkg/umask/*.go pkg/util/*.go pkg/volumes/*.go util/*.go
 
 LINTFLAGS ?=
 

--- a/pkg/binfmt/binfmt.go
+++ b/pkg/binfmt/binfmt.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+package binfmt
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/containers/storage/pkg/unshare"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// MaybeRegister() calls Register() if the current context is a rootless one,
+// or if the "container" environment variable suggests that we're in a
+// container.
+func MaybeRegister(configurationSearchDirectories []string) error {
+	if unshare.IsRootless() || os.Getenv("container") != "" { // we _also_ own our own mount namespace
+		return Register(configurationSearchDirectories)
+	}
+	return nil
+}
+
+// Register() registers binfmt.d emulators described by configuration files in
+// the passed-in slice of directories, or in the union of /etc/binfmt.d,
+// /run/binfmt.d, and /usr/lib/binfmt.d if the slice has no items.  If any
+// emulators are configured, it will attempt to mount a binfmt_misc filesystem
+// in the current mount namespace first, ignoring only EPERM and EACCES errors.
+func Register(configurationSearchDirectories []string) error {
+	if len(configurationSearchDirectories) == 0 {
+		configurationSearchDirectories = []string{"/etc/binfmt.d", "/run/binfmt.d", "/usr/lib/binfmt.d"}
+	}
+	mounted := false
+	for _, searchDir := range configurationSearchDirectories {
+		globs, err := filepath.Glob(filepath.Join(searchDir, "*.conf"))
+		if err != nil {
+			return fmt.Errorf("looking for binfmt.d configuration in %q: %w", searchDir, err)
+		}
+		for _, conf := range globs {
+			f, err := os.Open(conf)
+			if err != nil {
+				return fmt.Errorf("reading binfmt.d configuration: %w", err)
+			}
+			scanner := bufio.NewScanner(f)
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+				if len(line) == 0 || line[0] == ';' || line[0] == '#' {
+					continue
+				}
+				if !mounted {
+					if err = unix.Mount("none", "/proc/sys/fs/binfmt_misc", "binfmt_misc", 0, ""); err != nil {
+						if errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EACCES) {
+							// well, we tried. no need to make a stink about it
+							return nil
+						}
+						return fmt.Errorf("mounting binfmt_misc: %w", err)
+					}
+					mounted = true
+				}
+				reg, err := os.Create("/proc/sys/fs/binfmt_misc/register")
+				if err != nil {
+					return fmt.Errorf("registering(open): %w", err)
+				}
+				if _, err = fmt.Fprintf(reg, "%s\n", line); err != nil {
+					return fmt.Errorf("registering(write): %w", err)
+				}
+				logrus.Tracef("registered binfmt %q", line)
+				if err = reg.Close(); err != nil {
+					return fmt.Errorf("registering(close): %w", err)
+				}
+			}
+			if err := f.Close(); err != nil {
+				return fmt.Errorf("reading binfmt.d configuration: %w", err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/binfmt/binfmt_unsupported.go
+++ b/pkg/binfmt/binfmt_unsupported.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package binfmt
+
+import "syscall"
+
+// MaybeRegister() returns no error.
+func MaybeRegister(configurationSearchDirectories []string) error {
+	return nil
+}
+
+// Register() returns an error.
+func Register(configurationSearchDirectories []string) error {
+	return syscall.ENOSYS
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

If we're running a command in a working container whose platform doesn't match our own, attempt to register any emulators for which we find configurations of the type included in Fedora's qemu-user-static packages.

#### How to verify it

In-container tests, provided the CI node is new enough, will start being able to use emulation if they couldn't before.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

* Linux 6.6 and later allow binfmt_misc to be mounted inside user namespaces.
* This should be helpful for people who are using our Fedora-based images on systems which don't provide their own qemu-user-static binaries.

#### Does this PR introduce a user-facing change?

```release-note
buildah container images will now attempt to use the qemu-user-static binaries they include, if they also include configuration for them, for running binaries built for non-native architectures.
```