### PR TITLE
pkg/parse.GetBuildOutput(): use strings.Cut()

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -704,7 +704,7 @@ func AuthConfig(creds string) (*types.DockerAuthConfig, error) {
 // GetBuildOutput is responsible for parsing custom build output argument i.e `build --output` flag.
 // Takes `buildOutput` as string and returns BuildOutputOption
 func GetBuildOutput(buildOutput string) (define.BuildOutputOption, error) {
-	if len(buildOutput) == 1 && buildOutput == "-" {
+	if buildOutput == "-" {
 		// Feature parity with buildkit, output tar to stdout
 		// Read more here: https://docs.docker.com/engine/reference/commandline/build/#custom-build-outputs
 		return define.BuildOutputOption{
@@ -723,56 +723,48 @@ func GetBuildOutput(buildOutput string) (define.BuildOutputOption, error) {
 	}
 	isDir := true
 	isStdout := false
-	typeSelected := false
-	pathSelected := false
-	path := ""
-	tokens := strings.Split(buildOutput, ",")
-	for _, option := range tokens {
-		arr := strings.SplitN(option, "=", 2)
-		if len(arr) != 2 {
+	typeSelected := ""
+	pathSelected := ""
+	for _, option := range strings.Split(buildOutput, ",") {
+		key, value, found := strings.Cut(option, "=")
+		if !found {
 			return define.BuildOutputOption{}, fmt.Errorf("invalid build output options %q, expected format key=value", buildOutput)
 		}
-		switch arr[0] {
+		switch key {
 		case "type":
-			if typeSelected {
-				return define.BuildOutputOption{}, fmt.Errorf("duplicate %q not supported", arr[0])
+			if typeSelected != "" {
+				return define.BuildOutputOption{}, fmt.Errorf("duplicate %q not supported", key)
 			}
-			typeSelected = true
-			switch arr[1] {
+			typeSelected = value
+			switch typeSelected {
 			case "local":
 				isDir = true
 			case "tar":
 				isDir = false
 			default:
-				return define.BuildOutputOption{}, fmt.Errorf("invalid type %q selected for build output options %q", arr[1], buildOutput)
+				return define.BuildOutputOption{}, fmt.Errorf("invalid type %q selected for build output options %q", value, buildOutput)
 			}
 		case "dest":
-			if pathSelected {
-				return define.BuildOutputOption{}, fmt.Errorf("duplicate %q not supported", arr[0])
+			if pathSelected != "" {
+				return define.BuildOutputOption{}, fmt.Errorf("duplicate %q not supported", key)
 			}
-			pathSelected = true
-			path = arr[1]
+			pathSelected = value
 		default:
-			return define.BuildOutputOption{}, fmt.Errorf("unrecognized key %q in build output option: %q", arr[0], buildOutput)
+			return define.BuildOutputOption{}, fmt.Errorf("unrecognized key %q in build output option: %q", key, buildOutput)
 		}
 	}
 
-	if !typeSelected || !pathSelected {
-		return define.BuildOutputOption{}, fmt.Errorf("invalid build output option %q, accepted keys are type and dest must be present", buildOutput)
+	if typeSelected == "" || pathSelected == "" {
+		return define.BuildOutputOption{}, fmt.Errorf(`invalid build output option %q, accepted keys are "type" and "dest" must be present`, buildOutput)
 	}
 
-	if path == "-" {
+	if pathSelected == "-" {
 		if isDir {
-			return define.BuildOutputOption{}, fmt.Errorf("invalid build output option %q, type=local and dest=- is not supported", buildOutput)
+			return define.BuildOutputOption{}, fmt.Errorf(`invalid build output option %q, "type=local" can not be used with "dest=-"`, buildOutput)
 		}
-		return define.BuildOutputOption{
-			Path:     "",
-			IsDir:    false,
-			IsStdout: true,
-		}, nil
 	}
 
-	return define.BuildOutputOption{Path: path, IsDir: isDir, IsStdout: isStdout}, nil
+	return define.BuildOutputOption{Path: pathSelected, IsDir: isDir, IsStdout: isStdout}, nil
 }
 
 // TeeType parses a string value and returns a TeeType

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -260,3 +260,42 @@ func TestSystemContextFromFlagSet(t *testing.T) {
 		DockerRegistryUserAgent:     fmt.Sprintf("Buildah/%s", define.Version),
 	})
 }
+
+func TestGetBuildOutput(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       string
+		output      define.BuildOutputOption
+	}{
+		{
+			description: "hyphen",
+			input:       "-",
+			output: define.BuildOutputOption{
+				IsStdout: true,
+			},
+		},
+		{
+			description: "just-a-path",
+			input:       "/tmp",
+			output: define.BuildOutputOption{
+				IsDir: true,
+				Path:  "/tmp",
+			},
+		},
+		{
+			description: "normal-path",
+			input:       "type=local,dest=/tmp",
+			output: define.BuildOutputOption{
+				IsDir: true,
+				Path:  "/tmp",
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			result, err := GetBuildOutput(testCase.input)
+			require.NoErrorf(t, err, "expected to be able to parse %q", testCase.input)
+			assert.Equal(t, testCase.output, result)
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Use strings.Cut() to make pkg/parse.GetBuildOutput() a little easier to follow.

#### How to verify it

New unit test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```