### PR TITLE
imagebuildah: do not depend on go/types

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	gotypes "go/types"
 	"io"
 	"maps"
 	"net/http"
@@ -527,9 +526,9 @@ func platformIsAcceptable(platform *v1.Platform, logger *logrus.Logger) bool {
 		logger.Trace("rejecting potential base image with no platform information")
 		return false
 	}
-	if gotypes.SizesFor("gc", platform.Architecture) == nil {
-		// the compiler's never heard of this
-		logger.Tracef("rejecting potential base image architecture %q for which Go has no knowledge of how to do unsafe code", platform.Architecture)
+	if slices.Contains([]string{"", "unknown"}, platform.Architecture) {
+		// we're hard-wired to reject images with these values
+		logger.Tracef("rejecting potential base image for which the Architecture value is always-rejected value %q", platform.Architecture)
 		return false
 	}
 	if slices.Contains([]string{"", "unknown"}, platform.OS) {


### PR DESCRIPTION
This package is quite large, this import costs us 1.4MB in binary size. 1MB when stip'ed.

I am not sure what the point of validation the architecture like this is. This seems to limit the build to architectures known by go which may not be the same as architectures users try to build. The commit 98f8707535 which added this check doesn't seem to add an actual reason either why we check the go compiler architecture list either.

Instead use the some logic like for the OS and only reject an empty or "unknown" value.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

