### PR TITLE
Ensure extendedGlob returns paths in lexical order

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,6 +49,7 @@ func init() {
 // "**" component in the pattern, filepath.Glob() will be called with the "**"
 // replaced with all of the subdirectories under that point, and the results
 // will be concatenated.
+// The matched paths are returned in lexical order, which makes the output deterministic.
 func extendedGlob(pattern string) (matches []string, err error) {
 	subdirs := func(dir string) []string {
 		var subdirectories []string
@@ -113,6 +115,7 @@ func extendedGlob(pattern string) (matches []string, err error) {
 		}
 		matches = append(matches, theseMatches...)
 	}
+	sort.Strings(matches)
 	return matches, nil
 }
 

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -2341,3 +2341,18 @@ func TestConditionalRemoveNoChroot(t *testing.T) {
 	testConditionalRemove(t)
 	canChroot = couldChroot
 }
+
+func TestSortedExtendedGlob(t *testing.T) {
+	tmpdir := t.TempDir()
+	buf := []byte("buffer")
+	expect := []string{}
+	for _, name := range []string{"z", "y", "x", "a", "b", "c", "d", "e", "f"} {
+		require.NoError(t, os.WriteFile(filepath.Join(tmpdir, name), buf, 0o600))
+		expect = append(expect, filepath.Join(tmpdir, name))
+	}
+	sort.Strings(expect)
+
+	matched, err := extendedGlob(filepath.Join(tmpdir, "*"))
+	require.NoError(t, err, "globbing")
+	require.ElementsMatch(t, expect, matched, "sorted globbing")
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:
The `filepath.Glob` function does not provide deterministic output. In order to achieve a reproducible build, files must be copied in a deterministic manner, and `filepath.Glob` did not guarantee this. Other functions such as `filepath.Walk` and `os.ReadDir` return deterministic output. So copying files to the image is done in the same order each time.

#### How to verify it

#### Which issue(s) this PR fixes:

Fixes: https://issues.redhat.com/browse/RUN-2661

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

