### PR TITLE
commit: always return the config digest as the image ID

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -1086,7 +1086,11 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 	}
 	logrus.Debugf("printing final image id %q", imageID)
 	if b.iidfile != "" {
-		if err = os.WriteFile(b.iidfile, []byte("sha256:"+imageID), 0o644); err != nil {
+		iid := imageID
+		if iid != "" {
+			iid = "sha256:" + iid // only prepend a digest algorithm name if we actually got a value back
+		}
+		if err = os.WriteFile(b.iidfile, []byte(iid), 0o644); err != nil {
 			return imageID, ref, fmt.Errorf("failed to write image ID to file %q: %w", b.iidfile, err)
 		}
 	} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When committing, if we didn't get an image ID off the bat because the image wasn't being committed to local storage, try to return the image's configuration blob digest, which is what is traditionally used as the image's ID.

This allows the --iidfile flag to write a value to a file in situations where the image isn't being written to local storage.  The image ID is of limited value in these cases, since we can't use it to look up the image anywhere else, but at least we don't write a file that just has the digest name prefix or log an empty string.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes #6425.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```