### PR TITLE
feat: add --ssl-cert-file option to build command

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -83,6 +83,8 @@ type CommonBuildOptions struct {
 	ApparmorProfile string
 	// ShmSize is the "size" value to use when mounting an shmfs on the container's /dev/shm directory.
 	ShmSize string
+	// SSLCertFile specifies whether the host root CAs should be ephemerally mounted within the container
+	SSLCertFile bool
 	// Ulimit specifies resource limit options, in the form type:softlimit[:hardlimit].
 	// These types are recognized:
 	// "core": maximum core dump size (ulimit -c)

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -149,6 +149,7 @@ type FromAndBudResults struct {
 	RetryDelay     string
 	SecurityOpt    []string
 	ShmSize        string
+	SSLCertFile    bool
 	Ulimit         []string
 	Volumes        []string
 }
@@ -409,6 +410,7 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 	fs.String("variant", "", "override the `variant` of the specified image")
 	fs.StringArrayVar(&flags.SecurityOpt, "security-opt", []string{}, "security options (default [])")
 	fs.StringVar(&flags.ShmSize, "shm-size", defaultContainerConfig.Containers.ShmSize, "size of '/dev/shm'. The format is `<number><unit>`.")
+	fs.BoolVar(&flags.SSLCertFile, "ssl-cert-file", false, "mount host root CAs to /host-ssl-cert-file in container during build, and set SSL_CERT_FILE to point to it")
 	fs.StringSliceVar(&flags.Ulimit, "ulimit", defaultContainerConfig.Containers.DefaultUlimits.Get(), "ulimit options")
 	fs.StringArrayVarP(&flags.Volumes, "volume", "v", defaultContainerConfig.Volumes(), "bind mount a volume into the container")
 

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -162,6 +162,7 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 	cpuQuota, _ := flags.GetInt64("cpu-quota")
 	cpuShares, _ := flags.GetUint64("cpu-shares")
 	httpProxy, _ := flags.GetBool("http-proxy")
+	sslCertFile, _ := flags.GetBool("ssl-cert-file")
 	identityLabel, _ := flags.GetBool("identity-label")
 	omitHistory, _ := flags.GetBool("omit-history")
 
@@ -197,6 +198,7 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 		Volumes:       volumes,
 		Secrets:       secrets,
 		SSHSources:    sshsources,
+		SSLCertFile:   sslCertFile,
 		OCIHooksDir:   ociHooks,
 	}
 	securityOpts, _ := flags.GetStringArray("security-opt")

--- a/run_common.go
+++ b/run_common.go
@@ -326,6 +326,10 @@ func (b *Builder) configureEnvironment(g *generate.Generator, options RunOptions
 		}
 	}
 
