### PR TITLE
[skip-ci] Packit: constrain koji job to fedora package to avoid dupes

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -103,6 +103,7 @@ jobs:
   # Fedora Koji build
   - job: koji_build
     trigger: commit
+    packages: [buildah-fedora]
     sidetag_group: podman-releases
     # Dependents are not rpm dependencies, but the package whose bodhi update
     # should include this package.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

Avoids dup packit downstream jobs

#### How to verify it

Can only be verified at the time of Fedora koji builds. It doesn't affect upstream and is safe to merge.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

