### PR TITLE
Remove slirp for Podman6

### DIFF
--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -35,7 +35,6 @@ case $1 in
                     podman
                     runc
                     skopeo
-                    slirp4netns
         )
         case $OS_RELEASE_ID in
             fedora*)

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -664,15 +664,6 @@ Valid _mode_ values are:
 - **ns:**_path_: path to a network namespace to join;
 - **private**: create a new namespace for the container (default)
 - **\<network name|ID\>**: Join the network with the given name or ID, e.g. use `--network mynet` to join the network with the name mynet. Only supported for rootful users.
-- **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options, they can also be set with `network_cmd_options` in containers.conf:
-  - **allow_host_loopback=true|false**: Allow slirp4netns to reach the host loopback IP (default is 10.0.2.2 or the second IP from slirp4netns cidr subnet when changed, see the cidr option below). The default is false.
-  - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
-  - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
-  - **enable_ipv6=true|false**: Enable IPv6. Default is true. (Required for `outbound_addr6`).
-  - **outbound_addr=INTERFACE**: Specify the outbound interface slirp binds to (ipv4 traffic only).
-  - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp binds to.
-  - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp binds to (ipv6 traffic only).
-  - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp binds to.
 - **pasta[:OPTIONS,...]**: use **pasta**(1) to create a user-mode networking
     stack. \
     This is only supported in rootless mode. \
@@ -698,13 +689,12 @@ Valid _mode_ values are:
     - **pasta:--mtu,1500**: Specify a 1500 bytes MTU for the _tap_ interface in
         the container.
     - **pasta:--ipv4-only,-a,10.0.2.0,-n,24,-g,10.0.2.2,--dns-forward,10.0.2.3,-m,1500,--no-ndp,--no-dhcpv6,--no-dhcp**,
-        equivalent to default slirp4netns(1) options: disable IPv6, assign
+        disable IPv6, assign
         `10.0.2.0/24` to the `tap0` interface in the container, with gateway
         `10.0.2.3`, enable DNS forwarder reachable at `10.0.2.3`, set MTU to 1500
         bytes, disable NDP, DHCPv6 and DHCP support.
     - **pasta:-I,tap0,--ipv4-only,-a,10.0.2.0,-n,24,-g,10.0.2.2,--dns-forward,10.0.2.3,--no-ndp,--no-dhcpv6,--no-dhcp**,
-        equivalent to default slirp4netns(1) options with Podman overrides: same as
-        above, but leave the MTU to 65520 bytes
+        same as above, but leave the MTU to 65520 bytes
     - **pasta:-t,auto,-u,auto,-T,auto,-U,auto**: enable automatic port forwarding
         based on observed bound ports from both host and container sides
     - **pasta:-T,5201**: enable forwarding of TCP port 5201 from container to

--- a/docs/buildah-from.1.md
+++ b/docs/buildah-from.1.md
@@ -307,15 +307,6 @@ Valid _mode_ values are:
 - **ns:**_path_: path to a network namespace to join;
 - **private**: create a new namespace for the container (default)
 - **\<network name|ID\>**: Join the network with the given name or ID, e.g. use `--network mynet` to join the network with the name mynet. Only supported for rootful users.
-- **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options, they can also be set with `network_cmd_options` in containers.conf:
-  - **allow_host_loopback=true|false**: Allow slirp4netns to reach the host loopback IP (default is 10.0.2.2 or the second IP from slirp4netns cidr subnet when changed, see the cidr option below). The default is false.
-  - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
-  - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
-  - **enable_ipv6=true|false**: Enable IPv6. Default is true. (Required for `outbound_addr6`).
-  - **outbound_addr=INTERFACE**: Specify the outbound interface slirp binds to (ipv4 traffic only).
-  - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp binds to.
-  - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp binds to (ipv6 traffic only).
-  - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp binds to.
 - **pasta[:OPTIONS,...]**: use **pasta**(1) to create a user-mode networking
     stack. \
     This is only supported in rootless mode. \
@@ -341,13 +332,12 @@ Valid _mode_ values are:
     - **pasta:--mtu,1500**: Specify a 1500 bytes MTU for the _tap_ interface in
         the container.
     - **pasta:--ipv4-only,-a,10.0.2.0,-n,24,-g,10.0.2.2,--dns-forward,10.0.2.3,-m,1500,--no-ndp,--no-dhcpv6,--no-dhcp**,
-        equivalent to default slirp4netns(1) options: disable IPv6, assign
+        disable IPv6, assign
         `10.0.2.0/24` to the `tap0` interface in the container, with gateway
         `10.0.2.3`, enable DNS forwarder reachable at `10.0.2.3`, set MTU to 1500
         bytes, disable NDP, DHCPv6 and DHCP support.
     - **pasta:-I,tap0,--ipv4-only,-a,10.0.2.0,-n,24,-g,10.0.2.2,--dns-forward,10.0.2.3,--no-ndp,--no-dhcpv6,--no-dhcp**,
