### PR TITLE
add: add a new --timestamp flag

### DIFF
--- a/docs/buildah-add.1.md
+++ b/docs/buildah-add.1.md
@@ -83,6 +83,15 @@ from registries or retrieving content from HTTPS URLs.
 
 Defaults to `2s`.
 
+**--timestamp** *seconds*
+
+Set the timestamp ("mtime") for added content to exactly this number of seconds
+since the epoch (Unix time 0, i.e., 00:00:00 UTC on 1 January 1970) to help
+allow for deterministic builds.
+
+The destination directory into which the content is being copied will most
+likely reflect the time at which the content was added to it.
+
 **--tls-verify** *bool-value*
 
 Require verification of certificates when retrieving sources from HTTPS

--- a/docs/buildah-copy.1.md
+++ b/docs/buildah-copy.1.md
@@ -87,6 +87,15 @@ Duration of delay between retry attempts in case of failure when performing pull
 
 Defaults to `2s`.
 
+**--timestamp** *seconds*
+
+Set the timestamp ("mtime") for added content to exactly this number of seconds
+since the epoch (Unix time 0, i.e., 00:00:00 UTC on 1 January 1970) to help
+allow for deterministic builds.
+
+The destination directory into which the content is being copied will most
+likely reflect the time at which the content was added to it.
+
 **--tls-verify** *bool-value*
 
 Require verification of certificates when pulling images referred to with the


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a "--timestamp" flag to the "add" and "copy" CLIs, along with a corresponding field in `AddAndCopyOptions`.

When a timestamp is set, we'll force the timestamp on data copied in to be the specified value while reading it, so that the content will have the specified datestamp in the rootfs and when the image is committed.

#### How to verify it

Updated unit test!
New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah add` now offers a "--timestamp" flag.
```

