### PR TITLE
[release-1.33] Address CVE-2024-9675, bump Buildah to v1.33.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # Changelog
 
+## v1.33.10 (2024-10-17)
+
+    [release-1.33] Properly validate cache IDs and sources
+    vendor: update c/common to v0.57.7
+    [release-1.33] Bump to v1.33.9
+    [release-1.33] Fixes Listing tags in JFrog Artifactory may fail
+    Cross-build on Fedora
+
 ## v1.33.9 (2024-07-16)
 
     [release-1.33] Fixes Listing tags in JFrog Artifactory may fail

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+- Changelog for v1.33.10 (2024-10-17)
+  * [release-1.33] Properly validate cache IDs and sources
+  * vendor: update c/common to v0.57.7
+  * [release-1.33] Bump to v1.33.9
+  * [release-1.33] Fixes Listing tags in JFrog Artifactory may fail
+  * Cross-build on Fedora
+
 - Changelog for v1.33.9 (2024-07-16)
   * [release-1.33] Fixes Listing tags in JFrog Artifactory may fail
 

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.33.9"
+	Version = "1.33.10"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/internal/volumes/volumes.go
+++ b/internal/volumes/volumes.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/lockfile"
 	"github.com/containers/storage/pkg/unshare"
+	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 )
@@ -361,7 +362,11 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 			return newMount, nil, fmt.Errorf("no stage found with name %s", fromStage)
 		}
 		// path should be /contextDir/specified path
-		newMount.Source = filepath.Join(mountPoint, filepath.Clean(string(filepath.Separator)+newMount.Source))
+		evaluated, err := copier.Eval(mountPoint, string(filepath.Separator)+newMount.Source, copier.EvalOptions{})
+		if err != nil {
+			return newMount, nil, err
+		}
+		newMount.Source = evaluated
 	} else {
 		// we need to create cache on host if no image is being used
 
@@ -378,11 +383,15 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		}
 
 		if id != "" {
-			newMount.Source = filepath.Join(cacheParent, filepath.Clean(id))
-			buildahLockFilesDir = filepath.Join(BuildahCacheLockfileDir, filepath.Clean(id))
+			// Don't let the user control where we place the directory.
+			dirID := digest.FromString(id).Encoded()[:16]
+			newMount.Source = filepath.Join(cacheParent, dirID)
+			buildahLockFilesDir = filepath.Join(BuildahCacheLockfileDir, dirID)
 		} else {
-			newMount.Source = filepath.Join(cacheParent, filepath.Clean(newMount.Destination))
-			buildahLockFilesDir = filepath.Join(BuildahCacheLockfileDir, filepath.Clean(newMount.Destination))
+			// Don't let the user control where we place the directory.
+			dirID := digest.FromString(newMount.Destination).Encoded()[:16]
+			newMount.Source = filepath.Join(cacheParent, dirID)
+			buildahLockFilesDir = filepath.Join(BuildahCacheLockfileDir, dirID)
 		}
 		idPair := idtools.IDPair{
 			UID: uid,

--- a/internal/volumes/volumes.go
+++ b/internal/volumes/volumes.go
@@ -102,6 +102,12 @@ func GetBindMount(ctx *types.SystemContext, args []string, contextDir string, st
 			if len(kv) == 1 {
 				return newMount, "", fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
 			}
+			switch kv[1] {
+			default:
+				return newMount, "", fmt.Errorf("%v: %q: %w", kv[0], kv[1], errBadMntOption)
+			case "shared", "rshared", "private", "rprivate", "slave", "rslave":
+				// this should be the relevant parts of the same list of options we accepted above
+			}
 			newMount.Options = append(newMount.Options, kv[1])
 		case "src", "source":
 			if len(kv) == 1 {
@@ -276,6 +282,12 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		case "bind-propagation":
 			if len(kv) == 1 {
 				return newMount, nil, fmt.Errorf("%v: %w", kv[0], errBadOptionArg)
+			}
+			switch kv[1] {
+			default:
+				return newMount, nil, fmt.Errorf("%v: %q: %w", kv[0], kv[1], errBadMntOption)
+			case "shared", "rshared", "private", "rprivate", "slave", "rslave":
+				// this should be the relevant parts of the same list of options we accepted above
 			}
 			newMount.Options = append(newMount.Options, kv[1])
 		case "id":


### PR DESCRIPTION
The `--mount type=cache` argument to the `RUN` instruction in
Dockerfiles was using `filepath.Join` on user input, allowing
crafted paths to be used to gain access to paths on the host,
when the command should normally be limited only to Buildah;s own
cache and context directories. Switch to `filepath.SecureJoin` to
resolve the issue.

Fixes https://github.com/advisories/GHSA-586p-749j-fhwp
https://issues.redhat.com/browse/RHEL-61842
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

