### PR TITLE
Restore the default meaning of `--pull` (should be `always`).

### DIFF
--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -75,7 +75,7 @@ missing: pull images if the named images are not present in store,
 never: only use images present in store if available,
 newer: only pull images when newer images exist on the registry than those in the store.`)
 
-	flags.Lookup("pull").NoOptDefVal = "true" // allow `--pull ` to be set to `true` as expected.
+	flags.Lookup("pull").NoOptDefVal = "always" // treat a --pull with no argument like --pull=always
 
 	flags.BoolVar(&opts.pullAlways, "pull-always", false, "pull the image even if the named image is present in store")
 	if err := flags.MarkHidden("pull-always"); err != nil {

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -794,7 +794,8 @@ The `buildah build` command allows building images for all Linux architectures, 
 
 **--pull**
 
-Pull image policy. The default is **missing**.
+Pull image policy. If not specified, the default is **missing**. If an explicit
+**--pull** argument is provided without any value, use the **always** behavior.
 
 - **always**: Pull base and SBOM scanner images from the registries listed in
 registries.conf.  Raise an error if a base or SBOM scanner image is not found

--- a/docs/buildah-from.1.md
+++ b/docs/buildah-from.1.md
@@ -388,7 +388,8 @@ the help of emulation provided by packages like `qemu-user-static`.
 
 **--pull**
 
-Pull image policy. The default is **missing**.
+Pull image policy. If not specified, the default is **missing**. If an explicit
+**--pull** argument is provided without any value, use the **always** behavior.
 
 - **always**: Pull base and SBOM scanner images from the registries listed in
 registries.conf.  Raise an error if a base or SBOM scanner image is not found

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -281,7 +281,7 @@ always:  pull base and SBOM scanner images even if the named images are present 
 missing: pull base and SBOM scanner images if the named images are not present in store.
 never:   only use images present in store if available.
 newer:   only pull base and SBOM scanner images when newer images exist on the registry than those in the store.`)
-	fs.Lookup("pull").NoOptDefVal = "missing" // treat a --pull with no argument like --pull=missing
+	fs.Lookup("pull").NoOptDefVal = "always" // treat a --pull with no argument like --pull=always
 	fs.BoolVar(&flags.PullAlways, "pull-always", false, "pull the image even if the named image is present in store")
 	if err := fs.MarkHidden("pull-always"); err != nil {
 		panic(fmt.Sprintf("error marking the pull-always flag as hidden: %v", err))

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -527,9 +527,9 @@ func pullPolicyWithFlags(policySpec string, always, never bool) (define.PullPoli
 	}
 	policy := strings.ToLower(policySpec)
 	switch policy {
-	case "true", "missing", "ifmissing", "notpresent":
+	case "missing", "ifmissing", "notpresent":
 		return define.PullIfMissing, nil
-	case "always":
+	case "true", "always":
 		return define.PullAlways, nil
 	case "false", "never":
 		return define.PullNever, nil

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -410,6 +410,12 @@ load helpers
   run_buildah inspect --format "{{.FromImageDigest}}" docker.io/busybox
   fromDigest="$output"
   run_buildah pull $WITH_POLICY_JSON docker.io/busybox
+  run_buildah from $WITH_POLICY_JSON --name busyboxc --pull docker.io/busybox
+  expect_output --substring "Getting"
+  run_buildah rm busyboxc
+  run_buildah from $WITH_POLICY_JSON --name busyboxc --pull=true docker.io/busybox
+  expect_output --substring "Getting"
+  run_buildah rm busyboxc
   run_buildah from $WITH_POLICY_JSON --name busyboxc --pull-always docker.io/busybox
   expect_output --substring "Getting"
   run_buildah commit $WITH_POLICY_JSON busyboxc fakename-img

--- a/tests/rmi.bats
+++ b/tests/rmi.bats
@@ -237,7 +237,7 @@ EOF
   cid=$output
   run_buildah config --entrypoint '[ "/ENTRYPOINT" ]' $cid
   run_buildah commit $WITH_POLICY_JSON $cid new-image
-  run_buildah from --quiet --pull=true $WITH_POLICY_JSON new-image
+  run_buildah from --quiet $WITH_POLICY_JSON new-image
   cid=$output
   run_buildah config --env 'foo=bar' $cid
   run_buildah commit $WITH_POLICY_JSON $cid new-image-2


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

Now the bud --help output reads this, correctly showing both "missing" and "always" defaults, if --pull is explicitly provided or not:

```
      --pull string[="always"]                       pull base and SBOM scanner images from the registry. Values:
                                                     always:  pull base and SBOM scanner images even if the named images are present in store.
                                                     missing: pull base and SBOM scanner images if the named images are not present in store.
                                                     newer:   only pull base and SBOM scanner images when newer images exist on the registry than those in the store. (default "missing")
```

#### How to verify it

#### Which issue(s) this PR fixes:

Fixes #6266.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Restore the meaning of `--pull` (without argument), similar to the docker behavior: now defaults to `--pull=always`
```

