### PR TITLE
fix broken doc link

### DIFF
--- a/docs/tutorials/04-include-in-your-build-tool.md
+++ b/docs/tutorials/04-include-in-your-build-tool.md
@@ -12,7 +12,7 @@ In this tutorial I'll show you how to create a simple CLI tool that creates an i
 
 ## Bootstrap the project and install the dependencies
 
-Bootstrap the installation of development dependencies of Buildah by following the [Building from scratch](https://github.com/slinkydeveloper/buildah/blob/main/install.md#building-from-scratch) instructions and in particular creating a directory for the Buildah project by completing the instructions in the [Installation from GitHub](https://github.com/containers/buildah/blob/main/install.md#installation-from-github) section of that page.
+Bootstrap the installation of development dependencies of Buildah by following the [Building from scratch](https://github.com/containers/buildah/blob/main/install.md#building-from-scratch) instructions and in particular creating a directory for the Buildah project by completing the instructions in the [Installation from GitHub](https://github.com/containers/buildah/blob/main/install.md#installation-from-github) section of that page.
 
 Now let's bootstrap our project. Assuming you are in the directory of the project, run the following to initialize the go modules:
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Updates the link to the "Building from scratch" section in the "Include Buildah in your build tool" docs. Originally, this link pointed to a personal fork and was broken.

#### How to verify it

Open the link, which should go to here: https://github.com/containers/buildah/blob/main/install.md#building-from-scratch

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
