### PR TITLE
build: add support for `--inherit-annotations`

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -242,6 +242,9 @@ type BuildOptions struct {
 	// InheritLabels controls whether or not built images will retain the labels
 	// which were set in their base images
 	InheritLabels types.OptionalBool
+	// InheritAnnotations controls whether or not built images will retain the annotations
+	// which were set in their base images
+	InheritAnnotations types.OptionalBool
 	// AddCapabilities is a list of capabilities to add to the default set when
 	// handling RUN instructions.
 	AddCapabilities []string

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -505,6 +505,10 @@ Path to an alternative .containerignore (.dockerignore) file.
 Write the built image's ID to the file.  When `--platform` is specified more
 than once, attempting to use this option will trigger an error.
 
+**--inherit-annotations** *bool-value*
+
+Inherit the annotations from the base image or base stages. (default true).
+
 **--inherit-labels** *bool-value*
 
 Inherit the labels from the base image or base stages. (default true).

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -85,6 +85,7 @@ type Executor struct {
 	log                            func(format string, args ...any) // can be nil
 	in                             io.Reader
 	inheritLabels                  types.OptionalBool
+	inheritAnnotations             types.OptionalBool
 	out                            io.Writer
 	err                            io.Writer
 	signaturePolicyPath            string
@@ -273,6 +274,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		reportWriter:                            writer,
 		isolation:                               options.Isolation,
 		inheritLabels:                           options.InheritLabels,
+		inheritAnnotations:                      options.InheritAnnotations,
 		namespaceOptions:                        options.NamespaceOptions,
 		configureNetwork:                        options.ConfigureNetwork,
 		cniPluginPath:                           options.CNIPluginPath,

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -390,6 +390,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		IgnoreFile:              iopts.IgnoreFile,
 		In:                      stdin,
 		InheritLabels:           types.NewOptionalBool(iopts.InheritLabels),
+		InheritAnnotations:      types.NewOptionalBool(iopts.InheritAnnotations),
 		Isolation:               isolation,
 		Jobs:                    &iopts.Jobs,
 		Labels:                  iopts.Label,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -74,6 +74,7 @@ type BudResults struct {
 	From                string
 	Iidfile             string
 	InheritLabels       bool
+	InheritAnnotations  bool
 	Label               []string
 	LayerLabel          []string
 	Logfile             string
@@ -237,6 +238,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.BoolVar(&flags.Compress, "compress", false, "this is a legacy option, which has no effect on the image")
 	fs.BoolVar(&flags.CompatVolumes, "compat-volumes", false, "preserve the contents of VOLUMEs during RUN instructions")
 	fs.BoolVar(&flags.InheritLabels, "inherit-labels", true, "inherit the labels from the base image or base stages.")
+	fs.BoolVar(&flags.InheritAnnotations, "inherit-annotations", true, "inherit the annotations from the base image or base stages.")
 	fs.StringArrayVar(&flags.CPPFlags, "cpp-flag", []string{}, "set additional flag to pass to C preprocessor (cpp)")
 	fs.StringVar(&flags.Creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	fs.StringVarP(&flags.CWOptions, "cw", "", "", "confidential workload `options`")

--- a/tests/bud/base-with-labels/Containerfile2
+++ b/tests/bud/base-with-labels/Containerfile2
@@ -1,0 +1,3 @@
+FROM registry.fedoraproject.org/fedora-minimal
+RUN echo hello
+RUN echo world


### PR DESCRIPTION
Allows users to specify if they want to inherit annotations from base image or not.

Closes: https://github.com/containers/buildah/issues/6153

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
build: add support for `--inherit-annotations` which allows users to specify if they want to inherit annotations from base image or not.
```

