### PR TITLE
[release-1.41] Commit: don't depend on MountImage(), because .imagestore

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -8728,3 +8728,24 @@ _EOF
   diff -u ${TEST_SCRATCH_DIR}/squashed-layered-image-rootfs.txt ${TEST_SCRATCH_DIR}/squashed-image-rootfs.txt
   diff -u ${TEST_SCRATCH_DIR}/squashed-layered-image-rootfs.txt ${TEST_SCRATCH_DIR}/squashed-not-layered-image-rootfs.txt
 }
+
+@test "bud with a previously-used graphroot with base image in it used as imagestore" {
+  # there are subtle differences between "this was always the imagestore" and
+  # "this was a graphroot, but i'm using it as an imagestore now"
+  case "${STORAGE_DRIVER}" in
+    overlay) ;;
+    *) skip "imagestore flag is compatible with overlay, but not ${STORAGE_DRIVER}" ;;
+  esac
+
+  _prefetch quay.io/libpod/alpine:latest
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir -p ${contextdir}
+  cat > ${contextdir}/Dockerfile << _EOF
+FROM quay.io/libpod/alpine:latest
+RUN mkdir hello
+_EOF
+
+  run_buildah --root=${TEST_SCRATCH_DIR}/newroot --storage-opt=imagestore=${TEST_SCRATCH_DIR}/root build --pull=never --no-cache --layers=true ${contextdir}
+  run_buildah --root=${TEST_SCRATCH_DIR}/newroot --storage-opt=imagestore=${TEST_SCRATCH_DIR}/root build --pull=never ${contextdir}
+  run_buildah --root=${TEST_SCRATCH_DIR}/newroot --storage-opt=imagestore=${TEST_SCRATCH_DIR}/root build --pull=never --squash ${contextdir}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fall back to creating a new builder with it if MountImage() fails on the base image, because when the store is configured with its "imagestore" option, that can happen.

#### How to verify it

New integration test.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Manual cherry-pick of #6340.

#### Does this PR introduce a user-facing change?

```release-note
None
```