### PR TITLE
feat(build): add --mount option

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -145,9 +145,12 @@ type BuildOptions struct {
 	Runtime string
 	// RuntimeArgs adds global arguments for the runtime.
 	RuntimeArgs []string
-	// TransientMounts is a list of unparsed mounts that will be provided to
+	// TransientMounts is a list of unparsed src:dest volume instructions that will be provided to
 	// RUN instructions.
 	TransientMounts []string
+	// TransientRunMounts is a list of unparsed mounts (e.g. type=secret etc) that will be provided to
+	// RUN instructions.
+	TransientRunMounts []string
 	// CacheFrom specifies any remote repository which can be treated as
 	// potential cache source.
 	CacheFrom []reference.Named

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -639,6 +639,20 @@ Write information about the built image to the named file.  When `--platform`
 is specified more than once, attempting to use this option will trigger an
 error.
 
+**--mount** *mount-instruction*
+
+Adds this mount to each `RUN` command in a Containerfile before executing. For example:
+
+`buildah build --mount type=secret,id=mysecret ...`
+
+and a Containerfile entry of:
+
+`RUN cat /run/secrets/mysecret`
+
+Has the same effect as:
+
+`RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret`
+
 **--network**, **--net**=*mode*
 
 Sets the configuration for network namespaces when handling `RUN` instructions.

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -82,6 +82,7 @@ type executor struct {
 	runtime                        string
 	runtimeArgs                    []string
 	transientMounts                []Mount
+	transientRunMounts             []string
 	compression                    archive.Compression
 	output                         string
 	outputFormat                   string
@@ -281,6 +282,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		runtime:                                 options.Runtime,
 		runtimeArgs:                             options.RuntimeArgs,
 		transientMounts:                         transientMounts,
+		transientRunMounts:                      options.TransientRunMounts,
 		compression:                             options.Compression,
 		output:                                  options.Output,
 		outputFormat:                            options.OutputFormat,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -844,7 +844,7 @@ func (s *stageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 		NoPivot:              os.Getenv("BUILDAH_NOPIVOT") != "" || s.executor.noPivotRoot,
 		Quiet:                s.executor.quiet,
 		CompatBuiltinVolumes: types.OptionalBoolFalse,
-		RunMounts:            run.Mounts,
+		RunMounts:            slices.Concat(run.Mounts, s.executor.transientRunMounts),
 		Runtime:              s.executor.runtime,
 		Secrets:              s.executor.secrets,
 		SSHSources:           s.executor.sshsources,

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -454,6 +454,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		Target:                  iopts.Target,
 		Timestamp:               timestamp,
 		TransientMounts:         iopts.Volumes,
+		TransientRunMounts:      iopts.TransientRunMounts,
 		UnsetEnvs:               iopts.UnsetEnvs,
 		UnsetLabels:             iopts.UnsetLabels,
 		UnsetAnnotations:        iopts.UnsetAnnotations,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -131,6 +131,7 @@ type BudResults struct {
 	RewriteTimestamp    bool
 	CreatedAnnotation   bool
 	SourcePolicyFile    string
+	TransientRunMounts  []string
 }
 
 // FromAndBugResults represents the results for common flags
@@ -301,6 +302,7 @@ newer:   only pull base and SBOM scanner images when newer images exist on the r
 	fs.BoolVar(&flags.Rm, "rm", true, "remove intermediate containers after a successful build")
 	// "runtime" definition moved to avoid name collision in podman build.  Defined in cmd/buildah/build.go.
 	fs.StringSliceVar(&flags.RuntimeFlags, "runtime-flag", []string{}, "add global flags for the container runtime")
+	fs.StringArrayVar(&flags.TransientRunMounts, "mount", []string{}, "set transient mounts for each RUN instruction, e.g. type=secret,id=mysecret")
 	fs.StringVar(&flags.SbomPreset, "sbom", "", "scan working container using `preset` configuration")
 	fs.StringVar(&flags.SbomScannerImage, "sbom-scanner-image", "", "scan working container using scanner command from `image`")
 	fs.StringArrayVar(&flags.SbomScannerCommand, "sbom-scanner-command", nil, "scan working container using `command` in scanner image")
@@ -368,6 +370,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["logfile"] = commonComp.AutocompleteDefault
 	flagCompletion["manifest"] = commonComp.AutocompleteDefault
 	flagCompletion["metadata-file"] = commonComp.AutocompleteDefault
+	flagCompletion["mount"] = commonComp.AutocompleteNone
 	flagCompletion["os"] = commonComp.AutocompleteNone
 	flagCompletion["os-feature"] = commonComp.AutocompleteNone
 	flagCompletion["os-version"] = commonComp.AutocompleteNone


### PR DESCRIPTION
This allows adding an ephemeral mount to all RUN commands in a Containerfile during a build.

#### What type of PR is this?

> /kind feature

#### What this PR does / why we need it:

This adds a `--mount` option to `build` which has the effect of adding this mount to each `RUN` command in a Containerfile before executing. For example:

`buildah build --mount type=secret,id=mysecret ...`

and a Containerfile entry of:

`RUN cat /run/secrets/mysecret`

Has the same effect as:

`RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret`

This is useful in conjunction with #6285 for building existing Containerfile's with different environmental considerations (such as SSL_CERT_FILE data etc) without needing to modify the existing Containerfile's or causing changes to the produced images.

#### How to verify it

bats test added. 

```
FOO=world ./bin/buildah build \
      --secret id=mysecret,env=FOO \
      --mount type=secret,id=mysecret,dst=/bar,required \
      -f <(printf 'FROM busybox\nRUN echo "hello $(cat /bar) welcome"')
```

Prints:

`hello world welcome`

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

There is an existing field `TransientMounts` in `BuildOptions` that had comment suggesting it would do exactly as described by this PR, however it does not quite operate as described, rather it expects each argument to be a `src:dest` volume mount (I suspect it predates other types of mounts):
https://github.com/containers/buildah/blob/db61e10b3f420786e86769d4aa1a1d2384df14c7/define/build.go#L148-L150

Since that field was part of the public API, I didn't change it's behaviour in this PR, but I did adjust the comment and added a new fields for other mounts.

#### Does this PR introduce a user-facing change?

```release-note
This adds a `--mount` option to `build` which has the effect of adding this mount to each `RUN` command in a Containerfile before executing. For example:

`buildah build --mount type=secret,id=mysecret ...`

and a Containerfile entry of:

`RUN cat /run/secrets/mysecret`

Has the same effect as:

`RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret`
```

