### PR TITLE
docs: add --setopt "*.countme=false" to dnf examples

### DIFF
--- a/demos/buildah-scratch-demo.sh
+++ b/demos/buildah-scratch-demo.sh
@@ -19,14 +19,13 @@ function is_rootless() {
 ## as root. The `buildah unshare` command switches your user
 ## session to root within the user namespace.
 if is_rootless; then
-  buildah unshare $0
-  exit
+  exec buildah unshare $0
 fi
 
 demoimg=myshdemo
 quayuser=ipbabble
 myname=WilliamHenry
-distrorelease=30
+distrorelease=42
 pkgmgr=dnf   # switch to yum if using yum
 
 #Setting up some colors for helping read the demo output
@@ -55,9 +54,9 @@ ls $scratchmnt
 echo -e "${red}Note that the root of the scratch container is EMPTY!${reset}"
 read -p "${cyan}Time to install some basic bash capabilities: coreutils and bash packages${reset}"
 if [ "$pkgmgr" == "dnf" ]; then
-	$pkgmgr install --installroot $scratchmnt --release ${distrorelease} bash coreutils --setopt install_weak_deps=false -y
+	$pkgmgr install --installroot $scratchmnt --releasever ${distrorelease} bash coreutils --use-host-config --setopt "*.countme=false" --setopt install_weak_deps=false -y
 elif [ "$pkgmgr" == "yum" ]; then
-	$pkgmgr install --installroot $scratchmnt --releasever ${distrorelease} bash coreutils  -y
+	$pkgmgr install --installroot $scratchmnt --releasever ${distrorelease} bash coreutils ---use-host-config --setopt "*.countme=false" y
 else
 	echo -e "${red}[Error] Unknown package manager ${pkgmgr}${reset}"
 fi

--- a/docs/buildah-unshare.1.md
+++ b/docs/buildah-unshare.1.md
@@ -40,23 +40,26 @@ buildah unshare rm -fr $HOME/.local/share/containers/storage /run/user/\`id -u\`
 
 buildah unshare --mount containerID sh -c 'cat ${containerID}/etc/os-release'
 
-If you want to use buildah with a mount command then you can create a script that looks something like:
+buildah unshare --mount root=containerID sh -c 'cat ${root}/etc/os-release'
 
-```
-cat buildah-script.sh << _EOF
-#!/bin/sh
+If you want to use buildah with a 'mount' command then you can create a script that looks something like:
+
+```console
+cat > buildah-script.sh << _EOF
+#!/bin/bash
 ctr=$(buildah from scratch)
 mnt=$(buildah mount $ctr)
-dnf -y install --installroot=$mnt PACKAGES
+dnf -y install --installroot=$mnt --use-host-config --setopt "*.countme=false" PACKAGES
 dnf -y clean all --installroot=$mnt
 buildah config --entrypoint="/bin/PACKAGE" --env "FOO=BAR" $ctr
 buildah commit $ctr imagename
 buildah unmount $ctr
 _EOF
+chmod +x buildah-script.sh
 ```
 Then execute it with:
-```
-buildah unshare buildah-script.sh
+```console
+buildah unshare ./buildah-script.sh
 ```
 
 ## SEE ALSO

--- a/docs/tutorials/01-intro.md
+++ b/docs/tutorials/01-intro.md
@@ -18,11 +18,15 @@ Note that installation instructions below assume you are running a Linux distro 
 
 First step is to install Buildah. Run as root because you will need to be root for installing the Buildah package:
 
+```console
     $ sudo -s
+```
 
 Then install buildah by running:
 
+```console
     # dnf -y install buildah
+```
 
 ## Rootless User Configuration
 
@@ -32,37 +36,53 @@ If you plan to run Buildah as a user without root privileges, i.e. a "rootless u
 
 After installing Buildah we can see there are no images installed. The `buildah images` command will list all the images:
 
+```console
     # buildah images
+```
 
 We can also see that there are also no working containers by running:
 
+```console
     # buildah containers
+```
 
 When you build a working container from an existing image, Buildah defaults to appending '-working-container' to the image's name to construct a name for the container. The Buildah CLI conveniently returns the name of the new container. You can take advantage of this by assigning the returned value to a shell variable using standard shell assignment:
 
+```console
     # container=$(buildah from fedora)
+```
 
 It is not required to assign the container's name to a shell variable. Running `buildah from fedora` is sufficient. It just helps simplify commands later. To see the name of the container that we stored in the shell variable:
 
+```console
     # echo $container
+```
 
 What can we do with this new container? Let's try running bash:
 
+```console
     # buildah run $container bash
+```
 
 Notice we get a new shell prompt because we are running a bash shell inside of the container. It should be noted that `buildah run` is primarily intended for debugging and running commands as part of the build process. A more full-featured engine like Podman or a container runtime interface service like [CRI-O](https://github.com/kubernetes-sigs/cri-o) is more suited for starting containers in production.
 
 Be sure to `exit` out of the container and let's try running something else:
 
+```console
     # buildah run $container java
+```
 
 Oops. Java is not installed. A message containing something like the following was returned.
 
+```
     runc create failed: unable to start start container process: exec: "java": executable file not found in $PATH
+```
 
 Let's try installing it inside the container using:
 
+```console
     # buildah run $container -- dnf -y install java
+```
 
 The `--` syntax basically tells Buildah: there are no more `buildah run` command options after this point. The options after this point are for the command that's started inside the container. It is required if the command we specify includes command line options which are not meant for Buildah.
 
@@ -74,81 +94,108 @@ One of the advantages of using `buildah` to build OCI compliant container images
 
 Let's build a container and image from scratch. The special "image" name "scratch" tells Buildah to create an empty container.  The container has a small amount of metadata about the container but no real Linux content.
 
+```console
     # newcontainer=$(buildah from scratch)
+```
 
 You can see this new empty container by running:
 
+```console
     # buildah containers
+```
 
 You should see output similar to the following:
 
+```
     CONTAINER ID  BUILDER  IMAGE ID     IMAGE NAME                       CONTAINER NAME
     82af3b9a9488     *     3d85fcda5754 docker.io/library/fedora:latest  fedora-working-container
     ac8fa6be0f0a     *                  scratch                          working-container
+```
 
 Its container name is working-container by default and it's stored in the `$newcontainer` variable. Notice the image name (IMAGE NAME) is "scratch". This is a special value that indicates that the working container wasn't based on an image. When we run:
 
+```console
     # buildah images
+```
 
 We don't see the "scratch" image listed. There is no corresponding scratch image. A container based on "scratch" starts from nothing.
 
 So does this container actually do anything? Let's see.
 
+```console
     # buildah run $newcontainer bash
+```
 
 Nope. This really is empty. The package installer `dnf` is not even inside this container. It's essentially an empty layer on top of the kernel. So what can be done with that? Thankfully there is a `buildah mount` command.
 
+```console
     # scratchmnt=$(buildah mount $newcontainer)
+```
 
 Note: If attempting to mount in rootless mode, the command fails. Mounting a container can only be done in a mount namespace that you own. Create and enter a user namespace and mount namespace by executing the `buildah unshare` command. See buildah-mount(1) man page for more information.
 
+```console
     $ export newcontainer
     $ buildah unshare
     # scratchmnt=$(buildah mount $newcontainer)
+```
 
 By echoing `$scratchmnt` we can see the path for the [overlay mount point](https://wiki.archlinux.org/index.php/Overlay_filesystem), which is used as the root file system for the container.
 
+```console
     # echo $scratchmnt
     /var/lib/containers/storage/overlay/b78d0e11957d15b5d1fe776293bd40a36c28825fb6cf76f407b4d0a95b2a200d/merged
+```
 
 Notice that the overlay mount point is somewhere under `/var/lib/containers/storage` if you started out as root, and under your home directory's `.local/share/containers/storage` directory if you're in rootless mode. (See above on `containers/storage` or for more information see [containers/storage](https://github.com/containers/storage).)
 
 Now that we have a new empty container we can install or remove software packages or simply copy content into that container. So let's install `bash` and `coreutils` so that we can run bash scripts. This could easily be `nginx` or other packages needed for your container.
 
-**NOTE:** the version in the example below (40) relates to a Fedora version which is the Linux platform this example was run on.  If you are running dnf on the host to populate the container, the version you specify must be valid for the host or dnf will throw an error.  I.e. If you were to run this on a RHEL platform, you'd need to specify `--releasever 8.1` or similar instead of `--releasever 40`.  If you want the container to be a particular Linux platform, change `scratch` in the first line of the example to the platform you want, i.e. `# newcontainer=$(buildah from fedora)`, and then you can specify an appropriate version number for that Linux platform.
+**NOTE:** the version in the example below (42) relates to a Fedora version which is the Linux platform this example was run on.  If you are running dnf on the host to populate the container, the version you specify must be valid for the host or dnf will throw an error.  I.e. If you were to run this on a RHEL platform, you'd need to specify `--releasever 8.1` or similar instead of `--releasever 42`.  If you want the container to be a particular Linux platform, change `scratch` in the first line of the example to the platform you want, i.e. `# newcontainer=$(buildah from fedora)`, and then you can specify an appropriate version number for that Linux platform.
 
-    # dnf install --installroot $scratchmnt --releasever 40 bash coreutils --setopt install_weak_deps=false -y
+```console
+    # dnf install --installroot $scratchmnt --releasever 42 bash coreutils --use-host-config --setopt "*.countme=false" --setopt install_weak_deps=false -y
+```
 
 Let's try it out (showing the prompt in this example to demonstrate the difference):
 
+```console
     # buildah run $newcontainer sh
     sh-5.1# cd /usr/bin
     sh-5.1# ls
     sh-5.1# exit
+```
 
 Notice we now have a `/usr/bin` directory in the newcontainer's root file system. Let's first copy a simple file from our host into the container. Create a file called runecho.sh which contains the following:
 
+```console
     #!/usr/bin/env bash
     for i in `seq 0 9`;
     do
     	echo "This is a new container from ipbabble [" $i "]"
     done
+```
 
 Change the permissions on the file so that it can be run:
 
+```console
     # chmod +x runecho.sh
+```
 
 With `buildah` files can be copied into the new container.  We can then use `buildah run` to run that command within the container by specifying the command.  We can also configure the image we'll create from this container to run the command directly when we run it using [Podman](https://github.com/containers/podman) and its `podman run` command. In short the `buildah run` command is equivalent to the "RUN" command in a Dockerfile (it always needs to be told what to run), whereas `podman run` is equivalent to the `docker run` command (it can look at the image's configuration to see what to run).  Now let's copy this new command into the container's `/usr/bin` directory, configure the command to be run when the image is run by `podman`, and create an image from the container's root file system and configuration settings:
 
