### PR TITLE
`manifest add`: prefer lists when looking up for `--all`

### DIFF
--- a/internal/volumes/volumes.go
+++ b/internal/volumes/volumes.go
@@ -253,7 +253,7 @@ func GetBindMount(sys *types.SystemContext, args []string, contextDir string, st
 		// if mountPoint of image was not found in additionalMap
 		// or additionalMap was nil, try mounting image
 		if mountPoint == "" {
-			image, err := internalUtil.LookupImage(sys, store, fromWhere)
+			image, _, err := internalUtil.LookupImage(sys, store, fromWhere, false)
 			if err != nil {
 				return newMount, "", "", "", err
 			}
@@ -515,7 +515,7 @@ func GetCacheMount(sys *types.SystemContext, args []string, store storage.Store,
 		// it's not an additional build context, stage, or
 		// already-mounted image, but it might still be an image
 		if mountPoint == "" {
-			image, err := internalUtil.LookupImage(sys, store, fromWhere)
+			image, _, err := internalUtil.LookupImage(sys, store, fromWhere, false)
 			if err != nil {
 				return newMount, "", "", "", nil, err
 			}

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -112,6 +112,14 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     expect_output --substring ${IMAGE_LIST_ARM64_INSTANCE_DIGEST}
     expect_output --substring ${IMAGE_LIST_PPC64LE_INSTANCE_DIGEST}
     expect_output --substring ${IMAGE_LIST_S390X_INSTANCE_DIGEST}
+    run_buildah manifest create foo2
+    run_buildah manifest add --all foo2 foo
+    run_buildah manifest inspect foo2
+    expect_output --substring ${IMAGE_LIST_AMD64_INSTANCE_DIGEST}
+    expect_output --substring ${IMAGE_LIST_ARM_INSTANCE_DIGEST}
+    expect_output --substring ${IMAGE_LIST_ARM64_INSTANCE_DIGEST}
+    expect_output --substring ${IMAGE_LIST_PPC64LE_INSTANCE_DIGEST}
+    expect_output --substring ${IMAGE_LIST_S390X_INSTANCE_DIGEST}
 }
 
 @test "manifest-annotate global annotation" {

--- a/util/util.go
+++ b/util/util.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/containers/buildah/define"
+	"github.com/containers/buildah/internal/util"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -140,16 +141,7 @@ func ExpandNames(names []string, systemContext *types.SystemContext, store stora
 // name.  Please note that the second argument has been deprecated and has no
 // effect anymore.
 func FindImage(store storage.Store, _ string, systemContext *types.SystemContext, image string) (types.ImageReference, *storage.Image, error) {
-	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	localImage, _, err := runtime.LookupImage(image, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	ref, err := localImage.StorageReference()
+	localImage, ref, err := util.LookupImage(systemContext, store, image, false)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When looking up the image to add, if we were passed `--all`, set the flag that we pass to libimage to indicate that we prefer a list if there is one, so that it doesn't just hand us back one image from a list.

#### How to verify it

Updated test!

#### Which issue(s) this PR fixes:

Related to https://github.com/containers/podman/issues/27228.

#### Special notes for your reviewer:

Requires https://github.com/containers/container-libs/pull/382.

#### Does this PR introduce a user-facing change?

```release-note
None
```