### PR TITLE
[release-1.35] tag v1.35.5

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
     #### Global variables used for all tasks
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
-    DEST_BRANCH: "main"
+    DEST_BRANCH: "release-1.35"
     GOPATH: "/var/tmp/go"
     GOSRC: "${GOPATH}/src/github.com/containers/buildah"
     # Overrides default location (/tmp/cirrus) for repo clone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 # Changelog
 
+## v1.35.5 (2025-01-20)
+
+    Fix TOCTOU error when bind and cache mounts use "src" values
+    define.TempDirForURL(): always use an intermediate subdirectory
+    internal/volume.GetBindMount(): discard writes in bind mounts
+    pkg/overlay: add a MountLabel flag to Options
+    pkg/overlay: add a ForceMount flag to Options
+    Add internal/volumes.bindFromChroot()
+    Add an internal/open package
+    Properly validate cache IDs and sources
+    CVE-2024-9407: validate "bind-propagation" flag settings
+    Allow cache mounts to be stages or additional build contexts
+    Integration tests: switch some base images
+    Disable most packit copr targets
+    Cross-build on Fedora
+
 ## v1.35.4 (2024-05-09)
 
     [release-1.35] CVE-2024-3727 updates

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,18 @@
+- Changelog for v1.35.5 (2025-01-20)
+  * Fix TOCTOU error when bind and cache mounts use "src" values
+  * define.TempDirForURL(): always use an intermediate subdirectory
+  * internal/volume.GetBindMount(): discard writes in bind mounts
+  * pkg/overlay: add a MountLabel flag to Options
+  * pkg/overlay: add a ForceMount flag to Options
+  * Add internal/volumes.bindFromChroot()
+  * Add an internal/open package
+  * Properly validate cache IDs and sources
+  * CVE-2024-9407: validate "bind-propagation" flag settings
+  * Allow cache mounts to be stages or additional build contexts
+  * Integration tests: switch some base images
+  * Disable most packit copr targets
+  * Cross-build on Fedora
+
 - Changelog for v1.35.4 (2024-05-09)
   * [release-1.35] CVE-2024-3727 updates
   * integration test: handle new labels in "bud and test --unsetlabel"

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.35.4"
+	Version = "1.35.5"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Tag a v1.35.5 release to incorporate the recent security update.

#### How to verify it

The test suite should be enough.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Changes made in locations mounted using `--mount=type=bind` in RUN instructions in `buildah build` and specified to `buildah run` are now discarded.
```