### PR TITLE
Adding mohanboddu as community manager to MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@ describes the project's governance and the Project Roles used below.
 | Paul Holzinger    | [Luap99](https://github.com/Luap99)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
 | Giuseppe Scrivano | [giuseppe](https://github.com/giuseppe)                  | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
 | Miloslav Trmač    | [mtrmac](https://github.com/mtrmac)                      | Core Maintainer                  | [Red Hat](https://github.com/RedHatOfficial) |
+| Mohan Boddu       | [mohanboddu](https://github.com/mohanboddu)              | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
 | Neil Smith        | [actionmancan](https://github.com/actionmancan)          | Community Manager                | [Red Hat](https://github.com/RedHatOfficial) |
 | Tom Sweeney       | [TomSweeneyRedHat](https://github.com/TomSweeneyRedHat/) | Maintainer and Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
 | Lokesh Mandvekar  | [lsm5](https://github.com/lsm5)                          | Maintainer                       | [Red Hat](https://github.com/RedHatOfficial) |


### PR DESCRIPTION
Since I am a community manager for podman. I would like to add myself to the community manager role, as per https://github.com/containers/podman/blob/main/GOVERNANCE.md#maintainers-file, specifically "The MAINTAINERS.md file in the main Podman repository is used for project-spanning roles, including Core Maintainer and Community Manager."

https://github.com/containers/podman/blob/main/MAINTAINERS.md

#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Adding a community manager

#### Does this PR introduce a user-facing change?

```release-note
None
```

