### PR TITLE
Add conditional release-checking system test

### DIFF
--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -133,3 +133,12 @@ load helpers
   run_buildah images -q
   expect_output ""
 }
+
+@test "release" {
+  [[ "${RELEASE_TESTING:-false}" == "true" ]] || \
+    skip "Release testing may be enabled by setting \$RELEASE_TESTING = 'true'."
+
+  run_buildah --version
+
+  assert "$output" "!~" "dev" "The Buildah version string does not mention 'dev'."
+}

--- a/tests/tmt/system.fmf
+++ b/tests/tmt/system.fmf
@@ -12,6 +12,11 @@ environment:
     DUMPSPEC_BINARY: /usr/bin/buildah-dumpspec
     TMPDIR: /var/tmp
 
+adjust:
+    - when: initiator != "packit"
+      environment+:
+        RELEASE_TESTING: true
+
 /local/root:
     summary: System test
     test: bash ./system.sh


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Unfortunately on a number of occasions, Buildah has been released officially with a `-dev` suffix in the version number.  Assist in catching this mistake at release time by the addition of a simple conditional test.  Note that it must be positively enabled by a magic env. var. before executing the system tests.

Also (thanks to @lsm5) update the TMT test to trigger the new condition for future Fedora releases.

#### How to verify it

A [temporary commit](https://github.com/containers/buildah/pull/6243/commits/a66d9c99d1d9a65fd12fc233bce5b8150f2504a6) will be added to this PR to set `$RELEASE_TESTING = 'true'` while the version contains a `-dev` suffix.  This commit will be removed before final review/merging.

#### Which issue(s) this PR fixes:

None - there is no test to verify a dev version is not released

#### Special notes for your reviewer:

Ref. similar change in Skopeo: https://github.com/containers/skopeo/pull/2631

Once merged, I intend to backport this change to the supported RHEL release branches.

#### Does this PR introduce a user-facing change?

None