### PR TITLE
chroot: add newlines at the end of printed error messages

### DIFF
--- a/chroot/run_common.go
+++ b/chroot/run_common.go
@@ -498,7 +498,7 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 		BundlePath: bundlePath,
 	})
 	if conferr != nil {
-		fmt.Fprintf(os.Stderr, "error re-encoding configuration for %q", runUsingChrootExecCommand)
+		fmt.Fprintf(os.Stderr, "error re-encoding configuration for %q\n", runUsingChrootExecCommand)
 		os.Exit(1)
 	}
 
@@ -567,7 +567,7 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 				}
 			}
 		}
-		fmt.Fprintf(os.Stderr, "process exited with error: %v", err)
+		fmt.Fprintf(os.Stderr, "process exited with error: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -695,7 +695,7 @@ func runUsingChrootExecMain() {
 		}
 		logrus.Debugf("setting supplemental groups")
 		if err = syscall.Setgroups(gids); err != nil {
-			fmt.Fprintf(os.Stderr, "error setting supplemental groups list: %v", err)
+			fmt.Fprintf(os.Stderr, "error setting supplemental groups list: %v\n", err)
 			os.Exit(1)
 		}
 	} else {
@@ -703,7 +703,7 @@ func runUsingChrootExecMain() {
 		if strings.Trim(string(setgroups), "\n") != "deny" {
 			logrus.Debugf("clearing supplemental groups")
 			if err = syscall.Setgroups([]int{}); err != nil {
-				fmt.Fprintf(os.Stderr, "error clearing supplemental groups list: %v", err)
+				fmt.Fprintf(os.Stderr, "error clearing supplemental groups list: %v\n", err)
 				os.Exit(1)
 			}
 		}
@@ -711,7 +711,7 @@ func runUsingChrootExecMain() {
 
 	logrus.Debugf("setting gid")
 	if err = unix.Setresgid(int(user.GID), int(user.GID), int(user.GID)); err != nil {
-		fmt.Fprintf(os.Stderr, "error setting GID: %v", err)
+		fmt.Fprintf(os.Stderr, "error setting GID: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -732,7 +732,7 @@ func runUsingChrootExecMain() {
 
 	logrus.Debugf("setting uid")
 	if err = unix.Setresuid(int(user.UID), int(user.UID), int(user.UID)); err != nil {
-		fmt.Fprintf(os.Stderr, "error setting UID: %v", err)
+		fmt.Fprintf(os.Stderr, "error setting UID: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -745,7 +745,7 @@ func runUsingChrootExecMain() {
 	logrus.Debugf("Running %#v (PATH = %q)", cmd, os.Getenv("PATH"))
 	interrupted := make(chan os.Signal, 100)
 	if err = cmd.Start(); err != nil {
-		fmt.Fprintf(os.Stderr, "process failed to start with error: %v", err)
+		fmt.Fprintf(os.Stderr, "process failed to start with error: %v\n", err)
 	}
 	go func() {
 		for range interrupted {
@@ -772,7 +772,7 @@ func runUsingChrootExecMain() {
 				}
 			}
 		}
-		fmt.Fprintf(os.Stderr, "process exited with error: %v", err)
+		fmt.Fprintf(os.Stderr, "process exited with error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

If we print an error message to stderr, end it with a newline.  This should make it easier to tell the difference between multiple error messages.

#### How to verify it

Manual verification only.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```