### PR TITLE
cmd/buildah: rm unused code

### DIFF
--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/containers/buildah"
-	"github.com/containers/buildah/define"
-	is "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	"github.com/sirupsen/logrus"
@@ -77,31 +75,6 @@ func TestGetStore(t *testing.T) {
 	}
 }
 
-func TestGetSize(t *testing.T) {
-	// Make sure the tests are running as root
-	failTestIfNotRoot(t)
-
-	store, err := storage.GetStore(storeOptions)
-	if err != nil {
-		t.Fatal(err)
-	} else if store != nil {
-		is.Transport.SetStore(store)
-	}
-
-	// Pull an image so that we know we have at least one
-	pullTestImage(t)
-
-	images, err := store.Images()
-	if err != nil {
-		t.Fatalf("Error reading images: %v", err)
-	}
-
-	_, _, _, err = getDateAndDigestAndSize(getContext(), &testSystemContext, store, images[0])
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 func failTestIfNotRoot(t *testing.T) {
 	u, err := user.Current()
 	if err != nil {
@@ -109,31 +82,4 @@ func failTestIfNotRoot(t *testing.T) {
 	} else if u.Uid != "0" {
 		t.Fatal("tests will fail unless run as root")
 	}
-}
-
-func pullTestImage(t *testing.T) string {
-	store, err := storage.GetStore(storeOptions)
-	if err != nil {
-		t.Fatal(err)
-	}
-	commonOpts := &define.CommonBuildOptions{
-		LabelOpts: nil,
-	}
-	options := buildah.BuilderOptions{
-		FromImage:           "busybox:latest",
-		SignaturePolicyPath: signaturePolicyPath,
-		CommonBuildOpts:     commonOpts,
-		SystemContext:       &testSystemContext,
-	}
-
-	b, err := buildah.NewBuilder(getContext(), store, options)
-	if err != nil {
-		t.Fatal(err)
-	}
-	id := b.FromImageID
-	err = b.Delete()
-	if err != nil {
-		t.Fatal(err)
-	}
-	return id
 }

--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -4,10 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"regexp"
 	"strings"
-	"text/template"
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
@@ -260,26 +257,6 @@ func containersToGeneric(templParams []containerOutputParams) (genericParams []i
 		}
 	}
 	return genericParams
-}
-
-func containerOutputUsingTemplate(format string, params containerOutputParams) error {
-	if matched, err := regexp.MatchString("{{.*}}", format); err != nil {
-		return fmt.Errorf("validating format provided: %s: %w", format, err)
-	} else if !matched {
-		return fmt.Errorf("invalid format provided: %s", format)
-	}
-
-	tmpl, err := template.New("container").Parse(format)
-	if err != nil {
-		return fmt.Errorf("Template parsing error: %w", err)
-	}
-
-	err = tmpl.Execute(os.Stdout, params)
-	if err != nil {
-		return err
-	}
-	fmt.Println()
-	return nil
 }
 
 func containerOutputUsingFormatString(truncate bool, params containerOutputParams) {

--- a/cmd/buildah/containers_test.go
+++ b/cmd/buildah/containers_test.go
@@ -5,65 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"testing"
 )
-
-func TestContainerTemplateOutputValidFormat(t *testing.T) {
-	params := containerOutputParams{
-		ContainerID:   "e477836657bb",
-		Builder:       " ",
-		ImageID:       "f975c5035748",
-		ImageName:     "test/image:latest",
-		ContainerName: "test-container",
-	}
-
-	formatString := "Container ID: {{.ContainerID}}"
-	expectedString := "Container ID: " + params.ContainerID
-
-	output, err := captureOutputWithError(func() error {
-		return containerOutputUsingTemplate(formatString, params)
-	})
-	if err != nil {
-		t.Error(err)
-	} else if strings.TrimSpace(output) != expectedString {
-		t.Errorf("Errorf with template output:\nExpected: %s\nReceived: %s\n", expectedString, output)
-	}
-}
-
-func TestContainerTemplateOutputInvalidFormat(t *testing.T) {
-	params := containerOutputParams{
-		ContainerID:   "e477836657bb",
-		Builder:       " ",
-		ImageID:       "f975c5035748",
-		ImageName:     "test/image:latest",
-		ContainerName: "test-container",
-	}
-
-	formatString := "ContainerID"
-
-	err := containerOutputUsingTemplate(formatString, params)
-	if err == nil || err.Error() != "invalid format provided: ContainerID" {
-		t.Fatalf("expected error invalid format")
-	}
-}
-
-func TestContainerTemplateOutputNonexistentField(t *testing.T) {
-	params := containerOutputParams{
-		ContainerID:   "e477836657bb",
-		Builder:       " ",
-		ImageID:       "f975c5035748",
-		ImageName:     "test/image:latest",
-		ContainerName: "test-container",
-	}
-
-	formatString := "{{.ID}}"
-
-	err := containerOutputUsingTemplate(formatString, params)
-	if err == nil || !strings.Contains(err.Error(), "can't evaluate field ID") {
-		t.Fatalf("expected error nonexistent field")
-	}
-}
 
 func TestContainerFormatStringOutput(t *testing.T) {
 	params := containerOutputParams{
@@ -108,25 +51,6 @@ func TestContainerHeaderOutput(t *testing.T) {
 	if output != expectedOutput {
 		t.Errorf("Error outputting using format string:\n\texpected: %s\n\treceived: %s\n", expectedOutput, output)
 	}
-}
-
-func captureOutputWithError(f func() error) (string, error) {
-	old := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		return "", err
-	}
-	os.Stdout = w
-
-	if err := f(); err != nil {
-		return "", err
-	}
-
-	w.Close()
-	os.Stdout = old
-	var buf bytes.Buffer
-	io.Copy(&buf, r) //nolint
-	return buf.String(), err
 }
 
 // Captures output so that it can be compared to expected values


### PR DESCRIPTION
#### What type of PR is this?

> /kind cleanup

#### What this PR does / why we need it:

Removes some unused code and tests from cmd/buildah,
found by `golangci-lint run --tests=false`.

#### How to verify it

Existing CI should be adequate.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is a part of a bigger cleanup, separated out for ease of review.

#### Does this PR introduce a user-facing change?

```release-note
none
```

