### PR TITLE
[CI:DOCS] Document rw/src for --mount in buildah-run(1)

### DIFF
--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -136,6 +136,8 @@ Current supported mount TYPES are bind, cache, secret and tmpfs. Writes to `bind
 
               · ro, read-only: (default true for `type=bind`, false for `type=tmpfs`, `type=cache`).
 
+              · rw, read-write: (default false for `type=bind`, true for `type=tmpfs`, `type=cache`).
+
        Options specific to bind:
 
               · bind-propagation: shared, slave, private, rshared, rslave, or rprivate(default). See also mount(2). <sup>[[1]](#Footnote1)</sup>
@@ -143,6 +145,8 @@ Current supported mount TYPES are bind, cache, secret and tmpfs. Writes to `bind
               . bind-nonrecursive: do not setup a recursive bind mount.  By default it is recursive.
 
               · from: image name for the root of the source. Defaults to **--contextdir**, mandatory if **--contextdir** was not specified.
+
+              · src: location in the context directory (or image, if the **from** option is used) to mount instead of its top-level directory.
 
               · z: Set shared SELinux label on mounted destination. Use if SELinux is enabled on host machine.
 
@@ -166,7 +170,7 @@ Current supported mount TYPES are bind, cache, secret and tmpfs. Writes to `bind
 
               · mode: File mode for new cache directory in octal. Default 0755.
 
-              · ro, readonly: read only cache if set.
+              · src: location in the cache (or image, if the **from** option is used) to mount instead of its top-level directory.
 
               · uid: uid for cache directory.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The buildah-run manual doesn't describe the "src" or "rw" options for "--mount type=bind".

#### How to verify it

Manual inspection.

#### Which issue(s) this PR fixes:

Discussed in #6084.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```