### PR TITLE
stage_executor,getCreatedBy: expand buildArgs before invoking `generatePathChecksum`

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1896,6 +1896,10 @@ func (s *StageExecutor) getCreatedBy(node *parser.Node, addedContentSummary stri
 					continue
 				}
 				mountOptionSource = mountInfo.Source
+				mountOptionSource, err = imagebuilder.ProcessWord(mountOptionSource, s.stage.Builder.Arguments())
+				if err != nil {
+					return "", fmt.Errorf("getCreatedBy: while replacing arg variables with values for format %q: %w", mountOptionSource, err)
+				}
 				mountOptionFrom = mountInfo.From
 				// If source is not specified then default is '.'
 				if mountOptionSource == "" {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6757,6 +6757,16 @@ _EOF
   expect_output --substring "hello"
 }
 
+@test "bud-with-mount-relative-path-like-buildkit-arg-in-source" {
+  skip_if_no_runtime
+  skip_if_in_container
+  _prefetch alpine
+  local contextdir=${TEST_SCRATCH_DIR}/buildkit-mount
+  cp -R $BUDFILES/buildkit-mount $contextdir
+  run_buildah build --build-arg INPUTPATH_1=subdir -t testbud $WITH_POLICY_JSON -f $contextdir/Containerfile5 $contextdir/
+  expect_output --substring "hello"
+}
+
 @test "bud-with-mount-with-rw-like-buildkit" {
   skip_if_no_runtime
   skip_if_in_container

--- a/tests/bud/buildkit-mount/Containerfile5
+++ b/tests/bud/buildkit-mount/Containerfile5
@@ -1,0 +1,5 @@
+FROM alpine
+ARG INPUTPATH_1=subdir
+RUN mkdir /test
+# use option z if selinux is enabled
+RUN --mount=type=bind,source=${INPUTPATH_1:?}/,target=/test,z cat /test/input_file


### PR DESCRIPTION
Patch in PR https://github.com/containers/buildah/pull/5691 added a function to calculate and write checksum to history of `source` in `--mount` instructions but it did not add part to expand build args if they are present in `source` path.

Following PR Just corrects the above issue and also adds a new test to make sure we don't break this in future again.

Closes: https://github.com/containers/podman/issues/25425

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

