### PR TITLE
Add CommitOptions.OmitLayerHistoryEntry, for skipping the new bits

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -94,6 +94,14 @@ type CommitOptions struct {
 	// EmptyLayer tells the builder to omit the diff for the working
 	// container.
 	EmptyLayer bool
+	// OmitLayerHistoryEntry tells the builder to omit the diff for the
+	// working container and to not add an entry in the commit history.  By
+	// default, the rest of the image's history is preserved, subject to
+	// the OmitHistory setting.  N.B.: setting this flag, without any
+	// PrependedEmptyLayers, AppendedEmptyLayers, PrependedLinkedLayers, or
+	// AppendedLinkedLayers will more or less produce a copy of the base
+	// image.
+	OmitLayerHistoryEntry bool
 	// OmitTimestamp forces epoch 0 as created timestamp to allow for
 	// deterministic, content-addressable builds.
 	// Deprecated use HistoryTimestamp instead.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add an `OmitLayerHistoryEntry` field to `CommitOptions`, which more or less causes us to reproduce our base image, except with `PrependedEmptyLayers`, `AppendedEmptyLayers`, `PrependedLinkedLayers`, `AppendedLinkedLayers`, and config changes still added in.

#### How to verify it

New unit test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```