### PR TITLE
Don't BuildRequires: ostree-devel

### DIFF
--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -56,7 +56,6 @@ BuildRequires: go-rpm-macros
 BuildRequires: gpgme-devel
 BuildRequires: libassuan-devel
 BuildRequires: make
-BuildRequires: ostree-devel
 %if %{defined build_with_btrfs}
 BuildRequires: btrfs-progs-devel
 %endif


### PR DESCRIPTION
We are not opting into the ostree backend, and it doesn't build: https://github.com/containers/image/pull/2821 . So, stop referencing the dependency.

Should not change behavior.

@lsm5 @jnovy PTAL.

#### What type of PR is this?

> /kind cleanup

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

