### PR TITLE
Distinguish --mount=type=cache locations by ownership, too

### DIFF
--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -3455,6 +3455,25 @@ var internalTestCases = []testCase{
 		dockerUseBuildKit: true,
 		buildArgs:         map[string]string{"SOURCE": "e/**/**/*sub/*.txt"},
 	},
+	{
+		name:              "mount-cache-by-ownership",
+		dockerUseBuildKit: true,
+		dockerfileContents: strings.Join([]string{
+			"FROM mirror.gcr.io/busybox",
+			"USER 10",
+			"RUN --mount=type=cache,uid=10,target=/cache touch /cache/10.txt",
+			"USER 0",
+			"RUN --mount=type=cache,target=/cache touch /cache/0.txt",
+			"RUN mkdir -m 770 /results /results/0 /results/10 /results/0+10",
+			"RUN chown -R 10 /results",
+			"RUN --mount=type=cache,target=/cache cp -a /cache/* /results/0",
+			"USER 10",
+			"RUN --mount=type=cache,uid=10,target=/cache cp -a /cache/* /results/10",
+			"USER 0",
+			"RUN --mount=type=cache,uid=10,target=/cache cp -a /cache/* /results/0+10",
+			"RUN touch -r /bin `find /results -print`",
+		}, "\n"),
+	},
 }
 
 func TestCommit(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Normally, we select and distinguish --mount=type=cache directories that we create by either the "id" or "target" value used when mounting them, but we should also be distinguishing them by the owner UID/GID.

#### How to verify it

New conformance test!

#### Which issue(s) this PR fixes:

Addresses part of https://github.com/containers/podman/discussions/25260.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The host directory used when a `buildah build` RUN instruction or `buildah run` uses the `--mount=type=cache` option is now chosen based not only on its "target" or "id" value, but also on the combination of "uid" and "gid" flag values specified.
```