### PR TITLE
fix: simple non-scratch FROM image builds differ

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -2113,7 +2113,8 @@ func (s *StageExecutor) tagExistingImage(ctx context.Context, cacheID, output st
 		return "", nil, fmt.Errorf("getting source imageReference for %q: %w", cacheID, err)
 	}
 	options := cp.Options{
-		RemoveSignatures: true, // more like "ignore signatures", since they don't get removed when src and dest are the same image
+		RemoveSignatures:     true, // more like "ignore signatures", since they don't get removed when src and dest are the same image
+		DestinationTimestamp: s.executor.timestamp,
 	}
 	manifestBytes, err := cp.Image(ctx, policyContext, dest, src, &options)
 	if err != nil {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -7856,6 +7856,17 @@ _EOF
   diff "${outpath}.b" "${outpath}.c"
 }
 
+@test "build-with-timestamp-applies-to-oci-archive-with-base" {
+  local outpath="${TEST_SCRATCH_DIR}/timestamp-oci.tar"
+
+  run_buildah build -f <(echo 'FROM alpine') --tag=oci-archive:${outpath}.a --timestamp 0
+  sleep 1.1 # sleep at least 1 second, so that timestamps are incremented
+  run_buildah build -f <(echo 'FROM alpine') --tag=oci-archive:${outpath}.b --timestamp 0
+
+  # should be the same
+  diff "${outpath}.a" "${outpath}.b"
+}
+
 @test "bud-source-date-epoch-arg" {
   _prefetch busybox
   local timestamp=60


### PR DESCRIPTION
Pass through timestamp when copying existing image.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This respects `--timestamp 0` when "tagging" an existing image by exporting to an oci-archive.

#### How to verify it

See bats test added.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

