### PR TITLE
Add --transient-store global option

### DIFF
--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -35,6 +35,9 @@ func getStore(c *cobra.Command) (storage.Store, error) {
 	if c.Flag("imagestore").Changed {
 		options.ImageStore = globalFlagResults.ImageStore
 	}
+	if c.Flag("transient-store").Changed {
+		options.TransientStore = globalFlagResults.TransientStore
+	}
 	if c.Flag("storage-driver").Changed {
 		options.GraphDriverName = globalFlagResults.StorageDriver
 		// If any options setup in config, these should be dropped if user overrode the driver

--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -30,6 +30,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&options.RunRoot, "runroot", "", "storage state dir")
 	flag.StringVar(&options.GraphDriverName, "storage-driver", "", "storage driver")
 	flag.StringVar(&options.ImageStore, "imagestore", "", "storage imagestore")
+	flag.BoolVar(&options.TransientStore, "transient-store", false, "use transient storage")
 	flag.StringVar(&testSystemContext.SystemRegistriesConfPath, "registries-conf", "", "registries list")
 	flag.BoolVar(&debug, "debug", false, "turn on debug logging")
 	flag.Parse()
@@ -60,6 +61,7 @@ func TestGetStore(t *testing.T) {
 	flags.String("root", storeOptions.GraphRoot, "")
 	flags.String("runroot", storeOptions.RunRoot, "")
 	flags.String("imagestore", storeOptions.ImageStore, "")
+	flags.Bool("transient-store", storeOptions.TransientStore, "")
 	flags.String("storage-driver", storeOptions.GraphDriverName, "")
 	flags.String("signature-policy", "", "")
 	if err := flags.MarkHidden("signature-policy"); err != nil {

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -29,6 +29,7 @@ type globalFlags struct {
 	Root                       string
 	RunRoot                    string
 	ImageStore                 string
+	TransientStore             bool
 	StorageDriver              string
 	RegistriesConf             string
 	RegistriesConfDir          string
@@ -100,6 +101,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&globalFlagResults.CgroupManager, "cgroup-manager", defaultContainerConfig.Engine.CgroupManager, "cgroup manager")
 	rootCmd.PersistentFlags().StringVar(&globalFlagResults.StorageDriver, "storage-driver", storageOptions.GraphDriverName, "storage-driver")
 	rootCmd.PersistentFlags().StringVar(&globalFlagResults.ImageStore, "imagestore", storageOptions.ImageStore, "storage imagestore")
+	rootCmd.PersistentFlags().BoolVar(&globalFlagResults.TransientStore, "transient-store", storageOptions.TransientStore, "store some information in transient storage")
 	rootCmd.PersistentFlags().StringSliceVar(&globalFlagResults.StorageOpts, "storage-opt", defaultStoreDriverOptions, "storage driver option")
 	rootCmd.PersistentFlags().StringSliceVar(&globalFlagResults.UserNSUID, "userns-uid-map", []string{}, "default `ctrID:hostID:length` UID mapping to use")
 	rootCmd.PersistentFlags().StringSliceVar(&globalFlagResults.UserNSGID, "userns-gid-map", []string{}, "default `ctrID:hostID:length` GID mapping to use")

--- a/docs/buildah.1.md
+++ b/docs/buildah.1.md
@@ -36,7 +36,7 @@ be available.
 
 This will override the *imagestore* option in containers-storage.conf(5).
 
-**--log-level** **value**
+**--log-level** *level*
 
 The log level to be used. Either "trace", "debug", "info", "warn", "error", "fatal", or "panic", defaulting to "warn".
 
@@ -60,12 +60,12 @@ include a registry or domain portion.  It is not recommended that this option
 be used, as the default behavior of using the system-wide configuration
 (*/etc/containers/registries.d*) is most often preferred.
 
-**--root** **value**
+**--root** *path*
 
 Storage root dir (default: "/var/lib/containers/storage" for UID 0, "$HOME/.local/share/containers/storage" for other users).
 The default root dir is configured in /etc/containers/storage.conf.
 
-**--runroot** **value**
+**--runroot** *path*
 
 Storage state dir (default: "/run/containers/storage" for UID 0, "/run/user/$UID" for other users).
 The default state dir is configured in /etc/containers/storage.conf.
@@ -95,6 +95,10 @@ specify additional options via the `--storage-opt` flag.
 **--storage-opt** **value**
 
 Storage driver option, Default storage driver options are configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode). The `STORAGE_OPTS` environment variable overrides the default. The --storage-opt specified options overrides all.
+
+**--transient-store** *bool-value*
+
+Store metadata about containers under the storage state directory (**--runroot**), with the intention that records about them will be removed when the system is rebooted.  Additional garbage collection must still be performed at boot-time, so this option should remain disabled in most configurations. (default: false)
 
 **--userns-gid-map** *mapping*
 

--- a/info.go
+++ b/info.go
@@ -134,6 +134,7 @@ func storeInfo(store storage.Store) (map[string]any, error) {
 	info["GraphRoot"] = store.GraphRoot()
 	info["RunRoot"] = store.RunRoot()
 	info["GraphImageStore"] = store.ImageStore()
+	info["GraphTransientStore"] = store.TransientStore()
 	info["GraphDriverName"] = store.GraphDriverName()
 	info["GraphOptions"] = store.GraphOptions()
 	statusPairs, err := store.Status()

--- a/tests/copy/copy.go
+++ b/tests/copy/copy.go
@@ -142,6 +142,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&storeOptions.GraphRoot, "root", "", "storage root")
 	rootCmd.PersistentFlags().StringVar(&storeOptions.RunRoot, "runroot", "", "runtime root")
 	rootCmd.PersistentFlags().StringVar(&storeOptions.ImageStore, "imagestore", "", "storage imagestore")
+	rootCmd.PersistentFlags().BoolVar(&storeOptions.TransientStore, "transient-store", false, "store some information in transient storage")
 	rootCmd.PersistentFlags().StringVar(&storeOptions.GraphDriverName, "storage-driver", "", "storage driver")
 	rootCmd.PersistentFlags().StringSliceVar(&storeOptions.GraphDriverOptions, "storage-opt", nil, "storage option")
 	rootCmd.PersistentFlags().StringVar(&systemContext.SystemRegistriesConfPath, "registries-conf", "", "location of registries.conf")

--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -41,6 +41,7 @@ func main() {
 	runroot := flag.String("runroot", storeOptions.RunRoot, "storage runtime directory")
 	driver := flag.String("storage-driver", storeOptions.GraphDriverName, "storage driver")
 	imagestore := flag.String("imagestore", storeOptions.ImageStore, "storage imagestore")
+	transientStore := flag.Bool("transient-store", storeOptions.TransientStore, "store some information in transient storage")
 	opts := flag.String("storage-opts", "", "storage option list (comma separated)")
 	policy := flag.String("signature-policy", "", "signature policy file")
 	mtype := flag.String("expected-manifest-type", define.OCIv1ImageManifest, "expected manifest type")
@@ -80,6 +81,9 @@ func main() {
 	}
 	if imagestore != nil {
 		storeOptions.ImageStore = *imagestore
+	}
+	if transientStore != nil {
+		storeOptions.TransientStore = *transientStore
 	}
 	if opts != nil && *opts != "" {
 		storeOptions.GraphDriverOptions = strings.Split(*opts, ",")


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Add another global storage configuration option.

#### How to verify it

Uh, updated unit test.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The global `--transient-store` flag is now recognized.
```