### PR TITLE
Accept SOURCE_DATE_EPOCH as a build-arg

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/containerd/platforms"
 	"github.com/containers/buildah"
@@ -217,6 +218,15 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 		if err != nil {
 			return "", nil, err
 		}
+	}
+
+	if sourceDateEpoch, ok := options.Args[internal.SourceDateEpochName]; ok && options.SourceDateEpoch == nil {
+		sde, err := strconv.ParseInt(sourceDateEpoch, 10, 64)
+		if err != nil {
+			return "", nil, fmt.Errorf("parsing SOURCE_DATE_EPOCH build-arg %q: %w", sourceDateEpoch, err)
+		}
+		sdeTime := time.Unix(sde, 0)
+		options.SourceDateEpoch = &sdeTime
 	}
 
 	systemContext := options.SystemContext


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When SOURCE_DATE_EPOCH is passed in as a build-arg, treat it as we would if it was passed in via the environment or its own CLI flag.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```