### PR TITLE
commit,build: --source-date-epoch/--timestamp omit identity label

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -30,9 +30,10 @@ import (
 )
 
 const (
-	// BuilderIdentityAnnotation is the name of the annotation key containing
-	// the name and version of the producer of the image stored as an
-	// annotation on commit.
+	// BuilderIdentityAnnotation is the name of the label which will be set
+	// to contain the name and version of the producer of the image at
+	// commit-time.  (N.B. yes, the constant's name includes "Annotation",
+	// but it's added as a label.)
 	BuilderIdentityAnnotation = "io.buildah.version"
 )
 

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -492,7 +492,9 @@ those.
 
 **--identity-label** *bool-value*
 
-Adds default identity label `io.buildah.version` if set. (default true).
+Adds a label `io.buildah.version` with its value set to the version of buildah
+which built the image (default true unless `--timestamp` or
+`--source-date-epoch` is used).
 
 **--ignorefile** *file*
 

--- a/docs/buildah-commit.1.md
+++ b/docs/buildah-commit.1.md
@@ -146,7 +146,9 @@ environment variable.  `export BUILDAH_FORMAT=docker`
 
 **--identity-label** *bool-value*
 
-Adds default identity label `io.buildah.version` if set. (default true).
+Adds a label `io.buildah.version` with its value set to the version of buildah
+which committed the image (default true unless `--timestamp` or
+`--source-date-epoch` is used).
 
 **--iidfile** *ImageIDfile*
 

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -2436,8 +2436,15 @@ func (s *StageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	for k, v := range config.Labels {
 		s.builder.SetLabel(k, v)
 	}
-	if s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolUndefined || s.executor.commonBuildOptions.IdentityLabel == types.OptionalBoolTrue {
+	switch s.executor.commonBuildOptions.IdentityLabel {
+	case types.OptionalBoolTrue:
 		s.builder.SetLabel(buildah.BuilderIdentityAnnotation, define.Version)
+	case types.OptionalBoolFalse:
+		// nothing - don't clear it if there's a value set in the base image
+	default:
+		if s.executor.timestamp == nil && s.executor.sourceDateEpoch == nil {
+			s.builder.SetLabel(buildah.BuilderIdentityAnnotation, define.Version)
+		}
 	}
 	for _, key := range s.executor.unsetLabels {
 		s.builder.UnsetLabel(key)

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -184,7 +184,11 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 	cpuQuota, _ := flags.GetInt64("cpu-quota")
 	cpuShares, _ := flags.GetUint64("cpu-shares")
 	httpProxy, _ := flags.GetBool("http-proxy")
-	identityLabel, _ := flags.GetBool("identity-label")
+	var identityLabel types.OptionalBool
+	if flags.Changed("identity-label") {
+		b, _ := flags.GetBool("identity-label")
+		identityLabel = types.NewOptionalBool(b)
+	}
 	omitHistory, _ := flags.GetBool("omit-history")
 
 	ulimit := []string{}
@@ -208,7 +212,7 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 		DNSSearch:     dnsSearch,
 		DNSServers:    dnsServers,
 		HTTPProxy:     httpProxy,
-		IdentityLabel: types.NewOptionalBool(identityLabel),
+		IdentityLabel: identityLabel,
 		Memory:        memoryLimit,
 		MemorySwap:    memorySwap,
 		NoHostname:    noHostname,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When using either --source-date-epoch or --timestamp, default to not adding a label with our version number in it, since it can change between builds.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah build` no longer sets/updates the `io.buildah.version` label by default when either `--timestamp` or `--source-date-epoch` are used.
```