### PR TITLE
[release-1.41] Bump to v1.41.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 # Changelog
 
+## v1.41.2 (2025-08-13)
+
+    Rework how we decide what to filter out of layer diffs
+    Note that we have to build `true` first for the sake of its tests
+    copier.Stat(): return owner UID and GID if available
+    copier.Get(): ensure that directory entries end in "/"
+    copier.Get(): strip user and group names from entries
+    imagebuildah.Executor/StageExecutor: check numeric --from= values
+
 ## v1.41.1 (2025-08-06)
 
     [release-1.41] Bump Buildah to v1.41.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+- Changelog for v1.41.2 (2025-08-13)
+  * Rework how we decide what to filter out of layer diffs
+  * Note that we have to build `true` first for the sake of its tests
+  * copier.Stat(): return owner UID and GID if available
+  * copier.Get(): ensure that directory entries end in "/"
+  * copier.Get(): strip user and group names from entries
+  * imagebuildah.Executor/StageExecutor: check numeric --from= values
+
 - Changelog for v1.41.1 (2025-08-06)
   * [release-1.41] Bump Buildah to v1.41.1
   * [release-1.41] Bump c/* projects and Buildah to v1.41.1

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.41.1"
+	Version = "1.41.2"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
Bump to Buildah v1.41.2 in order to get some last minute fixes for a breaking change into Podman v5.6.0.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

