### PR TITLE
Introduce CommitResults(), add --metadata-file

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -418,4 +418,7 @@ type BuildOptions struct {
 	// CreatedAnnotation controls whether or not an "org.opencontainers.image.created"
 	// annotation is present in the output image.
 	CreatedAnnotation types.OptionalBool
+	// MetadataFile is the name of a file to which the builder should write a JSON map
+	// containing metadata about the built image.
+	MetadataFile string
 }

--- a/docker/types.go
+++ b/docker/types.go
@@ -257,3 +257,10 @@ type V2S2Manifest struct {
 	// configuration.
 	Layers []V2S2Descriptor `json:"layers"`
 }
+
+const (
+	// github.com/moby/buildkit/exporter/containerimage/exptypes/types.go
+	ExporterImageDigestKey       = "containerimage.digest"
+	ExporterImageConfigDigestKey = "containerimage.config.digest"
+	ExporterImageDescriptorKey   = "containerimage.descriptor"
+)

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -625,6 +625,12 @@ The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
 `k` (kilobytes), `m` (megabytes), or `g` (gigabytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
+**--metadata-file** *MetadataFile*
+
+Write information about the built image to the named file.  When `--platform`
+is specified more than once, attempting to use this option will trigger an
+error.
+
 **--network**, **--net**=*mode*
 
 Sets the configuration for network namespaces when handling `RUN` instructions.

--- a/docs/buildah-commit.1.md
+++ b/docs/buildah-commit.1.md
@@ -176,6 +176,10 @@ Write the image ID to the file.
 Name of the manifest list to which the built image will be added. Creates the manifest list
 if it does not exist. This option is useful for building multi architecture images.
 
+**--metadata-file** *MetadataFile*
+
+Write information about the committed image to the named file.
+
 **--omit-history** *bool-value*
 
 Omit build history information in the built image. (default false).

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -86,6 +86,9 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 	if len(options.Platforms) > 1 && options.IIDFile != "" {
 		return "", nil, fmt.Errorf("building multiple images, but iidfile %q can only be used to store one image ID", options.IIDFile)
 	}
+	if len(options.Platforms) > 1 && options.MetadataFile != "" {
+		return "", nil, fmt.Errorf("building multiple images, but metadata file %q can only be used to store information about one image", options.MetadataFile)
+	}
 
 	logger := logrus.New()
 	if options.Err != nil {

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1,0 +1,22 @@
+package metadata
+
+import (
+	"github.com/containers/buildah/docker"
+	"github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// Build constructs a map containing the passed-in information about a just-committed or reused-as-cache image.
+func Build(imageConfigDigest digest.Digest, descriptor v1.Descriptor) (map[string]any, error) {
+	metadata := make(map[string]any)
+	if imageConfigDigest.Validate() == nil {
+		metadata[docker.ExporterImageConfigDigestKey] = imageConfigDigest.String()
+	}
+	if descriptor.MediaType != "" && descriptor.Digest.Validate() == nil && descriptor.Size > 0 {
+		metadata[docker.ExporterImageDescriptorKey] = descriptor
+	}
+	if descriptor.Digest.Validate() == nil {
+		metadata[docker.ExporterImageDigestKey] = descriptor.Digest
+	}
+	return metadata, nil
+}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -418,6 +418,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		LogRusage:               iopts.LogRusage,
 		LogSplitByPlatform:      iopts.LogSplitByPlatform,
 		Manifest:                iopts.Manifest,
+		MetadataFile:            iopts.MetadataFile,
 		MaxPullPushRetries:      iopts.Retry,
 		NamespaceOptions:        namespaceOptions,
 		NoCache:                 iopts.NoCache,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -80,6 +80,7 @@ type BudResults struct {
 	Logfile             string
 	LogSplitByPlatform  bool
 	Manifest            string
+	MetadataFile        string
 	NoHostname          bool
 	NoHosts             bool
 	NoCache             bool
@@ -270,6 +271,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 		panic(fmt.Sprintf("error marking the rusage-logfile flag as hidden: %v", err))
 	}
 	fs.StringVar(&flags.Manifest, "manifest", "", "add the image to the specified manifest list. Creates manifest list if it does not exist")
+	fs.StringVar(&flags.MetadataFile, "metadata-file", "", "`file` to write metadata about the image to")
 	fs.BoolVar(&flags.NoCache, "no-cache", false, "do not use existing cached images for the container build. Build from the start with a new set of cached layers.")
 	fs.BoolVar(&flags.NoHostname, "no-hostname", false, "do not create new /etc/hostname file for RUN instructions, use the one from the base image.")
 	fs.BoolVar(&flags.NoHosts, "no-hosts", false, "do not create new /etc/hosts file for RUN instructions, use the one from the base image.")
@@ -360,6 +362,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["layer-label"] = commonComp.AutocompleteNone
 	flagCompletion["logfile"] = commonComp.AutocompleteDefault
 	flagCompletion["manifest"] = commonComp.AutocompleteDefault
+	flagCompletion["metadata-file"] = commonComp.AutocompleteDefault
 	flagCompletion["os"] = commonComp.AutocompleteNone
 	flagCompletion["os-feature"] = commonComp.AutocompleteNone
 	flagCompletion["os-version"] = commonComp.AutocompleteNone

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -135,6 +135,16 @@ load helpers
   test -s ${TEST_SCRATCH_DIR}/iidfile.txt
 }
 
+@test "commit metadata-file" {
+  _prefetch busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
+  cid=$output
+  run_buildah commit --metadata-file ${TEST_SCRATCH_DIR}/metadata.txt $cid
+  jq . ${TEST_SCRATCH_DIR}/metadata.txt
+  test -s ${TEST_SCRATCH_DIR}/metadata.txt
+  assert $(wc -c < ${TEST_SCRATCH_DIR}/metadata.txt) -gt 2
+}
+
 @test "commit rm test" {
   _prefetch alpine
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a CommitResults() method that returns a structure with information, to make it easier to extend.
Use it to add a `--metadata-file` flag to `buildah commit` and `buildah build`.

#### How to verify it

New and updated integration tests!

#### Which issue(s) this PR fixes:

Fixes #6428.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The `buildah build` and `buildah commit` commands now accept a `--metadata-file` flag.
```