### PR TITLE
Run(): always clean up options.ExternalImageMounts

### DIFF
--- a/run.go
+++ b/run.go
@@ -159,9 +159,9 @@ type RunOptions struct {
 	RunMounts []string
 	// Map of stages and container mountpoint if any from stage executor
 	StageMountPoints map[string]internal.StageMountDetails
-	// External Image mounts to be cleaned up.
-	// Buildah run --mount could mount image before RUN calls, RUN could cleanup
-	// them up as well
+	// IDs of mounted images to be unmounted before returning
+	// Deprecated: before 1.39, these images would not be consistently
+	// unmounted if Run() returned an error
 	ExternalImageMounts []string
 	// System context of current build
 	SystemContext *types.SystemContext


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Make sure that we consistently unmount the list of images that we're told to, even in cases where we return an error before arranging to do so in `Run()`.

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```