### PR TITLE
Losen the dependency on go-connections/tlsconfig

### DIFF
--- a/add.go
+++ b/add.go
@@ -144,7 +144,12 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 		return err
 	}
 	tlsClientConfig := &tls.Config{
-		CipherSuites: tlsconfig.DefaultServerAcceptedCiphers,
+		// As of 2025-08, tlsconfig.ClientDefault() differs from Go 1.23 defaults only in CipherSuites;
+		// so, limit us to only using that value. If go-connections/tlsconfig changes its policy, we
+		// will want to consider that and make a decision whether to follow suit.
+		// There is some chance that eventually the Go default will be to require TLS 1.3, and that point
+		// we might want to drop the dependency on go-connections entirely.
+		CipherSuites: tlsconfig.ClientDefault().CipherSuites,
 	}
 	if err := tlsclientconfig.SetupCertificates(certPath, tlsClientConfig); err != nil {
 		return err


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As of go-connections 0.6.0, there is no difference between "server" and "client" configuration; so, take this opportunity to switch from "server" defaults in client contexts, which were used for an unknown reason.

Also, don't use the whole tlsconfig.ClientDefault(), to _slightly_ move into the direction of using the Go built-in defaults, and to get a _bit_ closer to getting out of the business of managing TLS policy.

Should not change behavior (but the update from go-connections 0.5.0 to 0.6.0 did change the list of accepted TLS 1.2 cipher suites).

#### How to verify it

Reading the go-connections code

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

