### PR TITLE
relabel(): correct a misleading parameter name

### DIFF
--- a/run_common.go
+++ b/run_common.go
@@ -2053,8 +2053,8 @@ func setPdeathsig(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
 }
 
-func relabel(path, mountLabel string, recurse bool) error {
-	if err := label.Relabel(path, mountLabel, recurse); err != nil {
+func relabel(path, mountLabel string, shared bool) error {
+	if err := label.Relabel(path, mountLabel, shared); err != nil {
 		if !errors.Is(err, syscall.ENOTSUP) {
 			return err
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The "recurse" parameter of the relabel() function signature is passed to a function which calls it "shared".  There's no need for it to not have the same name.

#### How to verify it

This shouldn't change any behavior.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This one's more about making sure the recently-merged security fixes get a proper run-through on CI than anything else.

#### Does this PR introduce a user-facing change?
```release-note
None
```