### PR TITLE
[release-1.40] tag v1.40.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 # Changelog
 
+## v1.40.1 (2025-06-04)
+
+    vendor: update c/common to v0.63.1
+    CI: run integration tests on Fedora with both crun and runc
+    buildah-build(1): clarify that --cgroup-parent affects RUN instructions
+    runUsingRuntime: use named constants for runtime states
+    Add a dummy "runtime" that just dumps its config file
+    run: handle relabeling bind mounts ourselves
+    Tweak our handling of variant values, again
+
 ## v1.40.0 (2025-04-17)
 
     Bump c/storage to v1.58.0, c/image v5.35.0, c/common v0.63.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+- Changelog for v1.40.1 (2025-06-04)
+  * vendor: update c/common to v0.63.1
+  * CI: run integration tests on Fedora with both crun and runc
+  * buildah-build(1): clarify that --cgroup-parent affects RUN instructions
+  * runUsingRuntime: use named constants for runtime states
+  * Add a dummy "runtime" that just dumps its config file
+  * run: handle relabeling bind mounts ourselves
+  * Tweak our handling of variant values, again
+
 - Changelog for v1.40.0 (2025-04-17)
   * Bump c/storage to v1.58.0, c/image v5.35.0, c/common v0.63.0
   * fix(deps): update module github.com/docker/docker to v28.1.0+incompatible

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.40.0"
+	Version = "1.40.1"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Tag a v1.40.1 release, mainly to pick up #6197, #6201, and #6204.

#### How to verify it

No new tests, the existing suite should be satisfied.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
When building images for foreign platforms, the "variant" portion of the host's platform identifier should no longer be incorporated into the output image.
Buildah no longer assumes that an OCI runtime "knows" to relabel contents which are being mounted with the "z" or "Z" flags by `buildah run` or for RUN instructions by `buildah build`, and takes care of that itself.
Includes minor resolv.conf generation fixes.
```