### PR TITLE
cirrus: reduce task timeout

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,7 +50,7 @@ env:
 gcp_credentials: ENCRYPTED[ae0bf7370f0b6e446bc61d0865a2c55d3e166b3fab9466eb0393e38e1c66a31ca4c71ddc7e0139d47d075c36dd6d3fd7]
 
 # Default timeout for each task
-timeout_in: 120m
+timeout_in: 30m
 
 # Default VM to use unless set or modified by task
 gce_instance: &standardvm
@@ -100,7 +100,7 @@ smoke_task:
     # Don't bother running on branches (including cron), or for tags.
     skip: $CIRRUS_PR == ''
 
-    timeout_in: 30m
+    timeout_in: 10m
 
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
     build_script: '${SCRIPT_BASE}/build.sh |& ${_TIMESTAMP}'
@@ -164,8 +164,6 @@ unit_task:
       - smoke
       - vendor
 
-    timeout_in: 90m
-
     matrix:
         - env:
               STORAGE_DRIVER: 'vfs'
@@ -185,8 +183,6 @@ conformance_task:
     gce_instance:
         cpu: 4
         image_name: "${DEBIAN_CACHE_IMAGE_NAME}"
-
-    timeout_in: 65m
 
     matrix:
         - env:


### PR DESCRIPTION
With all the recent speed-ups here the timeout is way to high, all tasks should complete in under 30 mins generally. The smoke test in under 10min as it does not do much.

In particular I noticed at least two separate rootless integration tests time out after 120min[1,2], obviously the tests do not take that long and they are hanging somehwere instead. With a lower timeout we do not waste so much time when this happens.

[1] https://cirrus-ci.com/task/4733420225429504
[2] https://cirrus-ci.com/task/5597909967699968

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

