### PR TITLE
Support "--imagestore" global flags

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -32,6 +32,9 @@ func getStore(c *cobra.Command) (storage.Store, error) {
 		options.GraphRoot = globalFlagResults.Root
 		options.RunRoot = globalFlagResults.RunRoot
 	}
+	if c.Flag("imagestore").Changed {
+		options.ImageStore = globalFlagResults.ImageStore
+	}
 	if c.Flag("storage-driver").Changed {
 		options.GraphDriverName = globalFlagResults.StorageDriver
 		// If any options setup in config, these should be dropped if user overrode the driver

--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -29,6 +29,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&options.GraphRoot, "root", "", "storage root dir")
 	flag.StringVar(&options.RunRoot, "runroot", "", "storage state dir")
 	flag.StringVar(&options.GraphDriverName, "storage-driver", "", "storage driver")
+	flag.StringVar(&options.ImageStore, "imagestore", "", "storage imagestore")
 	flag.StringVar(&testSystemContext.SystemRegistriesConfPath, "registries-conf", "", "registries list")
 	flag.BoolVar(&debug, "debug", false, "turn on debug logging")
 	flag.Parse()
@@ -58,6 +59,7 @@ func TestGetStore(t *testing.T) {
 	flags := testCmd.PersistentFlags()
 	flags.String("root", storeOptions.GraphRoot, "")
 	flags.String("runroot", storeOptions.RunRoot, "")
+	flags.String("imagestore", storeOptions.ImageStore, "")
 	flags.String("storage-driver", storeOptions.GraphDriverName, "")
 	flags.String("signature-policy", "", "")
 	if err := flags.MarkHidden("signature-policy"); err != nil {

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -28,6 +28,7 @@ type globalFlags struct {
 	LogLevel                   string
 	Root                       string
 	RunRoot                    string
+	ImageStore                 string
 	StorageDriver              string
 	RegistriesConf             string
 	RegistriesConfDir          string
@@ -98,6 +99,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&globalFlagResults.RunRoot, "runroot", storageOptions.RunRoot, "storage state dir")
 	rootCmd.PersistentFlags().StringVar(&globalFlagResults.CgroupManager, "cgroup-manager", defaultContainerConfig.Engine.CgroupManager, "cgroup manager")
 	rootCmd.PersistentFlags().StringVar(&globalFlagResults.StorageDriver, "storage-driver", storageOptions.GraphDriverName, "storage-driver")
+	rootCmd.PersistentFlags().StringVar(&globalFlagResults.ImageStore, "imagestore", storageOptions.ImageStore, "storage imagestore")
 	rootCmd.PersistentFlags().StringSliceVar(&globalFlagResults.StorageOpts, "storage-opt", defaultStoreDriverOptions, "storage driver option")
 	rootCmd.PersistentFlags().StringSliceVar(&globalFlagResults.UserNSUID, "userns-uid-map", []string{}, "default `ctrID:hostID:length` UID mapping to use")
 	rootCmd.PersistentFlags().StringSliceVar(&globalFlagResults.UserNSGID, "userns-gid-map", []string{}, "default `ctrID:hostID:length` GID mapping to use")

--- a/docs/buildah.1.md
+++ b/docs/buildah.1.md
@@ -27,6 +27,15 @@ The CGroup manager to use for container cgroups. Supported values are cgroupfs o
 Note: Setting this flag can cause certain commands to break when called on containers previously created by the other CGroup manager type.
 Note: CGroup manager is not supported in rootless mode when using CGroups Version V1.
 
+**--imagestore** *path*
+
+Path under which content for pulled and built images will be stored.  By default, the configured **--root** location
+is used for pulled and built images as well as containers.  If the storage driver is
+*overlay*, then any images which have previously been written to the **--root** location will still
+be available.
+
+This will override the *imagestore* option in containers-storage.conf(5).
+
 **--log-level** **value**
 
 The log level to be used. Either "trace", "debug", "info", "warn", "error", "fatal", or "panic", defaulting to "warn".
@@ -53,13 +62,13 @@ be used, as the default behavior of using the system-wide configuration
 
 **--root** **value**
 
-Storage root dir (default: "/var/lib/containers/storage" for UID 0, "$HOME/.local/share/containers/storage" for other users)
-Default root dir is configured in /etc/containers/storage.conf
+Storage root dir (default: "/var/lib/containers/storage" for UID 0, "$HOME/.local/share/containers/storage" for other users).
+The default root dir is configured in /etc/containers/storage.conf.
 
 **--runroot** **value**
 
-Storage state dir (default: "/run/containers/storage" for UID 0, "/run/user/$UID" for other users)
-Default state dir is configured in /etc/containers/storage.conf
+Storage state dir (default: "/run/containers/storage" for UID 0, "/run/user/$UID" for other users).
+The default state dir is configured in /etc/containers/storage.conf.
 
 **--short-name-alias-conf** *path*
 

--- a/info.go
+++ b/info.go
@@ -133,6 +133,7 @@ func storeInfo(store storage.Store) (map[string]any, error) {
 	info := map[string]any{}
 	info["GraphRoot"] = store.GraphRoot()
 	info["RunRoot"] = store.RunRoot()
+	info["GraphImageStore"] = store.ImageStore()
 	info["GraphDriverName"] = store.GraphDriverName()
 	info["GraphOptions"] = store.GraphOptions()
 	statusPairs, err := store.Status()
@@ -144,6 +145,7 @@ func storeInfo(store storage.Store) (map[string]any, error) {
 		status[pair[0]] = pair[1]
 	}
 	info["GraphStatus"] = status
+
 	images, err := store.Images()
 	if err != nil {
 		logrus.Error(err, "error getting number of images")

--- a/tests/copy/copy.go
+++ b/tests/copy/copy.go
@@ -141,6 +141,7 @@ func main() {
 
 	rootCmd.PersistentFlags().StringVar(&storeOptions.GraphRoot, "root", "", "storage root")
 	rootCmd.PersistentFlags().StringVar(&storeOptions.RunRoot, "runroot", "", "runtime root")
+	rootCmd.PersistentFlags().StringVar(&storeOptions.ImageStore, "imagestore", "", "storage imagestore")
 	rootCmd.PersistentFlags().StringVar(&storeOptions.GraphDriverName, "storage-driver", "", "storage driver")
 	rootCmd.PersistentFlags().StringSliceVar(&storeOptions.GraphDriverOptions, "storage-opt", nil, "storage option")
 	rootCmd.PersistentFlags().StringVar(&systemContext.SystemRegistriesConfPath, "registries-conf", "", "location of registries.conf")

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -391,7 +391,7 @@ function run_buildah() {
         retry=$(( retry - 1 ))
 
         # stdout is only emitted upon error; this echo is to help a debugger
-        echo "${_LOG_PROMPT} $BUILDAH_BINARY $*"
+        echo "${_LOG_PROMPT} ${BUILDAH_BINARY} $*"
         run env CONTAINERS_CONF=${CONTAINERS_CONF:-$(dirname ${BASH_SOURCE})/containers.conf} timeout --foreground --kill=10 $BUILDAH_TIMEOUT ${BUILDAH_BINARY} ${BUILDAH_REGISTRY_OPTS} ${ROOTDIR_OPTS} "$@"
         # without "quotes", multiple lines are glommed together into one
         if [ -n "$output" ]; then

--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -40,6 +40,7 @@ func main() {
 	root := flag.String("root", storeOptions.GraphRoot, "storage root directory")
 	runroot := flag.String("runroot", storeOptions.RunRoot, "storage runtime directory")
 	driver := flag.String("storage-driver", storeOptions.GraphDriverName, "storage driver")
+	imagestore := flag.String("imagestore", storeOptions.ImageStore, "storage imagestore")
 	opts := flag.String("storage-opts", "", "storage option list (comma separated)")
 	policy := flag.String("signature-policy", "", "signature policy file")
 	mtype := flag.String("expected-manifest-type", define.OCIv1ImageManifest, "expected manifest type")
@@ -76,6 +77,9 @@ func main() {
 	if driver != nil {
 		storeOptions.GraphDriverName = *driver
 		storeOptions.GraphDriverOptions = nil
+	}
+	if imagestore != nil {
+		storeOptions.ImageStore = *imagestore
 	}
 	if opts != nil && *opts != "" {
 		storeOptions.GraphDriverOptions = strings.Split(*opts, ",")


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add the global `--imagestore` flag to the buildah command and to the copy and imgtype test helpers.

#### How to verify it

Updated unit test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The global `--imagestore` flag can now be used when configuring storage.
```

