### PR TITLE
[release-1.37] imagebuildah.StageExecutor: clean up volumes/volumeCache

### DIFF
--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/containers/buildah/imagebuildah"
@@ -73,7 +74,7 @@ func buildCmd(c *cobra.Command, inputArgs []string, iopts buildahcli.BuildOption
 	if c.Flag("logfile").Changed {
 		logfile, err := os.OpenFile(iopts.Logfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 		if err != nil {
-			return err
+			return fmt.Errorf("opening log file: %w", err)
 		}
 		iopts.Logwriter = logfile
 		defer iopts.Logwriter.Close()

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -143,7 +143,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 			}
 			contents, err = os.Open(dfile)
 			if err != nil {
-				return "", nil, err
+				return "", nil, fmt.Errorf("reading build instructions: %w", err)
 			}
 			dinfo, err = contents.Stat()
 			if err != nil {

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -222,7 +222,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		} else {
 			rusageLogFile, err = os.OpenFile(options.RusageLogFile, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("creating file to store rusage logs: %w", err)
 			}
 		}
 	}

--- a/tests/bud/preserve-volumes/Dockerfile
+++ b/tests/bud/preserve-volumes/Dockerfile
@@ -2,23 +2,27 @@ FROM alpine
 RUN mkdir -p /vol/subvol/subsubvol
 RUN dd if=/dev/zero bs=512 count=1 of=/vol/subvol/subsubvol/subsubvolfile
 VOLUME /vol/subvol
-# At this point, the contents below /vol/subvol should be frozen.
+# At this point, the contents below /vol/subvol may be frozen, so try to create
+# something that will be discarded if it was.
 RUN dd if=/dev/zero bs=512 count=1 of=/vol/subvol/subvolfile
-# In particular, /vol/subvol/subvolfile should be wiped out.
+# In particular, /vol/subvol/subvolfile should be wiped out if --compat-volumes
+# behavior was selected.
 RUN dd if=/dev/zero bs=512 count=1 of=/vol/volfile
-# However, /vol/volfile should exist.
+# However, /vol/volfile should always exist, since /vol was not a volume, but
+# we're making it one here.
 VOLUME /vol
 # And this should be redundant.
 VOLUME /vol/subvol
-# And now we've frozen /vol.
+# And now that we've frozen /vol, --compat-volumes should make this disappear,
+# too.
 RUN dd if=/dev/zero bs=512 count=1 of=/vol/anothervolfile
-# Which means that in the image we're about to commit, /vol/anothervolfile
-# shouldn't exist, either.
 
-# ADD files which should persist.
+# ADD files which should persist, regardless of the --compat-volumes setting.
 ADD Dockerfile /vol/Dockerfile
 RUN stat /vol/Dockerfile
 ADD Dockerfile /vol/Dockerfile2
 RUN stat /vol/Dockerfile2
-# We should still be saving and restoring volume caches.
+
+# This directory should still exist, since we cached /vol once it was declared
+# a VOLUME, and /vol/subvol was created before that (as a VOLUME, but still).
 RUN dd if=/dev/zero bs=512 count=1 of=/vol/subvol/subvolfile

--- a/tests/bud/volume-perms/Dockerfile
+++ b/tests/bud/volume-perms/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine
 VOLUME /vol/subvol
-# At this point, the directory should exist, with default permissions 0755, the
-# contents below /vol/subvol should be frozen, and we shouldn't get an error
-# from trying to write to it because we it was created automatically.
+# At this point, the directory should exist, and it should have default
+# permissions 0755, and we shouldn't get an error from trying to write to it
+# because we it was created automatically.  If this image is built with the
+# --compat-volumes flag, everything done after this point will be discarded.
+RUN chmod 0711 /vol/subvol
 RUN dd if=/dev/zero bs=512 count=1 of=/vol/subvol/subvolfile


### PR DESCRIPTION
Clean up the distinctions between the volumes slice and the volumeCache and volumeCacheInfo maps so that --compat-volumes will work correctly when we're building with multiple layers.  Manual cherry-pick of #5729.