### PR TITLE
Update "bud with --cpu-shares" test, and rename it

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6422,7 +6422,7 @@ _EOF
   expect_output --substring "memory"
 }
 
-@test "bud with --cpu-shares" {
+@test "bud with --cpu-shares, checked" {
   skip_if_chroot
   skip_if_rootless_environment
   skip_if_rootless_and_cgroupv1
@@ -6438,21 +6438,26 @@ _EOF
 
   if is_cgroupsv2; then
     cat > $mytmpdir/Containerfile << _EOF
-from alpine
-run printf "weight " && cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpu.weight
+FROM alpine
+RUN printf "weight " && cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpu.weight
 _EOF
-    expect="weight $((1 + ((${shares} - 2) * 9999) / 262142))"
+    # there's an old way to convert the value, and a new way to convert the value, and we don't know
+    # which one our runtime is using, so accept the values that either would compute for ${shares}
+    local oldexpect="weight $((1 + ((${shares} - 2) * 9999) / 262142))"
+    local newconverted=$(awk '{if ($1 <= 2) { print "1"} else if ($1 >= 262144) {print "10000"} else {l=log($1)/log(2); e=((((l+125)*l)/612.0) - 7.0/34.0); p = exp(e*log(10)); print int(p+1)}}' <<< "${shares}")
+    local newexpect="weight ${newconverted}"
+    expect="($oldexpect|$newexpect)"
   else
     cat > $mytmpdir/Containerfile << _EOF
-from alpine
-run printf "weight " && cat /sys/fs/cgroup/cpu/cpu.shares
+FROM alpine
+RUN printf "weight " && cat /sys/fs/cgroup/cpu/cpu.shares
 _EOF
     expect="weight ${shares}"
   fi
 
   run_buildah build --cpu-shares=${shares} -t testcpu \
                   $WITH_POLICY_JSON --file ${mytmpdir}/Containerfile .
-  expect_output --from="${lines[2]}" "${expect}"
+  expect_output --from="${lines[2]}" --substring "${expect}"
 }
 
 @test "bud with --cpuset-cpus" {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Update "the bud with --cpu-shares" test to expect the a cgroupsv2 value computed using either the older formula or the newer one introduced in github.com/opencontainers/cgroups v0.0.3, and give it a unique name so that it can be selected more easily with bats's "--filter" flag.

#### How to verify it

Updated test!

#### Which issue(s) this PR fixes:

Fixes #6270 

#### Special notes for your reviewer:

I thought the test errors in #6237 were flakes... nope!

#### Does this PR introduce a user-facing change?

```release-note
None
```