### PR TITLE
[skip-ci] Packit: set fedora-all after F40 EOL

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -95,8 +95,7 @@ jobs:
   - job: tests
     trigger: pull_request
     packages: [buildah-fedora]
-    targets: &fedora_copr_test_targets
-      - fedora-all-x86_64
+    targets:
       - fedora-all-x86_64
     tf_extra_params:
       environments:
@@ -109,7 +108,7 @@ jobs:
   - job: tests
     trigger: ignore
     packages: [buildah-centos]
-    targets: &centos_copr_test_targets
+    targets:
       - centos-stream-9-x86_64
       - centos-stream-10-x86_64
     tf_extra_params:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -46,13 +46,11 @@ jobs:
     notifications: &copr_build_failure_notification
       failure_comment:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
+    # Fedora aliases documentation: https://packit.dev/docs/configuration#aliases
+    # python3-fedora-distro-aliases provides `resolve-fedora-aliases` command
     targets: &fedora_copr_targets
-    # f40 ships go 1.22 and we require go 1.23 now. This should be revert to fedora-all
-    # once either f40 is rebased to go 1.23 or f42 is released and f40 EOL.
-      - fedora-latest-stable-x86_64
-      - fedora-latest-stable-aarch64
-      - fedora-development-x86_64
-      - fedora-development-aarch64
+      - fedora-all-x86_64
+      - fedora-all-aarch64
     enable_net: true
 
   # Ignore until golang is updated in distro buildroot to 1.23.3+
@@ -98,9 +96,8 @@ jobs:
     trigger: pull_request
     packages: [buildah-fedora]
     targets: &fedora_copr_test_targets
-    # See the other comment above, this should be reverted to fedora-all when possible.
-      - fedora-latest-stable-x86_64
-      - fedora-development-x86_64
+      - fedora-all-x86_64
+      - fedora-all-x86_64
     tf_extra_params:
       environments:
         - artifacts:


### PR DESCRIPTION
As the title says.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

 /kind other

#### What this PR does / why we need it:

Update fedora targets in packit

#### How to verify it

See packit jobs

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None


#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