+```console
     # To test with Podman, first install via:
     # dnf -y install podman
     # buildah copy $newcontainer ./runecho.sh /usr/bin/
     # buildah config --cmd /usr/bin/runecho.sh $newcontainer
     # buildah commit $newcontainer newimage
+```
 
 We've got a new image named "newimage". The container is still there because we didn't remove it.
 Now run the command in the container with Buildah specifying the command to run in the container:
 
+```console
     # buildah run $newcontainer /usr/bin/runecho.sh
     This is a new container from ipbabble [ 0 ]
     This is a new container from ipbabble [ 1 ]
@@ -160,9 +207,11 @@ Now run the command in the container with Buildah specifying the command to run 
     This is a new container from ipbabble [ 7 ]
     This is a new container from ipbabble [ 8 ]
     This is a new container from ipbabble [ 9 ]
+```
 
 Now use Podman to run the command in a new container based on our new image (no command required):
 
+```console
     # podman run --rm newimage
     This is a new container from ipbabble [ 0 ]
     This is a new container from ipbabble [ 1 ]
@@ -174,51 +223,69 @@ Now use Podman to run the command in a new container based on our new image (no 
     This is a new container from ipbabble [ 7 ]
     This is a new container from ipbabble [ 8 ]
     This is a new container from ipbabble [ 9 ]
+```
 
 It works! Congratulations, you have built a new OCI container image from scratch that uses bash scripting.
 
 Back to Buildah, let's add some more configuration information.
 
