### PR TITLE
[release-1.41] tag v1.41.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Changelog
 
+## v1.41.5 (2025-09-29)
+
+    [release-1.41] Run: create parent directories of mount targets with mode 0755
+    [release-1.41] tests/run.bats: "run masks" test: accept "unreadable" masked directories
+
 ## v1.41.4 (2025-09-03)
 
     [release-1.41] c/common to v0.64.2, ulikunitz/xv v0.5.12, docker/docker v28.3.3

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+- Changelog for v1.41.5 (2025-09-29)
+
+    [release-1.41] Run: create parent directories of mount targets with mode 0755
+    [release-1.41] tests/run.bats: "run masks" test: accept "unreadable" masked directories
+
 - Changelog for v1.41.4 (2025-09-03)
   * [release-1.41] c/common to v0.64.2, ulikunitz/xv v0.5.12, docker/docker v28.3.3
 

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.41.4"
+	Version = "1.41.5"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Tag a v1.41.5 release, mainly to pull in #6389.

Fixes: https://issues.redhat.com/browse/RHEL-115166 and https://issues.redhat.com/browse/RHEL-115167

#### How to verify it

Existing tests.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```