### PR TITLE
Only suppress "noted" items when not squashing

### DIFF
--- a/image.go
+++ b/image.go
@@ -50,11 +50,14 @@ const (
 	// containerExcludesDir is the subdirectory of the container data
 	// directory where we drop exclusions
 	containerExcludesDir = "commit-excludes"
+	// containerPulledUpDir is the subdirectory of the container
+	// data directory where we drop exclusions when we're not squashing
+	containerPulledUpDir = "commit-pulled-up"
 	// containerExcludesSubstring is the suffix of files under
-	// $cdir/containerExcludesDir which should be ignored, as they only
-	// exist because we use CreateTemp() to create uniquely-named files,
-	// but we don't want to try to use their contents until after they've
-	// been written to
+	// $cdir/containerExcludesDir and $cdir/containerPulledUpDir which
+	// should be ignored, as they only exist because we use CreateTemp() to
+	// create uniquely-named files, but we don't want to try to use their
+	// contents until after they've been written to
 	containerExcludesSubstring = ".tmp"
 )
 
@@ -1440,9 +1443,17 @@ func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageR
 		return nil, fmt.Errorf("getting the per-container data directory for %q: %w", b.ContainerID, err)
 	}
 
-	excludesFiles, err := filepath.Glob(filepath.Join(cdir, containerExcludesDir, "*"))
+	mountTargetFiles, err := filepath.Glob(filepath.Join(cdir, containerExcludesDir, "*"))
 	if err != nil {
 		return nil, fmt.Errorf("checking for commit exclusions for %q: %w", b.ContainerID, err)
+	}
+	pulledUpFiles, err := filepath.Glob(filepath.Join(cdir, containerPulledUpDir, "*"))
+	if err != nil {
+		return nil, fmt.Errorf("checking for commit pulled-up items for %q: %w", b.ContainerID, err)
+	}
+	excludesFiles := slices.Clone(mountTargetFiles)
+	if !options.ConfidentialWorkloadOptions.Convert && !options.Squash {
+		excludesFiles = append(excludesFiles, pulledUpFiles...)
 	}
 	var layerExclusions []copier.ConditionalRemovePath
 	for _, excludesFile := range excludesFiles {

--- a/run_common.go
+++ b/run_common.go
@@ -2152,23 +2152,28 @@ func (b *Builder) createMountTargets(spec *specs.Spec) ([]copier.ConditionalRemo
 	if err != nil {
 		return nil, fmt.Errorf("finding working container bookkeeping directory: %w", err)
 	}
-	if err := os.Mkdir(filepath.Join(cdir, containerExcludesDir), 0o700); err != nil && !errors.Is(err, os.ErrExist) {
-		return nil, fmt.Errorf("creating exclusions directory: %w", err)
+	for excludesDir, exclusions := range map[string][]copier.ConditionalRemovePath{
+		containerExcludesDir: remove,
+		containerPulledUpDir: noted,
+	} {
+		if err := os.Mkdir(filepath.Join(cdir, excludesDir), 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("creating exclusions directory: %w", err)
+		}
+		encoded, err := json.Marshal(exclusions)
+		if err != nil {
+			return nil, fmt.Errorf("encoding list of items to exclude at commit-time: %w", err)
+		}
+		f, err := os.CreateTemp(filepath.Join(cdir, excludesDir), "filter*"+containerExcludesSubstring)
+		if err != nil {
+			return nil, fmt.Errorf("creating exclusions file: %w", err)
+		}
+		defer os.Remove(f.Name())
+		defer f.Close()
+		if err := ioutils.AtomicWriteFile(strings.TrimSuffix(f.Name(), containerExcludesSubstring), encoded, 0o600); err != nil {
+			return nil, fmt.Errorf("writing exclusions file: %w", err)
+		}
 	}
-	encoded, err := json.Marshal(append(slices.Clone(noted), remove...))
-	if err != nil {
-		return nil, fmt.Errorf("encoding list of items to exclude at commit-time: %w", err)
-	}
-	f, err := os.CreateTemp(filepath.Join(cdir, containerExcludesDir), "filter*"+containerExcludesSubstring)
-	if err != nil {
-		return nil, fmt.Errorf("creating exclusions file: %w", err)
-	}
-	defer os.Remove(f.Name())
-	defer f.Close()
-	if err := ioutils.AtomicWriteFile(strings.TrimSuffix(f.Name(), containerExcludesSubstring), encoded, 0o600); err != nil {
-		return nil, fmt.Errorf("writing exclusions file: %w", err)
-	}
-	// return that set of paths directly, in case the caller would prefer
-	// to clear them out before commit-time
+	// return the set of to-remove-now paths directly, in case the caller would prefer
+	// to clear them out itself now instead of waiting until commit-time
 	return remove, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When suppressing what we think are pulled-up directories at commit-time, only do that when we're _not_ squashing the image, in which case we really do need to output it into the one layer that our output image will have.  This was a case I missed in #6296.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes a test failure in podman's "zstd chunked does not modify image content" system test.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```