+```console
     # buildah config --created-by "ipbabble"  $newcontainer
-    # buildah config --author "wgh at redhat.com @ipbabble" --label name=fedora40-bashecho $newcontainer
+    # buildah config --author "wgh at redhat.com @ipbabble" --label name=fedora42-bashecho $newcontainer
+```
 
 We can inspect the working container's metadata using the `inspect` command:
 
+```console
     # buildah inspect $newcontainer
+```
 
 We should probably unmount the working container's rootfs.  We will need to commit the container again to create an image that includes the two configuration changes we just made:
 
+```console
      # buildah unmount $newcontainer
      # buildah commit $newcontainer fedora-bashecho
      # buildah images
+```
 
 And you can see there is a new image called `localhost/fedora-bashecho:latest`. You can inspect the new image using:
 
+```console
     # buildah inspect --type=image fedora-bashecho
+```
 
 Later when you want to create a new container or containers from this image, you simply need to do `buildah from fedora-bashecho`. This will create a new container based on this image for you.
 
 Now that you have the new image you can remove the scratch container called working-container:
 
+```console
     # buildah rm $newcontainer
+```
 
 or
 
+```console
     # buildah rm working-container
+```
 
 ## OCI images built using Buildah are portable
 
 Let's test if this new OCI image is really portable to another container engine like Docker. First you should install Docker and start it. Notice that Docker requires a running daemon process in order to run any client commands. Buildah and Podman have no daemon requirement.
 
