### PR TITLE
Update Neil Smith's GitHub username in MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,7 +13,7 @@ describes the project's governance and the Project Roles used below.
 | Paul Holzinger    | [Luap99](https://github.com/Luap99)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
 | Giuseppe Scrivano | [giuseppe](https://github.com/giuseppe)                  | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
 | Miloslav Trmač    | [mtrmac](https://github.com/mtrmac)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
-| Neil Smith        | [Neil-Smith](https://github.com/Neil-Smith)              | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
+| Neil Smith        | [actionmancan](https://github.com/actionmancan)          | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
 | Tom Sweeney       | [TomSweeneyRedHat](https://github.com/TomSweeneyRedHat/) | Maintainer and Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
 | Lokesh Mandvekar  | [lsm5](https://github.com/lsm5)                          | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |
 | Aditya Rajan      | [flouthoc](https://github.com/flouthoc)                  | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |


### PR DESCRIPTION
This PR updates Neil Smith's GitHub username from 'Neil-Smith' to 'actionmancan' in the MAINTAINERS.md file.

- Changed GitHub username from 'Neil-Smith' to 'actionmancan'
- Fixed GitHub URL from https://github.com/Neil-Smith to https://github.com/actionmancan
- Corrected column alignment by removing extra spaces
- Maintains Neil Smith's role as Community Manager
- No functional changes, just updating the GitHub handle

Does this PR introduce a user-facing change?

```release-note
None
```

Signed-off-by: G A Neil Smith <nesmith@redhat.com>