### PR TITLE
fix: dockerfiles... always evaluates to an empty list

### DIFF
--- a/imagebuildah/build_linux_test.go
+++ b/imagebuildah/build_linux_test.go
@@ -1,0 +1,63 @@
+package imagebuildah
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/containers/buildah/define"
+)
+
+func TestFilesClosedProperlyByBuildDockerfiles(t *testing.T) {
+	// create files in in temp dir
+	var paths []string
+	for _, name := range []string{"Dockerfile", "Dockerfile.in"} {
+		fpath, err := filepath.Abs(filepath.Join(t.TempDir(), name))
+		assert.Nil(t, err)
+		assert.Nil(t, os.WriteFile(fpath, []byte("FROM scratch"), 0o644))
+		paths = append(paths, fpath)
+	}
+
+	// send files as above, and a missing one, so that we error early and return and don't try an actual build
+	_, _, err := BuildDockerfiles(context.Background(), nil, define.BuildOptions{}, append(append(make([]string, 0, len(paths)), paths...), "missing")...)
+	var pathErr *fs.PathError
+	assert.True(t, errors.As(err, &pathErr))
+	assert.Equal(t, "missing", pathErr.Path)
+
+	// verify (as best we can) that we don't think these files are still open
+	openFiles, err := currentOpenFiles()
+	assert.Nil(t, err)
+	for _, path := range paths {
+		assert.NotContains(t, openFiles, path)
+	}
+}
+
+// currentOpenFiles makes an effort at returning a map of which files are currently
+// open by our process. We don't fail if we can't follow symlinks from fds as this
+// perhaps they now longer exist between when we read them and when we tried to use
+// them. Instead we just ignore.
+func currentOpenFiles() (map[string]struct{}, error) {
+	rd := "/proc/self/fd"
+	es, err := os.ReadDir(rd)
+	if err != nil {
+		return nil, err
+	}
+	rv := make(map[string]struct{})
+	for _, de := range es {
+		if de.Type()&fs.ModeSymlink == fs.ModeSymlink {
+			dest, err := os.Readlink(filepath.Join(rd, de.Name()))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "cannot follow symlink, ignoring: %v\n", err)
+				continue
+			}
+			rv[dest] = struct{}{}
+		}
+	}
+	return rv, nil
+}


### PR DESCRIPTION
Even when dockerfiles is appended to later in this method, it has no entries at time of evaluation as an argument to the defer function, thus no files were ever closed as a result.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Spotted this when trying to debug why some resources where kept busy. Although this wasn't the root cause, the code as written was not doing what it looked like it intended to do, so was an easy fix.

#### How to verify it

Test added.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I had a longer PR prepped that would move the body of the loop over Dockerfiles into a separate function, so that each file could be closed immediately after use, but figured this shorter PR would be preferred.

I did a quick search of the code base other instance of using either `...` or `[]` on the same line as `defer` and couldn't find any, so I think this is the only instance of this type of issue in this codebase.

#### Does this PR introduce a user-facing change?

```release-note
None
```
