### PR TITLE
[skip-ci] Packit: Disable osh_diff_scan

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -54,6 +54,9 @@ jobs:
       - fedora-development-x86_64
       - fedora-development-aarch64
     enable_net: true
+    # Disable osh diff scan until Go support is available
+    # Ref: https://github.com/openscanhub/known-false-positives/pull/30#issuecomment-2858698495
+    osh_diff_scan_after_copr_build: false
 
   - job: copr_build
     trigger: pull_request


### PR DESCRIPTION
No golang support yet in osh diff scan.
Ref: https://github.com/openscanhub/known-false-positives/pull/30#issuecomment-2858698495

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

Disables osh diff scan

#### How to verify it

No packit job for osh diff scan will be seen.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->


None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```