### PR TITLE
Handle RUN --mount with relative targets and no configured workdir

### DIFF
--- a/run_common.go
+++ b/run_common.go
@@ -1605,7 +1605,7 @@ func (b *Builder) runSetupRunMounts(mountPoint string, mounts []string, sources 
 				mountImages = append(mountImages, image)
 			}
 		case "tmpfs":
-			mountSpec, err = b.getTmpfsMount(tokens, idMaps)
+			mountSpec, err = b.getTmpfsMount(tokens, idMaps, sources.WorkDir)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1665,9 +1665,9 @@ func (b *Builder) getBindMount(tokens []string, context *imageTypes.SystemContex
 	return &volumes[0], image, nil
 }
 
-func (b *Builder) getTmpfsMount(tokens []string, idMaps IDMaps) (*specs.Mount, error) {
+func (b *Builder) getTmpfsMount(tokens []string, idMaps IDMaps, workDir string) (*specs.Mount, error) {
 	var optionMounts []specs.Mount
-	mount, err := volumes.GetTmpfsMount(tokens)
+	mount, err := volumes.GetTmpfsMount(tokens, workDir)
 	if err != nil {
 		return nil, err
 	}

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -124,10 +124,16 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		return err
 	}
 
+	workDir := b.WorkDir()
 	if options.WorkingDir != "" {
 		g.SetProcessCwd(options.WorkingDir)
+		workDir = options.WorkingDir
 	} else if b.WorkDir() != "" {
 		g.SetProcessCwd(b.WorkDir())
+		workDir = b.WorkDir()
+	}
+	if workDir == "" {
+		workDir = string(os.PathSeparator)
 	}
 	mountPoint, err := b.Mount(b.MountLabel)
 	if err != nil {
@@ -249,6 +255,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	}
 
 	runMountInfo := runMountInfo{
+		WorkDir:          workDir,
 		ContextDir:       options.ContextDir,
 		Secrets:          options.Secrets,
 		SSHSources:       options.SSHSources,

--- a/run_linux.go
+++ b/run_linux.go
@@ -237,6 +237,10 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		workDir = options.WorkingDir
 	} else if b.WorkDir() != "" {
 		g.SetProcessCwd(b.WorkDir())
+		workDir = b.WorkDir()
+	}
+	if workDir == "" {
+		workDir = string(os.PathSeparator)
 	}
 	setupSelinux(g, b.ProcessLabel, b.MountLabel)
 	mountPoint, err := b.Mount(b.MountLabel)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the target location of a RUN --mount is specified as a relative path, we normally try to convert it to an absolute path by combining it with the currently-configured working directory.  If there is no such value, though, the result is still not an absolute path.  Work around this by using "/" when the configured working directory is "".
    
Set this field in the `runMountInfo` struct on FreeBSD, as we already did on Linux.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes #5738

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
RUN instructions which use the --mount flag with a relative "target" path no longer trigger an error if the current stage does not have a defined working directory.
```