### PR TITLE
feat: add support for preserving and labeling intermediate stage images

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -287,6 +287,12 @@ type BuildOptions struct {
 	OnBuild []string
 	// Layers tells the builder to commit an image for each step in the Dockerfile.
 	Layers bool
+	// SaveStages tells the builder to save intermediate stage images instead of removing them.
+	SaveStages bool
+	// StageLabels tells the builder to add metadata labels to all stage images (including the final image).
+	// These labels include stage name (stage alias or position) and base image (pullspec or image ID if
+	// stage uses another stage as base). This option requires SaveStages to be enabled.
+	StageLabels bool
 	// NoCache tells the builder to build the image from scratch without checking for a cache.
 	// It creates a new set of cached images for the build.
 	NoCache bool

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -886,6 +886,19 @@ consult the manpages of the selected container runtime.
 Note: Do not pass the leading `--` to the flag. To pass the runc flag `--log-format json`
 to buildah build, the option given would be `--runtime-flag log-format=json`.
 
+**--save-stages** *bool-value*
+
+Preserve intermediate stage images instead of removing them after the build completes
+(Default is `false`). By default, Buildah removes intermediate stage images to save space.
+This option keeps those images, which can be useful for debugging multi-stage builds or
+for reusing intermediate stages in subsequent builds.
+
+`--save-stages` can be used with `--layers` and subsequent builds with `--layers` can use
+the preserved intermediate layers as cache.
+
+When combined with `--stage-labels`, all stage images (including the final image) will
+include metadata labels for easier identification and management.
+
 **--sbom** *preset*
 
 Generate SBOMs (Software Bills Of Materials) for the output image by scanning
@@ -1139,6 +1152,21 @@ The socket path can be left empty to use the value of `default=$SSH_AUTH_SOCK`
 To later use the ssh agent, use the --mount flag in a `RUN` instruction within a `Containerfile`:
 
 `RUN --mount=type=secret,id=id mycmd`
+
+
+**--stage-labels** *bool-value*
+
+Add metadata labels to all intermediate stage images of the multistage build,
+including the final image (Default is `false`).
+This option requires `--save-stages` to be enabled.
+
+When enabled, all intermediate stage images and final image will be labeled with:
+  - `io.buildah.stage.name`: The stage alias (from `FROM ... AS alias`), or stage position
+    if no alias is specified
+  - `io.buildah.stage.base`: The base image used by this stage (pullspec or image ID
+    when stage uses another stage as base)
+
+These labels make it easier to identify, query, and manage images from multi-stage builds.
 
 **--stdin**
 
@@ -1472,6 +1500,14 @@ buildah build -v /var/lib/dnf:/var/lib/dnf:O -t imageName .
 
 buildah build --layers -t imageName .
 
+buildah build --save-stages -t imageName .
+
+buildah build --save-stages --layers -t imageName .
+
+buildah build --save-stages --stage-labels -t imageName .
+
+buildah build --save-stages --stage-labels --layers -t imageName .
+
 buildah build --no-cache -t imageName .
 
 buildah build -f Containerfile --layers --force-rm -t imageName .
@@ -1545,6 +1581,20 @@ buildah build --output type=local,dest=out .
 buildah build --output type=tar,dest=out.tar .
 
 buildah build -o - . > out.tar
+
+### Preserving and querying intermediate stage images
+
+Build a multi-stage image while preserving intermediate stages with metadata labels:
+
+buildah build --save-stages --stage-labels -t myapp .
+
+Find an intermediate image for a specific stage name:
+
+buildah images --filter "label=io.buildah.stage.name=builder"
+
+Find an intermediate image for a specific stage base image:
+
+buildah images --filter "label=io.buildah.stage.base=golang:1.21"
 
 ### Building an image using a URL
 

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -115,6 +115,9 @@ type executor struct {
 	layerLabels                             []string
 	annotations                             []string
 	layers                                  bool
+	saveStages                              bool
+	stageLabels                             bool
+	stageImageIDs                           map[string]string // Tracks image IDs for each stage (by name and position) for label references
 	noHostname                              bool
 	noHosts                                 bool
 	useCache                                bool
@@ -317,6 +320,9 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		mountLabel:                              mountLabel,
 		annotations:                             slices.Clone(options.Annotations),
 		layers:                                  options.Layers,
+		saveStages:                              options.SaveStages,
+		stageLabels:                             options.StageLabels,
+		stageImageIDs:                           make(map[string]string),
 		noHostname:                              options.CommonBuildOpts.NoHostname,
 		noHosts:                                 options.CommonBuildOpts.NoHosts,
 		useCache:                                !options.NoCache,
@@ -604,6 +610,19 @@ func (b *executor) buildStage(ctx context.Context, cleanupStages map[int]*stageE
 		prependInstructions = slices.Concat([]string{envLine}, prependInstructions)
 	}
 
+	// Create stage labels for all stage images including final stage
+	// Skip if stage has no instructions
+	if b.saveStages && b.stageLabels && len(stage.Node.Children) > 0 {
+		// Wait for base stage if it references a previous stage
+		// This ensures stageImageIDs map is populated before buildStageLabelLine reads it
+		if isStage, err := b.waitForStage(ctx, base, stages[:stageIndex]); isStage && err != nil {
+			return "", nil, false, fmt.Errorf("waiting for base stage %s: %w", base, err)
+		}
+
+		labelLine := b.buildStageLabelLine(&stage, base, stages[:stageIndex])
+		prependInstructions = slices.Concat([]string{labelLine}, prependInstructions)
+	}
+
 	// If we're supposed to be appending or prepending instructions to this stage, add them now.
 	if len(prependInstructions) > 0 {
 		addLines := strings.Join(prependInstructions, "\n")
@@ -660,6 +679,16 @@ func (b *executor) buildStage(ctx context.Context, cleanupStages map[int]*stageE
 		return "", nil, onlyBaseImage, err
 	}
 
+	// Store image ID for this stage so subsequent stages can reference it in labels
+	if imageID != "" {
+		b.stagesLock.Lock()
+		if stage.Name != "" {
+			b.stageImageIDs[stage.Name] = imageID
+		}
+		b.stageImageIDs[strconv.Itoa(stageIndex)] = imageID
+		b.stagesLock.Unlock()
+	}
+
 	// The stage succeeded, so remove its build container if we're
 	// told to delete successful intermediate/build containers for
 	// multi-layered builds.
@@ -690,6 +719,29 @@ func markDependencyStagesForTarget(dependencyMap map[string]*stageDependencyInfo
 			}
 		}
 	}
+}
+
+// buildStageLabelLine creates a LABEL instruction line for stage metadata
+func (b *executor) buildStageLabelLine(stage *imagebuilder.Stage, base string, stages imagebuilder.Stages) string {
+	labelLine := "LABEL"
+	labelLine += fmt.Sprintf(" %q=%q", "io.buildah.stage.name", stage.Name)
+	// Check if base of the stage is another (previous) stage.
+	// If yes, base is set as image ID of this stage.
+	// If not original base name is set (pullspec).
+	for i, st := range stages {
+		if st.Name == base || strconv.Itoa(st.Position) == base {
+			b.stagesLock.Lock()
+			if imgID, ok := b.stageImageIDs[base]; ok {
+				base = imgID
+			} else if imgID, ok := b.stageImageIDs[strconv.Itoa(i)]; ok {
+				base = imgID
+			}
+			b.stagesLock.Unlock()
+			break
+		}
+	}
+	labelLine += fmt.Sprintf(" %q=%q", "io.buildah.stage.base", base)
+	return labelLine
 }
 
 func (b *executor) warnOnUnsetBuildArgs(stages imagebuilder.Stages, dependencyMap map[string]*stageDependencyInfo, args map[string]string) {
@@ -1106,9 +1158,10 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 			// We're not populating the cache with intermediate
 			// images, so add this one to the list of images that
 			// we'll remove later.
-			// Only remove intermediate image is `--layers` is not provided
-			// or following stage was not only a base image ( i.e a different image ).
-			if !b.layers && !r.OnlyBaseImage {
+			// Only remove intermediate image if `--layers` is not provided,
+			// `--save-stages` is not enabled, or following stage was not
+			// only a base image (i.e. a different image).
+			if !b.layers && !b.saveStages && !r.OnlyBaseImage {
 				cleanupImages = append(cleanupImages, r.ImageID)
 			}
 		}

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1552,8 +1552,9 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 			// so we should commit this container to create
 			// an image, but only if it's the last stage,
 			// or if it's used as the basis for a later
-			// stage.
-			if lastStage || imageIsUsedLater {
+			// stage or we are forcing saving stages by
+			// --save-stages
+			if lastStage || imageIsUsedLater || s.executor.saveStages {
 				logCommit(s.output, i)
 				createdBy, err := s.getCreatedBy(node, addedContentSummary, lastStage && lastInstruction)
 				if err != nil {

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -223,6 +223,10 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		return options, nil, nil, errors.New("'rm' and 'force-rm' can only be set with either 'layers' or 'no-cache'")
 	}
 
+	if iopts.StageLabels && !iopts.SaveStages {
+		return options, nil, nil, errors.New(`"--stage-labels" requires "--save-stages"`)
+	}
+
 	if c.Flag("compress").Changed {
 		logrus.Debugf("--compress option specified but is ignored")
 	}
@@ -443,6 +447,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		Runtime:                 iopts.Runtime,
 		RuntimeArgs:             runtimeFlags,
 		RusageLogFile:           iopts.RusageLogFile,
+		SaveStages:              iopts.SaveStages,
 		SBOMScanOptions:         sbomScanOptions,
 		SignBy:                  iopts.SignBy,
 		SignaturePolicyPath:     iopts.SignaturePolicy,
@@ -450,6 +455,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		SkipUnusedStages:        skipUnusedStages,
 		SourceDateEpoch:         sourceDateEpoch,
 		Squash:                  iopts.Squash,
+		StageLabels:             iopts.StageLabels,
 		SystemContext:           systemContext,
 		Target:                  iopts.Target,
 		Timestamp:               timestamp,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -26,8 +26,10 @@ import (
 
 // LayerResults represents the results of the layer flags
 type LayerResults struct {
-	ForceRm bool
-	Layers  bool
+	ForceRm     bool
+	Layers      bool
+	SaveStages  bool
+	StageLabels bool
 }
 
 // UserNSResults represents the results for the UserNS flags
@@ -220,6 +222,8 @@ func GetLayerFlags(flags *LayerResults) pflag.FlagSet {
 	fs := pflag.FlagSet{}
 	fs.BoolVar(&flags.ForceRm, "force-rm", false, "always remove intermediate containers after a build, even if the build is unsuccessful.")
 	fs.BoolVar(&flags.Layers, "layers", UseLayers(), "use intermediate layers during build. Use BUILDAH_LAYERS environment variable to override.")
+	fs.BoolVar(&flags.SaveStages, "save-stages", false, "save intermediate stage images.")
+	fs.BoolVar(&flags.StageLabels, "stage-labels", false, "add metadata labels to intermediate stage images (requires --save-stages).")
 	return fs
 }
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -9484,3 +9484,681 @@ _EOF
   # even though different secret was passed to each(baz vs boz), we expect the same result, ie should not affect build history
   diff "${outpath}.a" "${outpath}.b"
 }
+
+@test "[test flags] --stage-labels without --save-stages should error" {
+  _prefetch alpine
+  target="stage-labels-error-test-$(safename)"
+
+  run_buildah 125 build $WITH_POLICY_JSON --stage-labels -t ${target} -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+  expect_output --substring '"--stage-labels" requires "--save-stages"'
+}
+
+@test "[test flags] bud with --save-stages=false does not save intermediate images" {
+  _prefetch alpine
+  target="save-stages-$(safename)"
+
+  run_buildah build $WITH_POLICY_JSON --save-stages=false -t ${target}-without-save -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+  run_buildah images -a
+  baseline_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  baseline_count=$(echo "$baseline_images" | wc -w)
+  assert "$baseline_count" == "0" "without save-stages should have 0 intermediate images"
+}
+
+@test "[test flags] --save-stages and --stage-labels=false does not label intermediate images" {
+  _prefetch alpine
+  target="save-stages-$(safename)"
+
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels=false -t ${target} -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+  run_buildah images -a
+  intermediate_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  intermediate_count=$(echo "$intermediate_images" | wc -w)
+  assert "$intermediate_count" == "1" "should have 1 intermediate image"
+
+  for image_id in $intermediate_images; do
+    run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $image_id
+    assert "$output" == "" "stage.name label should not be present when --stage-labels=false"
+
+    run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.base"}}' $image_id
+    assert "$output" == "" "stage.base label should not be present when --stage-labels=false"
+  done
+}
+
+@test "[test saving intermediate images] --save-stages on single-stage Dockerfile should not create intermediate images" {
+  _prefetch alpine
+  target="single-stage-test-$(safename)"
+
+  run_buildah build $WITH_POLICY_JSON --save-stages -t ${target} -f $BUDFILES/save-stages/Dockerfile.simple $BUDFILES/save-stages
+
+  run_buildah images -a
+  intermediate_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  intermediate_count=$(echo "$intermediate_images" | wc -w)
+  assert "$intermediate_count" == "0" "single-stage build should not create intermediate images"
+
+  run_buildah rmi ${target}
+}
+
+@test "[test saving intermediate images] --save-stages preserves intermediate image and skips unused" {
+  _prefetch alpine
+  target="save-stages-$(safename)"
+
+  # Build without --save-stages (baseline - should produce 0 intermediate images)
+  run_buildah build $WITH_POLICY_JSON -t ${target}-no-save -f $BUDFILES/save-stages/Dockerfile.two-build-stages-one-unused $BUDFILES/save-stages
+  run_buildah images -a
+  baseline_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  baseline_count=$(echo "$baseline_images" | wc -w)
+  assert "$baseline_count" == "0" "without save-stages should have 0 intermediate images"
+  run_buildah rmi ${target}-no-save
+
+  # Build with --save-stages (should produce 1 intermediate image: 'intermediate' stage)
+  # Note: 'builder' stage is skipped due to --skip-unused-stages=true (default)
+  run_buildah build $WITH_POLICY_JSON --save-stages -t ${target} -f $BUDFILES/save-stages/Dockerfile.two-build-stages-one-unused $BUDFILES/save-stages
+  run_buildah images -a
+  save_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  save_count=$(echo "$save_images" | wc -w)
+  assert "$save_count" == "1" "with save-stages should have 1 intermediate image (intermediate stage)"
+}
+
+@test "[test saving intermediate images] --save-stages preserves intermediate images for all stages" {
+  _prefetch alpine
+  target="save-stages-all-test-$(safename)"
+
+  # Build without --save-stages (baseline - should produce 0 intermediate images)
+  run_buildah build $WITH_POLICY_JSON -t ${target}-no-save -f $BUDFILES/save-stages/Dockerfile.three-build-stages-parent-child-independent $BUDFILES/save-stages
+  run_buildah images -a
+  baseline_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  baseline_count=$(echo "$baseline_images" | wc -w)
+  assert "$baseline_count" == "0" "without save-stages should have 0 intermediate images"
+  run_buildah rmi ${target}-no-save
+
+  # Build with --save-stages (should produce 3 intermediate images: parent, child, independent)
+  # This demonstrates that intermediate images are saved for ALL stages: for each in parent-child chain and independent stage
+  run_buildah build $WITH_POLICY_JSON --save-stages -t ${target} -f $BUDFILES/save-stages/Dockerfile.three-build-stages-parent-child-independent $BUDFILES/save-stages
+  run_buildah images -a
+  save_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  save_count=$(echo "$save_images" | wc -w)
+  assert "$save_count" == "3" "with save-stages should have 3 intermediate images (parent, child, independent)"
+}
+
+@test "[test labeling intermediate images] --stage-labels adds metadata to config and history of the intermediate image and final image" {
+  _prefetch alpine
+  target="stage-labels-test-$(safename)"
+
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels -t ${target} -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+  run_buildah images -a
+  intermediate_image=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  intermediate_count=$(echo "$intermediate_image" | wc -w)
+
+  assert "$intermediate_count" == "1" "should have exactly 1 intermediate image"
+
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $intermediate_image
+  assert "$output" "==" "intermediate" "stage.name should be 'intermediate'"
+
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.base"}}' $intermediate_image
+  assert "$output" "=~" "alpine" "stage.base should reference alpine image"
+
+  # Verify LABEL instruction appears in history (not just in config.Labels)
+  run_buildah inspect --format '{{range .OCIv1.History}}{{.CreatedBy}}{{"\n"}}{{end}}' $intermediate_image
+  expect_output --substring "LABEL"
+
+  # Verify exact label names and values in history
+  expect_output --substring '"io.buildah.stage.name"="intermediate"' "history should contain exact stage.name label"
+  expect_output --substring '"io.buildah.stage.base"="alpine"' "history should contain exact stage.base label"
+
+  # Verify final image also has stage labels (stage position and base pullspec)
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' ${target}
+  assert "$output" "==" "1" "final stage.name should be stage position '1' (no alias)"
+
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.base"}}' ${target}
+  assert "$output" "==" "alpine" "final stage.base should be 'alpine' pullspec"
+}
+
+@test "[test labeling intermediate images] chain of two stages - labels are indicating that one stage is using another stage as base" {
+  _prefetch alpine
+  target="chained-stages-test-$(safename)"
+
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels -t ${target} -f $BUDFILES/save-stages/Dockerfile.chained-two-build-stages $BUDFILES/save-stages
+
+  run_buildah images -a
+  all_intermediate_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+
+  parent_image_id=""
+  parent_name=""
+  parent_base=""
+  child_image_id=""
+  child_name=""
+  child_base=""
+
+  for image_id in $all_intermediate_images; do
+    run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $image_id
+    name="$output"
+
+    run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.base"}}' $image_id
+    base="$output"
+
+    # Check if base is in the list of intermediate images (stage is used by another stage as base)
+    is_child=false
+    for iid in $all_intermediate_images; do
+      # base in label is full image ID, but all_intermediate_images contains short IDs, so check prefix
+      if [[ "$base" == "$iid"* ]]; then
+        is_child=true
+        break
+      fi
+    done
+
+    if [ "$is_child" = true ]; then
+      # This is a child stage: its base is another intermediate image
+      child_image_id="$image_id"
+      child_name="$name"
+      child_base="$base"
+    else
+      # This is a parent stage that serves as base for another stage
+      parent_image_id="$image_id"
+      parent_name="$name"
+      parent_base="$base"
+    fi
+  done
+
+  assert "$parent_image_id" "!=" "" "parent stage should be present"
+  assert "$child_image_id" "!=" "" "child stage should be present"
+
+  assert "$parent_name" "==" "parent-stage" "parent stage name should be 'parent-stage'"
+  assert "$child_name" "==" "child-stage" "child stage name should be 'child-stage'"
+
+  assert "$parent_base" "=~" "alpine" "parent stage.base should reference alpine image"
+
+  # Verify child stage uses parent as base (child_base contains full ID, parent_image_id contains short ID)
+  assert "$child_base" "=~" "^$parent_image_id" "child stage.base should start with parent image ID"
+}
+
+@test "[test labeling intermediate images] --jobs 1 and 2 correctly resolve stage references to imageID in labels" {
+  _prefetch alpine
+
+  for jobs in 1 2; do
+    target="imageid-resolution-jobs${jobs}-$(safename)"
+
+    # Build with specified --jobs value
+    run_buildah build $WITH_POLICY_JSON --jobs $jobs --save-stages --stage-labels --layers -t ${target} -f $BUDFILES/save-stages/Dockerfile.chained-two-build-stages $BUDFILES/save-stages
+
+    run_buildah images -a
+    all_intermediate_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+
+    # Find parent-stage and child-stage intermediate images
+    parent_image=""
+    child_image=""
+    for image_id in $all_intermediate_images; do
+      run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $image_id
+      if [ "$output" = "parent-stage" ]; then
+        parent_image="$image_id"
+      elif [ "$output" = "child-stage" ]; then
+        child_image="$image_id"
+      fi
+    done
+
+    assert "$parent_image" "!=" "" "parent-stage intermediate image should exist (jobs=$jobs)"
+    assert "$child_image" "!=" "" "child-stage intermediate image should exist (jobs=$jobs)"
+
+    # Get child-stage base label value
+    run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.base"}}' $child_image
+    child_base="$output"
+
+    # Verify base label is an imageID from intermediate images (not alias "parent-stage")
+    found_in_images=false
+    for iid in $all_intermediate_images; do
+      if [[ "$child_base" == "$iid"* ]]; then
+        found_in_images=true
+        break
+      fi
+    done
+    assert "$found_in_images" == "true" "child stage.base should be imageID from intermediate images (jobs=$jobs)"
+
+    run_buildah rmi -a -f
+    _prefetch alpine
+  done
+}
+
+@test "[test labeling intermediate images] two independent intermediate images are correctly labeled" {
+  _prefetch alpine
+  target="two-stages-test-$(safename)"
+
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels -t ${target} -f $BUDFILES/save-stages/Dockerfile.two-build-stages $BUDFILES/save-stages
+
+  run_buildah images -a
+  all_intermediate_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+
+  intermediate_count=$(echo "$all_intermediate_images" | wc -w)
+  assert "$intermediate_count" == "2" "should have exactly 2 intermediate images"
+
+  stage_names=""
+  for image_id in $all_intermediate_images; do
+    run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $image_id
+    stage_name="$output"
+    stage_names="$stage_names $stage_name"
+
+    run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.base"}}' $image_id
+    assert "$output" "=~" "alpine" "stage base should be alpine"
+  done
+
+  assert "$stage_names" "=~" "alias1" "should have alias1 stage"
+  assert "$stage_names" "=~" "alias2" "should have alias2 stage"
+}
+
+@test "[test labeling intermediate images] intermediate images from chain of three stages are correctly labeled" {
+  _prefetch alpine
+  target="chained-multiple-stages-test-$(safename)"
+
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels -t ${target} -f $BUDFILES/save-stages/Dockerfile.chained-three-build-stages $BUDFILES/save-stages
+  run_buildah images -a
+  all_intermediate_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+
+  intermediate_count=$(echo "$all_intermediate_images" | wc -w)
+  assert "$intermediate_count" == "3" "should have exactly 3 intermediate images in chain"
+
+  declare -A stage_ids
+  declare -A stage_bases
+
+  for image_id in $all_intermediate_images; do
+    run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $image_id
+    stage_name="$output"
+    stage_ids[$stage_name]="$image_id"
+
+    run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.base"}}' $image_id
+    stage_bases[$stage_name]="$output"
+  done
+
+  # Verify all 3 stages exist and have correct names
+  assert "${stage_ids[base]}" "!=" "" "should have base stage"
+  assert "${stage_ids[stage1]}" "!=" "" "should have stage1 stage"
+  assert "${stage_ids[stage2]}" "!=" "" "should have stage2 stage"
+
+  # Verify stage base references
+  assert "${stage_bases[base]}" "=~" "alpine" "base should use alpine as base"
+  # stage_bases contains full IDs, stage_ids contains short IDs - use prefix match
+  assert "${stage_bases[stage1]}" "=~" "^${stage_ids[base]}" "stage1 base should start with base image ID"
+  assert "${stage_bases[stage2]}" "=~" "^${stage_ids[stage1]}" "stage2 base should start with stage1 image ID"
+}
+
+@test "[test labeling intermediate images] intermediate images with ARG in stage names and bases in Containerfile are correctly labeled" {
+  _prefetch alpine
+  target="arg-stages-chained-stages-test-$(safename)"
+
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels -t ${target} -f $BUDFILES/save-stages/Dockerfile.arg-build-stages-and-chained-build-stages $BUDFILES/save-stages
+
+  run_buildah images -a
+  all_intermediate_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+
+  intermediate_count=$(echo "$all_intermediate_images" | wc -w)
+  assert "$intermediate_count" == "2" "should have exactly 2 intermediate images"
+
+  declare -A stage_ids
+  declare -A stage_bases
+  declare -a found_stage_names
+
+  for image_id in $all_intermediate_images; do
+    run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $image_id
+    stage_name="$output"
+    stage_ids[$stage_name]="$image_id"
+    found_stage_names+=("$stage_name")
+
+    assert "$stage_name" "!~" '\$\{' "stage name should not contain unresolved ARG placeholders like \${...}"
+
+    run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.base"}}' $image_id
+    stage_base="$output"
+    stage_bases[$stage_name]="$stage_base"
+
+    assert "$stage_base" "!~" '\$\{' "stage base should not contain unresolved ARG placeholders like \${...}"
+  done
+
+  # Verify exact stage names are resolved from ARG variables (images returned newest first)
+  assert "${found_stage_names[0]}" == "second-stage" "first image should be 'second-stage' (resolved from \${SECOND_STAGE})"
+  assert "${found_stage_names[1]}" == "first-stage" "second image should be 'first-stage' (resolved from \${FIRST_STAGE})"
+
+  # Verify stage bases are resolved correctly
+  assert "${stage_bases[first-stage]}" == "alpine" "first-stage base should reference alpine image"
+  assert "${stage_bases[second-stage]}" "=~" "^${stage_ids[first-stage]}" "second-stage base should reference first-stage image ID (resolved from \${FIRST_STAGE})"
+}
+
+@test "[test labeling intermediate images] intermediate images without aliases are correctly labeled" {
+  _prefetch alpine
+  target=save-stages-no-aliases-$(safename)
+
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels -t ${target} -f $BUDFILES/save-stages/Dockerfile.chained-two-build-stages-no-aliases $BUDFILES/save-stages
+
+  run_buildah images -a
+  intermediate_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  num_intermediate=$(echo "$intermediate_images" | wc -w)
+  assert "$num_intermediate" "==" "2" "should have exactly 2 intermediate images (stage 0 and stage 1)"
+
+  declare -A stage_ids
+  for img_id in $intermediate_images; do
+    run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $img_id
+    stage_name="$output"
+    stage_ids[$stage_name]="$img_id"
+  done
+
+  stage0_id="${stage_ids[0]}"
+  assert "$stage0_id" "!=" "" "stage 0 should exist"
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.base"}}' $stage0_id
+  stage0_base="$output"
+  assert "$stage0_base" "=~" "alpine" "stage 0 stage.base should reference alpine image"
+
+  stage1_id="${stage_ids[1]}"
+  assert "$stage1_id" "!=" "" "stage 1 should exist"
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.base"}}' $stage1_id
+  stage1_base="$output"
+  assert "$stage1_base" "=~" "^$stage0_id" "stage 1 stage.base should reference stage 0 image ID"
+}
+
+@test "[test labeling intermediate images] empty intermediate stage (only FROM, no instructions) does not create labeled image" {
+  _prefetch alpine
+  target="empty-stage-$(safename)"
+
+  # Build with --save-stages --stage-labels
+  # The 'builder' stage has no instructions (only FROM alpine:latest AS builder)
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels -t ${target} -f $BUDFILES/save-stages/Dockerfile.empty-intermediate-build-stage $BUDFILES/save-stages
+
+  # Check intermediate images
+  run_buildah images -a
+  intermediate_images=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  num_intermediate=$(echo "$intermediate_images" | wc -w)
+
+  # Explanation: Empty stage (only FROM AS alias, no RUN/COPY/etc) is just an alias
+  # for the base image. It doesn't need metadata labels or a separate image.
+  # The final stage can reference it via COPY --from=builder, which resolves to alpine:latest.
+  assert "$num_intermediate" "==" "0" "empty intermediate stage (only FROM) should not create intermediate image with labels"
+}
+
+@test "[test final image] --save-stages build has same final image RootFS.DiffIDs count as build without args (all parent layers and single layer squashing all final stage instructions)" {
+  _prefetch alpine
+  target_cache="save-stages-layer-count-$(safename)"
+  target_normal="normal-layer-count-$(safename)"
+  target_layers="with-layers-count-$(safename)"
+
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels -t ${target_cache} -f $BUDFILES/save-stages/Dockerfile.two-build-stages $BUDFILES/save-stages
+  run_buildah inspect --format '{{len .OCIv1.RootFS.DiffIDs}}' ${target_cache}
+  save_stages_count=$output
+
+  run_buildah build $WITH_POLICY_JSON -t ${target_normal} -f $BUDFILES/save-stages/Dockerfile.two-build-stages $BUDFILES/save-stages
+  run_buildah inspect --format '{{len .OCIv1.RootFS.DiffIDs}}' ${target_normal}
+  normal_count=$output
+
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target_layers} -f $BUDFILES/save-stages/Dockerfile.two-build-stages $BUDFILES/save-stages
+  run_buildah inspect --format '{{len .OCIv1.RootFS.DiffIDs}}' ${target_layers}
+  layers_count=$output
+
+  assert "$save_stages_count" == "2" "--save-stages build should have exactly 2 layers for given Containerfile"
+  assert "$normal_count" == "2" "regular build should have exactly 2 layers for given Containerfile"
+  assert "$layers_count" == "4" "--layers should create exactly 4 layers (one per instruction) for given Containerfile"
+}
+
+@test "[test final image] final stage uses previous stage as base, but does not inherit its labels - it has its own labels" {
+  _prefetch alpine
+  target="final-no-inherit-labels-$(safename)"
+
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels -t ${target} -f $BUDFILES/save-stages/Dockerfile.final-uses-build-stage $BUDFILES/save-stages
+
+  run_buildah images -a
+  intermediate_image=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+
+  # Verify intermediate stage has stage labels
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $intermediate_image
+  assert "$output" "==" "intermediate" "intermediate stage should have stage.name label"
+
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.base"}}' $intermediate_image
+  assert "$output" "=~" "alpine" "intermediate stage should have stage.base label referencing alpine"
+
+  # Verify final image has its own labels
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' ${target}
+  assert "$output" "==" "1" "final image should have 1 as stage.name label"
+
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.base"}}' ${target}
+  assert "$output" "=~" "^$intermediate_image" "final image should have image ID of the previous stage as stage.base label"
+}
+
+@test "[test caching] Build 1: --layers --save-stages --stage-labels | Build 2: --layers --save-stages --stage-labels | Cache: layers can be reused" {
+  _prefetch alpine
+  target="cache-reuse-test-$(safename)"
+
+  run_buildah build $WITH_POLICY_JSON --layers --save-stages --stage-labels -t ${target}-first -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+  first_build_image_id=$(echo "$output" | tail -1)
+
+  # Get all intermediate layers from first build
+  run_buildah images -a
+  all_intermediate_layers_first=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  first_intermediate_layers_count=$(echo "$all_intermediate_layers_first" | wc -w)
+  assert "$first_intermediate_layers_count" -eq 4 "first build should create 4 intermediate layers (LABEL from --stage-labels for intermediate and final stage, RUN from intermediate stage, COPY from final stage)"
+
+  # Second build should reuse the layers created by first build (cache hit)
+  run_buildah build $WITH_POLICY_JSON --layers --save-stages --stage-labels -t ${target}-second -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+  second_build_image_id=$(echo "$output" | tail -1)
+
+  expect_output --substring "Using cache"
+
+  # Verify cache was used 4 times (LABEL from --stage-labels (intermediate and final stage), RUN from intermediate stage, COPY from final stage, RUN from final stage)
+  cache_count=$(echo "$output" | grep -c "Using cache")
+  assert "$cache_count" -eq 5 "should use cache 5 times (LABEL (intermediate and final stage), RUN intermediate, COPY, RUN final)"
+
+  # Get all intermediate layers from second build - second build should not add any more
+  run_buildah images -a
+  all_intermediate_layers_second=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  second_intermediate_layers_count=$(echo "$all_intermediate_layers_second" | wc -w)
+  assert "$second_intermediate_layers_count" -eq 4 "second build should also have 4 intermediate layers"
+
+  # Verify final image IDs match (complete cache hit)
+  assert "$first_build_image_id" "==" "$second_build_image_id" "final image ID should match when cache is fully reused"
+}
+
+@test "[test caching] Build 1: --save-stages | Build 2: --save-stages | Cache: intermediate images cannot be reused" {
+  _prefetch alpine
+  target="cache-accumulate-$(safename)"
+
+  # First build
+  run_buildah build $WITH_POLICY_JSON --save-stages -t ${target}-first -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+
+  run_buildah images -a
+  intermediate_images_first=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_first=$(echo "$intermediate_images_first" | wc -w)
+  assert "$count_first" -eq 1 "first build should create 1 intermediate image"
+
+  # Second build - intermediate images accumulate (no cache reuse without --layers)
+  run_buildah build $WITH_POLICY_JSON --save-stages -t ${target}-second -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+  assert "$output" "!~" "Using cache" "cache should not be used without --layers"
+
+  run_buildah images -a
+  intermediate_images_second=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_second=$(echo "$intermediate_images_second" | wc -w)
+  assert "$count_second" -eq 2 "second build should create another intermediate image (total 2)"
+
+  # Third build - accumulate more
+  run_buildah build $WITH_POLICY_JSON --save-stages -t ${target}-third -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+  assert "$output" "!~" "Using cache" "cache should not be used without --layers"
+
+  run_buildah images -a
+  intermediate_images_third=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_third=$(echo "$intermediate_images_third" | wc -w)
+  assert "$count_third" -eq 3 "third build should create another intermediate image (total 3)"
+}
+
+@test "[test caching] Build 1: --save-stages --stage-labels | Build 2: --save-stages --stage-labels | Cache: intermediate images cannot be reused" {
+  _prefetch alpine
+  target="cache-accumulate-labels-$(safename)"
+
+  # First build
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels -t ${target}-first -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+
+  run_buildah images -a
+  intermediate_images_first=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_first=$(echo "$intermediate_images_first" | wc -w)
+  assert "$count_first" -eq 1 "first build should create 1 intermediate image with labels"
+
+  # Second build - intermediate images accumulate (no cache reuse without --layers)
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels -t ${target}-second -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+  assert "$output" "!~" "Using cache" "cache should not be used without --layers (even with stage labels)"
+
+  run_buildah images -a
+  intermediate_images_second=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_second=$(echo "$intermediate_images_second" | wc -w)
+  assert "$count_second" -eq 2 "second build should create another intermediate image (total 2)"
+
+  # Third build - accumulate more
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels -t ${target}-third -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+  assert "$output" "!~" "Using cache" "cache should not be used without --layers (even with stage labels)"
+
+  run_buildah images -a
+  intermediate_images_third=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_third=$(echo "$intermediate_images_third" | wc -w)
+  assert "$count_third" -eq 3 "third build should create another intermediate image (total 3)"
+}
+
+@test "[test caching] Build 1: --save-stages --layers | Build 2: --save-stages --layers | Cache: intermediate images can be reused" {
+  _prefetch alpine
+  target="cache-reuse-layers-$(safename)"
+
+  # First build
+  run_buildah build $WITH_POLICY_JSON --save-stages --layers -t ${target}-first -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+  first_build_final_image_id=$(echo "$output" | tail -1)
+
+  run_buildah images -a
+  intermediate_images_first=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_first=$(echo "$intermediate_images_first" | wc -w)
+  assert "$count_first" -eq 2 "first build should create 2 intermediate layers (RUN from intermediate stage, COPY from final stage)"
+
+  # Build 2 should reuse all layers
+  run_buildah build $WITH_POLICY_JSON --save-stages --layers -t ${target}-second -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+  second_build_final_image_id=$(echo "$output" | tail -1)
+
+  expect_output --substring "Using cache"
+
+  # Verify cache was used 3 times (RUN from intermediate stage, COPY from final stage, RUN from final stage)
+  cache_count=$(echo "$output" | grep -c "Using cache")
+  assert "$cache_count" -eq 3 "should use cache 3 times (RUN intermediate, COPY, RUN final)"
+
+  run_buildah images -a
+  intermediate_images_second=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_second=$(echo "$intermediate_images_second" | wc -w)
+  assert "$count_second" -eq 2 "second build should reuse layers, not create new ones (still 2 total)"
+
+  # Full cache reuse - final image is same
+  assert $first_build_final_image_id "==" $second_build_final_image_id
+}
+
+@test "[test caching] Build 1: --save-stages --stage-labels --layers | Build 2: --save-stages --layers | Cache: No cache reuse - missing labels are causing cache miss for each stage" {
+  _prefetch alpine
+  target="cache-no-reuse-$(safename)"
+
+  # First build
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels --layers -t ${target}-first -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+
+  run_buildah images -a
+  intermediate_images_first=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_first=$(echo "$intermediate_images_first" | wc -w)
+  assert "$count_first" -eq 4 "first build should create 4 intermediate layers (LABEL (intermediate and final), RUN, COPY)"
+
+  # Build 2 - no cache reuse
+  run_buildah build $WITH_POLICY_JSON --save-stages --layers -t ${target}-second -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+
+  # Verify cache was not used
+  assert "$output" !~ "Using cache" "should NOT use cache because LABEL was added"
+
+  run_buildah images -a
+  intermediate_images_second=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_second=$(echo "$intermediate_images_second" | wc -w)
+  assert "$count_second" -eq 6 "second build should have 6 intermediate layers (4 from first + 2 instruction layers from second)"
+}
+
+@test "[test caching] Build 1: --save-stages --layers | Build 2: --save-stages --stage-labels --layers | Cache: No cache reuse - added labels are causing cache miss for each stage" {
+  _prefetch alpine
+  target="cache-no-reuse-$(safename)"
+
+  # First build
+  run_buildah build $WITH_POLICY_JSON --save-stages --layers -t ${target}-first -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+
+  run_buildah images -a
+  intermediate_images_first=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_first=$(echo "$intermediate_images_first" | wc -w)
+  assert "$count_first" -eq 2 "first build should create 2 intermediate layers (RUN from intermediate, COPY from final)"
+
+  # Second build (adds LABEL layers)
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels --layers -t ${target}-second -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+
+  # Verify cache was not used
+  assert "$output" !~ "Using cache" "should NOT use cache because LABEL was added"
+  run_buildah images -a
+  intermediate_images_second=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_second=$(echo "$intermediate_images_second" | wc -w)
+  assert "$count_second" -eq 6 "second build should have 6 intermediate layers (2 from first + 4 from second)"
+}
+
+@test "[test caching] Build 1: --layers | Build 2: --save-stages --stage-labels --layers | Cache: No cache reuse - added labels are causing cache miss for each stage" {
+  _prefetch alpine
+  target="cache-no-reuse-$(safename)"
+  
+  # First build
+  run_buildah build $WITH_POLICY_JSON --layers -t ${target}-first -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+
+  run_buildah images -a
+  intermediate_images_first=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_first=$(echo "$intermediate_images_first" | wc -w)
+  assert "$count_first" -eq 2 "first build should create 2 intermediate layers (RUN, COPY)"
+
+  # Second build (adds LABEL layer for interemediate and final stage)
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels --layers -t ${target}-second -f $BUDFILES/save-stages/Dockerfile.single-build-stage $BUDFILES/save-stages
+
+  # Verify cache was not used
+  assert "$output" !~ "Using cache" "should NOT use cache because LABEL was added"
+
+  run_buildah images -a
+  intermediate_images_second=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_second=$(echo "$intermediate_images_second" | wc -w)
+  assert "$count_second" -eq 6 "second build should have 6 intermediate layers (2 from first (instructions) + 4 from second (labels and instructions))"
+}
+
+@test "[test caching] Build 1: --save-stages --stage-labels --layers | Build 2: same flags, modified stage alias | Cache: intermediate stage rebuilt (name label changed)" {
+  _prefetch alpine
+  target="cache-miss-alias-change-$(safename)"
+
+  # Build 1: with alias "intermediate"
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels --layers -t ${target}-first -f $BUDFILES/save-stages/Dockerfile.single-build-stage-modifiable $BUDFILES/save-stages
+  first_build_final_image_id=$(echo "$output" | tail -1)
+
+  run_buildah images -a
+  intermediate_images_first=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_first=$(echo "$intermediate_images_first" | wc -w)
+  assert "$count_first" -eq 4 "first build should create 4 intermediate layers (LABEL (intermediate and final), RUN, COPY)"
+
+  # Get last layer from first stage (intermediate stage image)
+  first_intermediate_run_layer=$(echo "$intermediate_images_first" | awk 'NR==3')
+
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $first_intermediate_run_layer
+  assert "$output" "==" "intermediate" "first build intermediate stage image should have 'intermediate' as stage name"
+
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $first_build_final_image_id
+  assert "$output" "==" "1" "first build final image should have '1' index as stage name"
+
+  # Build 2: with modified alias "intermediate-renamed" - same Containerfile but different stage name
+  run_buildah build $WITH_POLICY_JSON --save-stages --stage-labels --layers -t ${target}-second -f $BUDFILES/save-stages/Dockerfile.single-build-stage-modifiable-renamed $BUDFILES/save-stages
+  second_build_final_image_id=$(echo "$output" | tail -1)
+
+  expect_output --substring "Using cache"
+
+  # Verify cache was used 3 times
+  cache_count=$(echo "$output" | grep -c "Using cache")
+  assert "$cache_count" -eq 3 "should use cache 3 times (LABEL final, COPY final, RUN final)" 
+
+  run_buildah images -a
+  intermediate_images_second=$(echo "$output" | awk '$1 == "<none>" && $2 == "<none>" {print $3}')
+  count_second=$(echo "$intermediate_images_second" | wc -w)
+  assert "$count_second" -eq 6 "second build should have 5 intermediate layers (4 from first + 2 new; LABEL intermediate and RUN intermediate)"
+
+  # Get last layer from first stage (intermediate stage image)
+  second_intermediate_run_layer=$(echo "$intermediate_images_second" | awk 'NR==1')
+
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $second_intermediate_run_layer
+  assert "$output" "==" "intermediate-renamed" "second build should have 'intermediate-renamed' as stage name"
+
+  # Unchanged
+  run_buildah inspect --format '{{index .OCIv1.Config.Labels "io.buildah.stage.name"}}' $second_build_final_image_id
+  assert "$output" "==" "1" "second build final image should have '1' index as stage name"
+
+  # Verify final image IDs match (complete cache hit)
+  assert "$first_build_final_image_id" "==" "$second_build_final_image_id" "final image ID should match when cache is fully reused"
+}

--- a/tests/bud/save-stages/Dockerfile.arg-build-stages-and-chained-build-stages
+++ b/tests/bud/save-stages/Dockerfile.arg-build-stages-and-chained-build-stages
@@ -1,0 +1,13 @@
+ARG PULLSPEC=alpine
+ARG FIRST_STAGE=first-stage
+ARG SECOND_STAGE=second-stage
+
+FROM ${PULLSPEC} AS ${FIRST_STAGE}
+RUN echo "first-stage content" > /output.txt
+
+FROM ${FIRST_STAGE} AS ${SECOND_STAGE}
+RUN echo "second-stage content" >> /output.txt
+
+FROM alpine
+COPY --from=second-stage /output.txt /app/output.txt
+RUN cat /app/output.txt

--- a/tests/bud/save-stages/Dockerfile.chained-three-build-stages
+++ b/tests/bud/save-stages/Dockerfile.chained-three-build-stages
@@ -1,0 +1,12 @@
+FROM alpine AS base
+RUN echo "base" > /output.txt
+
+FROM base AS stage1
+RUN echo "stage1" >> /output.txt
+
+FROM stage1 AS stage2
+RUN echo "stage2" >> /output.txt
+
+FROM alpine
+COPY --from=stage2 /output.txt /app/output.txt
+RUN cat /app/output.txt

--- a/tests/bud/save-stages/Dockerfile.chained-two-build-stages
+++ b/tests/bud/save-stages/Dockerfile.chained-two-build-stages
@@ -1,0 +1,9 @@
+FROM alpine AS parent-stage
+RUN echo "builder intermediate stage" > /output.txt
+
+FROM parent-stage AS child-stage
+RUN echo "final intermediate stage" >> /output.txt
+
+FROM alpine
+COPY --from=child-stage /output.txt /app/output.txt
+RUN cat /app/output.txt

--- a/tests/bud/save-stages/Dockerfile.chained-two-build-stages-no-aliases
+++ b/tests/bud/save-stages/Dockerfile.chained-two-build-stages-no-aliases
@@ -1,0 +1,9 @@
+FROM alpine
+RUN echo "stage 0" > /output.txt
+
+FROM 0
+RUN echo "stage 1" >> /output.txt
+
+FROM alpine
+COPY --from=1 /output.txt /app/output.txt
+RUN cat /app/output.txt

--- a/tests/bud/save-stages/Dockerfile.empty-intermediate-build-stage
+++ b/tests/bud/save-stages/Dockerfile.empty-intermediate-build-stage
@@ -1,0 +1,5 @@
+FROM alpine:latest AS builder
+
+FROM alpine:latest
+COPY --from=builder /etc/os-release /app/os-release
+RUN cat /app/os-release

--- a/tests/bud/save-stages/Dockerfile.final-uses-build-stage
+++ b/tests/bud/save-stages/Dockerfile.final-uses-build-stage
@@ -1,0 +1,7 @@
+FROM alpine:latest AS intermediate
+RUN echo "intermediate data" > /int.txt
+
+# Final stage uses intermediate stage as base (not external image)
+FROM intermediate
+RUN echo "final data" > /final.txt
+CMD ["cat", "/final.txt"]

--- a/tests/bud/save-stages/Dockerfile.simple
+++ b/tests/bud/save-stages/Dockerfile.simple
@@ -1,0 +1,2 @@
+FROM alpine
+RUN echo "single stage build"

--- a/tests/bud/save-stages/Dockerfile.single-build-stage
+++ b/tests/bud/save-stages/Dockerfile.single-build-stage
@@ -1,0 +1,6 @@
+FROM alpine AS intermediate
+RUN echo "intermediate" >> /build.txt
+
+FROM alpine
+COPY --from=intermediate /build.txt /app/build.txt
+RUN echo "final"

--- a/tests/bud/save-stages/Dockerfile.single-build-stage-modifiable
+++ b/tests/bud/save-stages/Dockerfile.single-build-stage-modifiable
@@ -1,0 +1,6 @@
+FROM alpine AS intermediate
+RUN echo "intermediate stage content" > /output.txt
+
+FROM alpine
+COPY --from=intermediate /output.txt /app/output.txt
+RUN cat /app/output.txt

--- a/tests/bud/save-stages/Dockerfile.single-build-stage-modifiable-renamed
+++ b/tests/bud/save-stages/Dockerfile.single-build-stage-modifiable-renamed
@@ -1,0 +1,6 @@
+FROM alpine AS intermediate-renamed
+RUN echo "intermediate stage content" > /output.txt
+
+FROM alpine
+COPY --from=intermediate-renamed /output.txt /app/output.txt
+RUN cat /app/output.txt

--- a/tests/bud/save-stages/Dockerfile.three-build-stages-parent-child-independent
+++ b/tests/bud/save-stages/Dockerfile.three-build-stages-parent-child-independent
@@ -1,0 +1,18 @@
+# Stage 1: parent (independent)
+FROM alpine:latest AS parent
+RUN echo "parent layer" > /parent.txt
+
+# Stage 2: child - uses stage 1 as parent
+FROM parent AS child
+RUN echo "child layer" > /child.txt
+
+# Stage 3: independent (standalone)
+FROM alpine:latest AS independent
+RUN echo "independent layer" > /independent.txt
+
+# Final stage: uses all 3 intermediate stages
+FROM alpine:latest
+COPY --from=parent /parent.txt /app/parent.txt
+COPY --from=child /child.txt /app/child.txt
+COPY --from=independent /independent.txt /app/independent.txt
+CMD ["cat", "/app/parent.txt", "/app/child.txt", "/app/independent.txt"]

--- a/tests/bud/save-stages/Dockerfile.two-build-stages
+++ b/tests/bud/save-stages/Dockerfile.two-build-stages
@@ -1,0 +1,10 @@
+FROM alpine AS alias1
+RUN echo "alias1" > /file1.txt
+
+FROM alpine AS alias2
+RUN echo "alias2" > /file2.txt
+
+FROM alpine
+COPY --from=alias1 /file1.txt /app/file1.txt
+COPY --from=alias2 /file2.txt /app/file2.txt
+RUN cat /app/file1.txt /app/file2.txt

--- a/tests/bud/save-stages/Dockerfile.two-build-stages-one-unused
+++ b/tests/bud/save-stages/Dockerfile.two-build-stages-one-unused
@@ -1,0 +1,9 @@
+FROM alpine AS builder
+RUN echo "building" > /build.txt
+
+FROM alpine AS intermediate
+RUN echo "intermediate" >> /build.txt
+
+FROM alpine
+COPY --from=intermediate /build.txt /app/build.txt
+RUN echo "final"


### PR DESCRIPTION
This adds support for preserving and labeling intermediate stage images (including final image) in multi-stage builds. `--save-stages` preserves only the final image from each intermediate stage, not every instruction layer (as `--layers` flag). This also keeps the final image's layer count same as in regular builds (with no additional args). `--stage-labels` adds label metadata containing base image and alias from Containerfile at the beginning of the stage.


New flags:
  - `--save-stages`: save intermediate stage final images instead of removing them.
        Build without added `--layers`, intermediate images are expected to accumulate on each build (no cache reuse).
        Build with added `--layers`, enables layer cache reuse for subsequent builds.

  - `--stage-labels`: adds metadata labels to intermediate stage images and final image:
    * `io.buildah.stage.name`: the stage name (alias or stage index if alias not specified)
    * `io.buildah.stage.base`: the base image (external image reference - pullpsec or
          parent stage image ID if its base is another stage)
    Requires `--save-stages`.
    Cache reuse depends of if first or second build has or has not `–stage-labels` argument or if alias/pullspec changed between builds in Containerfile

The implementation includes:
  - Validation that `--stage-labels` requires `--save-stages`
  - Detection when a stage uses another intermediate stage as base (and labeling the stage accordingly)
  - Stage labels are added to Containerfile via parse tree injection as LABEL at the beginning of the stage including final
  - Various test coverage for saving, labeling, and caching scenarios
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

**General use**: This functionality is useful for identification and debugging intermediate stage images in multi-stage builds.

**Specific need**: Identifying the content copied from intermediate stages in multi-stage builds into the final image is a hard requirement for supporting Contextual SBOM - an SBOM that understands the origin of each package.
While intermediate images can be extracted using the `--layers` option, this approach has several issues for our use case:
- Intermediate stage images are unlabeled, making it difficult to determine which image corresponds to which build stage - especially when the Containerfile reuses the same pullspec across multiple stages (pullspecs does not have to be unique, aliases must be).
- All instructions from all intermediate stages appear in the cache (visible via `buildah images --all`), which introduces unnecessary noise for our purposes.
- rootfs.diff_ids are not squashed in final stage: the final-stage image ends up containing diff IDs for every instruction in the final stage (due to the instructions reuse also for final stage). However, we need the final build image to resemble a regular build (without `--layers`), meaning:
  - it should contain the diff IDs inherited from the base image, and
  - exactly one diff ID representing the squashed final-stage instructions.

Related repositories: 
[konflux](https://github.com/konflux-ci/build-definitions) (uses mobster for SBOM generation), 
[mobster](https://github.com/konflux-ci/build-definitions) (implements contextual SBOM functionality requiring this change), 
[capo](https://github.com/konflux-ci/capo) (wraps builder content identification functionality for mobster), 
Contact person: emravec (RedHat) / @ezopezo (Github)

#### How to verify it

Run any multistage build with intermediate stage, with implemented arguments. Resulting intermediate images should be saved and correctly labeled. Example:
`buildah build --save-stages --stage-labels -t test:0.1 .`

#### Which issue(s) this PR fixes:

Fixes: #6257
Internal Jira: https://issues.redhat.com/browse/ISV-6122

#### Does this PR introduce a user-facing change?

```release-note
Add `--save-stages` and `--stage-labels` flags for preserving and labeling intermediate stage images in multi-stage builds.
```

