### PR TITLE
Finish updating to go 1.22

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -120,13 +120,14 @@ vendor_task:
 
     # Runs within Cirrus's "community cluster"
     container:
-        image: docker.io/library/golang:latest
+        image: docker.io/library/golang:1.22
         cpu: 1
         memory: 1
 
     timeout_in: 5m
 
     vendor_script:
+        - './hack/check_vendor_toolchain.sh Try updating the image used by the vendor_task in .cirrus.yml.'
         - 'make vendor'
         - './hack/tree_status.sh'
 

--- a/Makefile
+++ b/Makefile
@@ -202,10 +202,11 @@ test-unit: tests/testreport/testreport
 	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover $(RACEFLAGS) ./cmd/buildah -args --root $$tmp/root --runroot $$tmp/runroot --storage-driver vfs --signature-policy $(shell pwd)/tests/policy.json --registries-conf $(shell pwd)/tests/registries.conf
 
 vendor-in-container:
+	goversion=$(shell sed -e '/^go /!d' -e '/^go /s,.* ,,g' go.mod) ; \
 	if test -d `go env GOCACHE` && test -w `go env GOCACHE` ; then \
-		podman run --privileged --rm --env HOME=/root -v `go env GOCACHE`:/root/.cache/go-build --env GOCACHE=/root/.cache/go-build -v `pwd`:/src -w /src docker.io/library/golang:1.21 make vendor ; \
+		podman run --privileged --rm --env HOME=/root -v `go env GOCACHE`:/root/.cache/go-build --env GOCACHE=/root/.cache/go-build -v `pwd`:/src -w /src docker.io/library/golang:$$goversion make vendor ; \
 	else \
-		podman run --privileged --rm --env HOME=/root -v `pwd`:/src -w /src docker.io/library/golang:1.21 make vendor ; \
+		podman run --privileged --rm --env HOME=/root -v `pwd`:/src -w /src docker.io/library/golang:$$goversion make vendor ; \
 	fi
 
 .PHONY: vendor

--- a/hack/check_vendor_toolchain.sh
+++ b/hack/check_vendor_toolchain.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+topdir=$(dirname ${BASH_SOURCE})/..
+wantversion=$(sed -e '/^go /!d' -e '/^go /s,.* ,,g' ${topdir}/go.mod)
+goversion=$(go env GOVERSION)
+haveversion=${goversion/go}
+if test "${wantversion%.*}" != "${haveversion%.*}" ; then
+    echo go.mod uses Go "${wantversion%.*}" \("${wantversion}"\), but environment provides "${haveversion%.*}" \("${haveversion}"\).
+    echo "$@"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update references to specific versions of golang in the Makefile and the Cirrus CI configuration to match go.mod, and add a check in the 'vendor' target that CI runs that the image it's run inside is a close-enough match to the version listed in go.mod.

#### How to verify it

Run `make vendor-in-container`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```