### PR TITLE
[release-1.37] Do not error on trying to write IMA xattr as rootless

### DIFF
--- a/copier/xattrs.go
+++ b/copier/xattrs.go
@@ -10,15 +10,18 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containers/storage/pkg/unshare"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
 const (
 	xattrsSupported = true
+	imaXattr        = "security.ima"
 )
 
 var (
-	relevantAttributes    = []string{"security.capability", "security.ima", "user.*"} // the attributes that we preserve - we discard others
+	relevantAttributes    = []string{"security.capability", imaXattr, "user.*"} // the attributes that we preserve - we discard others
 	initialXattrListSize  = 64 * 1024
 	initialXattrValueSize = 64 * 1024
 )
@@ -93,7 +96,11 @@ func Lsetxattrs(path string, xattrs map[string]string) error {
 	for attribute, value := range xattrs {
 		if isRelevantXattr(attribute) {
 			if err := unix.Lsetxattr(path, attribute, []byte(value), 0); err != nil {
-				return fmt.Errorf("setting value of extended attribute %q on %q: %w", attribute, path, err)
+				if unshare.IsRootless() && attribute == imaXattr {
+					logrus.Warnf("Unable to set %q xattr on %q: %v", attribute, path, err)
+				} else {
+					return fmt.Errorf("setting value of extended attribute %q on %q: %w", attribute, path, err)
+				}
 			}
 		}
 	}

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -306,3 +306,16 @@ stuff/mystuff"
   run_buildah 125 add --checksum=sha256:0000000000000000000000000000000000000000000000000000000000000000 $cid ${TEST_SCRATCH_DIR}/randomfile /
   expect_output --substring "checksum flag is not supported for local sources"
 }
+
+@test "add file with IMA xattr" {
+    if ! getfattr -d -n 'security.ima' /usr/libexec/catatonit/catatonit | grep -q ima; then
+	skip "catatonit does not have IMA xattr, cannot perform test"
+    fi
+
+    run_buildah from --quiet scratch
+    cid=$output
+
+    # We do not care if the attribute was actually added, as rootless is allowed to discard it.
+    # Only that the add was actually successful.
+    run_buildah add $cid /usr/libexec/catatonit/catatonit /catatonit
+}


### PR DESCRIPTION
Backports #5741 to the release-1.37 branch

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

