### PR TITLE
copier: use `PAX` format instead of default `USTAR`

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -1545,6 +1545,8 @@ func mapWithPrefixedKeysWithoutKeyPrefix[K any](m map[string]K, p string) map[st
 func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath string, options GetOptions, tw *tar.Writer, hardlinkChecker *hardlinkChecker, idMappings *idtools.IDMappings) error {
 	// build the header using the name provided
 	hdr, err := tar.FileInfoHeader(srcfi, symlinkTarget)
+	// Use PAX format to support high-precision timestamps for `ModTime`.
+	hdr.Format = tar.FormatPAX
 	if err != nil {
 		return fmt.Errorf("generating tar header for %s (%s): %w", contentPath, symlinkTarget, err)
 	}

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -583,6 +583,13 @@ parents/y/b.txt"
   run_buildah run $ctr ls -1 /opt/
   expect_line_count 1
   assert "$output" = "test_file" "only contents of copied directory"
+  run_buildah mount $ctr
+  croot=$output
+  # Compare metadata and mtime. Display them in human-readable form, so if there's
+  # a mismatch it will be shown in the test log.
+  metadata_randomfile=$(stat --format '%s %a %u %g %F %Y' ${TEST_SCRATCH_DIR}/context/test_file)
+  metadata_ctrfile=$(stat --format '%s %a %u %g %F %Y' ${croot}/opt/test_file)
+  assert "$metadata_ctrfile" = "$metadata_randomfile" "meta_data[ctrfile] == meta_data[randomfile]"
 }
 
 @test "copy-file-relative-context-dir" {


### PR DESCRIPTION
File copied to container from host does not preserves `mtime` correctly because `USTAR` format only supports precision of 1 second, switch to `PAX` format which typically supports Nanosecond precision.

Helpful in RUN-2664: `Ensure that Buildah instructions that copy files do not make any changes`

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Ensure that Buildah instructions that copy retains mtime with nanosecond precision
```

