### PR TITLE
build,add: add support for corporate proxies

### DIFF
--- a/add.go
+++ b/add.go
@@ -141,7 +141,10 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 	}
 	tlsClientConfig.InsecureSkipVerify = insecureSkipTLSVerify == types.OptionalBoolTrue
 
-	tr := &http.Transport{TLSClientConfig: tlsClientConfig}
+	tr := &http.Transport{
+		TLSClientConfig: tlsClientConfig,
+		Proxy:           http.ProxyFromEnvironment,
+	}
 	httpClient := &http.Client{Transport: tr}
 	response, err := httpClient.Get(src)
 	if err != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -7272,6 +7272,15 @@ _EOF
   fi
 }
 
+@test "build proxy - ADD URL" {
+  _prefetch alpine
+  target=alpine-image
+  http_proxy=http://127.0.0.1:47 HTTPS_PROXY=http://127.0.0.1:47 \
+    run_buildah 125 build $WITH_POLICY_JSON -t alpine-image -f $BUDFILES/add-checksum/Containerfile $BUDFILES/add-checksum
+  expect_output --substring "127.0.0.1:47" "connection to fake proxy must fail"
+  expect_output --substring "connection refused" "connection to fake proxy must fail"
+}
+
 @test "bud-with-mount-bind-from-like-buildkit" {
   skip_if_no_runtime
   skip_if_in_container


### PR DESCRIPTION
Use the Proxy Environment http_proxy/HTTPS_PROXY/NO_PROXY to handle the http/https request.

#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

#### How to verify it

See instructions in initial error report. https://github.com/containers/podman/issues/25220

#### Which issue(s) this PR fixes:

`Fixes: https://github.com/containers/podman/issues/25220`

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


