### PR TITLE
build: `--mount=type=bind` ignore `modTime` for cache candidates

### DIFF
--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/containers/buildah"
 	digest "github.com/opencontainers/go-digest"
@@ -68,6 +69,11 @@ func generatePathChecksum(sourcePath string) (string, error) {
 			return err
 		}
 		header.Name = filepath.ToSlash(relPath)
+
+		// Zero out timestamp fields to ignore modification time in checksum calculation
+		header.ModTime = time.Time{}
+		header.AccessTime = time.Time{}
+		header.ChangeTime = time.Time{}
 
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return err

--- a/imagebuildah/util_test.go
+++ b/imagebuildah/util_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
@@ -51,6 +52,11 @@ func TestGeneratePathChecksum(t *testing.T) {
 			return err
 		}
 		header.Name = filepath.ToSlash(relPath)
+
+		// Zero out timestamp fields to match the modified generatePathChecksum function
+		header.ModTime = time.Time{}
+		header.AccessTime = time.Time{}
+		header.ChangeTime = time.Time{}
 
 		if err := tarWriter.WriteHeader(header); err != nil {
 			return err


### PR DESCRIPTION
When generating a checksum for files mounted into container via `--mount=type=bind` ignore their `ModTime`, `AccessTime` and `ChangeTime` so we can maintain cache burst consistency with `COPY` command.

Closes: https://github.com/containers/buildah/issues/6291

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
--mount=type=bind now does ignores modtime when looking for cache candidates.
```

