### PR TITLE
Document more buildah build --secret options

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -903,17 +903,25 @@ specified.  These text substitutions are performed:
 
 Generate SBOMs using the specified scanner image.
 
-**--secret**=**id=id,src=path**
+**--secret**=**id=id[,src=*envOrFile*][,env=ENV][,type=file|env]**
 
 Pass secret information to be used in the Containerfile for building images
 in a safe way that will not end up stored in the final image, or be seen in other stages.
-The secret will be mounted in the container at the default location of `/run/secrets/id`.
+The value of the secret will be read from an environment variable or file named
+by the "id" option, or named by the "src" option if it is specified, or from an
+environment variable specifed by the "env" option.
+The secret will be mounted in the container at `/run/secrets/*id*` by default.
 
 To later use the secret, use the --mount flag in a `RUN` instruction within a `Containerfile`:
 
 `RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret`
 
-Note: Changing the contents of secret files will not trigger a rebuild of layers that use said secrets.
+The location of the secret in the container can be overridden using the
+"target", "dst", or "destination" option of the `RUN --mount` flag.
+
+`RUN --mount=type=secret,id=mysecret,target=/run/secrets/myothersecret cat /run/secrets/myothersecret`
+
+Note: changing the contents of secret files will not trigger a rebuild of layers that use said secrets.
 
 **--security-opt**=[]
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6006,7 +6006,7 @@ _EOF
 SOMESECRETDATA
 _EOF
 
-  run_buildah bud --secret=id=mysecret,src=${mytmpdir}/mysecret $WITH_POLICY_JSON  -t secretmode -f $BUDFILES/run-mounts/Dockerfile.secret-mode $BUDFILES/run-mounts
+  run_buildah bud --secret=id=mysecret,src=${mytmpdir}/mysecret,type=file $WITH_POLICY_JSON  -t secretmode -f $BUDFILES/run-mounts/Dockerfile.secret-mode $BUDFILES/run-mounts
   expect_output --substring "400"
 }
 
@@ -6037,11 +6037,11 @@ _EOF
   _prefetch alpine
 
   run_buildah 125 build $WITH_POLICY_JSON  -t secretreq -f $BUDFILES/run-mounts/Dockerfile.secret-required $BUDFILES/run-mounts
-  expect_output --substring "secret required but no secret with id mysecret found"
+  expect_output --substring 'secret required but no secret with id "mysecret" found'
 
   # Also test secret required without value
   run_buildah 125 build $WITH_POLICY_JSON  -t secretreq -f $BUDFILES/run-mounts/Dockerfile.secret-required-wo-value $BUDFILES/run-mounts
-  expect_output --substring "secret required but no secret with id mysecret found"
+  expect_output --substring 'secret required but no secret with id "mysecret" found'
 }
 
 @test "bud with containerfile env secret" {
@@ -6061,6 +6061,10 @@ _EOF
   run_buildah from secretimg
   run_buildah 1 run secretimg-working-container cat /run/secrets/mysecret
   expect_output --substring "cat: can't open '/run/secrets/mysecret': No such file or directory"
+
+  run_buildah 125 build --secret=id=mysecret2,env=MYSECRET,true=false $WITH_POLICY_JSON -f $BUDFILES/run-mounts/Dockerfile.secret $BUDFILES/run-mounts
+  expect_output --substring "incorrect secret flag format"
+
   run_buildah rm -a
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind other

#### What this PR does / why we need it:

* Describe the "env" and "type" options in the buildah-build(1) man page.
* When parsing the "--secret=" flag for the CLI, instead of ignoring an option that we don't recognize, return an error.
* Even though the set of meaningful "id" values for secrets is passed in via the command line, don't directly use it to construct a file path.
* Change the default mode for SSH agent sockets that we create from 0o620 to 0o600.

#### How to verify it

Updated test to verify that we complain about unrecognized `--secret=` options!

#### Which issue(s) this PR fixes:

Resolves #5282, or at least points people in the right direction.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah build` will now complain if an unrecognized option is passed in the list of options to the `--secret` flag.
```