### PR TITLE
bud,run: runc does not support keep-groups

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -7425,7 +7425,7 @@ _EOF
   run_buildah build --group-add $id $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
   expect_output --substring "$id"
 
-  if is_rootless && has_supplemental_groups; then
+  if is_rootless && has_supplemental_groups && ! [[ $OCI =~ runc ]]; then
      run_buildah build --group-add keep-groups $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
      expect_output --substring "65534"
   fi

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -262,7 +262,7 @@ function configure_and_check_user() {
 	run_buildah run $cid id -G
 	expect_output --substring "$id"
 
-	if is_rootless && has_supplemental_groups; then
+	if is_rootless && has_supplemental_groups && ! [[ $OCI =~ runc ]]; then
 	   run_buildah from --group-add keep-groups --quiet --pull=false $WITH_POLICY_JSON alpine
 	   cid=$output
 	   run_buildah run $cid id -G


### PR DESCRIPTION
#### What type of PR is this?

> /kind failing-test 

#### What this PR does / why we need it:

Skip the final part of 2 tests that check `keep-groups` when the OCI runtime is `runc` as it doesn't support `keep-groups`.

#### How to verify it

https://openqa.opensuse.org/tests/5101660

TAP files for the above job:
- https://openqa.opensuse.org/tests/5101660/file/buildah-buildah-root.tap
- https://openqa.opensuse.org/tests/5101660/file/buildah-buildah-user.tap
- Commands run: https://openqa.opensuse.org/tests/5101660/logfile?filename=buildah-commands.txt

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Currently the tests fail with:

```
#not ok 454 build --group-add in 2902ms
# (from function `assert' in file tests/helpers.bash, line 537,
#  from function `expect_output' in file tests/helpers.bash, line 564,
#  in test file tests/bud.bats, line 7256)
#   `expect_output --substring "65534"' failed
# /var/tmp/buildah/tests /var/tmp/buildah
# # [checking for: docker.io/library/alpine]
# # [restoring from cache: /var/tmp/test.RdTF7C/bats-run-j6JS9l/suite/buildah-image-cache / docker.io/library/alpine]
# Getting image source signatures
# Copying blob sha256:9d16cba9fb961d1aafec9542f2bf7cb64acfc55245f9e4eb5abecd4cdc38d749
# Copying config sha256:961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4
# Writing manifest to image destination
# $ /usr/bin/buildah build --group-add 16335 --signature-policy /var/tmp/buildah/tests/policy.json /var/tmp/test.rdtf7c/buildah_tests.trirew
# STEP 1/2: FROM alpine
# STEP 2/2: RUN id -G
# 0 1 2 3 4 6 10 11 20 26 27 16335
# COMMIT
# Getting image source signatures
# Copying blob sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0
# Copying blob sha256:7619c5173ae54a9e8cb7882d6005beb3967d4e099c1d6787205c853b90cb8ecb
# Copying config sha256:dfe52373489c34414a7e5bea6b450d2fc7a77ef2f3507016e4c6d16292a80ce4
# Writing manifest to image destination
# --> dfe52373489c
# dfe52373489c34414a7e5bea6b450d2fc7a77ef2f3507016e4c6d16292a80ce4
# $ /usr/bin/buildah build --group-add keep-groups --signature-policy /var/tmp/buildah/tests/policy.json /var/tmp/test.rdtf7c/buildah_tests.trirew
# STEP 1/2: FROM alpine
# STEP 2/2: RUN id -G
# 0 1 2 3 4 6 10 11 20 26 27
# COMMIT
# Getting image source signatures
# Copying blob sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0
# Copying blob sha256:c8d2ed357afd4618be6d6d96ffd905ad174859e82b376f2dc5a155f88b35d6d9
# Copying config sha256:92fd6c14944ffb105adc25ba9e1afa38170ae130d9cf317b8f50edd8d48007f8
# Writing manifest to image destination
# --> 92fd6c14944f
# 92fd6c14944ffb105adc25ba9e1afa38170ae130d9cf317b8f50edd8d48007f8
# #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# #|     FAIL: buildah build --group-add keep-groups --signature-policy /var/tmp/buildah/tests/policy.json /var/tmp/test.rdtf7c/buildah_tests.trirew
# #| expected: =~ '65534'
# #|   actual:    'STEP 1/2: FROM alpine'
# #|         >    'STEP 2/2: RUN id -G'
# #|         >    '0 1 2 3 4 6 10 11 20 26 27'
# #|         >    'COMMIT'
# #|         >    'Getting image source signatures'
# #|         >    'Copying blob sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0'
# #|         >    'Copying blob sha256:c8d2ed357afd4618be6d6d96ffd905ad174859e82b376f2dc5a155f88b35d6d9'
# #|         >    'Copying config sha256:92fd6c14944ffb105adc25ba9e1afa38170ae130d9cf317b8f50edd8d48007f8'
# #|         >    'Writing manifest to image destination'
# #|         >    '--> 92fd6c14944f'
# #|         >    '92fd6c14944ffb105adc25ba9e1afa38170ae130d9cf317b8f50edd8d48007f8'
# #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```

```
#not ok 790 run --group-add in 1320ms
# (from function `assert' in file tests/helpers.bash, line 537,
#  from function `expect_output' in file tests/helpers.bash, line 564,
#  in test file tests/run.bats, line 269)
#   `expect_output --substring "65534"' failed
# /var/tmp/buildah/tests /var/tmp/buildah
# # [checking for: docker.io/library/alpine]
# # [restoring from cache: /var/tmp/test.RdTF7C/bats-run-j6JS9l/suite/buildah-image-cache / docker.io/library/alpine]
# Getting image source signatures
# Copying blob sha256:9d16cba9fb961d1aafec9542f2bf7cb64acfc55245f9e4eb5abecd4cdc38d749
# Copying config sha256:961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4
# Writing manifest to image destination
# $ /usr/bin/buildah from --group-add 7014 --quiet --pull=false --signature-policy /var/tmp/buildah/tests/policy.json alpine
# alpine-working-container
# $ /usr/bin/buildah run alpine-working-container id -G
# 0 1 2 3 4 6 10 11 20 26 27 7014
# $ /usr/bin/buildah from --group-add keep-groups --quiet --pull=false --signature-policy /var/tmp/buildah/tests/policy.json alpine
# alpine-working-container-1
# $ /usr/bin/buildah run alpine-working-container-1 id -G
# 0 1 2 3 4 6 10 11 20 26 27
# #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# #|     FAIL: buildah run alpine-working-container-1 id -G
# #| expected: =~ '65534'
# #|   actual:    '0 1 2 3 4 6 10 11 20 26 27'
# #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# /var/tmp/buildah
```

https://openqa.opensuse.org/tests/5100563/file/buildah-buildah-user.tap

#### Does this PR introduce a user-facing change?

None

```release-note

```

