### PR TITLE
copy: assume a destination with basename "." is a directory

### DIFF
--- a/add.go
+++ b/add.go
@@ -434,7 +434,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			destination = tmpDestination
 		}
 	}
-	destMustBeDirectory := (len(sources) > 1) || strings.HasSuffix(destination, string(os.PathSeparator)) || destination == b.WorkDir()
+	destMustBeDirectory := (len(sources) > 1) || strings.HasSuffix(destination, string(os.PathSeparator)) || path.Base(destination) == "." || destination == b.WorkDir()
 	destCanBeFile := false
 	if len(sources) == 1 {
 		if len(remoteSources) == 1 {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -8502,3 +8502,18 @@ _EOF
   assert "$status" = "0"
   assert "${#lines[*]}" = "1"
 }
+
+@test "bud COPY one file to ..../. creates the destination directory" {
+  _prefetch busybox
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir -p ${contextdir}
+  echo hello, this is a file > ${contextdir}/file.txt
+  cat > ${contextdir}/Dockerfile << _EOF
+FROM busybox
+COPY /file.txt /app/.
+WORKDIR /app
+RUN pwd
+_EOF
+  run_buildah build --layers ${contextdir}
+  run_buildah build ${contextdir}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Assume that if the destination location for an ADD or COPY has a basename of ".", that we're meant to treat it as a directory.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes #6308

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Destination locations specified for `buildah add` and `buildah copy`, and in ADD and COPY instructions for `buildah build`, that end with "/." are now always expected to be directories.
```