+	if b.CommonBuildOpts.SSLCertFile {
+		g.AddProcessEnv("SSL_CERT_FILE", "/host-ssl-cert-file")
+	}
+
 	for _, envSpec := range util.MergeEnv(util.MergeEnv(defaultEnv, b.Env()), options.Env) {
 		env := strings.SplitN(envSpec, "=", 2)
 		if len(env) > 1 {

--- a/run_linux.go
+++ b/run_linux.go
@@ -503,6 +503,14 @@ rootless=%d
 		bindFiles["/run/.containerenv"] = containerenvPath
 	}
 
+	if b.CommonBuildOpts.SSLCertFile {
+		resolvedSSLCertPath, err := util.ResolveRootCACertFile()
+		if err != nil {
+			return err
+		}
+		bindFiles["/host-ssl-cert-file"] = resolvedSSLCertPath
+	}
+
 	// Setup OCI hooks
 	_, err = b.setupOCIHooks(spec, (len(options.Mounts) > 0 || len(volumes) > 0))
 	if err != nil {

--- a/util/x509.go
+++ b/util/x509.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func ResolveRootCACertFile() (string, error) {
+	if rv, ok := os.LookupEnv("SSL_CERT_FILE"); ok {
+		return rv, nil
+	}
+	for _, potFile := range certFiles {
+		if _, err := os.Stat(potFile); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", fmt.Errorf("unexpected error resolving cert file: %w", err)
+		}
+		return potFile, nil
+	}
+	return "", errors.New("please set SSL_CERT_FILE to use --ssl-cert-file option")
+}

--- a/util/x509_unix.go
+++ b/util/x509_unix.go
@@ -1,0 +1,45 @@
+//go:build !windows
+
+package util
+
+// Source: https://cs.opensource.google/go/go/+/refs/tags/go1.24.1:src/crypto/x509/root_linux.go
+
+/*
+	Copyright 2009 The Go Authors.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are
+	met:
+
+	* Redistributions of source code must retain the above copyright
+	notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above
+	copyright notice, this list of conditions and the following disclaimer
+	in the documentation and/or other materials provided with the
+	distribution.
+	* Neither the name of Google LLC nor the names of its
+	contributors may be used to endorse or promote products derived from
+	this software without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+	A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+	OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+	LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+	DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+	THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Possible certificate files; stop after finding one.
+var certFiles = []string{
+	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+	"/etc/pki/tls/cacert.pem",                           // OpenELEC
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+	"/etc/ssl/cert.pem",                                 // Alpine Linux
+}

--- a/util/x509_windows.go
+++ b/util/x509_windows.go
@@ -1,0 +1,4 @@
+package util
+
+// not implemented
+var certFiles []string


### PR DESCRIPTION
This makes the root CAs from the host available to containers during a build.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This makes it easier to use `buildah` to build an image in environments that require custom certificate authorities to make outbound internet connections (for example when using a TLS intercepting HTTPS proxy).

Currently `buildah` will automatically pass `https_proxy` (and related) environment variables as ephemeral environment variables to the container for `RUN` commands.

This change adds an option `--with-ssl-cert-file` (defaults to `false`) that when set will:

1. Resolve the root CA file currently in use by the host (uses `SSL_CERT_FILE` if set, else falls back to searching common paths).
2. Mount this file within the container during the `RUN` command at a different location (`/host-ssl-cert-file`).
3. Sets `SSL_CERT_FILE=/host-ssl-cert-file`  ephemeral environment variable for `RUN` commands. 

A similar outcome can be achieved today by editing `buildah` command to bind mount the current CA store and then edit each `RUN` instruction in the `Containerfile` to use, however it felt like it would be nice to make a short-cut for this which seems to augment well the existing `https_proxy` variable propagation.

Current workaround:

```bash
./bin/buildah build --secret=id=ca,src=/etc/ssl/certs/ca-certificates.crt -f - <<'EOF'
FROM alpine:latest
ENV SSL_CERT_FILE=/host-ca-file
RUN --mount=type=secret,id=ca,target=/host-ca-file echo "SSL_CERT_FILE: ${SSL_CERT_FILE} - Contents:" && head -n10 "${SSL_CERT_FILE}"
EOF
```


#### How to verify it

Behaviour without flag:

```bash
./bin/buildah build -f - <<'EOF'
FROM alpine:latest
RUN echo "SSL_CERT_FILE: ${SSL_CERT_FILE} - Contents:" && head -n10 "${SSL_CERT_FILE}"
EOF
```

Output: 

```
STEP 1/2: FROM alpine:latest
STEP 2/2: RUN echo "SSL_CERT_FILE: ${SSL_CERT_FILE} - Contents:" && head -n10 "${SSL_CERT_FILE}"
SSL_CERT_FILE:  - Contents:
head: : No such file or directory
Error: building at STEP "RUN echo "SSL_CERT_FILE: ${SSL_CERT_FILE} - Contents:" && head -n10 "${SSL_CERT_FILE}"": while running runtime: exit status 1
```

Behaviour with flag:

```bash
./bin/buildah build --ssl-cert-file -f - <<'EOF'
FROM alpine:latest
RUN echo "SSL_CERT_FILE: ${SSL_CERT_FILE} - Contents:" && head -n10 "${SSL_CERT_FILE}"
EOF
```

Output:

```
STEP 1/2: FROM alpine:latest
STEP 2/2: RUN echo "SSL_CERT_FILE: ${SSL_CERT_FILE} - Contents:" && head -n10 "${SSL_CERT_FILE}"
SSL_CERT_FILE: /host-ssl-cert-file - Contents:
-----BEGIN CERTIFICATE-----
MIIH0zCCBbugAwIBAgIIXsO3pkN/pOAwDQYJKoZIhvcNAQEFBQAwQjESMBAGA1UE
(lots more output)
```

Tested with a local HTTPS proxy server with a self-signed CA and verified that basic `apk add --update --no-cache python3` and similar commands worked without error.

(Tested similar on `ubuntu` image, although `apt` I think runs over HTTP so test wasn't as meaningful)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I'm happy to add tests but wanted to get feedback on the direction first. It's quite a small PR, but I think quite helpful for those stuck behind corporate proxies. The automatic adding of `https_proxy` environment variables is a good start, and this aims to give the same experience for CAs.

Some issues to maybe fix first:

##### Search path for host CAs

To get the search path of commonly used host CA files I used the list found here:
https://cs.opensource.google/go/go/+/refs/tags/go1.24.1:src/crypto/x509/root_linux.go;l=9-17

Unfortunately that variable is private, and I'm not able to find anything within the standard x509 module that exports it or otherwise makes it available, which is why I put that list in a separate file and copy/pasted the Go LICENSE within there.

It feels less than ideal and open to other ideas.

##### Path to bind to within the container

This PR currently binds it to `/host-ssl-cert-file` so that it doesn't clash with commonly used paths within a container. This seemed to work fine in my limited testing when using `SSL_CERT_FILE` to point to it, however it's not clear whether `SSL_CERT_FILE` will work for all applications and whether it may be best to instead bind this on top of well-known locations for where this file normally is.

Happy to take feedback on alternate suggestions.

#### Does this PR introduce a user-facing change?

```release-note
Adds --ssl-cert-file option to build command. If set this propogates the host CAs into the container during the build process.
```

