### PR TITLE
Exclude pulled up parent directories at commit-time

### DIFF
--- a/image.go
+++ b/image.go
@@ -1462,6 +1462,7 @@ func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageR
 	if options.CompatLayerOmissions == types.OptionalBoolTrue {
 		layerExclusions = append(layerExclusions, compatLayerExclusions...)
 	}
+	logrus.Debugf("excluding these items from committed layer: %#v", layerExclusions)
 
 	manifestType := options.PreferredManifestType
 	if manifestType == "" {

--- a/run_common.go
+++ b/run_common.go
@@ -2119,7 +2119,7 @@ func (b *Builder) createMountTargets(spec *specs.Spec) ([]copier.ConditionalRemo
 	if len(targets.Paths) == 0 {
 		return nil, nil
 	}
-	created, err := copier.Ensure(rootfsPath, rootfsPath, targets)
+	created, _, err := copier.Ensure(rootfsPath, rootfsPath, targets)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change
/kind failing-test 

#### What this PR does / why we need it:

Have `copier.Ensure()` also return the parent directories of items that it created, along with information about them that can be used to filter them out of the layer at commit-time.

This modifies the signature of `copier.Ensure()`, but it was added between 1.40 and 1.41, and shouldn't (yet) have any external users.

When `copier.Ensure()` tells us about the parent directories of a mountpoint target that it created for us, add them to the list of items that we'll exclude from the commit unless something else causes them to be modified.

The "native" overlay diff method just walks the diff directory, so we can get directories in the committed layer that look exactly like the ones in the previous layer, depending on the storage driver.  And while it's barely noticeable, we can still control for it.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

This should resolve inconsistencies in the "podman diff container and image with same name" test seen in https://github.com/containers/podman/pull/26666.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```