### PR TITLE
feat: use HistoryTimestamp, if set, for oci-archive entries

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -415,7 +415,7 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 	}
 
 	var manifestBytes []byte
-	if manifestBytes, err = retryCopyImage(ctx, policyContext, maybeCachedDest, maybeCachedSrc, dest, getCopyOptions(b.store, options.ReportWriter, nil, systemContext, "", false, options.SignBy, options.OciEncryptLayers, options.OciEncryptConfig, nil), options.MaxRetries, options.RetryDelay); err != nil {
+	if manifestBytes, err = retryCopyImage(ctx, policyContext, maybeCachedDest, maybeCachedSrc, dest, getCopyOptions(b.store, options.ReportWriter, nil, systemContext, "", false, options.SignBy, options.OciEncryptLayers, options.OciEncryptConfig, nil, options.HistoryTimestamp), options.MaxRetries, options.RetryDelay); err != nil {
 		return imgID, nil, "", fmt.Errorf("copying layers and metadata for container %q: %w", b.ContainerID, err)
 	}
 	// If we've got more names to attach, and we know how to do that for

--- a/common.go
+++ b/common.go
@@ -27,7 +27,7 @@ const (
 	DOCKER = define.DOCKER
 )
 
-func getCopyOptions(store storage.Store, reportWriter io.Writer, sourceSystemContext *types.SystemContext, destinationSystemContext *types.SystemContext, manifestType string, removeSignatures bool, addSigner string, ociEncryptLayers *[]int, ociEncryptConfig *encconfig.EncryptConfig, ociDecryptConfig *encconfig.DecryptConfig) *cp.Options {
+func getCopyOptions(store storage.Store, reportWriter io.Writer, sourceSystemContext *types.SystemContext, destinationSystemContext *types.SystemContext, manifestType string, removeSignatures bool, addSigner string, ociEncryptLayers *[]int, ociEncryptConfig *encconfig.EncryptConfig, ociDecryptConfig *encconfig.DecryptConfig, destinationTimestamp *time.Time) *cp.Options {
 	sourceCtx := getSystemContext(store, nil, "")
 	if sourceSystemContext != nil {
 		*sourceCtx = *sourceSystemContext
@@ -47,6 +47,7 @@ func getCopyOptions(store storage.Store, reportWriter io.Writer, sourceSystemCon
 		OciEncryptConfig:      ociEncryptConfig,
 		OciDecryptConfig:      ociDecryptConfig,
 		OciEncryptLayers:      ociEncryptLayers,
+		DestinationTimestamp:  destinationTimestamp,
 	}
 }
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -7427,3 +7427,18 @@ EOF
   find ${TEST_SCRATCH_DIR}/buildcontext -ls
   expect_output "" "build should not be able to write to build context"
 }
+
+@test "build-with-timestamp-applies-to-oci-archive" {
+  local outpath="${TEST_SCRATCH_DIR}/timestamp-oci.tar"
+
+  run_buildah build -f <(echo 'FROM scratch') --tag=oci-archive:${outpath}.a --timestamp 0
+  run_buildah build -f <(echo 'FROM scratch') --tag=oci-archive:${outpath}.b --timestamp 1
+  sleep 1.1 # sleep at least 1 second, so that timestamps are incremented
+  run_buildah build -f <(echo 'FROM scratch') --tag=oci-archive:${outpath}.c --timestamp 1
+
+  # should be different
+  ! diff "${outpath}.a" "${outpath}.b"
+
+  # should be the same
+  diff "${outpath}.b" "${outpath}.c"
+}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -7436,8 +7436,8 @@ EOF
   sleep 1.1 # sleep at least 1 second, so that timestamps are incremented
   run_buildah build -f <(echo 'FROM scratch') --tag=oci-archive:${outpath}.c --timestamp 1
 
-  # should be different
-  ! diff "${outpath}.a" "${outpath}.b"
+  # should be different ( || false is due to bats weirdness )
+  ! diff "${outpath}.a" "${outpath}.b" || false
 
   # should be the same
   diff "${outpath}.b" "${outpath}.c"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR passes the existing HistoryTimetamp option, if set, to the `CopyOptions` passed to the `image/v5` library, which in turn uses this for timestamps for some destinations, specifically oci-archive.

#### How to verify it

Before this change, this command will produce different output on each run (provided each run is at least 1 second apart):

```bash
$ ./bin/buildah build -f <(echo 'FROM scratch') --tag=oci-archive:oci.tar --timestamp 0 &>/dev/null && sha256sum oci.tar
182557b969fb24723b29e18770a2add930115492b4b267bb0847cecc14b47647  oci.tar
$ ./bin/buildah build -f <(echo 'FROM scratch') --tag=oci-archive:oci.tar --timestamp 0 &>/dev/null && sha256sum oci.tar
cb7ffa809d00485700d207ea291c8be8939b5596c9d04deeeacf7e26beb0e7aa  oci.tar
```

After this change, the same output is produced each time:

```bash
$ ./bin/buildah build -f <(echo 'FROM scratch') --tag=oci-archive:oci.tar --timestamp 0 &>/dev/null && sha256sum oci.tar
b5706eba1022041e2eeceada4f0da68ccd002c768ddb9e28e4dd5ca422f73cd1  oci.tar
$ ./bin/buildah build -f <(echo 'FROM scratch') --tag=oci-archive:oci.tar --timestamp 0 &>/dev/null && sha256sum oci.tar
b5706eba1022041e2eeceada4f0da68ccd002c768ddb9e28e4dd5ca422f73cd1  oci.tar
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I'm guessing we would normally wait for a new version of github.com/containers/image/v5 to be released before bumping?

#### Does this PR introduce a user-facing change?

```release-note
The --timestamp option, if set, is now passed through to a destination of --tag=oci-archive: and is applied to the timestamp of entries in the tar archive.
```

