### PR TITLE
[release-1.39] chroot createPlatformContainer: use MS_REMOUNT

### DIFF
--- a/chroot/run_linux.go
+++ b/chroot/run_linux.go
@@ -263,7 +263,7 @@ func createPlatformContainer(options runUsingChrootExecSubprocOptions) error {
 		return fmt.Errorf("changing to host root directory: %w", err)
 	}
 	// make sure we only unmount things under this tree
-	if err := unix.Mount(".", ".", "bind", unix.MS_BIND|unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
+	if err := unix.Mount(".", ".", "bind", unix.MS_REMOUNT|unix.MS_BIND|unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
 		return fmt.Errorf("tweaking mount flags on host root directory before unmounting from mount namespace: %w", err)
 	}
 	// detach this (unnamed?) old directory


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When setting mount propagation on the root mount before unmounting it, use MS_REBIND, since we know it's already a bind mount, and we actually want to affect the extant bind mount instead of creating another right over it. Otherwise, we might as well have not bothered.

Cherry-picked from #5992.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

#6001/[RHEL-80446](https://issues.redhat.com/browse/RHEL-80446) and https://github.com/containers/buildah/pull/5874#issuecomment-2677427012.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```