### PR TITLE
CI: remove some inter-job dependencies, run cross-compile task with make -j, use /tmp for Go build cache

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -97,7 +97,7 @@ smoke_task:
         cpu: 4
 
     # Don't bother running on branches (including cron), or for tags.
-    only_if: $CIRRUS_PR != ''
+    skip: $CIRRUS_PR == ''
 
     timeout_in: 30m
 
@@ -140,8 +140,8 @@ cross_build_task:
         cpu: 8
         memory: "24G"
     alias: cross_build
-    only_if: >-
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
+    skip: >-
+        $CIRRUS_CHANGE_TITLE =~ '.*CI:DOCS.*'
     env:
         HOME: /root
     script:
@@ -154,13 +154,12 @@ cross_build_task:
 unit_task:
     name: 'Unit tests w/ $STORAGE_DRIVER'
     alias: unit
-    only_if: &not_build_docs >-
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:BUILD.*'
-    depends_on: &smoke_vendor_cross
+    skip: &not_build_docs >-
+        $CIRRUS_CHANGE_TITLE =~ '.*CI:DOCS.*' ||
+        $CIRRUS_CHANGE_TITLE =~ '.*CI:BUILD.*'
+    depends_on: &smoke_vendor
       - smoke
       - vendor
-      - cross_build
 
     timeout_in: 90m
 
@@ -181,8 +180,8 @@ unit_task:
 conformance_task:
     name: 'Debian Conformance w/ $STORAGE_DRIVER'
     alias: conformance
-    only_if: *not_build_docs
-    depends_on: *smoke_vendor_cross
+    skip: *not_build_docs
+    depends_on: *smoke_vendor
 
     gce_instance:
         image_name: "${DEBIAN_CACHE_IMAGE_NAME}"
@@ -203,8 +202,8 @@ conformance_task:
 integration_task:
     name: "Integration $DISTRO_NV w/ $STORAGE_DRIVER"
     alias: integration
-    only_if: *not_build_docs
-    depends_on: *smoke_vendor_cross
+    skip: *not_build_docs
+    depends_on: *smoke_vendor
 
     matrix:
         # VFS
@@ -260,8 +259,8 @@ integration_task:
 integration_rootless_task:
     name: "Integration rootless $DISTRO_NV w/ $STORAGE_DRIVER"
     alias: integration_rootless
-    only_if: *not_build_docs
-    depends_on: *smoke_vendor_cross
+    skip: *not_build_docs
+    depends_on: *smoke_vendor
 
     matrix:
         # Running rootless tests on overlay
@@ -300,8 +299,8 @@ integration_rootless_task:
 in_podman_task:
     name: "Containerized Integration"
     alias: in_podman
-    only_if: *not_build_docs
-    depends_on: *smoke_vendor_cross
+    skip: *not_build_docs
+    depends_on: *smoke_vendor
 
     env:
         # This is key, cause the scripts to re-execute themselves inside a container.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -171,11 +171,7 @@ unit_task:
               STORAGE_DRIVER: 'overlay'
 
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
-    build_script: '${SCRIPT_BASE}/build.sh |& ${_TIMESTAMP}'
     unit_test_script: '${SCRIPT_BASE}/test.sh unit |& ${_TIMESTAMP}'
-
-    binary_artifacts:
-        path: ./bin/*
 
 
 conformance_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,6 +9,7 @@ env:
     DEST_BRANCH: "main"
     GOPATH: "/var/tmp/go"
     GOSRC: "${GOPATH}/src/github.com/containers/buildah"
+    GOCACHE: "/tmp/go-build"
     # Overrides default location (/tmp/cirrus) for repo clone
     CIRRUS_WORKING_DIR: "${GOSRC}"
     # Shell used to execute all script commands

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,7 +56,7 @@ gce_instance: &standardvm
     image_project: "${IMAGE_PROJECT}"
     zone: "us-central1-c"  # Required by Cirrus for the time being
     cpu: 2
-    memory: "4Gb"
+    memory: "4G"
     disk: 200  # Gigabytes, do not set less than 200 per obscure GCE docs re: I/O performance
     image_name: "${FEDORA_CACHE_IMAGE_NAME}"
 
@@ -69,7 +69,7 @@ meta_task:
     container:
         image: "quay.io/libpod/imgts:latest"
         cpu: 1
-        memory: 1
+        memory: "1G"
 
     env:
         # Space-separated list of images used by this repository state
@@ -93,7 +93,8 @@ smoke_task:
     name: "Smoke Test"
 
     gce_instance:
-        memory: "12Gb"
+        memory: "12G"
+        cpu: 4
 
     # Don't bother running on branches (including cron), or for tags.
     only_if: $CIRRUS_PR != ''
@@ -135,6 +136,9 @@ vendor_task:
 # Confirm cross-compile ALL architectures on a Mac OS-X VM.
 cross_build_task:
     name: "Cross Compile"
+    gce_instance:
+        cpu: 8
+        memory: "24G"
     alias: cross_build
     only_if: >-
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
@@ -142,8 +146,7 @@ cross_build_task:
         HOME: /root
     script:
         - go version
-        - make cross CGO_ENABLED=0
-
+        - make -j cross CGO_ENABLED=0
     binary_artifacts:
         path: ./bin/*
 


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

As a quick attempt to speed up our CI's total start-to-finish time, this hits what we think will be low-hanging fruit.

#### How to verify it

Check the clock duration for https://cirrus-ci.com/github/containers/buildah/pull%2F5856 compared to builds for other pull requests.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```