### PR TITLE
[release-1.26] Add conditional release-checking system test

### DIFF
--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -133,3 +133,12 @@ load helpers
   run_buildah images -q
   expect_output ""
 }
+
+@test "release" {
+  [[ "${RELEASE_TESTING:-false}" == "true" ]] || \
+    skip "Release testing may be enabled by setting \$RELEASE_TESTING = 'true'."
+
+  run_buildah --version
+
+  assert "$output" "!~" "dev" "The Buildah version string does not mention 'dev'."
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Unfortunately on a number of occasions, Buildah has been released officially with a `-dev` suffix in the version number.  Assist in catching this mistake at release time by the addition of a simple conditional test.  Note that it must be positively enabled by a magic env. var. before executing the system tests.

Ref: original PR https://github.com/containers/buildah/pull/6243

#### How to verify it

CI will pass.  Original PR confirmed (expected) test failure on `main` with magic env. var. set.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This PR was crafted and prepared with the assistance of AI

If required, I'm happy to do a test-commit and verify this fails when magic env. var. is set.  

#### Does this PR introduce a user-facing change?


```release-note
None
```

