### PR TITLE
tests: add quotes to names

### DIFF
--- a/tests/add.bats
+++ b/tests/add.bats
@@ -307,7 +307,7 @@ stuff/mystuff"
   expect_output --substring "checksum flag is not supported for local sources"
 }
 
-@test add-https-retry-ca {
+@test "add https retry ca" {
   createrandom ${TEST_SCRATCH_DIR}/randomfile
   mkdir -p ${TEST_SCRATCH_DIR}/private
   starthttpd ${TEST_SCRATCH_DIR} "" ${TEST_SCRATCH_DIR}/localhost.crt ${TEST_SCRATCH_DIR}/private/localhost.key

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6905,7 +6905,7 @@ _EOF
   expect_output --substring "\-\-platform=$platform"
 }
 
-@test build-add-https-retry-ca {
+@test "build add https retry ca" {
   createrandom ${TEST_SCRATCH_DIR}/randomfile
   mkdir -p ${TEST_SCRATCH_DIR}/private
   starthttpd ${TEST_SCRATCH_DIR} "" ${TEST_SCRATCH_DIR}/localhost.crt ${TEST_SCRATCH_DIR}/private/localhost.key

--- a/tests/chroot.bats
+++ b/tests/chroot.bats
@@ -2,7 +2,7 @@
 
 load helpers
 
-@test chroot-mount-flags {
+@test "chroot mount flags" {
   skip_if_no_unshare
   if ! test -e /etc/subuid ; then
     skip "we can't bind mount over /etc/subuid during the test if there is no /etc/subuid file"


### PR DESCRIPTION
In podman we also run the bud tests, there I noticed a issue with the podman skip logic as it was unable to fine the build-add-https-retry-ca test name as it always expects quotes[1]

In general names should be human readable so add quotes and use spaces over a dash as word separator.

[1] https://github.com/containers/podman/pull/24135

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug

 /kind cleanup

> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

