### PR TITLE
[release-1.34] integration tests: switch some base images

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,12 +18,6 @@ jobs:
     targets:
       - fedora-all-x86_64
       - fedora-all-aarch64
-      - fedora-eln-x86_64
-      - fedora-eln-aarch64
-      - centos-stream+epel-next-8-x86_64
-      - centos-stream+epel-next-8-aarch64
-      - centos-stream+epel-next-9-x86_64
-      - centos-stream+epel-next-9-aarch64
     additional_repos:
       - "copr://rhcontainerbot/podman-next"
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -329,6 +329,7 @@ _EOF
 }
 
 @test "bud build with heredoc content" {
+  _prefetch quay.io/fedora/python-311
   run_buildah build -t heredoc $WITH_POLICY_JSON -f $BUDFILES/heredoc/Containerfile .
   expect_output --substring "print first line from heredoc"
   expect_output --substring "print second line from heredoc"
@@ -4450,15 +4451,17 @@ EOM
 }
 
 @test "bud arg and env var with same name" {
+  _prefetch busybox
   # Regression test for https://github.com/containers/buildah/issues/2345
   run_buildah build $WITH_POLICY_JSON -t testctr $BUDFILES/dupe-arg-env-name
   expect_output --substring "https://example.org/bar"
 }
 
 @test "bud copy chown with newuser" {
+  _prefetch quay.io/fedora/fedora
   # Regression test for https://github.com/containers/buildah/issues/2192
   run_buildah build $WITH_POLICY_JSON -t testctr -f $BUDFILES/copy-chown/Containerfile.chown_user $BUDFILES/copy-chown
-  expect_output --substring "myuser myuser"
+  expect_output --substring "myuser:myuser"
 }
 
 @test "bud-builder-identity" {

--- a/tests/bud/build-with-from/Containerfile
+++ b/tests/bud/build-with-from/Containerfile
@@ -1,4 +1,5 @@
-FROM fedora as builder 
+# "fedora" is replaced as the base image at test-time using the --from flag
+FROM fedora as builder
 FROM busybox
 COPY --from=builder /bin/df /tmp/df_tester
 

--- a/tests/bud/copy-chown/Containerfile.chown_user
+++ b/tests/bud/copy-chown/Containerfile.chown_user
@@ -1,8 +1,7 @@
-FROM ubuntu:latest
+FROM quay.io/fedora/fedora
 
 ENV MYUSER=myuser
-
 RUN useradd --create-home --home /"${MYUSER}" "${MYUSER}"
 COPY --chown="${MYUSER}" ./copychown.txt /somewhere
 
-RUN ls -alF /somewhere
+RUN stat -c "%U:%G" /somewhere

--- a/tests/bud/dupe-arg-env-name/Containerfile
+++ b/tests/bud/dupe-arg-env-name/Containerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM busybox
 ARG FOO=bar
 ARG WEBROOT=https://example.org/
 

--- a/tests/bud/heredoc/Containerfile
+++ b/tests/bud/heredoc/Containerfile
@@ -1,4 +1,7 @@
-FROM fedora
+FROM quay.io/fedora/python-311
+
+USER root
+WORKDIR /
 
 RUN <<EOF
 echo "print first line from heredoc"


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Replace some of the base images we've been using (particularly centos:8, which will EOL soon) with other images hosted on quay.io.

We already use registries.conf at test-time to redirect some image references there, so this will slightly reduce the number of registries which we need to be able to reach while running these tests.

Manually cherry-picked from #5499 to resolve conflicts.

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```