-        equivalent to default slirp4netns(1) options with Podman overrides: same as
-        above, but leave the MTU to 65520 bytes
+        same as above, but leave the MTU to 65520 bytes
     - **pasta:-t,auto,-u,auto,-T,auto,-U,auto**: enable automatic port forwarding
         based on observed bound ports from both host and container sides
     - **pasta:-T,5201**: enable forwarding of TCP port 5201 from container to

--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -195,15 +195,6 @@ Valid _mode_ values are:
 - **ns:**_path_: path to a network namespace to join;
 - **private**: create a new namespace for the container (default)
 - **\<network name|ID\>**: Join the network with the given name or ID, e.g. use `--network mynet` to join the network with the name mynet. Only supported for rootful users.
-- **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options, they can also be set with `network_cmd_options` in containers.conf:
-  - **allow_host_loopback=true|false**: Allow slirp4netns to reach the host loopback IP (default is 10.0.2.2 or the second IP from slirp4netns cidr subnet when changed, see the cidr option below). The default is false.
-  - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
-  - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
-  - **enable_ipv6=true|false**: Enable IPv6. Default is true. (Required for `outbound_addr6`).
-  - **outbound_addr=INTERFACE**: Specify the outbound interface slirp binds to (ipv4 traffic only).
-  - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp binds to.
-  - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp binds to (ipv6 traffic only).
-  - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp binds to.
 - **pasta[:OPTIONS,...]**: use **pasta**(1) to create a user-mode networking
     stack. \
     This is only supported in rootless mode. \
@@ -229,13 +220,12 @@ Valid _mode_ values are:
     - **pasta:--mtu,1500**: Specify a 1500 bytes MTU for the _tap_ interface in
         the container.
     - **pasta:--ipv4-only,-a,10.0.2.0,-n,24,-g,10.0.2.2,--dns-forward,10.0.2.3,-m,1500,--no-ndp,--no-dhcpv6,--no-dhcp**,
-        equivalent to default slirp4netns(1) options: disable IPv6, assign
+        disable IPv6, assign
         `10.0.2.0/24` to the `tap0` interface in the container, with gateway
         `10.0.2.3`, enable DNS forwarder reachable at `10.0.2.3`, set MTU to 1500
         bytes, disable NDP, DHCPv6 and DHCP support.
     - **pasta:-I,tap0,--ipv4-only,-a,10.0.2.0,-n,24,-g,10.0.2.2,--dns-forward,10.0.2.3,--no-ndp,--no-dhcpv6,--no-dhcp**,
-        equivalent to default slirp4netns(1) options with Podman overrides: same as
-        above, but leave the MTU to 65520 bytes
+        same as above, but leave the MTU to 65520 bytes
     - **pasta:-t,auto,-u,auto,-T,auto,-U,auto**: enable automatic port forwarding
         based on observed bound ports from both host and container sides
     - **pasta:-T,5201**: enable forwarding of TCP port 5201 from container to

