### PR TITLE
[CI:DOCS] Touch up changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,7 @@
     Add PrependedLinkedLayers/AppendedLinkedLayers to CommitOptions
     integration tests: teach starthttpd() about TLS and pid files
 
-## vv1.37.0 (2024-07-26)
+## v1.37.0 (2024-07-26)
 
     Bump c/storage, c/image, c/common for v1.37.0
     "build with basename resolving user arg" tests: correct ARG use

--- a/changelog.txt
+++ b/changelog.txt
@@ -118,7 +118,7 @@
   * Add PrependedLinkedLayers/AppendedLinkedLayers to CommitOptions
   * integration tests: teach starthttpd() about TLS and pid files
 
-- Changelog for vv1.37.0 (2024-07-26)
+- Changelog for v1.37.0 (2024-07-26)
   * Bump c/storage, c/image, c/common for v1.37.0
   * "build with basename resolving user arg" tests: correct ARG use
   * bud-multiple-platform-no-run test: correct ARG use


### PR DESCRIPTION
The changelog.txt and CHANGELOG.md files each had "vv1.37" instead of "v1.37".  This corrects that.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

