### PR TITLE
[skip-ci] Packit: Ignore ELN and CentOS Stream jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -55,8 +55,9 @@ jobs:
       - fedora-development-aarch64
     enable_net: true
 
+  # Ignore until golang is updated in distro buildroot to 1.23.3+
   - job: copr_build
-    trigger: pull_request
+    trigger: ignore
     packages: [buildah-eln]
     notifications: *copr_build_failure_notification
     targets:
@@ -68,8 +69,9 @@ jobs:
           - "https://kojipkgs.fedoraproject.org/repos/eln-build/latest/aarch64/"
     enable_net: true
 
+  # Ignore until golang is updated in distro buildroot to 1.23.3+
   - job: copr_build
-    trigger: pull_request
+    trigger: ignore
     packages: [buildah-centos]
     notifications: *copr_build_failure_notification
     targets: &centos_copr_targets
@@ -105,9 +107,10 @@ jobs:
           - type: repository-file
             id: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/fedora-$releasever/rhcontainerbot-podman-next-fedora-$releasever.repo
 
+  # Ignore until golang is updated in distro buildroot to 1.23.3+
   # Tests on CentOS Stream for main branch PRs
   - job: tests
-    trigger: pull_request
+    trigger: ignore
     packages: [buildah-centos]
     targets: &centos_copr_test_targets
       - centos-stream-9-x86_64


### PR DESCRIPTION
Ignore these jobs until go 1.23.3+ is available in their buildroots

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

Make CI green

#### How to verify it

CentOS Stream and ELN packit jobs won't show up

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->


None


#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

