### PR TITLE
build: add --source-date-epoch and --rewrite-timestamp flags

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -295,9 +295,23 @@ type BuildOptions struct {
 	SignBy string
 	// Architecture specifies the target architecture of the image to be built.
 	Architecture string
-	// Timestamp sets the created timestamp to the specified time, allowing
-	// for deterministic, content-addressable builds.
+	// Timestamp specifies a timestamp to use for the image's created-on
+	// date, the corresponding field in new history entries, the timestamps
+	// to set on contents in new layer diffs, and the timestamps to set on
+	// contents written as specified in the BuildOutput field.  If left
+	// unset, the current time is used for the configuration and manifest,
+	// and layer contents are recorded as-is.
 	Timestamp *time.Time
+	// SourceDateEpoch specifies a timestamp to use for the image's
+	// created-on date and the corrsponding field in new history entries,
+	// and any content written as specified in the BuildOutput field.  If
+	// left unset, the current time is used for the configuration and
+	// manifest, and layer and BuildOutput contents retain their original
+	// timestamps.
+	SourceDateEpoch *time.Time
+	// RewriteTimestamp, if set, forces timestamps in generated layers to
+	// not be later than the SourceDateEpoch, if it is also set.
+	RewriteTimestamp bool
 	// OS is the specifies the operating system of the image to be built.
 	OS string
 	// MaxPullPushRetries is the maximum number of attempts we'll make to pull or push any one

--- a/docs/buildah-commit.1.md
+++ b/docs/buildah-commit.1.md
@@ -318,6 +318,9 @@ When --source-date-epoch is set, the "created" timestamp is always set to the ti
 specified, which should allow for identical images to be committed at different
 times.
 
+Conflicts with the similar **--timestamp** flag, which also sets its specified
+time on layer contents.
+
 **--squash**
 
 Squash all of the new image's layers (including those inherited from a base image) into a single new layer.
@@ -337,6 +340,9 @@ When --timestamp is set, the "created" timestamp is always set to the time
 specified, which should allow for identical images to be committed at different
 times.  All content in the new layer added as part of the image will also bear
 this timestamp.
+
+Conflicts with the similar **--source-date-epoch** flag, which by default does
+not affect the timestamps of layer contents.
 
 **--tls-verify** *bool-value*
 

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
+	"github.com/containers/buildah/internal"
 	internalUtil "github.com/containers/buildah/internal/util"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/pkg/sshagent"
@@ -43,18 +44,19 @@ import (
 // instruction in the Dockerfile, since that's usually an indication of a user
 // error, but for these values we make exceptions and ignore them.
 var builtinAllowedBuildArgs = map[string]struct{}{
-	"HTTP_PROXY":     {},
-	"http_proxy":     {},
-	"HTTPS_PROXY":    {},
-	"https_proxy":    {},
-	"FTP_PROXY":      {},
-	"ftp_proxy":      {},
-	"NO_PROXY":       {},
-	"no_proxy":       {},
-	"TARGETARCH":     {},
-	"TARGETOS":       {},
-	"TARGETPLATFORM": {},
-	"TARGETVARIANT":  {},
+	"HTTP_PROXY":                 {},
+	"http_proxy":                 {},
+	"HTTPS_PROXY":                {},
+	"https_proxy":                {},
+	"FTP_PROXY":                  {},
+	"ftp_proxy":                  {},
+	"NO_PROXY":                   {},
+	"no_proxy":                   {},
+	"TARGETARCH":                 {},
+	"TARGETOS":                   {},
+	"TARGETPLATFORM":             {},
+	"TARGETVARIANT":              {},
+	internal.SourceDateEpochName: {},
 }
 
 // Executor is a buildah-based implementation of the imagebuilder.Executor
@@ -164,6 +166,8 @@ type Executor struct {
 	compatVolumes                           types.OptionalBool
 	compatScratchConfig                     types.OptionalBool
 	noPivotRoot                             bool
+	sourceDateEpoch                         *time.Time
+	rewriteTimestamp                        bool
 }
 
 type imageTypeAndHistoryAndDiffIDs struct {
@@ -330,6 +334,8 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		compatVolumes:                           options.CompatVolumes,
 		compatScratchConfig:                     options.CompatScratchConfig,
 		noPivotRoot:                             options.NoPivotRoot,
+		sourceDateEpoch:                         options.SourceDateEpoch,
+		rewriteTimestamp:                        options.RewriteTimestamp,
 	}
 	if exec.err == nil {
 		exec.err = os.Stderr

--- a/internal/types.go
+++ b/internal/types.go
@@ -6,8 +6,10 @@ const (
 	// external items which are downloaded for a build, typically a tarball
 	// being used as an additional build context.
 	BuildahExternalArtifactsDir = "buildah-external-artifacts"
-	// SourceDateEpochName is the name of the SOURCE_DATE_EPOCH environment
-	// variable when it's read from the environment by our main().
+	// SourceDateEpochName is both the name of the SOURCE_DATE_EPOCH
+	// environment variable and the built-in ARG that carries its value,
+	// whether it's read from the environment by our main(), or passed in
+	// via CLI or API flags.
 	SourceDateEpochName = "SOURCE_DATE_EPOCH"
 )
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -54,8 +54,7 @@ func NormalizePlatform(platform v1.Platform) v1.Platform {
 func ExportFromReader(input io.Reader, opts define.BuildOutputOption) error {
 	var err error
 	if !filepath.IsAbs(opts.Path) {
-		opts.Path, err = filepath.Abs(opts.Path)
-		if err != nil {
+		if opts.Path, err = filepath.Abs(opts.Path); err != nil {
 			return err
 		}
 	}
@@ -72,26 +71,22 @@ func ExportFromReader(input io.Reader, opts define.BuildOutputOption) error {
 			noLChown = true
 		}
 
-		err = os.MkdirAll(opts.Path, 0o700)
-		if err != nil {
+		if err = os.MkdirAll(opts.Path, 0o700); err != nil {
 			return fmt.Errorf("failed while creating the destination path %q: %w", opts.Path, err)
 		}
 
-		err = chrootarchive.Untar(input, opts.Path, &archive.TarOptions{NoLchown: noLChown})
-		if err != nil {
+		if err = chrootarchive.Untar(input, opts.Path, &archive.TarOptions{NoLchown: noLChown}); err != nil {
 			return fmt.Errorf("failed while performing untar at %q: %w", opts.Path, err)
 		}
 	} else {
 		outFile := os.Stdout
 		if !opts.IsStdout {
-			outFile, err = os.Create(opts.Path)
-			if err != nil {
+			if outFile, err = os.Create(opts.Path); err != nil {
 				return fmt.Errorf("failed while creating destination tar at %q: %w", opts.Path, err)
 			}
 			defer outFile.Close()
 		}
-		_, err = io.Copy(outFile, input)
-		if err != nil {
+		if _, err = io.Copy(outFile, input); err != nil {
 			return fmt.Errorf("failed while performing copy to %q: %w", opts.Path, err)
 		}
 	}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -257,10 +258,18 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 			return options, nil, nil, err
 		}
 	}
-	var timestamp *time.Time
+	var timestamp, sourceDateEpoch *time.Time
 	if c.Flag("timestamp").Changed {
 		t := time.Unix(iopts.Timestamp, 0).UTC()
 		timestamp = &t
+	}
+	if iopts.SourceDateEpoch != "" {
+		u, err := strconv.ParseInt(iopts.SourceDateEpoch, 10, 64)
+		if err != nil {
+			return options, nil, nil, fmt.Errorf("error parsing source-date-epoch offset %q: %w", iopts.SourceDateEpoch, err)
+		}
+		s := time.Unix(u, 0).UTC()
+		sourceDateEpoch = &s
 	}
 	if c.Flag("output").Changed {
 		for _, buildOutput := range iopts.BuildOutputs {
@@ -405,6 +414,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		Quiet:                   iopts.Quiet,
 		RemoveIntermediateCtrs:  iopts.Rm,
 		ReportWriter:            reporter,
+		RewriteTimestamp:        iopts.RewriteTimestamp,
 		Runtime:                 iopts.Runtime,
 		RuntimeArgs:             runtimeFlags,
 		RusageLogFile:           iopts.RusageLogFile,
@@ -412,6 +422,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		SignBy:                  iopts.SignBy,
 		SignaturePolicyPath:     iopts.SignaturePolicy,
 		SkipUnusedStages:        types.NewOptionalBool(iopts.SkipUnusedStages),
+		SourceDateEpoch:         sourceDateEpoch,
 		Squash:                  iopts.Squash,
 		SystemContext:           systemContext,
 		Target:                  iopts.Target,

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1083,6 +1083,6 @@ function dir_image_diff() {
 #########################
 # prints the relative path of the most recent layer for "dir" image in "$1"
 function dir_image_last_diff() {
-  local output=$(dir_image_diff "$1")
+  local output=$(dir_image_diff "$1" - 1)
   echo "$output"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Use $SOURCE_DATE_EPOCH as the default for the `--source-date-epoch` flag to the "build" CLI.

When a source-date-epoch is set, we'll use it when writing new history entries, force timestamps in data written for `--output` to the specified timestamp, and populate a "SOURCE_DATE_EPOCH" ARG that we treat as always being set, and which we don't complain about being left unused. By default, this will not affect timestamps in newly-added layers.

Add a `--rewrite-timestamp` flag, which "clamps" timestamps in newly-added layers to not be later than the `--source-date-epoch` value if the `--source-date-epoch` flag is set, but has no effect otherwise.

Fix a bug in the `dir_image_last_diff()` helper function introduced in a57e7f4b2491d064de0151d682b590a929370a0f as part of #6178.

#### How to verify it

New integration tests!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah build` now recognizes `--source-date-epoch` and `--rewrite-timestamp` flags, which affect the dates recorded in the new image's configuration and the timestamps on the contents of the new layers and content generated in response to the `--output` flag.
```