### PR TITLE
internal/util.SetHas(): handle maps of [generic]generic

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -98,7 +98,7 @@ func ExportFromReader(input io.Reader, opts define.BuildOutputOption) error {
 	return nil
 }
 
-func SetHas(m map[string]struct{}, k string) bool {
+func SetHas[K comparable, V any](m map[K]V, k K) bool {
 	_, ok := m[k]
 	return ok
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetHas(t *testing.T) {
+	m := map[string]string{
+		"key1": "ignored",
+	}
+	assert.True(t, SetHas(m, "key1"))
+	assert.False(t, SetHas(m, "key2"))
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Make `SetHas()` a generic function for checking if a map holds a value of whatever kind for a key of some comparable kind.

#### How to verify it

New unit test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```