### PR TITLE
Add a link to project governance and MAINTAINERS file

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,3 @@
+## The Buildah Project Community Governance
+
+The Buildah project, as part of Podman Container Tools, follows the [Podman Project Governance](https://github.com/containers/podman/blob/main/GOVERNANCE.md).

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,0 @@
-Dan Walsh <dwalsh@redhat.com> (@rhatdan)
-Nalin Dahyabhai <nalin@redhat.com> (@nalind)
-Tom Sweeney <tsweeney@redhat.com> (@tomsweeneyredhat)
-Urvashi Mohnani <umohnani@redhat.com> (@umohnani8)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,31 @@
+# Buildah Maintainers
+
+[GOVERNANCE.md](https://github.com/containers/podman/blob/main/GOVERNANCE.md)
+describes the project's governance and the Project Roles used below.
+
+## Maintainers
+
+| Maintainer        | GitHub ID                                                | Project Roles                    | Affiliation                                  |
+|-------------------|----------------------------------------------------------|----------------------------------|----------------------------------------------|
+| Brent Baude       | [baude](https://github.com/baude)                        | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Nalin Dahyabhai   | [nalind](https://github.com/nalind)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Matthew Heon      | [mheon](https://github.com/mheon)                        | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Paul Holzinger    | [Luap99](https://github.com/Luap99)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Giuseppe Scrivano | [giuseppe](https://github.com/giuseppe)                  | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Miloslav Trmač    | [mtrmac](https://github.com/mtrmac)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Neil Smith        | [Neil-Smith](https://github.com/Neil-Smith)              | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
+| Tom Sweeney       | [TomSweeneyRedHat](https://github.com/TomSweeneyRedHat/) | Maintainer and Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
+| Lokesh Mandvekar  | [lsm5](https://github.com/lsm5)                          | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
+| Dan Walsh         | [rhatdan](https://github.com/rhatdan)                    | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
+| Ashley Cui        | [ashley-cui](https://github.com/ashley-cui)              | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+| Aditya Rajan      | [flouthoc](https://github.com/flouthoc)                  | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+| Jan Rodák         | [Honny1](https://github.com/Honny1)                      | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+| Valentin Rothberg | [vrothberg](https://github.com/vrothberg)                | Reviewer                         | [Red Hat](https://github.com/RedHatOfficial) |
+
+## Alumni
+
+None at present
+
+## Credits
+
+The structure of this document was based off of the equivalent one in the [CRI-O Project](https://github.com/cri-o/cri-o/blob/main/MAINTAINERS.md).

--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,24 @@
 approvers:
-  - TomSweeneyRedHat
+  - baude
+  - giuseppe
   - lsm5
+  - Luap99
+  - mheon
+  - mtrmac
   - nalind
   - rhatdan
-  - umohnani8
+  - TomSweeneyRedHat
 reviewers:
   - ashley-cui
   - baude
-  - edsantiago
   - flouthoc
   - giuseppe
   - Honny1
+  - lsm5
+  - Luap99
   - mheon
+  - mtrmac
+  - nalind
+  - rhatdan
+  - TomSweeneyRedHat
   - vrothberg


### PR DESCRIPTION
The MAINTAINERS file is based on the current OWNERS file. I added our core maintainers as they are expected to have commit bits on all project repositories.

The existing MAINTAINERS file, which appears out of date, was removed in favor of the new one (which has all CNCF mandated information).

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

Administrative work to link to the new governance model and add a CNCF-compliant maintainers list

#### How to verify it

N/A

#### Which issue(s) this PR fixes:

N/A

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

