### PR TITLE
copier: ignore user.overlay.* xattrs

### DIFF
--- a/copier/xattrs.go
+++ b/copier/xattrs.go
@@ -21,6 +21,7 @@ const (
 
 var (
 	relevantAttributes    = []string{"security.capability", imaXattr, "user.*"} // the attributes that we preserve - we discard others
+	irrelevantAttributes  = []string{"user.overlay.*"}                          // the attributes that we discard, even from the relevantAttributes list
 	initialXattrListSize  = 64 * 1024
 	initialXattrValueSize = 64 * 1024
 )
@@ -32,6 +33,13 @@ func isRelevantXattr(attribute string) bool {
 		matched, err := filepath.Match(relevant, attribute)
 		if err != nil || !matched {
 			continue
+		}
+		for _, irrelevant := range irrelevantAttributes {
+			matched, err := filepath.Match(irrelevant, attribute)
+			if err != nil || !matched {
+				continue
+			}
+			return false
 		}
 		return true
 	}

--- a/copier/xattrs_test.go
+++ b/copier/xattrs_test.go
@@ -10,12 +10,37 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
 	// exercise the ERANGE-handling logic
 	initialXattrListSize = 1
 	initialXattrValueSize = 1
+}
+
+func TestXattrIsRelevant(t *testing.T) {
+	cases := []struct {
+		xattrName string
+		relevant  bool
+	}{
+		{"user.a", true},
+		{"user.b", true},
+		{"security.foo", false},
+		{imaXattr, true},
+		{"security.capability", true},
+		{"user.overlay.base", false},
+	}
+	for _, c := range cases {
+		t.Run(c.xattrName, func(t *testing.T) {
+			relevant := isRelevantXattr(c.xattrName)
+			if c.relevant {
+				require.True(t, relevant, "should be considered relevant and kept")
+			} else {
+				require.False(t, relevant, "should be considered irrelevant and discarded")
+			}
+		})
+	}
 }
 
 func TestXattrs(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

When reading content, and when squashing images, discard xattrs in the user.overlay namespace, to match the storage library's output when it's generating layer diffs.

#### How to verify it

New unit test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```