### PR TITLE
build: --source-date-epoch/--timestamp use static hostname/cid

### DIFF
--- a/image.go
+++ b/image.go
@@ -308,12 +308,21 @@ func (i *containerImageRef) newDockerSchema2ManifestBuilder() (manifestBuilder, 
 	if err := json.Unmarshal(i.dconfig, &dimage); err != nil {
 		return nil, err
 	}
+	// Suppress the hostname and domainname if we're running with the
+	// equivalent of either --timestamp or --source-date-epoch.
+	if i.created != nil {
+		dimage.Config.Hostname = "sandbox"
+		dimage.Config.Domainname = ""
+	}
 	// Set the parent, but only if we want to be compatible with "classic" docker build.
 	if i.compatSetParent == types.OptionalBoolTrue {
 		dimage.Parent = docker.ID(i.parent)
 	}
 	// Set the container ID and containerConfig in the docker format.
 	dimage.Container = i.containerID
+	if i.created != nil {
+		dimage.Container = ""
+	}
 	if dimage.Config != nil {
 		dimage.ContainerConfig = *dimage.Config
 	}

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1034,9 +1034,14 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		for _, p := range builder.Ports() {
 			ports[docker.Port(p)] = struct{}{}
 		}
+		hostname, domainname := builder.Hostname(), builder.Domainname()
+		containerName := builder.Container
+		if s.executor.timestamp != nil || s.executor.sourceDateEpoch != nil {
+			hostname, domainname, containerName = "sandbox", "", ""
+		}
 		dConfig := docker.Config{
-			Hostname:     builder.Hostname(),
-			Domainname:   builder.Domainname(),
+			Hostname:     hostname,
+			Domainname:   domainname,
 			User:         builder.User(),
 			Env:          builder.Env(),
 			Cmd:          builder.Cmd(),
@@ -1063,7 +1068,7 @@ func (s *StageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		dImage := docker.Image{
 			Parent:          builder.FromImageID,
 			ContainerConfig: dConfig,
-			Container:       builder.Container,
+			Container:       containerName,
 			Author:          builder.Maintainer(),
 			Architecture:    builder.Architecture(),
 			RootFS:          rootfs,

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -7767,3 +7767,58 @@ EOF
     layer=$((++layer))
   done
 }
+
+@test "bud-with-timestamp-config-effects" {
+  _prefetch busybox
+  local timestamp=60
+  mkdir -p $TEST_SCRATCH_DIR/context
+  cat > $TEST_SCRATCH_DIR/context/Dockerfile << EOF
+  FROM busybox
+  RUN hostname | tee /hostname.txt
+EOF
+  local config
+  local diff
+  local hostname
+
+  for cliflag in timestamp source-date-epoch ; do
+    run_buildah build --"$cliflag"=$timestamp --layers --no-cache -t dir:$TEST_SCRATCH_DIR/docker-layers-$cliflag --format=docker $TEST_SCRATCH_DIR/context
+    config=$(dir_image_config "$TEST_SCRATCH_DIR"/docker-layers-$cliflag)
+    run jq -r .config.Hostname "$TEST_SCRATCH_DIR"/docker-layers-$cliflag/"$config"
+    echo "$output"
+    test $status -eq 0
+    assert "$output" == sandbox
+    run jq -r .config.Domainname "$TEST_SCRATCH_DIR"/docker-layers-$cliflag/"$config"
+    echo "$output"
+    test $status -eq 0
+    assert "$output" == ""
+    run jq -r .container "$TEST_SCRATCH_DIR"/docker-layers-$cliflag/"$config"
+    echo "$output"
+    test $status -eq 0
+    assert "$output" == null
+    mkdir "$TEST_SCRATCH_DIR"/diff-docker-layers-$cliflag
+    diff=$(dir_image_last_diff "$TEST_SCRATCH_DIR"/docker-layers-$cliflag)
+    tar -C "$TEST_SCRATCH_DIR"/docker-layers-$cliflag -xf "$TEST_SCRATCH_DIR"/docker-layers-$cliflag/"$diff"
+    hostname=$(cat "$TEST_SCRATCH_DIR"/docker-layers-$cliflag/hostname.txt)
+    assert $hostname = sandbox "expected the hostname to be the static value 'sandbox'"
+
+    run_buildah build --"$cliflag"=$timestamp -t dir:"$TEST_SCRATCH_DIR"/docker-squashed-$cliflag --format=docker $TEST_SCRATCH_DIR/context
+    config=$(dir_image_config "$TEST_SCRATCH_DIR"/docker-squashed-$cliflag)
+    run jq -r .config.Hostname "$TEST_SCRATCH_DIR"/docker-squashed-$cliflag/"$config"
+    echo "$output"
+    test $status -eq 0
+    assert "$output" == sandbox
+    run jq -r .config.Domainname "$TEST_SCRATCH_DIR"/docker-squashed-$cliflag/"$config"
+    echo "$output"
+    test $status -eq 0
+    assert "$output" == ""
+    run jq -r .container "$TEST_SCRATCH_DIR"/docker-squashed-$cliflag/"$config"
+    echo "$output"
+    test $status -eq 0
+    assert "$output" == null
+    mkdir "$TEST_SCRATCH_DIR"/diff-docker-squashed-$cliflag
+    diff=$(dir_image_last_diff "$TEST_SCRATCH_DIR"/docker-squashed-$cliflag)
+    tar -C "$TEST_SCRATCH_DIR"/docker-squashed-$cliflag -xf "$TEST_SCRATCH_DIR"/docker-squashed-$cliflag/"$diff"
+    hostname=$(cat "$TEST_SCRATCH_DIR"/docker-squashed-$cliflag/hostname.txt)
+    assert $hostname = sandbox "expected the hostname to be the static value 'sandbox'"
+  done
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

When using either `--source-date-epoch` or `--timestamp`, make sure that handling of RUN instructions uses a defined hostname if possible, and commits using a reference to a static container name.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah build` sets a fixed hostname for RUN instructions when invoked with `--timestamp` or `--source-date-epoch`.
When building or committing images with the `--timestamp` or `--source-date-epoch` flags, the hostname, domain name, and name-of-container-which-was-committed will be set to fixed values.
```