### PR TITLE
createPlatformContainer: drop MS_REMOUNT|MS_BIND

### DIFF
--- a/chroot/run_linux.go
+++ b/chroot/run_linux.go
@@ -263,7 +263,7 @@ func createPlatformContainer(options runUsingChrootExecSubprocOptions) error {
 		return fmt.Errorf("changing to host root directory: %w", err)
 	}
 	// make sure we only unmount things under this tree
-	if err := unix.Mount(".", ".", "bind", unix.MS_REMOUNT|unix.MS_BIND|unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
+	if err := unix.Mount(".", ".", "", unix.MS_SLAVE|unix.MS_REC, ""); err != nil {
 		return fmt.Errorf("tweaking mount flags on host root directory before unmounting from mount namespace: %w", err)
 	}
 	// detach this (unnamed?) old directory


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When attempting to change the mount propagation of the old root directory tree before unmounting it, it's enough that we pass the requested propagation flags.

In particular, MS_REC is the only flag that is supposed to be allowed to be specified along with a mount propagation flag, but in practice it was only triggering an error some of the time, and CI wasn't one of those times.

#### How to verify it

The added integration test mounts the root filesystem as an overlay and then runs buildah as a rootless user on top of that, which is more comparable to a root-on-composefs configuration, which triggered the error.

#### Which issue(s) this PR fixes:

Fixes errors detected in [RHEL-79560](https://issues.redhat.com/browse/RHEL-79560).

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
"chroot" isolation should no longer require the "--no-pivot" flag be specified in order to function on "image mode" systems.
```