### PR TITLE
[skip-ci] RPM: use default gobuild macro on RHEL

### DIFF
--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -7,19 +7,14 @@
 %global debug_package   %{nil}
 %endif
 
-# RHEL's default %%gobuild macro doesn't account for the BUILDTAGS variable, so we
-# set it separately here and do not depend on RHEL's go-[s]rpm-macros package
-# until that's fixed.
-# c9s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227328
-# c8s bz: https://bugzilla.redhat.com/show_bug.cgi?id=2227331
-%if %{defined rhel}
-%define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback libtrust_openssl ${BUILDTAGS:-}" -ldflags "-linkmode=external -compressdwarf=false ${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags'" -a -v -x %{?**};
-%endif
-
 %global gomodulesmode GO111MODULE=on
 
-%if 0%{defined fedora}
+%if %{defined fedora}
 %define build_with_btrfs 1
+%endif
+
+%if %{defined rhel}
+%define fips 1
 %endif
 
 %global git0 https://github.com/containers/%{name}
@@ -127,6 +122,10 @@ export LDFLAGS="-X main.buildInfo=`date +%s` -X main.cniVersion=${CNI_VERSION}"
 export BUILDTAGS="seccomp $(hack/systemd_tag.sh) $(hack/libsubid_tag.sh)"
 %if !%{defined build_with_btrfs}
 export BUILDTAGS+=" btrfs_noversion exclude_graphdriver_btrfs"
+%endif
+
+%if %{defined fips}
+export BUILDTAGS+=" libtrust_openssl"
 %endif
 
 %gobuild -o bin/%{name} ./cmd/%{name}

--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -150,6 +150,9 @@ rm %{buildroot}%{_datadir}/%{name}/test/system/tools/build/*
 #define license tag if not already defined
 %{!?_licensedir:%global license %doc}
 
+# Include check to silence rpmlint.
+%check
+
 %files
 %license LICENSE vendor/modules.txt
 %doc README.md


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


/kind other

#### What this PR does / why we need it:
rpm spec cleanup

#### How to verify it
rhel builds will work as expected, rpmlint will no longer complain

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

