### PR TITLE
Allow extendedGlob to work with Windows paths

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -70,12 +70,14 @@ func extendedGlob(pattern string) (matches []string, err error) {
 		components := []string{}
 		dir := pattern
 		file := ""
-		for dir != "" && dir != string(os.PathSeparator) {
+		for dir != filepath.VolumeName(dir) && dir != string(os.PathSeparator) {
 			dir, file = filepath.Split(dir)
-			components = append([]string{file}, components...)
+			if file != "" {
+				components = append([]string{file}, components...)
+			}
 			dir = strings.TrimSuffix(dir, string(os.PathSeparator))
 		}
-		patterns := []string{string(os.PathSeparator)}
+		patterns := []string{filepath.VolumeName(dir) + string(os.PathSeparator)}
 		for i := range components {
 			var nextPatterns []string
 			if components[i] == "**" {

--- a/copier/xattrs_test.go
+++ b/copier/xattrs_test.go
@@ -1,3 +1,5 @@
+//go:build linux || netbsd || freebsd || darwin
+
 package copier
 
 import (


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

This PR fixes processing of Windows style paths in extendedGlob. The first issue fixed is an infinite loop when presented with a windows style path (i.e. `C:\Some\Path\**.txt`). The second issue is ensuring that the pattern includes the drive letter on Windows. The fix primarily depends on the behavior of `filepath.VolumeName`. On Windows it will return the drive letter for a path, while on other systems it returns an empty string.

Additionally, I limited xattrs_test.go to the same go:build targets as xattrs.go, as that was preventing me from running tests properly on Windows.

I found this issue while looking to make `podman container cp` work properly on Windows. I'm also working on a PR for the podman repo to fix some additional issues, but would need this scenario fixed before I can proceed to open that PR, otherwise the command enters an infinite loop and never completes (currently it fails due to a separate path parsing bug in the `cp` command implementation).

#### How to verify it

Run the `TestExtendedGlob` test case on Windows (i.e. `go test ./copier/... -run TestExtendedGlob`). There are still test failures for other tests in the copier package on Windows, but the test coverage for this method now passes.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

