### PR TITLE
RUN: only use an overlay for --mount=type=bind,rw on overlay

### DIFF
--- a/add.go
+++ b/add.go
@@ -585,7 +585,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	// Copy each source in turn.
 	for _, src := range sources {
 		var multiErr *multierror.Error
-		var getErr, closeErr, renameErr, putErr error
+		var getErr, closeErr, renameErr, putErr, cleanupErr error
 		var wg sync.WaitGroup
 		if urlsource.IsRemote(src) || urlsource.IsGit(src) {
 			pipeReader, pipeWriter := io.Pipe()
@@ -627,6 +627,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 					writer := io.WriteCloser(pipeWriter)
 					repositoryDir := filepath.Join(cloneDir, subdir)
 					getErr = copier.Get(repositoryDir, repositoryDir, getOptions, []string{"."}, writer)
+					cleanupErr = os.RemoveAll(cloneDir)
 				}()
 			} else {
 				go func() {
@@ -674,7 +675,10 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			if putErr != nil {
 				putErr = fmt.Errorf("storing %q: %w", src, putErr)
 			}
-			multiErr = multierror.Append(getErr, putErr)
+			if cleanupErr != nil {
+				cleanupErr = fmt.Errorf("cleaning up copy of %q: %w", src, cleanupErr)
+			}
+			multiErr = multierror.Append(getErr, putErr, cleanupErr)
 			if multiErr != nil && multiErr.ErrorOrNil() != nil {
 				if len(multiErr.Errors) > 1 {
 					return multiErr.ErrorOrNil()

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -193,7 +193,16 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 	if err != nil {
 		return fmt.Errorf("building system context: %w", err)
 	}
-	mounts, mountedImages, intermediateMounts, _, targetLocks, err := volumes.GetVolumes(systemContext, store, builder.MountLabel, iopts.volumes, iopts.mounts, iopts.contextDir, builder.IDMappingOptions, iopts.workingDir, tmpDir)
+
+	var excludes []string
+	if iopts.contextDir != "" {
+		excludes, _, err = parse.ContainerIgnoreFile(iopts.contextDir, "", nil)
+		if err != nil {
+			return fmt.Errorf("parsing ignore file under context directory %s: %w", iopts.contextDir, err)
+		}
+	}
+
+	mounts, mountedImages, intermediateMounts, _, targetLocks, err := volumes.GetVolumes(systemContext, store, builder.MountLabel, iopts.volumes, iopts.mounts, iopts.contextDir, builder.IDMappingOptions, iopts.workingDir, tmpDir, excludes)
 	if err != nil {
 		return err
 	}

--- a/define/types.go
+++ b/define/types.go
@@ -55,7 +55,7 @@ const (
 	SNP TeeType = "snp"
 )
 
-// DefaultRlimitValue is the value set by default for nofile and nproc
+// RLimitDefaultValue is the value set by default for nofile and nproc
 const RLimitDefaultValue = uint64(1048576)
 
 // TeeType is a supported trusted execution environment type.

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -289,7 +289,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 		}
 
 		builds.Go(func() error {
-			contextDirectory, processLabel, mountLabel, usingContextOverlay, cleanupOverlay, err := platformSetupContextDirectoryOverlay(store, &options)
+			contextDirectory, processLabel, mountLabel, usingContextOverlay, cleanupOverlay, err := platformSetupContextDirectoryOverlay(store, paths, &options)
 			if err != nil {
 				return fmt.Errorf("mounting an overlay over build context directory: %w", err)
 			}

--- a/imagebuildah/build_linux.go
+++ b/imagebuildah/build_linux.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -18,8 +19,33 @@ import (
 	"go.podman.io/buildah/pkg/overlay"
 	"go.podman.io/buildah/pkg/parse"
 	"go.podman.io/storage"
+	"go.podman.io/storage/pkg/fileutils"
 	"go.podman.io/storage/pkg/idtools"
+	"golang.org/x/sys/unix"
 )
+
+// includeDirectoryAnyway returns true if "path" is a prefix for an exception
+// known to "pm".  If "path" is a directory that "pm" claims matches its list
+// of patterns, but "pm"'s list of exclusions contains a pattern for which
+// "path" is a prefix, then IncludeDirectoryAnyway() will return true.
+// This is not always correct, because it relies on the directory part of any
+// exception paths to be specified without wildcards.
+func includeDirectoryAnyway(path string, pm *fileutils.PatternMatcher) bool {
+	if !pm.Exclusions() {
+		return false
+	}
+	prefix := strings.TrimPrefix(path, string(os.PathSeparator)) + string(os.PathSeparator)
+	for _, pattern := range pm.Patterns() {
+		if !pattern.Exclusion() {
+			continue
+		}
+		spec := strings.TrimPrefix(pattern.String(), string(os.PathSeparator))
+		if strings.HasPrefix(spec, prefix) {
+			return true
+		}
+	}
+	return false
+}
 
 // platformSetupContextDirectoryOverlay() either sets up an overlay _over_ the
 // build context directory, or creates a temporary copy of it, and sorts out
@@ -28,7 +54,7 @@ import (
 // value that indicates whether the caller can write directly to the location;
 // and a cleanup function which should be called when the location is no longer
 // needed (on success). Returned errors should be treated as fatal.
-func platformSetupContextDirectoryOverlay(store storage.Store, options *define.BuildOptions) (string, string, string, bool, func(), error) {
+func platformSetupContextDirectoryOverlay(store storage.Store, containerFiles []string, options *define.BuildOptions) (string, string, string, bool, func(), error) {
 	var succeeded bool
 	var tmpDir, tmpContextDir, contentDir string
 	cleanup := func() {
@@ -86,6 +112,68 @@ func platformSetupContextDirectoryOverlay(store storage.Store, options *define.B
 		if err != nil {
 			return "", "", "", false, nil, fmt.Errorf("creating overlay scaffolding for build context directory: %w", err)
 		}
+		// while we're in here, we might as well process exclusions
+		excludes, ignoresFile, err := parse.ContainerIgnoreFile(contextDirectoryAbsolute, options.IgnoreFile, containerFiles)
+		if err != nil {
+			return "", "", "", false, nil, fmt.Errorf("parsing ignore file under context directory %s: %w", contextDirectoryAbsolute, err)
+		}
+		if len(excludes) > 0 {
+			pm, err := fileutils.NewPatternMatcher(excludes)
+			if err != nil {
+				return "", "", "", false, nil, fmt.Errorf("parsing ignores for build context directory: %w", err)
+			}
+			dates := make(map[string][]unix.Timespec)
+			modified := make(map[string]struct{})
+			if err := filepath.WalkDir(contextDirMountSpec.Source, func(p string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				rel, err := filepath.Rel(contextDirMountSpec.Source, p)
+				if err != nil {
+					return fmt.Errorf("computing the path of %q relative to %q: %w", p, contextDirMountSpec.Source, err)
+				}
+				if rel == "." {
+					return nil
+				}
+				if d.IsDir() {
+					fileInfo, err := d.Info()
+					if err != nil {
+						return fmt.Errorf("reading info about %q: %w", p, err)
+					}
+					ts, err := unix.TimeToTimespec(fileInfo.ModTime())
+					if err != nil {
+						return fmt.Errorf("converting datestamp on %q: %w", p, err)
+					}
+					dates[p] = []unix.Timespec{ts, ts}
+				}
+				excluded, err := pm.Matches(rel) //nolint:staticcheck
+				if err != nil {
+					return fmt.Errorf("checking if %q under %q should be excluded: %w", rel, contextDirectoryAbsolute, err)
+				}
+				if excluded && (!d.IsDir() || !includeDirectoryAnyway(rel, pm)) {
+					modified[filepath.Dir(p)] = struct{}{}
+					err = os.RemoveAll(p)
+					if err == nil {
+						logrus.Debugf("%s filtered out using %s", rel, ignoresFile)
+						logrus.Debugf("Skipping excluded path: %s", rel)
+						if d.IsDir() {
+							return fs.SkipDir
+						}
+					}
+					return err
+				}
+				return nil
+			}); err != nil {
+				return "", "", "", false, nil, fmt.Errorf("processing ignores for build context directory: %w", err)
+			}
+			for modifiedDirectory := range modified {
+				if ts, ok := dates[modifiedDirectory]; ok {
+					if err := unix.UtimesNano(modifiedDirectory, ts); err != nil {
+						return "", "", "", false, nil, fmt.Errorf("resetting datestamp on %q: %w", modifiedDirectory, err)
+					}
+				}
+			}
+		}
 		// going forward, pretend that the merged directory is the actual context directory
 		logrus.Debugf("mounted an overlay at %q over %q", contextDirMountSpec.Source, contextDirectoryAbsolute)
 		succeeded = true
@@ -97,7 +185,7 @@ func platformSetupContextDirectoryOverlay(store storage.Store, options *define.B
 			return "", "", "", false, nil, fmt.Errorf("creating a temporary directory under %s: %w", tmpDir, err)
 		}
 		// copy the contents of the default build context to the new location so that it can be written to more or less safely
-		excludes, _, err := parse.ContainerIgnoreFile(contextDirectoryAbsolute, options.IgnoreFile, nil)
+		excludes, _, err := parse.ContainerIgnoreFile(contextDirectoryAbsolute, options.IgnoreFile, containerFiles)
 		if err != nil {
 			return "", "", "", false, nil, fmt.Errorf("parsing ignore file under context directory %s: %w", contextDirectoryAbsolute, err)
 		}

--- a/imagebuildah/build_linux.go
+++ b/imagebuildah/build_linux.go
@@ -16,6 +16,7 @@ import (
 	"go.podman.io/buildah/define"
 	"go.podman.io/buildah/internal/tmpdir"
 	"go.podman.io/buildah/pkg/overlay"
+	"go.podman.io/buildah/pkg/parse"
 	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/idtools"
 )
@@ -96,9 +97,14 @@ func platformSetupContextDirectoryOverlay(store storage.Store, options *define.B
 			return "", "", "", false, nil, fmt.Errorf("creating a temporary directory under %s: %w", tmpDir, err)
 		}
 		// copy the contents of the default build context to the new location so that it can be written to more or less safely
+		excludes, _, err := parse.ContainerIgnoreFile(contextDirectoryAbsolute, options.IgnoreFile, nil)
+		if err != nil {
+			return "", "", "", false, nil, fmt.Errorf("parsing ignore file under context directory %s: %w", contextDirectoryAbsolute, err)
+		}
 		getOptions := copier.GetOptions{
 			ChownDirs:  &idtools.IDPair{UID: 0, GID: 0},
 			ChownFiles: &idtools.IDPair{UID: 0, GID: 0},
+			Excludes:   excludes,
 		}
 		var wg sync.WaitGroup
 		var putErr, getErr, labelErr error

--- a/imagebuildah/build_linux.go
+++ b/imagebuildah/build_linux.go
@@ -3,34 +3,42 @@ package imagebuildah
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
+	"sync"
 
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
+	"go.podman.io/buildah/copier"
 	"go.podman.io/buildah/define"
 	"go.podman.io/buildah/internal/tmpdir"
 	"go.podman.io/buildah/pkg/overlay"
 	"go.podman.io/storage"
-	"golang.org/x/sys/unix"
+	"go.podman.io/storage/pkg/idtools"
 )
 
-// platformSetupContextDirectoryOverlay() sets up an overlay _over_ the build
-// context directory, and sorts out labeling.  Returns the location which
-// should be used as the default build context; the process label and mount
-// label for the build, if any; a boolean value that indicates whether we did,
-// in fact, mount an overlay; and a cleanup function which should be called
-// when the location is no longer needed (on success). Returned errors should
-// be treated as fatal.
+// platformSetupContextDirectoryOverlay() either sets up an overlay _over_ the
+// build context directory, or creates a temporary copy of it, and sorts out
+// labeling.  Returns the location which should be used as the default build
+// context; the process label and mount label for the build, if any; a boolean
+// value that indicates whether the caller can write directly to the location;
+// and a cleanup function which should be called when the location is no longer
+// needed (on success). Returned errors should be treated as fatal.
 func platformSetupContextDirectoryOverlay(store storage.Store, options *define.BuildOptions) (string, string, string, bool, func(), error) {
 	var succeeded bool
-	var tmpDir, contentDir string
+	var tmpDir, tmpContextDir, contentDir string
 	cleanup := func() {
 		if contentDir != "" {
 			if err := overlay.CleanupContent(tmpDir); err != nil {
 				logrus.Debugf("cleaning up overlay scaffolding for build context directory: %v", err)
+			}
+		}
+		if tmpContextDir != "" {
+			if err := os.RemoveAll(tmpContextDir); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				logrus.Debugf("removing temporary directory tree %q: %v", tmpContextDir, err)
 			}
 		}
 		if tmpDir != "" {
@@ -49,38 +57,85 @@ func platformSetupContextDirectoryOverlay(store storage.Store, options *define.B
 	if err != nil {
 		return "", "", "", false, nil, fmt.Errorf("determining absolute path of %q: %w", options.ContextDirectory, err)
 	}
-	var st unix.Stat_t
-	if err := unix.Stat(contextDirectoryAbsolute, &st); err != nil {
-		return "", "", "", false, nil, fmt.Errorf("checking ownership of %q: %w", options.ContextDirectory, err)
-	}
 	// figure out the labeling situation
 	processLabel, mountLabel, err := label.InitLabels(options.CommonBuildOpts.LabelOpts)
 	if err != nil {
 		return "", "", "", false, nil, err
 	}
-	// create a temporary directory
+	// create a temporary directory for whatever we're doing
 	tmpDir, err = os.MkdirTemp(tmpdir.GetTempDir(), "buildah-context-")
 	if err != nil {
 		return "", "", "", false, nil, fmt.Errorf("creating temporary directory: %w", err)
 	}
-	// create the scaffolding for an overlay mount under it
-	contentDir, err = overlay.TempDir(tmpDir, 0, 0)
-	if err != nil {
-		return "", "", "", false, nil, fmt.Errorf("creating overlay scaffolding for build context directory: %w", err)
+	switch store.GraphDriverName() {
+	case "overlay":
+		// create the scaffolding for an overlay mount under it
+		contentDir, err = overlay.TempDir(tmpDir, 0, 0)
+		if err != nil {
+			return "", "", "", false, nil, fmt.Errorf("creating overlay scaffolding for build context directory: %w", err)
+		}
+		// mount an overlay that uses it as a lower
+		overlayOptions := overlay.Options{
+			GraphOpts:  slices.Clone(store.GraphOptions()),
+			ForceMount: true,
+			MountLabel: mountLabel,
+		}
+		targetDir := filepath.Join(contentDir, "target")
+		contextDirMountSpec, err := overlay.MountWithOptions(contentDir, contextDirectoryAbsolute, targetDir, &overlayOptions)
+		if err != nil {
+			return "", "", "", false, nil, fmt.Errorf("creating overlay scaffolding for build context directory: %w", err)
+		}
+		// going forward, pretend that the merged directory is the actual context directory
+		logrus.Debugf("mounted an overlay at %q over %q", contextDirMountSpec.Source, contextDirectoryAbsolute)
+		succeeded = true
+		return contextDirMountSpec.Source, processLabel, mountLabel, true, cleanup, nil
+	default:
+		// create a subdirectory under it
+		tmpContextDir = filepath.Join(tmpDir, "build-context")
+		if err := os.Mkdir(tmpContextDir, 0o755); err != nil {
+			return "", "", "", false, nil, fmt.Errorf("creating a temporary directory under %s: %w", tmpDir, err)
+		}
+		// copy the contents of the default build context to the new location so that it can be written to more or less safely
+		getOptions := copier.GetOptions{
+			ChownDirs:  &idtools.IDPair{UID: 0, GID: 0},
+			ChownFiles: &idtools.IDPair{UID: 0, GID: 0},
+		}
+		var wg sync.WaitGroup
+		var putErr, getErr, labelErr error
+		copyReader, copyWriter := io.Pipe()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			putErr = copier.Put(tmpContextDir, tmpContextDir, copier.PutOptions{}, copyReader)
+			copyReader.Close()
+			labelErr = label.Relabel(tmpContextDir, mountLabel, true)
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			getErr = copier.Get(contextDirectoryAbsolute, contextDirectoryAbsolute, getOptions, []string{"."}, copyWriter)
+			copyWriter.Close()
+		}()
+		wg.Wait()
+		var errs []error
+		if getErr != nil {
+			errs = append(errs, getErr)
+		}
+		if putErr != nil {
+			errs = append(errs, putErr)
+		}
+		if labelErr != nil {
+			errs = append(errs, labelErr)
+		}
+		if len(errs) > 0 {
+			grouped := errs[0]
+			if len(errs) > 1 {
+				grouped = errors.Join(errs...)
+			}
+			return "", "", "", false, nil, fmt.Errorf("creating copy of build context directory: %w", grouped)
+		}
+		logrus.Debugf("created a copy of %q at %q", contextDirectoryAbsolute, tmpContextDir)
+		succeeded = true
+		return tmpContextDir, processLabel, mountLabel, true, cleanup, nil
 	}
-	// mount an overlay that uses it as a lower
-	overlayOptions := overlay.Options{
-		GraphOpts:  slices.Clone(store.GraphOptions()),
-		ForceMount: true,
-		MountLabel: mountLabel,
-	}
-	targetDir := filepath.Join(contentDir, "target")
-	contextDirMountSpec, err := overlay.MountWithOptions(contentDir, contextDirectoryAbsolute, targetDir, &overlayOptions)
-	if err != nil {
-		return "", "", "", false, nil, fmt.Errorf("creating overlay scaffolding for build context directory: %w", err)
-	}
-	// going forward, pretend that the merged directory is the actual context directory
-	logrus.Debugf("mounted an overlay at %q over %q", contextDirMountSpec.Source, contextDirectoryAbsolute)
-	succeeded = true
-	return contextDirMountSpec.Source, processLabel, mountLabel, true, cleanup, nil
 }

--- a/imagebuildah/build_notlinux.go
+++ b/imagebuildah/build_notlinux.go
@@ -27,7 +27,7 @@ import (
 // indicates whether the caller can write directly to the location; and a
 // cleanup function which should be called when the location is no longer
 // needed (on success). Returned errors should be treated as fatal.
-func platformSetupContextDirectoryOverlay(store storage.Store, options *define.BuildOptions) (string, string, string, bool, func(), error) {
+func platformSetupContextDirectoryOverlay(store storage.Store, containerFiles []string, options *define.BuildOptions) (string, string, string, bool, func(), error) {
 	var succeeded bool
 	var tmpDir string
 	cleanup := func() {
@@ -58,7 +58,7 @@ func platformSetupContextDirectoryOverlay(store storage.Store, options *define.B
 		return "", "", "", false, nil, fmt.Errorf("creating a temporary directory under %s: %w", tmpDir, err)
 	}
 	// copy the contents of the default build context to the new location so that it can be written to more or less safely
-	excludes, _, err := parse.ContainerIgnoreFile(contextDirectoryAbsolute, options.IgnoreFile, nil)
+	excludes, _, err := parse.ContainerIgnoreFile(contextDirectoryAbsolute, options.IgnoreFile, containerFiles)
 	if err != nil {
 		return "", "", "", false, nil, fmt.Errorf("parsing ignore file under context directory %s: %w", contextDirectoryAbsolute, err)
 	}

--- a/imagebuildah/build_notlinux.go
+++ b/imagebuildah/build_notlinux.go
@@ -15,6 +15,7 @@ import (
 	"go.podman.io/buildah/copier"
 	"go.podman.io/buildah/define"
 	"go.podman.io/buildah/internal/tmpdir"
+	"go.podman.io/buildah/pkg/parse"
 	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/idtools"
 )
@@ -57,9 +58,14 @@ func platformSetupContextDirectoryOverlay(store storage.Store, options *define.B
 		return "", "", "", false, nil, fmt.Errorf("creating a temporary directory under %s: %w", tmpDir, err)
 	}
 	// copy the contents of the default build context to the new location so that it can be written to more or less safely
+	excludes, _, err := parse.ContainerIgnoreFile(contextDirectoryAbsolute, options.IgnoreFile, nil)
+	if err != nil {
+		return "", "", "", false, nil, fmt.Errorf("parsing ignore file under context directory %s: %w", contextDirectoryAbsolute, err)
+	}
 	getOptions := copier.GetOptions{
 		ChownDirs:  &idtools.IDPair{UID: 0, GID: 0},
 		ChownFiles: &idtools.IDPair{UID: 0, GID: 0},
+		Excludes:   excludes,
 	}
 	var wg sync.WaitGroup
 	var putErr, getErr error

--- a/imagebuildah/build_notlinux.go
+++ b/imagebuildah/build_notlinux.go
@@ -3,18 +3,95 @@
 package imagebuildah
 
 import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"go.podman.io/buildah/copier"
 	"go.podman.io/buildah/define"
+	"go.podman.io/buildah/internal/tmpdir"
 	"go.podman.io/storage"
+	"go.podman.io/storage/pkg/idtools"
 )
 
-// platformSetupContextDirectoryOverlay() should set up an overlay _over_ the
-// build context directory, and sort out labeling.  Should return the location
-// which should be used as the default build context; the process label and
-// mount label for the build, if any; a boolean value that indicates whether we
-// did, in fact, mount an overlay; and a cleanup function which should be
-// called when the location is no longer needed (on success).  Returned errors
-// should be treated as fatal.
-// TODO: currenty a no-op on this platform.
+// platformSetupContextDirectoryOverlay() either creates a temporary copy of
+// the default build context directory.  Returns the location which should be
+// used as the default build context; an empty process label and mount label
+// for the build that makes more sense elsewhere; a boolean value that
+// indicates whether the caller can write directly to the location; and a
+// cleanup function which should be called when the location is no longer
+// needed (on success). Returned errors should be treated as fatal.
 func platformSetupContextDirectoryOverlay(store storage.Store, options *define.BuildOptions) (string, string, string, bool, func(), error) {
-	return options.ContextDirectory, "", "", false, func() {}, nil
+	var succeeded bool
+	var tmpDir string
+	cleanup := func() {
+		if tmpDir != "" {
+			if err := os.Remove(tmpDir); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				logrus.Debugf("removing should-be-empty temporary directory %q: %v", tmpDir, err)
+			}
+		}
+	}
+	defer func() {
+		if !succeeded {
+			cleanup()
+		}
+	}()
+	// double-check that the context directory location is an absolute path
+	contextDirectoryAbsolute, err := filepath.Abs(options.ContextDirectory)
+	if err != nil {
+		return "", "", "", false, nil, fmt.Errorf("determining absolute path of %q: %w", options.ContextDirectory, err)
+	}
+	// create a temporary parent directory for the copy of the build context
+	tmpDir, err = os.MkdirTemp(tmpdir.GetTempDir(), "buildah-context-")
+	if err != nil {
+		return "", "", "", false, nil, fmt.Errorf("creating temporary directory: %w", err)
+	}
+	// create a subdirectory under it
+	tmpContextDir := filepath.Join(tmpDir, "build-context")
+	if err := os.Mkdir(tmpContextDir, 0o755); err != nil {
+		return "", "", "", false, nil, fmt.Errorf("creating a temporary directory under %s: %w", tmpDir, err)
+	}
+	// copy the contents of the default build context to the new location so that it can be written to more or less safely
+	getOptions := copier.GetOptions{
+		ChownDirs:  &idtools.IDPair{UID: 0, GID: 0},
+		ChownFiles: &idtools.IDPair{UID: 0, GID: 0},
+	}
+	var wg sync.WaitGroup
+	var putErr, getErr error
+	copyReader, copyWriter := io.Pipe()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		putErr = copier.Put(tmpContextDir, tmpContextDir, copier.PutOptions{}, copyReader)
+		copyReader.Close()
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		getErr = copier.Get(contextDirectoryAbsolute, contextDirectoryAbsolute, getOptions, []string{"."}, copyWriter)
+		copyWriter.Close()
+	}()
+	wg.Wait()
+	var errs []error
+	if getErr != nil {
+		errs = append(errs, getErr)
+	}
+	if putErr != nil {
+		errs = append(errs, putErr)
+	}
+	if len(errs) > 0 {
+		grouped := errs[0]
+		if len(errs) > 1 {
+			grouped = errors.Join(errs...)
+		}
+		return "", "", "", false, nil, fmt.Errorf("creating copy of build context directory: %w", grouped)
+	}
+	logrus.Debugf("created a copy of %q at %q", contextDirectoryAbsolute, tmpContextDir)
+	succeeded = true
+	return tmpContextDir, "", "", true, cleanup, nil
 }

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -161,7 +161,7 @@ type executor struct {
 	imageInfoLock                           sync.Mutex
 	imageInfoCache                          map[string]imageTypeAndHistoryAndDiffIDs
 	fromOverride                            string
-	additionalBuildContexts                 map[string]*define.AdditionalBuildContext
+	additionalBuildContexts                 map[string]*additionalBuildContext
 	manifest                                string
 	secrets                                 map[string]define.Secret
 	sshsources                              map[string]*sshagent.Source
@@ -187,6 +187,11 @@ type executor struct {
 	rewriteTimestamp                        bool
 	createdAnnotation                       types.OptionalBool
 	metadataFile                            string
+}
+
+type additionalBuildContext struct {
+	define.AdditionalBuildContext
+	cleanupDirectory string
 }
 
 type imageTypeAndHistoryAndDiffIDs struct {
@@ -266,6 +271,16 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 	buildOutputs := slices.Clone(options.BuildOutputs)
 	if options.BuildOutput != "" { //nolint:staticcheck
 		buildOutputs = append(buildOutputs, options.BuildOutput) //nolint:staticcheck
+	}
+
+	var additionalBuildContexts map[string]*additionalBuildContext
+	if len(options.AdditionalBuildContexts) > 0 {
+		additionalBuildContexts = make(map[string]*additionalBuildContext)
+		for k, abc := range options.AdditionalBuildContexts {
+			additionalBuildContexts[k] = &additionalBuildContext{
+				AdditionalBuildContext: *abc,
+			}
+		}
 	}
 
 	exec := executor{
@@ -358,7 +373,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		rusageLogFile:                           rusageLogFile,
 		imageInfoCache:                          make(map[string]imageTypeAndHistoryAndDiffIDs),
 		fromOverride:                            options.From,
-		additionalBuildContexts:                 options.AdditionalBuildContexts,
+		additionalBuildContexts:                 additionalBuildContexts,
 		manifest:                                options.Manifest,
 		secrets:                                 secrets,
 		sshsources:                              sshsources,
@@ -864,6 +879,16 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 				closer.Close()
 			}
 		}
+
+		for _, abc := range b.additionalBuildContexts {
+			if abc.cleanupDirectory != "" {
+				if err := os.RemoveAll(abc.cleanupDirectory); err != nil {
+					logrus.Debugf("cleaning up directory %q: %v", abc.cleanupDirectory, err)
+				}
+				abc.cleanupDirectory = ""
+			}
+		}
+
 		return lastErr
 	}
 

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -34,6 +34,7 @@ import (
 	"go.podman.io/buildah/internal/tmpdir"
 	"go.podman.io/buildah/internal/urlsource"
 	internalUtil "go.podman.io/buildah/internal/util"
+	"go.podman.io/buildah/pkg/overlay"
 	"go.podman.io/buildah/pkg/parse"
 	"go.podman.io/buildah/pkg/rusage"
 	"go.podman.io/buildah/pkg/sourcepolicy"
@@ -321,12 +322,24 @@ func (s *stageExecutor) volumeCacheRestoreVFS() (err error) {
 // using it as a lower for an overlay mount in the same location, and then
 // discarding the upper.
 func (s *stageExecutor) volumeCacheSaveOverlay() (mounts []specs.Mount, err error) {
+	containerDir, err := s.executor.store.ContainerDirectory(s.builder.ContainerID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to locate temporary directory for container")
+	}
+	volumeCacheDir := filepath.Join(containerDir, "volume-cache")
+	options := overlay.Options{
+		MountLabel: s.builder.MountLabel,
+		ForceMount: true,
+	}
 	for cachedPath := range s.volumeCache {
 		volumePath := filepath.Join(s.mountPoint, cachedPath)
-		mount := specs.Mount{
-			Source:      volumePath,
-			Destination: cachedPath,
-			Options:     []string{"O", "private"},
+		tmpdir, err := overlay.TempDir(volumeCacheDir, 0, 0)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create temporary directory for cache for volumes")
+		}
+		mount, err := overlay.MountWithOptions(tmpdir, volumePath, cachedPath, &options)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create temporary directory for cache for volumes")
 		}
 		mounts = append(mounts, mount)
 	}
@@ -335,7 +348,12 @@ func (s *stageExecutor) volumeCacheSaveOverlay() (mounts []specs.Mount, err erro
 
 // Reset the contents of each of the executor's list of volumes.
 func (s *stageExecutor) volumeCacheRestoreOverlay() error {
-	return nil
+	containerDir, err := s.executor.store.ContainerDirectory(s.builder.ContainerID)
+	if err != nil {
+		return fmt.Errorf("unable to locate temporary directory for container")
+	}
+	volumeCacheDir := filepath.Join(containerDir, "volume-cache")
+	return overlay.CleanupContent(volumeCacheDir)
 }
 
 // Save the contents of each of the executor's list of volumes for which we

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -876,6 +876,7 @@ func (s *stageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 		Args:                 s.executor.runtimeArgs,
 		Cmd:                  config.Cmd,
 		ContextDir:           s.executor.contextDir,
+		ContextDirExcludes:   s.executor.excludes,
 		ConfigureNetwork:     s.executor.configureNetwork,
 		Entrypoint:           config.Entrypoint,
 		Env:                  config.Env,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -484,7 +484,7 @@ func (s *stageExecutor) performCopy(excludes []string, copies ...imagebuilder.Co
 			if fromErr != nil {
 				return fmt.Errorf("unable to resolve argument %q: %w", copy.From, fromErr)
 			}
-			var additionalBuildContext *define.AdditionalBuildContext
+			var additionalBuildContext *additionalBuildContext
 			if foundContext, ok := s.executor.additionalBuildContexts[from]; ok {
 				additionalBuildContext = foundContext
 			} else {
@@ -506,7 +506,7 @@ func (s *stageExecutor) performCopy(excludes []string, copies ...imagebuilder.Co
 					if additionalBuildContext.IsURL {
 						// Check if following buildContext was already
 						// downloaded before in any other RUN step. If not
-						// download it and populate DownloadCache field for
+						// download it and populate DownloadedCache field for
 						// future RUN steps.
 						if additionalBuildContext.DownloadedCache == "" {
 							// additional context contains a tar file
@@ -521,6 +521,7 @@ func (s *stageExecutor) performCopy(excludes []string, copies ...imagebuilder.Co
 							contextDir = filepath.Join(path, subdir)
 							// populate cache for next RUN step
 							additionalBuildContext.DownloadedCache = contextDir
+							additionalBuildContext.cleanupDirectory = path
 						} else {
 							contextDir = additionalBuildContext.DownloadedCache
 						}
@@ -727,7 +728,7 @@ func (s *stageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 						if additionalBuildContext.IsURL {
 							// Check if following buildContext was already
 							// downloaded before in any other RUN step. If not
-							// download it and populate DownloadCache field for
+							// download it and populate DownloadedCache field for
 							// future RUN steps.
 							if additionalBuildContext.DownloadedCache == "" {
 								// additional context contains a tar file
@@ -742,6 +743,7 @@ func (s *stageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 								mountPoint = filepath.Join(path, subdir)
 								// populate cache for next RUN step
 								additionalBuildContext.DownloadedCache = mountPoint
+								additionalBuildContext.cleanupDirectory = path
 							} else {
 								mountPoint = additionalBuildContext.DownloadedCache
 							}

--- a/internal/volumes/volumes.go
+++ b/internal/volumes/volumes.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -77,6 +79,30 @@ func mountIsReadWrite(m specs.Mount) bool {
 	return rw
 }
 
+// convertToOverlayOrMakeTempCopy accepts a specs.Mount that specifies a bind
+// mount, and returns either a replacement for it that instead mounts an
+// overlay at the desired location, using the original source location as a
+// "lower", or a temporary copy of the original source location, so that writes
+// to it will succeed, but not affect the original location.
+func convertToOverlayOrTempCopy(m specs.Mount, store storage.Store, mountLabel, tmpDir string, uid, gid int) (newMount specs.Mount, overlayDir string, err error) {
+	switch store.GraphDriverName() {
+	case "overlay":
+		if newMount, overlayDir, err = convertToOverlay(m, store, mountLabel, tmpDir, uid, gid); err != nil {
+			return newMount, "", err
+		}
+	default:
+		if newMount, overlayDir, err = makeTempCopy(m, tmpDir, uid, gid); err != nil {
+			return newMount, "", err
+		}
+	}
+	return newMount, overlayDir, nil
+}
+
+// convertToOverlay accepts a specs.Mount that specifies a bind mount, and
+// returns a replacement for it that instead mounts an overlay at the desired
+// location, using the original source location as a "lower", so that writes to
+// it will be redirected to it to a temporary location which can later be
+// discarded, leaving the original location unmodified.
 func convertToOverlay(m specs.Mount, store storage.Store, mountLabel, tmpDir string, uid, gid int) (specs.Mount, string, error) {
 	overlayDir, err := overlay.TempDir(tmpDir, uid, gid)
 	if err != nil {
@@ -93,7 +119,7 @@ func convertToOverlay(m specs.Mount, store storage.Store, mountLabel, tmpDir str
 		// do the normal thing of mounting this directory as a lower with a temporary upper
 		mountThisInstead, err = overlay.MountWithOptions(overlayDir, m.Source, m.Destination, &options)
 		if err != nil {
-			return specs.Mount{}, "", fmt.Errorf("setting up overlay of %q: %w", m.Source, err)
+			return specs.Mount{}, "", fmt.Errorf("setting up overlay of directory %q: %w", m.Source, err)
 		}
 	} else {
 		// mount the parent directory as the lower with a temporary upper, and return a
@@ -103,7 +129,7 @@ func convertToOverlay(m specs.Mount, store storage.Store, mountLabel, tmpDir str
 		destination := m.Destination
 		mountedOverlay, err := overlay.MountWithOptions(overlayDir, sourceDir, destination, &options)
 		if err != nil {
-			return specs.Mount{}, "", fmt.Errorf("setting up overlay of %q: %w", sourceDir, err)
+			return specs.Mount{}, "", fmt.Errorf("setting up overlay of directory %q containing %q: %w", sourceDir, sourceBase, err)
 		}
 		if mountedOverlay.Type != define.TypeBind {
 			if err2 := overlay.RemoveTemp(overlayDir); err2 != nil {
@@ -115,6 +141,91 @@ func convertToOverlay(m specs.Mount, store storage.Store, mountLabel, tmpDir str
 		mountThisInstead.Source = filepath.Join(mountedOverlay.Source, sourceBase)
 		mountThisInstead.Destination = destination
 	}
+	return mountThisInstead, overlayDir, nil
+}
+
+// makeTempCopy accepts a specs.Mount that specifies a bind mount, and returns
+// a replacement for it that instead bind mounts a temporary copy of the
+// original source location, so that writes to it will succeed without actually
+// modifying the original copy.
+func makeTempCopy(m specs.Mount, tmpDir string, uid, gid int) (specs.Mount, string, error) {
+	succeeded := false
+	overlayDir, err := overlay.TempDir(tmpDir, uid, gid)
+	if err != nil {
+		return specs.Mount{}, "", fmt.Errorf("setting up temporary copy of %q: %w", m.Destination, err)
+	}
+	defer func() {
+		if !succeeded {
+			if err := overlay.RemoveTemp(overlayDir); err != nil {
+				logrus.Warnf("%v", err)
+			}
+		}
+	}()
+	mergedDir := filepath.Join(overlayDir, "merge")
+	fileInfo, err := os.Stat(m.Source)
+	if err != nil {
+		return specs.Mount{}, "", fmt.Errorf("setting up temporary copy of %q: %w", m.Source, err)
+	}
+	copiedDir := filepath.Join(mergedDir, "copied")
+	if fileInfo.IsDir() {
+		if err = os.Mkdir(copiedDir, fileInfo.Mode()); err != nil {
+			return specs.Mount{}, "", fmt.Errorf("creating top-level directory for copy of %q: %w", m.Source, err)
+		}
+	} else {
+		if err = os.Mkdir(copiedDir, 0o755); err != nil {
+			return specs.Mount{}, "", fmt.Errorf("creating parent directory for copy of %q: %w", m.Source, err)
+		}
+	}
+	if err = os.Chown(copiedDir, uid, gid); err != nil {
+		return specs.Mount{}, "", fmt.Errorf("setting ownership of %q: %w", m.Source, err)
+	}
+	forceOwner := idtools.IDPair{UID: uid, GID: gid}
+	getOptions := copier.GetOptions{
+		ChownDirs:  &forceOwner,
+		ChownFiles: &forceOwner,
+	}
+	var wg sync.WaitGroup
+	var putErr, getErr error
+	copyReader, copyWriter := io.Pipe()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		putErr = copier.Put(copiedDir, copiedDir, copier.PutOptions{}, copyReader)
+		copyReader.Close()
+	}()
+	mountThisInstead := m
+	mountThisInstead.Options = append(slices.Clone(define.BindOptions), "z")
+	wg.Add(1)
+	if fileInfo.IsDir() {
+		// copy the directory to the temporary directory
+		go func() {
+			defer wg.Done()
+			getErr = copier.Get(m.Source, m.Source, getOptions, []string{"."}, copyWriter)
+			copyWriter.Close()
+		}()
+		// point the if-everything-works mount at the temporary driectory
+		mountThisInstead.Type = define.TypeBind
+		mountThisInstead.Source = copiedDir
+		mountThisInstead.Destination = m.Destination
+	} else {
+		// copy just the one thing to the temporary directory
+		sourceDir := filepath.Dir(m.Source)
+		sourceBase := filepath.Base(m.Source)
+		go func() {
+			defer wg.Done()
+			getErr = copier.Get(sourceDir, sourceDir, getOptions, []string{sourceBase}, copyWriter)
+			copyWriter.Close()
+		}()
+		// point the if-everything-works mount at the new copy of the item
+		mountThisInstead.Type = define.TypeBind
+		mountThisInstead.Source = filepath.Join(copiedDir, sourceBase)
+		mountThisInstead.Destination = m.Destination
+	}
+	wg.Wait()
+	if getErr != nil || putErr != nil {
+		return specs.Mount{}, "", fmt.Errorf("creating a temporary copy: %w", errors.Join(getErr, putErr))
+	}
+	succeeded = true
 	return mountThisInstead, overlayDir, nil
 }
 
@@ -339,7 +450,8 @@ func GetBindMount(sys *types.SystemContext, args []string, contextDir string, st
 
 	overlayDir := ""
 	if !skipOverlay && (mountedImage != "" || mountIsReadWrite(newMount)) {
-		if newMount, overlayDir, err = convertToOverlay(newMount, store, mountLabel, tmpDir, 0, 0); err != nil {
+		newMount, overlayDir, err = convertToOverlayOrTempCopy(newMount, store, mountLabel, tmpDir, 0, 0)
+		if err != nil {
 			return newMount, "", "", "", err
 		}
 	}
@@ -672,7 +784,9 @@ func GetCacheMount(sys *types.SystemContext, args []string, store storage.Store,
 
 	overlayDir := ""
 	if needToOverlay {
-		if newMount, overlayDir, err = convertToOverlay(newMount, store, mountLabel, tmpDir, 0, 0); err != nil {
+		var err error
+		newMount, overlayDir, err = convertToOverlayOrTempCopy(newMount, store, mountLabel, tmpDir, 0, 0)
+		if err != nil {
 			return newMount, "", "", "", nil, err
 		}
 	}

--- a/internal/volumes/volumes_test.go
+++ b/internal/volumes/volumes_test.go
@@ -33,13 +33,13 @@ func TestGetMount(t *testing.T) {
 
 	t.Run("GetBindMount", func(t *testing.T) {
 		for _, argNeeder := range []string{"from", "bind-propagation", "src", "source", "target", "dst", "destination", "relabel"} {
-			_, _, _, _, err := GetBindMount(sys, []string{argNeeder}, tempDir, store, "", nil, tempDir, tempDir)
+			_, _, _, _, err := GetBindMount(sys, []string{argNeeder}, tempDir, store, "", nil, tempDir, tempDir, nil)
 			assert.ErrorIsf(t, err, errBadOptionArg, "option %q was supposed to have an arg, but wasn't flagged when it didn't have one", argNeeder)
-			_, _, _, _, err = GetBindMount(sys, []string{argNeeder + "="}, tempDir, store, "", nil, tempDir, tempDir)
+			_, _, _, _, err = GetBindMount(sys, []string{argNeeder + "="}, tempDir, store, "", nil, tempDir, tempDir, nil)
 			assert.ErrorIsf(t, err, errBadOptionArg, "option %q was supposed to have an arg, but wasn't flagged when it didn't have one", argNeeder)
 		}
 		for _, argHater := range []string{"bind-nonrecursive", "nodev", "noexec", "nosuid", "ro", "readonly", "rw", "readwrite", "shared", "rshared", "private", "rprivate", "slave", "rslave", "Z", "z", "U", "no-dereference"} {
-			_, _, _, _, err := GetBindMount(sys, []string{argHater + "=nonce"}, tempDir, store, "", nil, tempDir, tempDir)
+			_, _, _, _, err := GetBindMount(sys, []string{argHater + "=nonce"}, tempDir, store, "", nil, tempDir, tempDir, nil)
 			assert.ErrorIsf(t, err, errBadOptionNoArg, "option %q is not supposed to have an arg, but wasn't flagged when it tried to supply one", argHater)
 		}
 	})

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -151,7 +151,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		}
 	} else {
 		// The context directory could be a URL.  Try to handle that.
-		tempDir, subDir, err := define.TempDirForURL("", "buildah", cliArgs[0])
+		tempDir, subDir, err := define.TempDirForURL("", "buildah-context-", cliArgs[0])
 		if err != nil {
 			return options, nil, nil, fmt.Errorf("prepping temporary context directory: %w", err)
 		}

--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -57,8 +57,8 @@ type Options struct {
 
 // TempDir generates a uniquely-named directory under ${containerDir}/overlay
 // which can be used as a parent directory for the upper and working
-// directories for an overlay mount, creates "upper" and "work" directories
-// beneath it, and then returns the path of the new directory.
+// directories for an overlay mount, creates "upper", "work", and "merge"
+// directories beneath it, and then returns the path of the new directory.
 func TempDir(containerDir string, rootUID, rootGID int) (string, error) {
 	contentDir := filepath.Join(containerDir, "overlay")
 	if err := idtools.MkdirAllAndChown(contentDir, 0o700, idtools.IDPair{UID: rootUID, GID: rootGID}); err != nil {
@@ -126,12 +126,10 @@ func findMountProgram(graphOptions []string) string {
 	}
 
 	for _, i := range graphOptions {
-		s := strings.SplitN(i, "=", 2)
-		if len(s) != 2 {
+		key, val, ok := strings.Cut(i, "=")
+		if !ok {
 			continue
 		}
-		key := s[0]
-		val := s[1]
 		if _, has := mountMap[key]; has {
 			return val
 		}
@@ -146,7 +144,7 @@ func mountWithMountProgram(mountProgram, overlayOptions, mergeDir string) error 
 	cmd := exec.Command(mountProgram, "-o", overlayOptions, mergeDir)
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("exec %s: %w", mountProgram, err)
+		return fmt.Errorf("exec %s -o %q %q: %w", mountProgram, overlayOptions, mergeDir, err)
 	}
 	return nil
 }

--- a/run.go
+++ b/run.go
@@ -115,6 +115,8 @@ type RunOptions struct {
 	WorkingDir string
 	// ContextDir is used as the root directory for the source location for mounts that are of type "bind".
 	ContextDir string
+	// ContextDirExcludes is the set of items to ignore if we need to copy the contents of ContextDir somewhere else.
+	ContextDirExcludes []string
 	// Shell is default shell to run in a container.
 	Shell string
 	// Cmd is an override for the configured default command.

--- a/run_common.go
+++ b/run_common.go
@@ -1320,7 +1320,7 @@ func init() {
 // If this succeeds, after the command which uses the spec finishes running,
 // the caller must call b.cleanupRunMounts() on the returned runMountArtifacts
 // structure.
-func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath string, optionMounts []specs.Mount, bindFiles map[string]string, builtinVolumes []string, compatBuiltinVolumes types.OptionalBool, volumeMounts []string, runFileMounts []string, runMountInfo runMountInfo) (*runMountArtifacts, error) {
+func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath string, optionMounts []specs.Mount, bindFiles map[string]string, builtinVolumes []string, compatBuiltinVolumes types.OptionalBool, volumeMounts []string, runFileMounts []string, runMountInfo runMountInfo, excludes []string) (*runMountArtifacts, error) {
 	// Start building a new list of mounts.
 	var mounts []specs.Mount
 	haveMount := func(destination string) bool {
@@ -1378,7 +1378,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 		processGID: int(processGID),
 	}
 	// Get the list of mounts that are just for this Run() call.
-	runMounts, mountArtifacts, err := b.runSetupRunMounts(bundlePath, runFileMounts, runMountInfo, idMaps)
+	runMounts, mountArtifacts, err := b.runSetupRunMounts(bundlePath, runFileMounts, runMountInfo, idMaps, excludes)
 	if err != nil {
 		return nil, err
 	}
@@ -1506,7 +1506,7 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, builtin
 // If this function succeeds, the caller must free the returned
 // runMountArtifacts by calling b.cleanupRunMounts() after the command being
 // executed with those mounts has finished.
-func (b *Builder) runSetupRunMounts(bundlePath string, mounts []string, sources runMountInfo, idMaps IDMaps) ([]specs.Mount, *runMountArtifacts, error) {
+func (b *Builder) runSetupRunMounts(bundlePath string, mounts []string, sources runMountInfo, idMaps IDMaps, excludes []string) ([]specs.Mount, *runMountArtifacts, error) {
 	tmpFiles := make([]string, 0, len(mounts))
 	mountImages := make([]string, 0, len(mounts))
 	intermediateMounts := make([]string, 0, len(mounts))
@@ -1601,7 +1601,7 @@ func (b *Builder) runSetupRunMounts(bundlePath string, mounts []string, sources 
 					return nil, nil, err
 				}
 			}
-			mountSpec, image, intermediateMount, overlayDir, err := b.getBindMount(tokens, sources.SystemContext, sources.ContextDir, sources.StageMountPoints, idMaps, sources.WorkDir, bundleMountsDir)
+			mountSpec, image, intermediateMount, overlayDir, err := b.getBindMount(tokens, sources.SystemContext, sources.ContextDir, sources.StageMountPoints, idMaps, sources.WorkDir, bundleMountsDir, excludes)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1661,12 +1661,12 @@ func (b *Builder) runSetupRunMounts(bundlePath string, mounts []string, sources 
 	return finalMounts, artifacts, nil
 }
 
-func (b *Builder) getBindMount(tokens []string, sys *types.SystemContext, contextDir string, stageMountPoints map[string]internal.StageMountDetails, idMaps IDMaps, workDir, tmpDir string) (*specs.Mount, string, string, string, error) {
+func (b *Builder) getBindMount(tokens []string, sys *types.SystemContext, contextDir string, stageMountPoints map[string]internal.StageMountDetails, idMaps IDMaps, workDir, tmpDir string, excludes []string) (*specs.Mount, string, string, string, error) {
 	if contextDir == "" {
 		return nil, "", "", "", errors.New("context directory for current run invocation is not configured")
 	}
 	var optionMounts []specs.Mount
-	optionMount, image, intermediateMount, overlayMount, err := volumes.GetBindMount(sys, tokens, contextDir, b.store, b.MountLabel, stageMountPoints, workDir, tmpDir)
+	optionMount, image, intermediateMount, overlayMount, err := volumes.GetBindMount(sys, tokens, contextDir, b.store, b.MountLabel, stageMountPoints, workDir, tmpDir, excludes)
 	if err != nil {
 		return nil, "", "", "", err
 	}

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -272,7 +272,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		SystemContext:    options.SystemContext,
 	}
 
-	runArtifacts, err = b.setupMounts(mountPoint, spec, path, options.Mounts, bindFiles, volumes, options.CompatBuiltinVolumes, b.CommonBuildOpts.Volumes, options.RunMounts, runMountInfo)
+	runArtifacts, err = b.setupMounts(mountPoint, spec, path, options.Mounts, bindFiles, volumes, options.CompatBuiltinVolumes, b.CommonBuildOpts.Volumes, options.RunMounts, runMountInfo, options.ContextDirExcludes)
 	if err != nil {
 		return fmt.Errorf("resolving mountpoints for container %q: %w", b.ContainerID, err)
 	}

--- a/run_linux.go
+++ b/run_linux.go
@@ -1164,6 +1164,8 @@ func (b *Builder) runSetupVolumeMounts(mountLabel string, volumeMounts []string,
 				UpperDirOptionFragment: upperDir,
 				WorkDirOptionFragment:  workDir,
 				GraphOpts:              slices.Clone(b.store.GraphOptions()),
+				ForceMount:             true,
+				MountLabel:             b.MountLabel,
 			}
 
 			overlayMount, err := overlay.MountWithOptions(contentDir, host, container, &overlayOpts)

--- a/run_linux.go
+++ b/run_linux.go
@@ -507,7 +507,7 @@ rootless=%d
 		SystemContext:    options.SystemContext,
 	}
 
-	runArtifacts, err = b.setupMounts(mountPoint, spec, path, options.Mounts, bindFiles, volumes, options.CompatBuiltinVolumes, b.CommonBuildOpts.Volumes, options.RunMounts, runMountInfo)
+	runArtifacts, err = b.setupMounts(mountPoint, spec, path, options.Mounts, bindFiles, volumes, options.CompatBuiltinVolumes, b.CommonBuildOpts.Volumes, options.RunMounts, runMountInfo, options.ContextDirExcludes)
 	if err != nil {
 		return fmt.Errorf("resolving mountpoints for container %q: %w", b.ContainerID, err)
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1018,16 +1018,22 @@ symlink(subdir)"
 
 @test "bud with .dockerignore #2" {
   _prefetch busybox
-  run_buildah 125 build -t testbud3 $WITH_POLICY_JSON $BUDFILES/dockerignore3
+  run_buildah 125 build --debug -t testbud3 $WITH_POLICY_JSON $BUDFILES/dockerignore3
   expect_output --substring 'building.*"COPY test1.txt /upload/test1.txt".*no such file or directory'
-  expect_output --substring 'filtered out using /[^ ]*/.dockerignore'
+  expect_output --substring 'Skipping excluded path: test1.txt'
+  if test "$STORAGE_DRIVER" = overlay ; then
+    expect_output --substring 'filtered out using /[^ ]*/.dockerignore'
+  fi
 }
 
 @test "bud with .dockerignore #4" {
   _prefetch busybox
-  run_buildah 125 build -t testbud3 $WITH_POLICY_JSON -f Dockerfile.test $BUDFILES/dockerignore4
+  run_buildah 125 build --debug -t testbud3 $WITH_POLICY_JSON -f Dockerfile.test $BUDFILES/dockerignore4
   expect_output --substring 'building.*"COPY test1.txt /upload/test1.txt".*no such file or directory'
-  expect_output --substring '1 filtered out using /[^ ]*/Dockerfile.test.dockerignore'
+  expect_output --substring 'Skipping excluded path: test1.txt'
+  if test "$STORAGE_DRIVER" = overlay ; then
+    expect_output --substring 'filtered out using /[^ ]*/Dockerfile.test.dockerignore'
+  fi
 }
 
 @test "bud with .dockerignore #6" {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3500,7 +3500,8 @@ function validate_instance_compression {
   mkdir -p "${tmpdir}"
   TMPDIR="${tmpdir}" run_buildah build $WITH_POLICY_JSON -t ${target} "${gitrepo}"
   run_buildah from "${target}"
-  run find "${tmpdir}" -type d -print
+  # make sure we didn't litter leftover temporary build context directories
+  run find "${tmpdir}" -print
   echo "$output"
   test "${#lines[*]}" -le 2
 }

--- a/tests/bud/buildkit-mount/Containerfile5
+++ b/tests/bud/buildkit-mount/Containerfile5
@@ -3,3 +3,4 @@ ARG INPUTPATH_1=subdir
 RUN mkdir /test
 # use option z if selinux is enabled
 RUN --mount=type=bind,source=${INPUTPATH_1:?}/,target=/test,z cat /test/input_file
+RUN --mount=type=bind,source=${INPUTPATH_1:?}/,target=/test,z --mount=type=bind,source=${INPUTPATH_1:?}/,target=/test2,rw,z cmp /test/input_file /test2/input_file

--- a/tests/overlay.bats
+++ b/tests/overlay.bats
@@ -74,6 +74,13 @@ load helpers
   mkdir ${TEST_SCRATCH_DIR}/a:lower
   touch ${TEST_SCRATCH_DIR}/a:lower/foo
 
+  if test $(stat -f -c %T ${TEST_SCRATCH_DIR}/a:lower) = overlayfs; then
+    # we'll try to use fuse-overlayfs, which at least through 1.13
+    # can't accept ":" in layer locations, escaped or not, so bail
+    # now instead of breaking the whole thing
+    skip "unable to test bind from an overlay location that includes colon characters"
+  fi
+
   # This should succeed.
   # Add double backslash, because shell will escape.
   run_buildah from --quiet -v ${TEST_SCRATCH_DIR}/a\\:lower:/a\\:lower:O --quiet $WITH_POLICY_JSON $image

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -353,15 +353,6 @@ function configure_and_check_user() {
 @test "run overlay --volume with custom upper and workdir" {
 	skip_if_no_runtime
 
-	zflag=
-	if which selinuxenabled > /dev/null 2> /dev/null ; then
-		if selinuxenabled ; then
-			zflag=z
-		fi
-	fi
-
-	find_oci_runtime
-
 	${OCI} --version
 	_prefetch alpine
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
@@ -370,16 +361,16 @@ function configure_and_check_user() {
 	mkdir -p ${TEST_SCRATCH_DIR}/workdir
 	mkdir -p ${TEST_SCRATCH_DIR}/lower
 
-	echo 'hello' >> ${TEST_SCRATCH_DIR}/lower/hello
+	echo 'hello' > ${TEST_SCRATCH_DIR}/lower/hello
 
 	# As a baseline, this should succeed.
-	run_buildah run -v ${TEST_SCRATCH_DIR}/lower:/test:O,upperdir=${TEST_SCRATCH_DIR}/upperdir,workdir=${TEST_SCRATCH_DIR}/workdir${zflag:+:${zflag}}  $cid cat /test/hello
+	run_buildah run -v ${TEST_SCRATCH_DIR}/lower:/test:O,upperdir=${TEST_SCRATCH_DIR}/upperdir,workdir=${TEST_SCRATCH_DIR}/workdir $cid cat /test/hello
 	expect_output "hello"
-	run_buildah run -v ${TEST_SCRATCH_DIR}/lower:/test:O,upperdir=${TEST_SCRATCH_DIR}/upperdir,workdir=${TEST_SCRATCH_DIR}/workdir${zflag:+:${zflag}}  $cid sh -c 'echo "world" > /test/world'
+	run_buildah run -v ${TEST_SCRATCH_DIR}/lower:/test:O,upperdir=${TEST_SCRATCH_DIR}/upperdir,workdir=${TEST_SCRATCH_DIR}/workdir $cid sh -c 'echo "world" > /test/world'
 
-	#upper dir should persist content
+	# upper dir should persist content
 	result="$(< ${TEST_SCRATCH_DIR}/upperdir/world)"
-	test "$result" == "world"
+	assert "$result" == "world"
 }
 
 @test "run --volume with U flag" {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -438,6 +438,12 @@ function configure_and_check_user() {
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	mkdir -p ${TEST_SCRATCH_DIR}/was:empty
+	if test $(stat -f -c %T ${TEST_SCRATCH_DIR}/was:empty) = overlayfs; then
+		# we'll try to use fuse-overlayfs, which at least through 1.13
+		# can't accept ":" in layer locations, escaped or not, so bail
+		# now instead of breaking the whole thing
+		skip "unable to test read-write bind from an overlay location that includes colon characters"
+	fi
 	# As a baseline, this should succeed.
 	local mount=type=tmpfs,dst=/var/tmpfs-not-empty
 	run_buildah   run --mount $mount $cid touch /var/tmpfs-not-empty/testfile

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -439,23 +439,28 @@ function configure_and_check_user() {
 	cid=$output
 	mkdir -p ${TEST_SCRATCH_DIR}/was:empty
 	# As a baseline, this should succeed.
-	run_buildah run --mount type=tmpfs,dst=/var/tmpfs-not-empty                                                      $cid touch /var/tmpfs-not-empty/testfile
+	local mount=type=tmpfs,dst=/var/tmpfs-not-empty
+	run_buildah   run --mount $mount $cid touch /var/tmpfs-not-empty/testfile
 	# This should succeed, but the writes should effectively be discarded
-	run_buildah run --mount type=bind,src=${TEST_SCRATCH_DIR}/was:empty,dst=/var/not-empty,rw${zflag}                $cid touch /var/not-empty/testfile
+	local mount=type=bind,src=${TEST_SCRATCH_DIR}/was:empty,dst=/var/not-empty,rw${zflag}
+	run_buildah   run --mount $mount $cid touch /var/not-empty/testfile
 	if test -r ${TEST_SCRATCH_DIR}/was:empty/testfile ; then
 		die write to mounted type=bind was not discarded, ${TEST_SCRATCH_DIR}/was:empty/testfile exists
 	fi
 	# If we're parsing the options at all, this should be read-only, so it should fail.
-	run_buildah 1 run --mount type=bind,src=${TEST_SCRATCH_DIR}/was:empty,dst=/var/not-empty,ro${zflag}              $cid touch /var/not-empty/testfile
+	local mount=type=bind,src=${TEST_SCRATCH_DIR}/was:empty,dst=/var/not-empty,ro${zflag}
+	run_buildah 1 run --mount $mount $cid touch /var/not-empty/testfile
 	# Even if the parent directory doesn't exist yet, this should succeed, but again the write should be discarded.
-	run_buildah run --mount type=bind,src=${TEST_SCRATCH_DIR}/was:empty,dst=/var/multi-level/subdirectory,rw${zflag} $cid touch /var/multi-level/subdirectory/testfile
+	local mount=type=bind,src=${TEST_SCRATCH_DIR}/was:empty,dst=/var/multi-level/subdirectory,rw${zflag}
+	run_buildah   run --mount $mount $cid touch /var/multi-level/subdirectory/testfile
 	if test -r ${TEST_SCRATCH_DIR}/was:empty/testfile ; then
 		die write to mounted type=bind was not discarded, ${TEST_SCRATCH_DIR}/was:empty/testfile exists
 	fi
 	# And check the same for file volumes, which make life harder because the kernel's overlay
 	# filesystem really only wants to be dealing with directories.
 	: > ${TEST_SCRATCH_DIR}/was:empty/testfile
-	run_buildah run --mount type=bind,src=${TEST_SCRATCH_DIR}/was:empty/testfile,dst=/var/different-multi-level/subdirectory/testfile,rw${zflag} $cid sh -c 'echo wrote > /var/different-multi-level/subdirectory/testfile'
+	local mount=type=bind,src=${TEST_SCRATCH_DIR}/was:empty/testfile,dst=/var/different-multi-level/subdirectory/testfile,rw${zflag}
+	run_buildah   run --mount $mount $cid sh -c 'echo wrote > /var/different-multi-level/subdirectory/testfile'
 	if test -s ${TEST_SCRATCH_DIR}/was:empty/testfile ; then
 		die write to mounted type=bind was not discarded, ${TEST_SCRATCH_DIR}/was:empty/testfile was written to
 	fi


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Only use an overlay for --mounts of type=bind,rw, where changes should be discarded, if the storage driver is overlay.  Otherwise, make a temporary copy.

#### How to verify it

Updated CI to test {vfs|overlay} over {vfs|overlay}, which would have caught this.

#### Which issue(s) this PR fixes:

Should fix #5988.

#### Special notes for your reviewer:

Basically what https://github.com/containers/buildah/issues/5988#issuecomment-2718307144 suggested.

#### Does this PR introduce a user-facing change?

```release-note
When not using overlay for storage, running `buildah run` or executing a `buildah build` RUN instruction with the `--mount=type=bind,rw` flag will now use a temporary copy to ensure that writes are discarded, instead of attempting to mount an overlay filesystem using the source location as a "lower".
```