### PR TITLE
"root fs only mounted once" test: accept root with only the rw option

### DIFF
--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1027,7 +1027,7 @@ _EOF
   echo "$output" > ${TEST_SCRATCH_DIR}/mountinfo1
   echo "# mountinfo unfiltered:"
   cat ${TEST_SCRATCH_DIR}/mountinfo1
-  grep ' / rw,' ${TEST_SCRATCH_DIR}/mountinfo1 > ${TEST_SCRATCH_DIR}/mountinfo2
+  grep ' / rw[, ]' ${TEST_SCRATCH_DIR}/mountinfo1 > ${TEST_SCRATCH_DIR}/mountinfo2
   echo "# mountinfo grepped:"
   cat ${TEST_SCRATCH_DIR}/mountinfo2
   wc -l < ${TEST_SCRATCH_DIR}/mountinfo2 > ${TEST_SCRATCH_DIR}/mountinfo3


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

When checking /proc/self/mountinfo for a root filesystem, also match "/" mounted with "rw" as its only mount option, as an alternative to being mounted with "rw" and other options at the same time.

#### How to verify it

The test should fail less often if run under sudo on... my laptop.  Maybe your computer, too.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```