### PR TITLE
chroot: on Linux, try to pivot_root before falling back to chroot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ FREEBSD_CROSS_TARGETS := $(filter bin/buildah.freebsd.%,$(ALL_CROSS_TARGETS))
 .PHONY: cross
 cross: $(LINUX_CROSS_TARGETS) $(DARWIN_CROSS_TARGETS) $(WINDOWS_CROSS_TARGETS) $(FREEBSD_CROSS_TARGETS)
 
-bin/buildah.%:
+bin/buildah.%: $(SOURCES)
 	mkdir -p ./bin
 	GOOS=$(word 2,$(subst ., ,$@)) GOARCH=$(word 3,$(subst ., ,$@)) $(GO_BUILD) $(BUILDAH_LDFLAGS) -o $@ -tags "containers_image_openpgp" ./cmd/buildah
 

--- a/chroot/run_common.go
+++ b/chroot/run_common.go
@@ -48,12 +48,13 @@ func init() {
 type runUsingChrootExecSubprocOptions struct {
 	Spec       *specs.Spec
 	BundlePath string
+	NoPivot    bool
 }
 
 // RunUsingChroot runs a chrooted process, using some of the settings from the
 // passed-in spec, and using the specified bundlePath to hold temporary files,
 // directories, and mountpoints.
-func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reader, stdout, stderr io.Writer) (err error) {
+func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reader, stdout, stderr io.Writer, noPivot bool) (err error) {
 	var confwg sync.WaitGroup
 	var homeFound bool
 	for _, env := range spec.Process.Env {
@@ -97,6 +98,7 @@ func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reade
 	config, conferr := json.Marshal(runUsingChrootSubprocOptions{
 		Spec:       spec,
 		BundlePath: bundlePath,
+		NoPivot:    noPivot,
 	})
 	if conferr != nil {
 		return fmt.Errorf("encoding configuration for %q: %w", runUsingChrootCommand, conferr)
@@ -196,6 +198,7 @@ func runUsingChrootMain() {
 		fmt.Fprintf(os.Stderr, "invalid options spec in runUsingChrootMain\n")
 		os.Exit(1)
 	}
+	noPivot := options.NoPivot
 
 	// Prepare to shuttle stdio back and forth.
 	rootUID32, rootGID32, err := util.GetHostRootIDs(options.Spec)
@@ -442,7 +445,7 @@ func runUsingChrootMain() {
 	}()
 
 	// Set up mounts and namespaces, and run the parent subprocess.
-	status, err := runUsingChroot(options.Spec, options.BundlePath, ctty, stdin, stdout, stderr, closeOnceRunning)
+	status, err := runUsingChroot(options.Spec, options.BundlePath, ctty, stdin, stdout, stderr, noPivot, closeOnceRunning)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error running subprocess: %v\n", err)
 		os.Exit(1)
@@ -463,7 +466,7 @@ func runUsingChrootMain() {
 // runUsingChroot, still in the grandparent process, sets up various bind
 // mounts and then runs the parent process in its own user namespace with the
 // necessary ID mappings.
-func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io.Reader, stdout, stderr io.Writer, closeOnceRunning []*os.File) (wstatus unix.WaitStatus, err error) {
+func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io.Reader, stdout, stderr io.Writer, noPivot bool, closeOnceRunning []*os.File) (wstatus unix.WaitStatus, err error) {
 	var confwg sync.WaitGroup
 
 	// Create a new mount namespace for ourselves and bind mount everything to a new location.
@@ -496,6 +499,7 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 	config, conferr := json.Marshal(runUsingChrootExecSubprocOptions{
 		Spec:       spec,
 		BundlePath: bundlePath,
+		NoPivot:    noPivot,
 	})
 	if conferr != nil {
 		fmt.Fprintf(os.Stderr, "error re-encoding configuration for %q\n", runUsingChrootExecCommand)
@@ -619,8 +623,10 @@ func runUsingChrootExecMain() {
 	// Try to chroot into the root.  Do this before we potentially
 	// block the syscall via the seccomp profile. Allow the
 	// platform to override this - on FreeBSD, we use a simple
-	// jail to set the hostname in the container
+	// jail to set the hostname in the container, and on Linux
+	// we attempt to pivot_root.
 	if err := createPlatformContainer(options); err != nil {
+		logrus.Debugf("createPlatformContainer: %v", err)
 		var oldst, newst unix.Stat_t
 		if err := unix.Stat(options.Spec.Root.Path, &oldst); err != nil {
 			fmt.Fprintf(os.Stderr, "error stat()ing intended root directory %q: %v\n", options.Spec.Root.Path, err)

--- a/chroot/run_freebsd.go
+++ b/chroot/run_freebsd.go
@@ -41,6 +41,7 @@ var (
 type runUsingChrootSubprocOptions struct {
 	Spec       *specs.Spec
 	BundlePath string
+	NoPivot    bool
 }
 
 func setPlatformUnshareOptions(spec *specs.Spec, cmd *unshare.Cmd) error {

--- a/chroot/run_test.go
+++ b/chroot/run_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func testMinimal(t *testing.T, modify func(g *generate.Generator, rootDir, bundleDir string), verify func(t *testing.T, report *types.TestReport)) {
+func testMinimalWithPivot(t *testing.T, noPivot bool, modify func(g *generate.Generator, rootDir, bundleDir string), verify func(t *testing.T, report *types.TestReport)) {
 	t.Helper()
 	g, err := generate.New("linux")
 	if err != nil {
@@ -100,8 +100,8 @@ func testMinimal(t *testing.T, modify func(g *generate.Generator, rootDir, bundl
 	}
 
 	output := new(bytes.Buffer)
-	if err := RunUsingChroot(g.Config, bundleDir, "/", new(bytes.Buffer), output, output); err != nil {
-		t.Fatalf("run: %v: %s", err, output.String())
+	if err := RunUsingChroot(g.Config, bundleDir, "/", new(bytes.Buffer), output, output, noPivot); err != nil {
+		t.Fatalf("run(noPivot=false): %v: %s", err, output.String())
 	}
 
 	var report types.TestReport
@@ -111,6 +111,14 @@ func testMinimal(t *testing.T, modify func(g *generate.Generator, rootDir, bundl
 
 	if verify != nil {
 		verify(t, &report)
+	}
+}
+
+func testMinimal(t *testing.T, modify func(g *generate.Generator, rootDir, bundleDir string), verify func(t *testing.T, report *types.TestReport)) {
+	for _, noPivot := range []bool{false, true} {
+		t.Run(fmt.Sprintf("noPivot=%v", noPivot), func(t *testing.T) {
+			testMinimalWithPivot(t, noPivot, modify, verify)
+		})
 	}
 }
 

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -328,7 +328,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		}
 		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, networkString, moreCreateArgs, spec, mountPoint, path, containerName, b.Container, hostsFile, resolvFile)
 	case IsolationChroot:
-		err = chroot.RunUsingChroot(spec, path, homeDir, options.Stdin, options.Stdout, options.Stderr)
+		err = chroot.RunUsingChroot(spec, path, homeDir, options.Stdin, options.Stdout, options.Stderr, options.NoPivot)
 	default:
 		err = errors.New("don't know how to run this command")
 	}

--- a/run_linux.go
+++ b/run_linux.go
@@ -531,7 +531,7 @@ rootless=%d
 		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, networkString, moreCreateArgs, spec,
 			mountPoint, path, define.Package+"-"+filepath.Base(path), b.Container, hostsFile, resolvFile)
 	case IsolationChroot:
-		err = chroot.RunUsingChroot(spec, path, homeDir, options.Stdin, options.Stdout, options.Stderr)
+		err = chroot.RunUsingChroot(spec, path, homeDir, options.Stdin, options.Stdout, options.Stderr, options.NoPivot)
 	case IsolationOCIRootless:
 		moreCreateArgs := []string{"--no-new-keyring"}
 		if options.NoPivot {


### PR DESCRIPTION
Unless --no-pivot or the equivalent API flag is set, try to pivot_root() to enter the rootfs during Run().  Fall back to using chroot() as before if that fails for any reason.

#### What type of PR is this?

/kind design

#### What this PR does / why we need it:

When using chroot isolation, if we can pivot_root() instead of using chroot() for running the command, do that, because it's closer to what a proper runtime can do.

#### How to verify it

Extended unit tests!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

We still need chroot() for things like unpacking layers while pulling images, so if you're hoping this means we no longer ever need CAP_SYS_CHROOT, sorry.

#### Does this PR introduce a user-facing change?

```release-note
`buildah build` or `buildah run` with `--isolation chroot` will now default to using pivot_root() internally, unless the `--no-pivot` CLI flag is used.
```