### PR TITLE
Document that zstd:chunked is downgraded to zstd when encrypting

### DIFF
--- a/docs/buildah-push.1.md
+++ b/docs/buildah-push.1.md
@@ -41,6 +41,7 @@ The default certificates directory is _/etc/containers/certs.d_.
 **--compression-format** *format*
 
 Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.
+`zstd:chunked` is incompatible with encrypting images, and will be treated as `zstd` with a warning in that case.
 
 **--compression-level** *level*
 


### PR DESCRIPTION
#### What type of PR is this?

> /kind documentation

#### What this PR does / why we need it:

Refer to https://github.com/containers/image/blob/93fa49b0f1fb78470512e0484012ca7ad3c5c804/copy/single.go#L153-L157 .

#### How to verify it

N/A

#### Which issue(s) this PR fixes:

None

… fully; a part of https://github.com/containers/common/issues/2117 .

#### Does this PR introduce a user-facing change?
```release-note
None
```

