### PR TITLE
cli: hide the `completion` command instead of disabling it outright

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -85,8 +85,8 @@ func init() {
 	defaultContainerConfig.CheckCgroupsAndAdjustConfig()
 
 	cobra.OnInitialize(initConfig)
-	// Disable the implicit `completion` command in cobra.
-	rootCmd.CompletionOptions.DisableDefaultCmd = true
+	// Hide the implicit `completion` command in cobra.
+	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 	// rootCmd.TraverseChildren = true
 	rootCmd.Version = fmt.Sprintf("%s (image-spec %s, runtime-spec %s)", define.Version, ispecs.Version, rspecs.Version)
 	rootCmd.PersistentFlags().BoolVar(&globalFlagResults.Debug, "debug", false, "print debugging information")


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Hide the cobra built-in `completion` command instead of disabling it outright, since eventually we want to switch to using it instead of the hand-written scripts we're currently using.

#### How to verify it

Run `buildah completion` and if it doesn't only produce an error, we're good.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```