### PR TITLE
Run: create parent directories of mount targets with mode 0755

### DIFF
--- a/run_common.go
+++ b/run_common.go
@@ -2121,6 +2121,12 @@ func (b *Builder) createMountTargets(spec *specs.Spec) ([]copier.ConditionalRemo
 				// forced permissions
 				mode = &perms
 			}
+			if mode == nil && destination != cleanedDestination {
+				// parent directories default to 0o755, for
+				// the sake of commands running as UID != 0
+				perms := os.FileMode(0o755)
+				mode = &perms
+			}
 			targets.Paths = append(targets.Paths, copier.EnsurePath{
 				Path:     destination,
 				Typeflag: typeFlag,

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1361,6 +1361,8 @@ _EOF
   RUN --mount=type=cache,id=${cacheid},target=/var/tmp,uid=1000,gid=1000 stat / /var/tmp
   RUN --mount=type=cache,id=${cacheid},target=/var/tmp,uid=1000,gid=1000 test \`stat -c %u /var/tmp\` -eq 1000
   RUN --mount=type=cache,id=${cacheid},target=/var/tmp,uid=1000,gid=1000 touch /var/tmp/should-be-able-to-write
+  RUN --mount=type=cache,id=${cacheid},target=/new-parent/var/tmp,uid=1000,gid=1000 touch /var/tmp/should-be-able-to-write
+  RUN --mount=type=cache,id=${cacheid},target=/var/new-parent/tmp,uid=1000,gid=1000 touch /var/tmp/should-be-able-to-write
 EOF
   run_buildah build $WITH_POLICY_JSON ${contextdir}
 
@@ -1372,12 +1374,63 @@ EOF
   RUN --mount=type=cache,id=${cacheid},target=/var/tmp,uid=1000,gid=1000 stat / /var/tmp
   RUN --mount=type=cache,id=${cacheid},target=/var/tmp,uid=1000,gid=1000 test \`stat -c %u /var/tmp\` -eq 1000
   RUN --mount=type=cache,id=${cacheid},target=/var/tmp,uid=1000,gid=1000 touch /var/tmp/should-be-able-to-write
+  RUN --mount=type=cache,id=${cacheid},target=/new/parent/var/tmp,uid=1000,gid=1000 touch /new/parent/var/tmp/should-be-able-to-write
+  RUN --mount=type=cache,id=${cacheid},target=/var/new/parent/tmp,uid=1000,gid=1000 touch /var/new/parent/tmp/should-be-able-to-write
 EOF
   if test `id -u` -eq 0 ; then
     run_buildah build --userns-uid-map 0:1:1023 --userns-gid-map 0:1:1023 $WITH_POLICY_JSON ${contextdir}
   else
     run_buildah build --userns auto:size=1023 $WITH_POLICY_JSON ${contextdir}
   fi
+}
+
+@test "build-mount-cache-writeable-as-unprivileged-user" {
+  _prefetch busybox
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir ${contextdir}
+
+  cat > ${contextdir}/Dockerfile << EOF
+  FROM busybox
+  USER 1000:1000
+  RUN --mount=type=cache,target=/usr/local/bin,id=/usr/local/bin/$$,uid=1000,gid=1000 touch /usr/local/bin/new-file
+  RUN --mount=type=cache,target=/var/not/already/there,id=/var/not/already/there/$$,uid=1000,gid=1000 touch /var/not/already/there/new-file
+EOF
+  run_buildah build $WITH_POLICY_JSON ${contextdir}
+}
+
+@test "build-mount-bind-readable-as-unprivileged-user" {
+  _prefetch busybox
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir ${contextdir}
+
+  cat > ${contextdir}/Dockerfile << EOF
+  FROM busybox
+  USER 1000:1000
+  RUN --mount=type=bind,target=/usr/local,from=busybox busybox ls /usr/local/bin/busybox
+  RUN --mount=type=bind,target=/var/not/already/there,from=busybox busybox ls /var/not/already/there/bin/busybox
+EOF
+  run_buildah build $WITH_POLICY_JSON ${contextdir}
+}
+
+@test "build-mount-secret-readable-as-unprivileged-user" {
+  _prefetch busybox
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir ${contextdir}
+  local secretfile=${TEST_SCRATCH_DIR}/secret.txt
+
+  echo -n hidingInPlainSight > ${secretfile}
+  cat > ${contextdir}/Dockerfile << EOF
+  FROM busybox
+  USER 1000:1000
+  RUN --mount=type=secret,id=theSecret,target=/var/not/already/there,uid=1000,gid=1000 wc -c /var/not/already/there
+EOF
+  run_buildah build --secret id=theSecret,type=file,src=${secretfile} $WITH_POLICY_JSON ${contextdir}
+  cat > ${contextdir}/Dockerfile << EOF
+  FROM busybox
+  USER 1000:1000
+  RUN --mount=type=secret,id=theSecret,target=/top/var/tmp/there,uid=1000,gid=1000 wc -c /top/var/tmp/there
+EOF
+  run_buildah build --secret id=theSecret,type=file,src=${secretfile} $WITH_POLICY_JSON ${contextdir}
 }
 
 @test "build test if supplemental groups has gid with --isolation chroot" {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -982,13 +982,13 @@ _EOF
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
 	for mask in /proc/acpi /proc/interrupts /proc/kcore /proc/keys /proc/latency_stats /proc/sched_debug /proc/scsi /proc/timer_list /proc/timer_stats /sys/devices/virtual/powercap /sys/firmware /sys/fs/selinux; do
-	        if test -d $mask; then
-                   run_buildah run $cid sh -c "echo $mask/*" # globbing will fail whether it's simply unreadable, or readable but empty
-                   expect_output "$mask/*" "Directories should be empty"
+		if test -d $mask; then
+			run_buildah run $cid sh -c "echo $mask/*" # globbing will fail whether it's simply unreadable, or readable but empty
+			expect_output "$mask/*" "Directories should be empty"
 		fi
 		if test -f $mask; then
-		   run_buildah run $cid cat $mask
-		   expect_output "" "Directories should be empty"
+			run_buildah run $cid cat $mask
+			expect_output "" "Directories should be empty"
 		fi
 	done
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Relax the permissions on directories we create to hold mount targets, from 0700 to 0755.

#### How to verify it

New integration tests!

#### Which issue(s) this PR fixes:

Fixes #6361 
Fixes https://github.com/containers/podman/issues/27044

#### Special notes for your reviewer:

#6233 was apparently a bit too tight, permissions-wise, when creating directories instead of leaving them for the runtime.

#### Does this PR introduce a user-facing change?

```release-note
Parent directories created for mounts used by `buildah run` or by RUN instructions in `buildah build` will be world-readable again.
```