### PR TITLE
CVE-2024-9407: validate "bind-propagation" flag settings

### DIFF
--- a/internal/volumes/volumes.go
+++ b/internal/volumes/volumes.go
@@ -104,6 +104,12 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
 			if !hasArgValue {
 				return newMount, "", fmt.Errorf("%v: %w", argName, errBadOptionArg)
 			}
+			switch argValue {
+			default:
+				return newMount, "", fmt.Errorf("%v: %q: %w", argName, argValue, errBadMntOption)
+			case "shared", "rshared", "private", "rprivate", "slave", "rslave":
+				// this should be the relevant parts of the same list of options we accepted above
+			}
 			newMount.Options = append(newMount.Options, argValue)
 		case "src", "source":
 			if !hasArgValue {
@@ -275,6 +281,12 @@ func GetCacheMount(args []string, _ storage.Store, _ string, additionalMountPoin
 		case "bind-propagation":
 			if !hasArgValue {
 				return newMount, nil, fmt.Errorf("%v: %w", argName, errBadOptionArg)
+			}
+			switch argValue {
+			default:
+				return newMount, nil, fmt.Errorf("%v: %q: %w", argName, argValue, errBadMntOption)
+			case "shared", "rshared", "private", "rprivate", "slave", "rslave":
+				// this should be the relevant parts of the same list of options we accepted above
 			}
 			newMount.Options = append(newMount.Options, argValue)
 		case "id":

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6946,3 +6946,28 @@ _EOF
   run_buildah run testctr -- sh -c 'cd podman-tag && git ls-remote --tags origin v5.0.0^{} | cut -f1'
   assert "$output" = "$local_head_hash"
 }
+
+@test "build-validates-bind-bind-propagation" {
+  _prefetch alpine
+
+  cat > ${TEST_SCRATCH_DIR}/Containerfile << _EOF
+FROM alpine as base
+FROM alpine
+RUN --mount=type=bind,from=base,source=/,destination=/var/empty,rw,bind-propagation=suid pwd
+_EOF
+
+  run_buildah 125 build $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
+  expect_output --substring "invalid mount option"
+}
+
+@test "build-validates-cache-bind-propagation" {
+  _prefetch alpine
+
+  cat > ${TEST_SCRATCH_DIR}/Containerfile << _EOF
+FROM alpine
+RUN --mount=type=cache,destination=/var/empty,rw,bind-propagation=suid pwd
+_EOF
+
+  run_buildah 125 build $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
+  expect_output --substring "invalid mount option"
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Validate that the value for the "bind-propagation" flag when handling "bind" and "cache" mounts in `buildah run` or in RUN instructions is one of the values that we would accept without the "bind-propagation=" prefix.

#### How to verify it

New integration tests!

#### Which issue(s) this PR fixes:

Addresses CVE-2024-9407.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```