### PR TITLE
build: allow --output to be specified multiple times

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -167,9 +167,12 @@ type BuildOptions struct {
 	AdditionalBuildContexts map[string]*AdditionalBuildContext
 	// Name of the image to write to.
 	Output string
-	// BuildOutput specifies if any custom build output is selected for following build.
-	// It allows end user to export recently built rootfs into a directory or tar.
-	// See the documentation of 'buildah build --output' for the details of the format.
+	// BuildOutputs specifies if any custom build output is selected for
+	// following build.  It allows the end user to export the image's
+	// rootfs to a directory or a tar archive.  See the documentation of
+	// 'buildah build --output' for the details of the syntax.
+	BuildOutputs []string
+	// Deprecated: use BuildOutputs instead.
 	BuildOutput string
 	// ConfidentialWorkload controls whether or not, and if so, how, we produce an
 	// image that's meant to be run using krun as a VM instead of a conventional

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -151,9 +151,9 @@ type Executor struct {
 	logPrefix                               string
 	unsetEnvs                               []string
 	unsetLabels                             []string
-	processLabel                            string // Shares processLabel of first stage container with containers of other stages in same build
-	mountLabel                              string // Shares mountLabel of first stage container with containers of other stages in same build
-	buildOutput                             string // Specifies instructions for any custom build output
+	processLabel                            string   // Shares processLabel of first stage container with containers of other stages in same build
+	mountLabel                              string   // Shares mountLabel of first stage container with containers of other stages in same build
+	buildOutputs                            []string // Specifies instructions for any custom build output
 	osVersion                               string
 	osFeatures                              []string
 	envs                                    []string
@@ -227,6 +227,11 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 				return nil, fmt.Errorf("creating file to store rusage logs: %w", err)
 			}
 		}
+	}
+
+	buildOutputs := slices.Clone(options.BuildOutputs)
+	if options.BuildOutput != "" { //nolint:staticcheck
+		buildOutputs = append(buildOutputs, options.BuildOutput) //nolint:staticcheck
 	}
 
 	exec := Executor{
@@ -314,7 +319,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		logPrefix:                               logPrefix,
 		unsetEnvs:                               slices.Clone(options.UnsetEnvs),
 		unsetLabels:                             slices.Clone(options.UnsetLabels),
-		buildOutput:                             options.BuildOutput,
+		buildOutputs:                            buildOutputs,
 		osVersion:                               options.OSVersion,
 		osFeatures:                              slices.Clone(options.OSFeatures),
 		envs:                                    slices.Clone(options.Envs),

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -263,12 +263,16 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		timestamp = &t
 	}
 	if c.Flag("output").Changed {
-		buildOption, err := parse.GetBuildOutput(iopts.BuildOutput)
-		if err != nil {
-			return options, nil, nil, err
-		}
-		if buildOption.IsStdout {
-			iopts.Quiet = true
+		for _, buildOutput := range iopts.BuildOutputs {
+			// if any of these go to stdout, we need to avoid
+			// interspersing our random output in with it
+			buildOption, err := parse.GetBuildOutput(buildOutput)
+			if err != nil {
+				return options, nil, nil, err
+			}
+			if buildOption.IsStdout {
+				iopts.Quiet = true
+			}
 		}
 	}
 	var confidentialWorkloadOptions define.ConfidentialWorkloadOptions
@@ -351,7 +355,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		Architecture:            systemContext.ArchitectureChoice,
 		Args:                    args,
 		BlobDirectory:           iopts.BlobCache,
-		BuildOutput:             iopts.BuildOutput,
+		BuildOutputs:            iopts.BuildOutputs,
 		CacheFrom:               cacheFrom,
 		CacheTo:                 cacheTo,
 		CacheTTL:                cacheTTL,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -108,7 +108,7 @@ type BudResults struct {
 	SkipUnusedStages    bool
 	Stdin               bool
 	Tag                 []string
-	BuildOutput         string
+	BuildOutputs        []string
 	Target              string
 	TLSVerify           bool
 	Jobs                int
@@ -307,7 +307,7 @@ newer:   only pull base and SBOM scanner images when newer images exist on the r
 	fs.StringArrayVar(&flags.SSH, "ssh", []string{}, "SSH agent socket or keys to expose to the build. (format: default|<id>[=<socket>|<key>[,<key>]])")
 	fs.BoolVar(&flags.Stdin, "stdin", false, "pass stdin into containers")
 	fs.StringArrayVarP(&flags.Tag, "tag", "t", []string{}, "tagged `name` to apply to the built image")
-	fs.StringVarP(&flags.BuildOutput, "output", "o", "", "output destination (format: type=local,dest=path)")
+	fs.StringArrayVarP(&flags.BuildOutputs, "output", "o", nil, "output destination (format: type=local,dest=path)")
 	fs.StringVar(&flags.Target, "target", "", "set the target build stage to build")
 	fs.Int64Var(&flags.Timestamp, "timestamp", 0, "set created timestamp to the specified epoch seconds to allow for deterministic builds, defaults to current time")
 	fs.BoolVar(&flags.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -7531,6 +7531,18 @@ EOF
   expect_output "" "build should not be able to write to build context"
 }
 
+@test "build-with-two-outputs" {
+  _prefetch busybox
+  mkdir -p "${TEST_SCRATCH_DIR}"/context
+  cat > "${TEST_SCRATCH_DIR}"/context/Containerfile << _EOF
+FROM busybox
+RUN truncate -s1 /built.txt
+_EOF
+  run_buildah build --output type=local,dest=${TEST_SCRATCH_DIR}/output1 --output ${TEST_SCRATCH_DIR}/output2 $WITH_POLICY_JSON "${TEST_SCRATCH_DIR}"/context
+  test -s "${TEST_SCRATCH_DIR}"/output1/built.txt
+  test -s "${TEST_SCRATCH_DIR}"/output2/built.txt
+}
+
 @test "build-with-timestamp-applies-to-oci-archive" {
   local outpath="${TEST_SCRATCH_DIR}/timestamp-oci.tar"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Allow --output to be specified multiple times for `buildah build`. That's of limited usefulness right now, but as exporters get added, it won't be, and it's better to provide the new multiple-values API field sooner rather than later.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah build`'s "--output" flag can now be specified multiple times.
```

