### PR TITLE
chroot: use $PATH when finding commands

### DIFF
--- a/chroot/run_common.go
+++ b/chroot/run_common.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -741,6 +742,15 @@ func runUsingChrootExecMain() {
 	if err = unix.Setresuid(int(user.UID), int(user.UID), int(user.UID)); err != nil {
 		fmt.Fprintf(os.Stderr, "error setting UID: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Set $PATH to the value for the container, so that when args[0] is not an absolute path,
+	// exec.Command() can find it using exec.LookPath().
+	for _, env := range slices.Backward(options.Spec.Process.Env) {
+		if val, ok := strings.CutPrefix(env, "PATH="); ok {
+			os.Setenv("PATH", val)
+			break
+		}
 	}
 
 	// Actually run the specified command.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Use the $PATH from the runtime config when the command to run isn't an absolute path and the command isn't being processed by the shell.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes https://github.com/containers/podman/discussions/27024.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The chroot isolation handler should now correctly use $PATH to find the binary to run when RUN instructions express the command to run in exec form, and which do not do so using an absolute path.
```