### PR TITLE
Properly validate cache IDs and sources

### DIFF
--- a/internal/volumes/volumes.go
+++ b/internal/volumes/volumes.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/lockfile"
 	"github.com/containers/storage/pkg/unshare"
+	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 )
@@ -374,7 +375,11 @@ func GetCacheMount(args []string, _ storage.Store, _ string, additionalMountPoin
 			return newMount, nil, fmt.Errorf("no stage found with name %s", fromStage)
 		}
 		// path should be /contextDir/specified path
-		newMount.Source = filepath.Join(mountPoint, filepath.Clean(string(filepath.Separator)+newMount.Source))
+		evaluated, err := copier.Eval(mountPoint, string(filepath.Separator)+newMount.Source, copier.EvalOptions{})
+		if err != nil {
+			return newMount, nil, err
+		}
+		newMount.Source = evaluated
 	} else {
 		// we need to create the cache directory on the host if no image is being used
 
@@ -391,11 +396,15 @@ func GetCacheMount(args []string, _ storage.Store, _ string, additionalMountPoin
 		}
 
 		if id != "" {
-			newMount.Source = filepath.Join(cacheParent, filepath.Clean(id))
-			buildahLockFilesDir = filepath.Join(BuildahCacheLockfileDir, filepath.Clean(id))
+			// Don't let the user control where we place the directory.
+			dirID := digest.FromString(id).Encoded()[:16]
+			newMount.Source = filepath.Join(cacheParent, dirID)
+			buildahLockFilesDir = filepath.Join(BuildahCacheLockfileDir, dirID)
 		} else {
-			newMount.Source = filepath.Join(cacheParent, filepath.Clean(newMount.Destination))
-			buildahLockFilesDir = filepath.Join(BuildahCacheLockfileDir, filepath.Clean(newMount.Destination))
+			// Don't let the user control where we place the directory.
+			dirID := digest.FromString(newMount.Destination).Encoded()[:16]
+			newMount.Source = filepath.Join(cacheParent, dirID)
+			buildahLockFilesDir = filepath.Join(BuildahCacheLockfileDir, dirID)
 		}
 		idPair := idtools.IDPair{
 			UID: uid,

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6971,3 +6971,37 @@ _EOF
   run_buildah 125 build $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
   expect_output --substring "invalid mount option"
 }
+
+@test "build-check-cve-2024-9675" {
+  _prefetch alpine
+
+  touch ${TEST_SCRATCH_DIR}/file.txt
+
+  cat > ${TEST_SCRATCH_DIR}/Containerfile <<EOF
+FROM alpine
+RUN --mount=type=cache,id=../../../../../../../../../../../$TEST_SCRATCH_DIR,target=/var/tmp \
+ls -l /var/tmp && cat /var/tmp/file.txt
+EOF
+
+  run_buildah 1 build --no-cache ${TEST_SCRATCH_DIR}
+  expect_output --substring "cat: can't open '/var/tmp/file.txt': No such file or directory"
+
+  cat > ${TEST_SCRATCH_DIR}/Containerfile <<EOF
+FROM alpine
+RUN --mount=type=cache,source=../../../../../../../../../../../$TEST_SCRATCH_DIR,target=/var/tmp \
+ls -l /var/tmp && cat /var/tmp/file.txt
+EOF
+
+  run_buildah 1 build --no-cache ${TEST_SCRATCH_DIR}
+  expect_output --substring "cat: can't open '/var/tmp/file.txt': No such file or directory"
+
+  mkdir ${TEST_SCRATCH_DIR}/cve20249675
+  cat > ${TEST_SCRATCH_DIR}/cve20249675/Containerfile <<EOF
+FROM alpine
+RUN --mount=type=cache,from=testbuild,source=../,target=/var/tmp \
+ls -l /var/tmp && cat /var/tmp/file.txt
+EOF
+
+  run_buildah 1 build --security-opt label=disable --build-context testbuild=${TEST_SCRATCH_DIR}/cve20249675/ --no-cache ${TEST_SCRATCH_DIR}/cve20249675/
+  expect_output --substring "cat: can't open '/var/tmp/file.txt': No such file or directory"
+}


### PR DESCRIPTION
The `--mount type=cache` argument to the `RUN` instruction in Dockerfiles was using `filepath.Join` on user input, allowing crafted paths to be used to gain access to paths on the host, when the command should normally be limited only to Buildah;s own cache and context directories. Switch to `filepath.SecureJoin` to resolve the issue.

Fixes CVE-2024-9675


#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
> /kind bug

#### What this PR does / why we need it:

This fixes a CVE in Buildah that allows arbitrary directories from the host to be mounted into build containers.

#### How to verify it

Reproducer script:

```
#!/bin/bash

set -o errexit

mkdir /root/dir
echo SHOULDNTSEETHIS > /root/dir/file.txt
mkdir /root/ctr

cat << EOF > /root/ctr/Containerfile
FROM alpine
RUN --mount=type=cache,id=../../../../../../../../../../../root/dir,target=/var/tmp \
ls -l /var/tmp && cat /var/tmp/file.txt && touch /var/tmp/BREAKOUT 
EOF

cd /root/ctr
buildah bud --no-cache .
ls -l /root/dir/BREAKOUT
```

Reproduces without this patch, no longer reproduces with it.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed CVE-2024-9675 which allowed arbitrary paths from the host to be mounted into a build container using the `--mount type=cache` argument to the `RUN` instruction in Dockerfiles.
```

