### PR TITLE
build: add --iidfile-raw CLI option

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -262,6 +262,8 @@ type BuildOptions struct {
 	DefaultMountsFilePath string
 	// IIDFile tells the builder to write the image ID to the specified file
 	IIDFile string
+	// IIDFileRaw tells the builder to write the image ID to the specified file without the algorithm prefix
+	IIDFileRaw string
 	// Squash tells the builder to produce an image with a single layer instead of with
 	// possibly more than one layer, by only committing a new layer after processing the
 	// final instruction.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -515,6 +515,14 @@ Path to an alternative .containerignore (.dockerignore) file.
 Write the built image's ID to the file.  When `--platform` is specified more
 than once, attempting to use this option will trigger an error.
 
+**--iidfile-raw** *ImageIDfile*
+
+Write the built image's ID to the file without the algorithm prefix
+(e.g., `sha256:`). When `--platform` is specified more than once, attempting to
+use this option will trigger an error.
+
+An alias `--raw-iidfile` is also available.
+
 **--inherit-annotations** *bool-value*
 
 Inherit the annotations from the base image or base stages. (default true).

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -83,11 +83,16 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 	if len(paths) == 0 {
 		return "", nil, errors.New("building: no dockerfiles specified")
 	}
-	if len(options.Platforms) > 1 && options.IIDFile != "" {
-		return "", nil, fmt.Errorf("building multiple images, but iidfile %q can only be used to store one image ID", options.IIDFile)
-	}
-	if len(options.Platforms) > 1 && options.MetadataFile != "" {
-		return "", nil, fmt.Errorf("building multiple images, but metadata file %q can only be used to store information about one image", options.MetadataFile)
+	if len(options.Platforms) > 1 {
+		if options.IIDFile != "" {
+			return "", nil, fmt.Errorf("building multiple images, but iidfile %q can only be used to store one image ID", options.IIDFile)
+		}
+		if options.IIDFileRaw != "" {
+			return "", nil, fmt.Errorf("building multiple images, but iidfile-raw %q can only be used to store one image ID", options.IIDFileRaw)
+		}
+		if options.MetadataFile != "" {
+			return "", nil, fmt.Errorf("building multiple images, but metadata file %q can only be used to store information about one image", options.MetadataFile)
+		}
 	}
 
 	logger := logrus.New()

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -106,6 +106,7 @@ type executor struct {
 	commonBuildOptions                      *define.CommonBuildOptions
 	defaultMountsFilePath                   string
 	iidfile                                 string
+	iidfileRaw                              string
 	squash                                  bool
 	labels                                  []string
 	layerLabels                             []string
@@ -293,6 +294,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		commonBuildOptions:                      options.CommonBuildOpts,
 		defaultMountsFilePath:                   options.DefaultMountsFilePath,
 		iidfile:                                 options.IIDFile,
+		iidfileRaw:                              options.IIDFileRaw,
 		squash:                                  options.Squash,
 		labels:                                  slices.Clone(options.Labels),
 		layerLabels:                             slices.Clone(options.LayerLabels),
@@ -1107,7 +1109,13 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 		if err = os.WriteFile(b.iidfile, []byte(iid), 0o644); err != nil {
 			return imageID, ref, fmt.Errorf("failed to write image ID to file %q: %w", b.iidfile, err)
 		}
-	} else {
+	}
+	if b.iidfileRaw != "" {
+		if err = os.WriteFile(b.iidfileRaw, []byte(imageID), 0o644); err != nil {
+			return imageID, ref, fmt.Errorf("failed to write image ID to file %q: %w", b.iidfileRaw, err)
+		}
+	}
+	if b.iidfile == "" && b.iidfileRaw == "" {
 		if _, err := stdout.Write([]byte(imageID + "\n")); err != nil {
 			return imageID, ref, fmt.Errorf("failed to write image ID to stdout: %w", err)
 		}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -408,6 +408,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		GroupAdd:                iopts.GroupAdd,
 		IDMappingOptions:        idmappingOptions,
 		IIDFile:                 iopts.Iidfile,
+		IIDFileRaw:              iopts.IidfileRaw,
 		IgnoreFile:              iopts.IgnoreFile,
 		In:                      stdin,
 		InheritLabels:           inheritLabels,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -73,6 +73,7 @@ type BudResults struct {
 	Format              string
 	From                string
 	Iidfile             string
+	IidfileRaw          string
 	InheritLabels       bool
 	InheritAnnotations  bool
 	Label               []string
@@ -253,6 +254,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringSliceVarP(&flags.File, "file", "f", []string{}, "`pathname or URL` of a Dockerfile")
 	fs.StringVar(&flags.Format, "format", DefaultFormat(), "`format` of the built image's manifest and metadata. Use BUILDAH_FORMAT environment variable to override.")
 	fs.StringVar(&flags.Iidfile, "iidfile", "", "`file` to write the image ID to")
+	fs.StringVar(&flags.IidfileRaw, "iidfile-raw", "", "`file` to write the image ID to (without algorithm prefix)")
 	fs.IntVar(&flags.Jobs, "jobs", 1, "how many stages to run in parallel")
 	fs.StringArrayVar(&flags.Label, "label", []string{}, "set metadata for an image (default [])")
 	fs.StringArrayVar(&flags.LayerLabel, "layer-label", []string{}, "set metadata for an intermediate image (default [])")
@@ -357,6 +359,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["hooks-dir"] = commonComp.AutocompleteNone
 	flagCompletion["ignorefile"] = commonComp.AutocompleteDefault
 	flagCompletion["iidfile"] = commonComp.AutocompleteDefault
+	flagCompletion["iidfile-raw"] = commonComp.AutocompleteDefault
 	flagCompletion["jobs"] = commonComp.AutocompleteNone
 	flagCompletion["label"] = commonComp.AutocompleteNone
 	flagCompletion["layer-label"] = commonComp.AutocompleteNone
@@ -545,6 +548,8 @@ func AliasFlags(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "os"
 	case "purge":
 		name = "rm"
+	case "raw-iidfile":
+		name = "iidfile-raw"
 	case "tty":
 		name = "terminal"
 	}


### PR DESCRIPTION
Works much the same way as --iidfile but does not include algorithm prefix.

Also aliased to --raw-iidfile.

Ref: https://github.com/containers/skopeo/issues/2750#issuecomment-3558195067

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


> /kind feature


#### What this PR does / why we need it:

Adds a new `--iidfile-raw` CLI option to buildah build to write just the image id with no algorithm prefix to a file.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->


None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
New `buildah build` CLI option `iidfile-raw` / `raw-iidfile` to write image id to a file without algorithm prefix.
```