+```console
     # dnf -y install docker
     # systemctl start docker
+```
 
 Let's copy that image from where containers/storage stores it to where the Docker daemon stores its images, so that we can run it using Docker. We can achieve this using `buildah push`. This copies the image to Docker's storage area which is located under `/var/lib/docker`. Docker's storage is managed by the Docker daemon. This needs to be explicitly stated by telling Buildah to push the image to the Docker daemon using `docker-daemon:`.
 
+```console
     # buildah push fedora-bashecho docker-daemon:fedora-bashecho:latest
+```
 
 Under the covers, the containers/image library calls into the containers/storage library to read the image's contents from where buildah keeps them, and sends them to the local Docker daemon, which writes them to where it keeps them. This can take a little while. And usually you won't need to do this. If you're using `buildah` you are probably not using Docker. This is just for demo purposes. Let's try it:
 
+```console
     # docker run --rm fedora-bashecho
     This is a new container from ipbabble [ 0 ]
     This is a new container from ipbabble [ 1 ]
@@ -230,10 +297,13 @@ Under the covers, the containers/image library calls into the containers/storage
     This is a new container from ipbabble [ 7 ]
     This is a new container from ipbabble [ 8 ]
     This is a new container from ipbabble [ 9 ]
+```
 
 OCI container images built with `buildah` are completely standard as expected. So now it might be time to run:
 
+```console
     # dnf -y remove docker
+```
 
 ## Using Containerfiles/Dockerfiles with Buildah
 
@@ -241,6 +311,7 @@ What if you have been using Docker for a while and have some existing Dockerfile
 
 Find one of your Dockerfiles or create a file called Dockerfile. Use the following example or some variation if you'd like:
 
+```Dockerfile
     # Base on the most recently released Fedora
     FROM fedora:latest
     MAINTAINER ipbabble email buildahboy@redhat.com # not a real email
@@ -254,22 +325,31 @@ Find one of your Dockerfiles or create a file called Dockerfile. Use the followi
 
     # Run the httpd
     CMD ["/usr/sbin/httpd", "-DFOREGROUND"]
+```
 
 Now run `buildah build` with the name of the Dockerfile and the name to be given to the created image (e.g. fedora-httpd):
 
+```console
     # buildah build -f Dockerfile -t fedora-httpd .
+```
 
 or, because `buildah build` defaults to `Dockerfile` and using the current directory as the build context:
 
+```console
     # buildah build -t fedora-httpd
+```
 
 You will see all the steps of the Dockerfile executing. Afterwards `buildah images` will show you the new image. Now we can create a container from the image and test it with `podman run`:
 
+```console
     # podman run --rm -p 8123:80 fedora-httpd
+```
 
 While that container is running, in another shell run:
 
+```console
     # curl localhost:8123
+```
 
 You will see the standard Apache webpage.
 

--- a/docs/tutorials/03-on-build.md
+++ b/docs/tutorials/03-on-build.md
@@ -15,19 +15,27 @@ The following assumes installation on Fedora.
 
 Run as root because you will need to be root for installing the Buildah package:
 
+```console
     $ sudo -s
+```
 
 Then install Buildah by running:
 
+```console
     # dnf -y install buildah
+```
 
 After installing Buildah check to see that there are no images installed. The `buildah images` command will list all the images:
 
+```console
     # buildah images
+```
 
 We can also see that there are also no containers by running:
 
+```console
     # buildah containers
+```
 
 ## Examples
 
@@ -41,7 +49,7 @@ The first example was provided by Chris Collins (GitHub @clcollins), the idea is
 
 First create two Dockerfiles:
 
-```
+```Dockerfile
 $ cat << EOF > Dockerfile
 FROM registry.fedoraproject.org/fedora:latest
 RUN touch /foo
@@ -56,7 +64,7 @@ EOF
 
 Now to create the first container image and verify that ONBUILD has been set:
 
