### PR TITLE
build: return `ExecErrorCodeGeneric` when git operation fails instead of relaying error code directly from git

### DIFF
--- a/define/types.go
+++ b/define/types.go
@@ -267,14 +267,18 @@ func cloneToDirectory(url, dir string) ([]byte, string, error) {
 	cmd = exec.Command("git", "init", dir)
 	combinedOutput, err := cmd.CombinedOutput()
 	if err != nil {
-		return combinedOutput, gitSubdir, fmt.Errorf("failed while performing `git init`: %w", err)
+		// Return err.Error() instead of err as we want buildah to override error code with more predictable
+		// value.
+		return combinedOutput, gitSubdir, fmt.Errorf("failed while performing `git init`: %s", err.Error())
 	}
 	// add origin
 	cmd = exec.Command("git", "remote", "add", "origin", gitRepo)
 	cmd.Dir = dir
 	combinedOutput, err = cmd.CombinedOutput()
 	if err != nil {
-		return combinedOutput, gitSubdir, fmt.Errorf("failed while performing `git remote add`: %w", err)
+		// Return err.Error() instead of err as we want buildah to override error code with more predictable
+		// value.
+		return combinedOutput, gitSubdir, fmt.Errorf("failed while performing `git remote add`: %s", err.Error())
 	}
 
 	logrus.Debugf("fetching repo %q and branch (or commit ID) %q to %q", gitRepo, gitRef, dir)
@@ -283,14 +287,18 @@ func cloneToDirectory(url, dir string) ([]byte, string, error) {
 	cmd.Dir = dir
 	combinedOutput, err = cmd.CombinedOutput()
 	if err != nil {
-		return combinedOutput, gitSubdir, fmt.Errorf("failed while performing `git fetch`: %w", err)
+		// Return err.Error() instead of err as we want buildah to override error code with more predictable
+		// value.
+		return combinedOutput, gitSubdir, fmt.Errorf("failed while performing `git fetch`: %s", err.Error())
 	}
 
 	cmd = exec.Command("git", "checkout", "FETCH_HEAD")
 	cmd.Dir = dir
 	combinedOutput, err = cmd.CombinedOutput()
 	if err != nil {
-		return combinedOutput, gitSubdir, fmt.Errorf("failed while performing `git checkout`: %w", err)
+		// Return err.Error() instead of err as we want buildah to override error code with more predictable
+		// value.
+		return combinedOutput, gitSubdir, fmt.Errorf("failed while performing `git checkout`: %s", err.Error())
 	}
 	return combinedOutput, gitSubdir, nil
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2919,13 +2919,13 @@ function validate_instance_compression {
 
 @test "bud-git-context-failure" {
   # We need git to be around to try cloning a repository, even though it'll fail
-  # and exit with return code 128.
+  # and buildah will exit with return code 125.
   if ! which git ; then
     skip "no git in PATH"
   fi
   target=giturl-image
   gitrepo=git:///tmp/no-such-repository
-  run_buildah 128 build $WITH_POLICY_JSON -t ${target} "${gitrepo}"
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} "${gitrepo}"
   # Expect part of what git would have told us... before things went horribly wrong
   expect_output --substring "failed while performing"
   expect_output --substring "git fetch"
@@ -7318,7 +7318,7 @@ _EOF
 FROM scratch
 ADD https://github.com/containers/crun.git#nosuchbranch /src
 _EOF
-  run_buildah 128 build -f $contextdir/Dockerfile -t git-image $contextdir
+  run_buildah 125 build -f $contextdir/Dockerfile -t git-image $contextdir
   expect_output --substring "couldn't find remote ref nosuchbranch"
 }
 


### PR DESCRIPTION
Only propagate error message from git and let buildah reflect error code
`125`.

Reason: Buildah should return predicatable error code from the set of
defined error codes in exec_codes.go at https://github.com/containers/buildah/blob/main/pkg/cli/exec_codes.go#L6
anything other that predefined error codes introduces inconsistency thus making testing difficult in CI and podman.

Users should expect buildah to refect ExecErrorCodeGeneric with error message kept intact from the underlying `git`
commands.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build: return 125 when git operation fails instead of relaying error code directly from git
```

