### PR TITLE
test: do not untar archive into fs when checking file names

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2733,11 +2733,8 @@ FROM alpine
 RUN echo 'hello'> hello
 _EOF
   run_buildah build --output type=tar,dest=$mytmpdir/rootfs.tar $WITH_POLICY_JSON -t test-bud -f $mytmpdir/Containerfile .
-  # explode tar
-  mkdir $mytmpdir/rootfs
-  tar -C $mytmpdir/rootfs -xvf $mytmpdir/rootfs.tar
-  ls $mytmpdir/rootfs
-  # exported rootfs must contain `hello` file which we created inside the image
+  # verify tar content
+  run tar -tf $mytmpdir/rootfs.tar
   expect_output --substring 'hello'
 }
 
@@ -2751,10 +2748,9 @@ RUN echo 'hello'> hello
 _EOF
   # Using buildah() defined in helpers.bash since run_buildah adds unwanted chars to tar created by pipe.
   buildah build $WITH_POLICY_JSON -o - -t test-bud -f $mytmpdir/Containerfile . > $mytmpdir/rootfs.tar
-  # explode tar
-  mkdir $mytmpdir/rootfs
-  tar -C $mytmpdir/rootfs -xvf $mytmpdir/rootfs.tar
-  ls $mytmpdir/rootfs/hello
+  # verify tar content
+  run tar -tf $mytmpdir/rootfs.tar
+  expect_output --substring 'hello'
 }
 
 @test "build with custom build output and output rootfs to tar with no additional step" {
@@ -2767,10 +2763,8 @@ _EOF
 FROM alpine
 _EOF
   run_buildah build --output type=tar,dest=$mytmpdir/rootfs.tar $WITH_POLICY_JSON -t test-bud -f $mytmpdir/Containerfile .
-  # explode tar
-  mkdir $mytmpdir/rootfs
-  tar -C $mytmpdir/rootfs -xvf $mytmpdir/rootfs.tar
-  run ls $mytmpdir/rootfs
+  # verify tar content
+  run tar -tf $mytmpdir/rootfs.tar
   # exported rootfs must contain `var`,`bin` directory which exists in alpine
   # so output of `ls $mytmpdir/rootfs` must contain following strings
   expect_output --substring 'var'


### PR DESCRIPTION
#### What type of PR is this?

> /kind cleanup

#### What this PR does / why we need it:

In BATS tests, it avoids untar'ing archives into the filesystem when it is not needed. Instead, it uses `tar -t` to list the archive files instead.

As a bonus, it also fixes the test `build with custom build output and output rootfs to tar`, which does not check the output of the right command (it seems like it wanted to read the output of `ls` but it read the output of `run_buildah`

#### How to verify it

Run test suite

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

