### PR TITLE
chroot createPlatformContainer: use MS_REMOUNT

### DIFF
--- a/chroot/run_linux.go
+++ b/chroot/run_linux.go
@@ -263,7 +263,7 @@ func createPlatformContainer(options runUsingChrootExecSubprocOptions) error {
 		return fmt.Errorf("changing to host root directory: %w", err)
 	}
 	// make sure we only unmount things under this tree
-	if err := unix.Mount(".", ".", "bind", unix.MS_BIND|unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
+	if err := unix.Mount(".", ".", "bind", unix.MS_REMOUNT|unix.MS_BIND|unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
 		return fmt.Errorf("tweaking mount flags on host root directory before unmounting from mount namespace: %w", err)
 	}
 	// detach this (unnamed?) old directory

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1015,3 +1015,23 @@ _EOF
   CONTAINERS_CONF=${TEST_SCRATCH_DIR}/containers.conf run_buildah run "$(cat ${TEST_SCRATCH_DIR}/cid)" hostname
   expect_output "$sanitizedname"
 }
+
+@test "root fs only mounted once" {
+  if test `uname` != Linux ; then
+    skip "not meaningful except on Linux"
+  fi
+  _prefetch busybox
+  run_buildah from --pull=never --quiet busybox
+  cid="$output"
+  run_buildah run $cid cat /proc/self/mountinfo
+  echo "$output" > ${TEST_SCRATCH_DIR}/mountinfo1
+  echo "# mountinfo unfiltered:"
+  cat ${TEST_SCRATCH_DIR}/mountinfo1
+  grep ' / rw,' ${TEST_SCRATCH_DIR}/mountinfo1 > ${TEST_SCRATCH_DIR}/mountinfo2
+  echo "# mountinfo grepped:"
+  cat ${TEST_SCRATCH_DIR}/mountinfo2
+  wc -l < ${TEST_SCRATCH_DIR}/mountinfo2 > ${TEST_SCRATCH_DIR}/mountinfo3
+  echo "# mountinfo count:"
+  cat ${TEST_SCRATCH_DIR}/mountinfo3
+  assert $(cat ${TEST_SCRATCH_DIR}/mountinfo3) -eq 1
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When setting mount propagation on the root mount before unmounting it, use `MS_REBIND`, since we know it's already a bind mount, and we actually want to affect the extant bind mount instead of creating another right over it. Otherwise, we might as well have not bothered.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Related to KONFLUX-5871.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```