-```
+```console
 # buildah build --format=docker -f Dockerfile -t onbuild-image .
 # buildah inspect --format '{{.Docker.Config.OnBuild}}' onbuild-image
 [RUN touch /bar]
@@ -64,7 +72,7 @@ Now to create the first container image and verify that ONBUILD has been set:
 
 The second container image is now created and the `/bar` file will be created within it:
 
-```
+```console
 # buildah build --format=docker -f Dockerfile-2 -t result-image .
 STEP 1: FROM onbuild-image
 STEP 2: RUN touch /bar    # Note /bar is created here based on the ONBUILD in the base image
@@ -82,7 +90,7 @@ Instead of using a Dockerfile to create the onbuild-image, Buildah allows you to
 
 First a Fedora container will be created with `buildah from`, then the `/foo` file will be added with `buildah run`.  The `buildah config` command will configure ONBUILD to add `/bar` when a container image is created from the primary image, and finally the image will be saved with `buildah commit`.
 
-```
+```console
 # buildah from --format=docker --name onbuild-container registry.fedoraproject.org/fedora:latest
 # buildah run onbuild-container touch /foo
 # buildah config --onbuild="RUN touch /bar" onbuild-container
@@ -93,7 +101,7 @@ First a Fedora container will be created with `buildah from`, then the `/foo` fi
 ```
 The onbuild-image has been created, so now create a container from it using the same commands as the first example using the second Dockerfile:
 
-```
+```console
 # buildah build --format=docker -f Dockerfile-2 -t result-image .
 STEP 1: FROM onbuild-image
 STEP 2: RUN touch /bar    #  Note /bar is created here based on the ONBUILD in the base image
@@ -106,7 +114,7 @@ $ container=$(buildah from result-image)
 ```
 Or for bonus points, piece the secondary container image together with Buildah commands directly:
 
-```
+```console
 # buildah from --format=docker --name result-container onbuild-image
 result-container
 # buildah run result-container touch /baz
@@ -118,7 +126,7 @@ result-container
 
 For this example the ONBUILD instructions in the primary container image will be used to copy a shell script and then run it in the secondary container image.  For the script, we'll make use of the shell script from the [Introduction Tutorial](01-intro.md).  First create a file in the local directory called `runecho.sh` containing the following:
 
-```
+```console
 #!/usr/bin/env bash
 
 for i in `seq 0 9`;
@@ -128,13 +136,13 @@ done
 ```
 Change the permissions on the file so that it can be run:
 
-```
+```console
 $ chmod +x runecho.sh
 ```
 
 Now create a second primary container image.  This image has multiple ONBUILD instructions, the first ONBUILD instruction copies the file into the image and a second ONBUILD instruction to then run it.  We're going to do this example using only Buildah commands.  A Dockerfile could be translated easily and used from these commands, or these commands could be saved to a script directly.
 
-```
+```console
 # buildah from --format=docker --name onbuild-container-2 fedora:latest
 onbuild-container-2
 # buildah config --onbuild="COPY ./runecho.sh /usr/bin/runecho.sh" onbuild-container-2
@@ -147,7 +155,7 @@ onbuild-container-2
 
 Now the secondary container can be created from the second primary container image onbuild-image-2.  The runecho.sh script will be copied to the container's /usr/bin directory and then run from there when the secondary container is created.
 
-```
+```console
 # buildah from --format=docker --name result-container-2 onbuild-image-2
 STEP 1: COPY ./runecho.sh /usr/bin/runecho.sh
 STEP 2: RUN /usr/bin/runecho.sh
@@ -164,7 +172,7 @@ result-container-2
 ```
 As result-container-2 has a copy of the script stored in its /usr/bin it can be run at anytime.
 
-```
+```console
 # buildah run result-container-2 /usr/bin/runecho.sh
 This is a new container pull ipbabble [ 1 ]
 This is a new container pull ipbabble [ 2 ]

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -23,4 +23,3 @@ Learn how to include Buildah as a library in your build tool.
 **[Rootless OpenShift container](05-openshift-rootless-build.md)**
 
 Learn how to build an image from a rootless OpenShift container.
-


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

* Consistently use --releasever instead of --release in dnf examples
* Remove trailing whitespace
* Use --use-host-config --setopt "*.countme=false" when running dnf with an empty --installroot
* Use Fedora 42 instead of Fedora 30 in examples
* Block quote console examples in tutorials

#### How to verify it

Read 'em.

#### Which issue(s) this PR fixes:

Adds hints for folks hitting #6212.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```