### PR TITLE
Use Fedora 42 instead of 41 in that one conformance test

### DIFF
--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -21,8 +21,8 @@ bash
 docker pull mirror.gcr.io/alpine
 docker pull mirror.gcr.io/busybox
 docker pull quay.io/libpod/centos:7
-docker pull registry.fedoraproject.org/fedora-minimal:41-aarch64
-docker pull registry.fedoraproject.org/fedora-minimal:41-amd64
+docker pull registry.fedoraproject.org/fedora-minimal:42-aarch64
+docker pull registry.fedoraproject.org/fedora-minimal:42-x86_64
 docker pull registry.fedoraproject.org/fedora-minimal
 ```
 

--- a/tests/conformance/testdata/header-builtin/Dockerfile
+++ b/tests/conformance/testdata/header-builtin/Dockerfile
@@ -1,7 +1,7 @@
 # if TARGETARCH is defined, we'l pull the x86_64 image
-FROM registry.fedoraproject.org/fedora-minimal:41${TARGETARCH:+-x86_64} AS amd64
+FROM registry.fedoraproject.org/fedora-minimal:42${TARGETARCH:+-x86_64} AS amd64
 # if TARGETARCH is defined, we'l pull the aarch64 image
-FROM registry.fedoraproject.org/fedora-minimal:41${TARGETARCH:+-aarch64} AS arm64
+FROM registry.fedoraproject.org/fedora-minimal:42${TARGETARCH:+-aarch64} AS arm64
 
 # run "file" against both shared libraries
 FROM registry.fedoraproject.org/fedora-minimal AS native


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

One of our conformance tests uses fedora-minimal:41 as a base image.  This updates it to use :42.

#### How to verify it

Updated conformance test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```