### PR TITLE
Allow cache mounts to be stages and additional build contexts

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -639,7 +639,12 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 							// to `mountPoint` replaced from additional
 							// build-context. Reason: Parser will use this
 							//  `from` to refer from stageMountPoints map later.
-							stageMountPoints[from] = internal.StageMountDetails{IsStage: false, DidExecute: true, MountPoint: mountPoint}
+							stageMountPoints[from] = internal.StageMountDetails{
+								IsAdditionalBuildContext: true,
+								IsImage:                  true,
+								DidExecute:               true,
+								MountPoint:               mountPoint,
+							}
 							break
 						}
 						// Most likely this points to path on filesystem
@@ -671,7 +676,11 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 								mountPoint = additionalBuildContext.DownloadedCache
 							}
 						}
-						stageMountPoints[from] = internal.StageMountDetails{IsStage: false, DidExecute: true, MountPoint: mountPoint}
+						stageMountPoints[from] = internal.StageMountDetails{
+							IsAdditionalBuildContext: true,
+							DidExecute:               true,
+							MountPoint:               mountPoint,
+						}
 						break
 					}
 					// If the source's name corresponds to the
@@ -683,7 +692,11 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 					// If the source's name is a stage, return a
 					// pointer to its rootfs.
 					if otherStage, ok := s.executor.stages[from]; ok && otherStage.index < s.index {
-						stageMountPoints[from] = internal.StageMountDetails{IsStage: true, DidExecute: otherStage.didExecute, MountPoint: otherStage.mountPoint}
+						stageMountPoints[from] = internal.StageMountDetails{
+							IsStage:    true,
+							DidExecute: otherStage.didExecute,
+							MountPoint: otherStage.mountPoint,
+						}
 						break
 					} else {
 						// Treat the source's name as the name of an image.
@@ -691,7 +704,11 @@ func (s *StageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 						if err != nil {
 							return nil, fmt.Errorf("%s from=%s: no stage or image found with that name", flag, from)
 						}
-						stageMountPoints[from] = internal.StageMountDetails{IsStage: false, DidExecute: true, MountPoint: mountPoint}
+						stageMountPoints[from] = internal.StageMountDetails{
+							IsImage:    true,
+							DidExecute: true,
+							MountPoint: mountPoint,
+						}
 						break
 					}
 				default:

--- a/internal/types.go
+++ b/internal/types.go
@@ -12,7 +12,9 @@ const (
 // StageExecutor has ability to mount stages/images in current context and
 // automatically clean them up.
 type StageMountDetails struct {
-	DidExecute bool   // tells if the stage which is being mounted was freshly executed or was part of older cache
-	IsStage    bool   // true if the mountpoint is a temporary directory or a stage's rootfs, false if it's an image
-	MountPoint string // mountpoint of the stage or image's root directory
+	DidExecute               bool   // true if this is a freshly-executed stage, or an image, possibly from a non-local cache
+	IsStage                  bool   // true if the mountpoint is a stage's rootfs
+	IsImage                  bool   // true if the mountpoint is an image's rootfs
+	IsAdditionalBuildContext bool   // true if the mountpoint is an additional build context
+	MountPoint               string // mountpoint of the stage or image's root directory or path of the additional build context
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6689,7 +6689,7 @@ _EOF
 
   # try reading something from persistent cache in a different build
   TMPDIR=${TEST_SCRATCH_DIR} run_buildah 125 build -t testbud $WITH_POLICY_JSON -f $contextdir/Dockerfilecachefromimage
-  expect_output --substring "no stage found with name buildkitbase"
+  expect_output --substring "no stage or additional build context found with name buildkitbase"
 }
 
 @test "bud-with-mount-cache-multiple-from-like-buildkit" {
@@ -7106,7 +7106,9 @@ RUN --mount=type=cache,from=testbuild,source=../,target=/var/tmp \
 ls -l /var/tmp && cat /var/tmp/file.txt
 EOF
 
-  run_buildah 1 build --security-opt label=disable --build-context testbuild=${TEST_SCRATCH_DIR}/cve20249675/ --no-cache ${TEST_SCRATCH_DIR}/cve20249675/
+  mkdir ${TEST_SCRATCH_DIR}/cachedir
+
+  run_buildah 1 build --security-opt label=disable --build-context testbuild=${TEST_SCRATCH_DIR}/cachedir/ --no-cache ${TEST_SCRATCH_DIR}/cve20249675/
   expect_output --substring "cat: can't open '/var/tmp/file.txt': No such file or directory"
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Allow cache mounts (RUN --mount=type=cache) to refer to other stages, and to additional build contexts.  Leave the don't-allow-images behavior there for now.

Update the build-check-cve-2024-9675 integration test to use different directories for its main build context and the additional build context that it uses for its final run.

#### How to verify it

Updated integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```