--- a/run_common.go
+++ b/run_common.go
@@ -387,13 +387,6 @@ func DefaultNamespaceOptions() (define.NamespaceOptions, error) {
 func checkAndOverrideIsolationOptions(isolation define.Isolation, options *RunOptions) error {
 	switch isolation {
 	case IsolationOCIRootless:
-		// only change the netns if the caller did not set it
-		if ns := options.NamespaceOptions.Find(string(specs.NetworkNamespace)); ns == nil {
-			if _, err := exec.LookPath("slirp4netns"); err != nil {
-				// if slirp4netns is not installed we have to use the hosts net namespace
-				options.NamespaceOptions.AddOrReplace(define.NamespaceOption{Name: string(specs.NetworkNamespace), Host: true})
-			}
-		}
 		fallthrough
 	case IsolationOCI:
 		pidns := options.NamespaceOptions.Find(string(specs.PIDNamespace))

--- a/run_linux.go
+++ b/run_linux.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/docker/go-units"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -33,7 +32,6 @@ import (
 	"go.podman.io/common/libnetwork/etchosts"
 	"go.podman.io/common/libnetwork/pasta"
 	"go.podman.io/common/libnetwork/resolvconf"
-	"go.podman.io/common/libnetwork/slirp4netns"
 	nettypes "go.podman.io/common/libnetwork/types"
 	netUtil "go.podman.io/common/libnetwork/util"
 	"go.podman.io/common/pkg/capabilities"
@@ -689,46 +687,6 @@ func addCommonOptsToSpec(commonOpts *define.CommonBuildOptions, g *generate.Gene
 	return nil
 }
 
-func setupSlirp4netnsNetwork(config *config.Config, netns, cid string, options, hostnames []string) (func(), *netResult, error) {
-	// we need the TmpDir for the slirp4netns code
-	if err := os.MkdirAll(config.Engine.TmpDir, 0o751); err != nil {
-		return nil, nil, fmt.Errorf("failed to create tempdir: %w", err)
-	}
-	res, err := slirp4netns.Setup(&slirp4netns.SetupOptions{
-		Config:       config,
-		ContainerID:  cid,
-		Netns:        netns,
-		ExtraOptions: options,
-		Pdeathsig:    syscall.SIGKILL,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	ip, err := slirp4netns.GetIP(res.Subnet)
-	if err != nil {
-		return nil, nil, fmt.Errorf("get slirp4netns ip: %w", err)
-	}
-
-	dns, err := slirp4netns.GetDNS(res.Subnet)
-	if err != nil {
-		return nil, nil, fmt.Errorf("get slirp4netns dns ip: %w", err)
-	}
-
-	result := &netResult{
-		entries:           etchosts.HostEntries{{IP: ip.String(), Names: hostnames}},
-		dnsServers:        []string{dns.String()},
-		ipv6:              res.IPv6,
-		keepHostResolvers: true,
-	}
-
-	return func() {
-		syscall.Kill(res.Pid, syscall.SIGKILL) //nolint:errcheck
-		var status syscall.WaitStatus
-		syscall.Wait4(res.Pid, &status, 0, nil) //nolint:errcheck
-	}, result, nil
-}
-
 func setupPasta(config *config.Config, netns string, options, hostnames []string) (func(), *netResult, error) {
 	res, err := pasta.Setup(&pasta.SetupOptions{
 		Config:       config,
@@ -776,8 +734,6 @@ func (b *Builder) runConfigureNetwork(pid int, isolation define.Isolation, optio
 	}
 	if isolation == IsolationOCIRootless && name == "" {
 		switch defConfig.Network.DefaultRootlessNetworkCmd {
-		case slirp4netns.BinaryName, "":
-			name = slirp4netns.BinaryName
 		case pasta.BinaryName:
 			name = pasta.BinaryName
 		default:
@@ -787,8 +743,6 @@ func (b *Builder) runConfigureNetwork(pid int, isolation define.Isolation, optio
 	}
 
 	switch {
-	case name == slirp4netns.BinaryName:
-		return setupSlirp4netnsNetwork(defConfig, netns, containerName, netOpts, hostnames)
 	case name == pasta.BinaryName:
 		return setupPasta(defConfig, netns, netOpts, hostnames)
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -7715,22 +7715,6 @@ _EOF
   fi
 }
 
-@test "bud with --network slirp4netns" {
-  skip_if_no_runtime
-  skip_if_in_container
-  skip_if_chroot
-
-  _prefetch alpine
-
-  run_buildah bud $WITH_POLICY_JSON --network slirp4netns $BUDFILES/network
-  # default subnet is 10.0.2.100/24
-  assert "$output" =~ "10.0.2.100/24" "ip addr shows default subnet"
-
-  run_buildah bud $WITH_POLICY_JSON --network slirp4netns:cidr=192.168.255.0/24,mtu=2000 $BUDFILES/network
-  assert "$output" =~ "192.168.255.100/24" "ip addr shows custom subnet"
-  assert "$output" =~ "mtu 2000" "ip addr shows mtu 2000"
-}
-
 @test "bud with --network pasta" {
   skip_if_no_runtime
   skip_if_chroot

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -730,10 +730,6 @@ function configure_and_check_user() {
 	expect_output --substring "(10.88.*|10.0.2.100)[[:blank:]]$cid"
 	assert "$output" !~ "(10.88.*|10.0.2.100)[[:blank:]]host1 $cid" "Container IP should not contain host1"
 
-	# check slirp4netns sets correct hostname with another cidr
-	run_buildah run --network slirp4netns:cidr=192.168.2.0/24 --hostname $hostname $cid cat /etc/hosts
-	expect_output --substring "192.168.2.100[[:blank:]]$hostname $cid"
-
 	run_buildah run --network=container $cid cat /etc/hosts
 	m=$(buildah mount $cid)
 	run cat $m/etc/hosts
@@ -816,9 +812,9 @@ function configure_and_check_user() {
 	# filter out 127... nameservers
 	run grep -v "nameserver 127." <<< "$output"
 	nameservers="$output"
-	# in case of rootless add extra slirp4netns nameserver
+	# in case of rootless add extra pasta nameserver
 	if is_rootless; then
-		nameservers="nameserver 10.0.2.3
+		nameservers="nameserver 169.254.1.1
 $output"
 	fi
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine

--- a/tests/tmt/system.fmf
+++ b/tests/tmt/system.fmf
@@ -1,7 +1,6 @@
 require:
     - buildah-tests
     - git-daemon
-    - slirp4netns
 
 environment:
     BUILDAH_BINARY: /usr/bin/buildah


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind cleanup


#### What this PR does / why we need it:

For podman6

#### How to verify it

Verify buildah doesn't work with slirp

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Slirp4netns support has been removed.
```

Rebased on the cgroups v1 removal PR.