### PR TITLE
stage_executor: history should include heredoc summary correctly

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1943,17 +1943,20 @@ func (s *StageExecutor) getCreatedBy(node *parser.Node, addedContentSummary stri
 		if len(node.Original) > 4 {
 			shArg = node.Original[4:]
 		}
-		if buildArgs != "" {
-			return "|" + strconv.Itoa(len(strings.Split(buildArgs, " "))) + " " + buildArgs + " /bin/sh -c " + shArg + appendCheckSum, nil
-		}
-		result := "/bin/sh -c " + shArg
+
+		heredoc := ""
+		result := ""
 		if len(node.Heredocs) > 0 {
 			for _, doc := range node.Heredocs {
 				heredocContent := strings.TrimSpace(doc.Content)
-				result = result + "\n" + heredocContent
+				heredoc = heredoc + "\n" + heredocContent
 			}
 		}
-		return result + appendCheckSum, nil
+		if buildArgs != "" {
+			result = result + "|" + strconv.Itoa(len(strings.Split(buildArgs, " "))) + " " + buildArgs + " "
+		}
+		result = result + "/bin/sh -c " + shArg + heredoc + appendCheckSum
+		return result, nil
 	case "ADD", "COPY":
 		destination := node
 		for destination.Next != nil {


### PR DESCRIPTION
`getCreatedBy` ignores heredoc summary when build args are specified following PR makes sure the behaviour is correct.

Also test is modified to make sure buildah correctly burst cache if heredoc content is changed.

Closes: https://github.com/containers/podman/issues/25469

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
stage_executor: history should include heredoc summary correctly
```

