### PR TITLE
[release-1.26] Properly validate cache IDs and sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Changelog
 
+## v1.26.8 (2024-10-21)
+
+    Properly validate cache IDs and sources
+
 ## v1.26.7 (2024-04-01)
 
     [release-1.26] conformance tests: don't break on trailing zeroes

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+- Changelog for v1.26.8 (2024-10-21)
+  * Properly validate cache IDs and sources
+
 - Changelog for v1.26.7 (2024-04-01)
   * [release-1.26] conformance tests: don't break on trailing zeroes
   * [release-1.26] CVE-2024-1753 container escape fix

--- a/contrib/rpm/buildah.spec
+++ b/contrib/rpm/buildah.spec
@@ -26,7 +26,7 @@
 
 Name:           buildah
 # Bump version in define/types.go too
-Version:        1.26.7
+Version:        1.26.8
 Release:        1.git%{shortcommit}%{?dist}
 Summary:        A command line tool used to creating OCI Images
 License:        ASL 2.0
@@ -100,6 +100,9 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} install install.completions
 %{_datadir}/bash-completion/completions/*
 
 %changelog
+* Mon Oct 21 2024 David Shea <dshea@redhat.com> 1.26.8-1
+- Properly validate cache IDs and sources
+
 * Mon Apr 1 2024 Tom Sweeney <tsweeney@redhat.com> 1.26.7-1
 - [release-1.26] conformance tests: don't break on trailing zeroes
 - [release-1.26] CVE-2024-1753 container escape fix

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.26.7"
+	Version = "1.26.8"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/lockfile"
+	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
@@ -305,7 +306,11 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 			return newMount, lockedTargets, fmt.Errorf("no stage found with name %s", fromStage)
 		}
 		// path should be /contextDir/specified path
-		newMount.Source = filepath.Join(mountPoint, filepath.Clean(string(filepath.Separator)+newMount.Source))
+		evaluated, err := copier.Eval(mountPoint, string(filepath.Separator)+newMount.Source, copier.EvalOptions{})
+		if err != nil {
+			return newMount, nil, err
+		}
+		newMount.Source = evaluated
 	} else {
 		// we need to create cache on host if no image is being used
 
@@ -322,9 +327,13 @@ func GetCacheMount(args []string, store storage.Store, imageMountLabel string, a
 		}
 
 		if id != "" {
-			newMount.Source = filepath.Join(cacheParent, filepath.Clean(id))
+			// Don't let the user control where we place the directory.
+			dirID := digest.FromString(id).Encoded()[:16]
+			newMount.Source = filepath.Join(cacheParent, dirID)
 		} else {
-			newMount.Source = filepath.Join(cacheParent, filepath.Clean(newMount.Destination))
+			// Don't let the user control where we place the directory.
+			dirID := digest.FromString(newMount.Destination).Encoded()[:16]
+			newMount.Source = filepath.Join(cacheParent, dirID)
 		}
 		idPair := idtools.IDPair{
 			UID: uid,

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4621,3 +4621,44 @@ _EOF
   assert "$status" -eq 2 "exit code from ls"
   expect_output --substring "No such file or directory"
 }
+
+@test "build-check-cve-2024-9675" {
+  _prefetch alpine
+
+  # SELinux can successfully block this exploit.
+  if ! which selinuxenabled > /dev/null 2> /dev/null ; then
+      searg=""
+  elif selinuxenabled ; then
+      searg="--security-opt=label=disable"
+  fi
+
+  touch ${TEST_SCRATCH_DIR}/file.txt
+
+  cat > ${TEST_SCRATCH_DIR}/Containerfile <<EOF
+FROM alpine
+RUN --mount=type=cache,id=../../../../../../../../../../../$TEST_SCRATCH_DIR,target=/var/tmp \
+ls -l /var/tmp && cat /var/tmp/file.txt
+EOF
+
+  run_buildah 1 build --no-cache $searg ${TEST_SCRATCH_DIR}
+  expect_output --substring "cat: can't open '/var/tmp/file.txt': No such file or directory"
+
+  cat > ${TEST_SCRATCH_DIR}/Containerfile <<EOF
+FROM alpine
+RUN --mount=type=cache,source=../../../../../../../../../../../$TEST_SCRATCH_DIR,target=/var/tmp \
+ls -l /var/tmp && cat /var/tmp/file.txt
+EOF
+
+  run_buildah 1 build --no-cache $searg ${TEST_SCRATCH_DIR}
+  expect_output --substring "cat: can't open '/var/tmp/file.txt': No such file or directory"
+
+  mkdir ${TEST_SCRATCH_DIR}/cve20249675
+  cat > ${TEST_SCRATCH_DIR}/cve20249675/Containerfile <<EOF
+FROM alpine
+RUN --mount=type=cache,from=testbuild,source=../,target=/var/tmp \
+ls -l /var/tmp && cat /var/tmp/file.txt
+EOF
+
+  run_buildah 1 build --no-cache $searg --build-context testbuild=${TEST_SCRATCH_DIR}/cve20249675/ ${TEST_SCRATCH_DIR}/cve20249675/
+  expect_output --substring "cat: can't open '/var/tmp/file.txt': No such file or directory"
+}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3113,7 +3113,7 @@ EOM
   skip_if_no_runtime
 
   ${OCI} --version
-  _prefetch alpine
+  _prefetch alpine busybox
   _prefetch debian
 
   run_buildah build --build-arg base=alpine --build-arg toolchainname=busybox --build-arg destinationpath=/tmp --pull=false $WITH_POLICY_JSON -f $BUDFILES/from-with-arg/Containerfile .


### PR DESCRIPTION
Backport the changes from https://github.com/containers/buildah/pull/5778 to release-1.26

The `--mount type=cache` argument to the `RUN` instruction in Dockerfiles was using `filepath.Join` on user input, allowing crafted paths to be used to gain access to paths on the host, when the command should normally be limited only to Buildah;s own cache and context directories. Switch to `filepath.SecureJoin` to resolve the issue.

Fixes CVE-2024-9675

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind bug

#### What this PR does / why we need it:

#### How to verify it

Includes the new test from the original change, `build-check-cve-2024-9675`

#### Which issue(s) this PR fixes:

https://issues.redhat.com/browse/RHEL-62366
https://issues.redhat.com/browse/RHEL-62371


<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed CVE-2024-9675 which allowed arbitrary paths from the host to be mounted into a build container using the `--mount type=cache` argument to the `RUN` instruction in Dockerfiles.

```

