### PR TITLE
Add option --unexpose to remove exposed ports

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -326,6 +326,8 @@ type BuildOptions struct {
 	// to match the set of platforms for which all of the build's base
 	// images are available.  If this field is set, Platforms is ignored.
 	AllPlatforms bool
+	// UnexposePorts is a list of ports to not expose from final image.
+	UnexposePorts []string
 	// UnsetEnvs is a list of environments to not add to final image.
 	UnsetEnvs []string
 	// UnsetLabels is a list of labels to not add to final image from base image.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -1029,6 +1029,10 @@ include:
   "sigpending": maximum number of pending signals (ulimit -i)
   "stack": maximum stack size (ulimit -s)
 
+**--unexpose** *port*
+
+Unexpose port which was exposed from base image.
+
 **--unsetenv** *env*
 
 Unset environment variables from the final image.

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -149,6 +149,7 @@ type Executor struct {
 	secrets                                 map[string]define.Secret
 	sshsources                              map[string]*sshagent.Source
 	logPrefix                               string
+	unexposePorts                           []string
 	unsetEnvs                               []string
 	unsetLabels                             []string
 	processLabel                            string // Shares processLabel of first stage container with containers of other stages in same build
@@ -311,6 +312,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		secrets:                                 secrets,
 		sshsources:                              sshsources,
 		logPrefix:                               logPrefix,
+		unexposePorts:                           slices.Clone(options.UnexposePorts),
 		unsetEnvs:                               slices.Clone(options.UnsetEnvs),
 		unsetLabels:                             slices.Clone(options.UnsetLabels),
 		buildOutput:                             options.BuildOutput,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1271,7 +1271,7 @@ func (s *StageExecutor) Execute(ctx context.Context, base string) (imgID string,
 
 	if len(children) == 0 {
 		// There are no steps.
-		if s.builder.FromImageID == "" || s.executor.squash || s.executor.confidentialWorkload.Convert || len(s.executor.labels) > 0 || len(s.executor.annotations) > 0 || len(s.executor.unsetEnvs) > 0 || len(s.executor.unsetLabels) > 0 || len(s.executor.sbomScanOptions) > 0 {
+		if s.builder.FromImageID == "" || s.executor.squash || s.executor.confidentialWorkload.Convert || len(s.executor.labels) > 0 || len(s.executor.annotations) > 0 || len(s.executor.unexposePorts) > 0 || len(s.executor.unsetEnvs) > 0 || len(s.executor.unsetLabels) > 0 || len(s.executor.sbomScanOptions) > 0 {
 			// We either don't have a base image, or we need to
 			// transform the contents of the base image, or we need
 			// to make some changes to just the config blob.  Whichever
@@ -2254,7 +2254,9 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	s.builder.SetUser(config.User)
 	s.builder.ClearPorts()
 	for p := range config.ExposedPorts {
-		s.builder.SetPort(string(p))
+		if !slices.Contains(s.executor.unexposePorts, string(p)) {
+			s.builder.SetPort(string(p))
+		}
 	}
 	for _, envSpec := range config.Env {
 		key, val, _ := strings.Cut(envSpec, "=")

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -414,6 +414,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		Target:                  iopts.Target,
 		Timestamp:               timestamp,
 		TransientMounts:         iopts.Volumes,
+		UnexposePorts:           iopts.UnexposePorts,
 		UnsetEnvs:               iopts.UnsetEnvs,
 		UnsetLabels:             iopts.UnsetLabels,
 	}

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -112,6 +112,7 @@ type BudResults struct {
 	Jobs                int
 	LogRusage           bool
 	RusageLogFile       string
+	UnexposePorts       []string
 	UnsetEnvs           []string
 	UnsetLabels         []string
 	Envs                []string
@@ -309,6 +310,7 @@ newer:   only pull base and SBOM scanner images when newer images exist on the r
 	fs.Int64Var(&flags.Timestamp, "timestamp", 0, "set created timestamp to the specified epoch seconds to allow for deterministic builds, defaults to current time")
 	fs.BoolVar(&flags.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	fs.String("variant", "", "override the `variant` of the specified image")
+	fs.StringSliceVar(&flags.UnexposePorts, "unexpose", nil, "unexpose from final image, which was exposed in base image")
 	fs.StringSliceVar(&flags.UnsetEnvs, "unsetenv", nil, "unset environment variable from final image")
 	fs.StringSliceVar(&flags.UnsetLabels, "unsetlabel", nil, "unset label when inheriting labels from base image")
 	return fs
@@ -363,6 +365,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["tag"] = commonComp.AutocompleteNone
 	flagCompletion["target"] = commonComp.AutocompleteNone
 	flagCompletion["timestamp"] = commonComp.AutocompleteNone
+	flagCompletion["unexpose"] = commonComp.AutocompleteNone
 	flagCompletion["unsetenv"] = commonComp.AutocompleteNone
 	flagCompletion["unsetlabel"] = commonComp.AutocompleteNone
 	flagCompletion["variant"] = commonComp.AutocompleteNone


### PR DESCRIPTION
Fixes: https://github.com/containers/buildah/issues/5867

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
buildah bud --unexpose option added to remove exposed ports from base image.
```

