### PR TITLE
tests: bud: make parallel-safe

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -220,6 +220,25 @@ function random_string() {
     head /dev/urandom | tr -dc a-zA-Z0-9 | head -c$length
 }
 
+##############
+#  safename  #  Returns a pseudorandom string suitable for container/image/etc names
+##############
+#
+# Name will include the bats test number and a pseudorandom element,
+# eg "t123-xyz123". safename() will return the same string across
+# multiple invocations within a given test; this makes it easier for
+# a maintainer to see common name patterns.
+#
+# String is lower-case so it can be used as an image name
+#
+function safename() {
+    safenamepath=$BATS_SUITE_TMPDIR/.safename.$BATS_SUITE_TEST_NUMBER
+    if [[ ! -e $safenamepath ]]; then
+        echo -n "t${BATS_SUITE_TEST_NUMBER}-$(random_string 8 | tr A-Z a-z)" >$safenamepath
+    fi
+    cat $safenamepath
+}
+
 function buildah() {
     ${BUILDAH_BINARY} ${BUILDAH_REGISTRY_OPTS} ${ROOTDIR_OPTS} "$@"
 }


### PR DESCRIPTION
- all images pushed to a local registry must have a unique name

- all cache tests must use a private TMPDIR

- in force-compression test, use a custom-crafted image with
  no possibility of sharing layers with any other image that
  any other test might push to the registry.

- use a private crun tmpdir in seccomp test, because crun
  does some unexpected caching.

And, forgive me, a little refactoring of unpleasant duplication

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```