### PR TITLE
manifest add: add --artifact-annotation

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -39,7 +39,7 @@ type manifestCreateOpts struct {
 
 type manifestAddOpts struct {
 	authfile, certDir, creds, os, arch, variant, osVersion string
-	features, osFeatures, annotations                      []string
+	features, osFeatures, annotations, artifactAnnotations []string
 	tlsVerify, insecure, all                               bool
 	artifact, artifactExcludeTitles                        bool
 	artifactType, artifactLayerType                        string
@@ -149,6 +149,7 @@ func init() {
 	flags.StringVar(&manifestAddOpts.artifactLayerType, "artifact-layer-type", "", "artifact layer media type")
 	flags.BoolVar(&manifestAddOpts.artifactExcludeTitles, "artifact-exclude-titles", false, fmt.Sprintf(`refrain from setting %q annotations on "layers"`, v1.AnnotationTitle))
 	flags.StringVar(&manifestAddOpts.artifactSubject, "artifact-subject", "", "artifact subject reference")
+	flags.StringSliceVar(&manifestAddOpts.artifactAnnotations, "artifact-annotation", nil, "artifact annotation")
 	flags.StringVar(&manifestAddOpts.authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	flags.StringVar(&manifestAddOpts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	flags.StringVar(&manifestAddOpts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
@@ -523,6 +524,13 @@ func manifestAddCmd(c *cobra.Command, args []string, opts manifestAddOpts) error
 			options.ConfigDescriptor.Size = -1
 			options.ConfigFile = opts.artifactConfigFile
 		}
+		if len(opts.artifactAnnotations) > 0 {
+			options.Annotations = make(map[string]string, len(opts.artifactAnnotations))
+			for _, annotation := range opts.artifactAnnotations {
+				k, v, _ := strings.Cut(annotation, "=")
+				options.Annotations[k] = v
+			}
+		}
 		options.ExcludeTitles = opts.artifactExcludeTitles
 		instanceDigest, err = list.AddArtifact(getContext(), systemContext, options, artifactSpec...)
 		if err != nil {
@@ -531,7 +539,7 @@ func manifestAddCmd(c *cobra.Command, args []string, opts manifestAddOpts) error
 		}
 	} else {
 		var changedArtifactFlags []string
-		for _, artifactOption := range []string{"artifact-type", "artifact-config", "artifact-config-type", "artifact-layer-type", "artifact-subject", "artifact-exclude-titles"} {
+		for _, artifactOption := range []string{"artifact-type", "artifact-config", "artifact-config-type", "artifact-layer-type", "artifact-subject", "artifact-exclude-titles", "artifact-annotation"} {
 			if c.Flags().Changed(artifactOption) {
 				changedArtifactFlags = append(changedArtifactFlags, "--"+artifactOption)
 			}

--- a/docs/buildah-manifest-add.1.md
+++ b/docs/buildah-manifest-add.1.md
@@ -43,6 +43,11 @@ Create an artifact manifest and add it to the image index.  Arguments after the
 index name will be interpreted as file names rather than as image references.
 In most scenarios, the **--artifact-type** option should also be specified.
 
+**--artifact-annotation** *annotation=value*
+
+When creating an artifact manifest and adding it to the image index, set an
+annotation in the artifact manifest.
+
 **--artifact-config** *filename*
 
 When creating an artifact manifest and adding it to the image index, use the

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -55,8 +55,8 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run sha256sum $TEST_SCRATCH_DIR/randomfile
     blobencoded="${output%% *}"
     run_buildah manifest create foo
-    run_buildah manifest add --artifact --artifact-type image/jpeg --artifact-layer-type image/not-validated --artifact-config-type text/x-not-really --artifact-subject busybox foo $TEST_SCRATCH_DIR/randomfile2
-    run_buildah manifest add --artifact --artifact-type image/png --artifact-layer-type image/not-validated --artifact-config-type text/x-not-really --artifact-subject busybox foo $TEST_SCRATCH_DIR/randomfile
+    run_buildah manifest add --artifact --artifact-type image/jpeg --artifact-layer-type image/not-validated --artifact-config-type text/x-not-really --artifact-subject busybox --artifact-annotation up=down foo $TEST_SCRATCH_DIR/randomfile2
+    run_buildah manifest add --artifact --artifact-type image/png --artifact-layer-type image/not-validated --artifact-config-type text/x-not-really --artifact-subject busybox --artifact-annotation left=right foo $TEST_SCRATCH_DIR/randomfile
     digest="${output##* }"
     alg="${digest%%:*}"
     encoded="${digest##*:}"
@@ -72,6 +72,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     assert "$output" =~ '"artifactType":"image/png"' "cat $TEST_SCRATCH_DIR/pushed/blobs/$alg/$encoded"
     assert "$output" =~ '"mediaType":"image/not-validated"' "cat $TEST_SCRATCH_DIR/pushed/blobs/$alg/$encoded"
     assert "$output" =~ '"mediaType":"text/x-not-really"' "cat $TEST_SCRATCH_DIR/pushed/blobs/$alg/$encoded"
+    assert "$output" =~ '"annotations":\{"left":"right"\}' "cat $TEST_SCRATCH_DIR/pushed/blobs/$alg/$encoded"
     run_buildah manifest rm foo
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a --artifact-annotation flag to `buildah manifest add` that can be used to set annotations in the artifact manifest that we generate and then add to an image index.

#### How to verify it

Updated integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah manifest add` now includes a `--artifact-annotation` flag which can be used to add an annotation to the artifact manifest which is generated and then added to the image index.
```