### PR TITLE
run_freebsd.go: only import runtime-spec once

### DIFF
--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -31,7 +31,6 @@ import (
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/docker/go-units"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
@@ -351,7 +350,7 @@ func addCommonOptsToSpec(commonOpts *define.CommonBuildOptions, g *generate.Gene
 
 // setupSpecialMountSpecChanges creates special mounts for depending
 // on the namespaces - nothing yet for freebsd
-func setupSpecialMountSpecChanges(spec *spec.Spec, shmSize string) ([]specs.Mount, error) {
+func setupSpecialMountSpecChanges(spec *specs.Spec, shmSize string) ([]specs.Mount, error) {
 	return spec.Mounts, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The `github.com/opencontainers/runtime-spec/specs-go` module was being imported twice, once with a non-default package name, and once with its default name, which is more than we needed.

#### How to verify it

No functional changes, the cross-compile check should be enough.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```