### PR TITLE
Enable building Windows container images

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -296,12 +296,18 @@ func TestCommitCompression(t *testing.T) {
 		name           string
 		expectError    bool
 		layerMediaType string
+		os             string
 	}{
-		{archive.Uncompressed, "uncompressed", false, v1.MediaTypeImageLayer},
-		{archive.Gzip, "gzip", false, v1.MediaTypeImageLayerGzip},
-		{archive.Bzip2, "bz2", true, ""},
-		{archive.Xz, "xz", true, ""},
-		{archive.Zstd, "zstd", false, v1.MediaTypeImageLayerZstd},
+		{archive.Uncompressed, "uncompressed", false, v1.MediaTypeImageLayer, ""},
+		{archive.Uncompressed, "uncompressed-win", false, v1.MediaTypeImageLayer, "windows"},
+		{archive.Gzip, "gzip", false, v1.MediaTypeImageLayerGzip, ""},
+		{archive.Gzip, "gzip-win", false, v1.MediaTypeImageLayerGzip, "windows"},
+		{archive.Bzip2, "bz2", true, "", ""},
+		{archive.Bzip2, "bz2-win", true, "", "windows"},
+		{archive.Xz, "xz", true, "", ""},
+		{archive.Xz, "xz-win", true, "", "windows"},
+		{archive.Zstd, "zstd", false, v1.MediaTypeImageLayerZstd, ""},
+		{archive.Zstd, "zstd-win", false, v1.MediaTypeImageLayerZstd, "windows"},
 	} {
 		t.Run(compressor.name, func(t *testing.T) {
 			var ref types.ImageReference
@@ -310,6 +316,7 @@ func TestCommitCompression(t *testing.T) {
 				SystemContext:         &testSystemContext,
 				Compression:           compressor.compression,
 			}
+			b.OCIv1.OS = compressor.os
 			imageName := compressor.name
 			ref, err := imageStorage.Transport.ParseStoreReference(store, imageName)
 			require.NoErrorf(t, err, "parsing reference for to-be-committed local image %q", imageName)

--- a/image.go
+++ b/image.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/containers/buildah/copier"
@@ -59,6 +60,37 @@ const (
 	// create uniquely-named files, but we don't want to try to use their
 	// contents until after they've been written to
 	containerExcludesSubstring = ".tmp"
+
+	// Windows-specific PAX record keys
+	keyFileAttr     = "MSWINDOWS.fileattr"
+	keySDRaw        = "MSWINDOWS.rawsd"
+	keyCreationTime = "LIBARCHIVE.creationtime"
+	// FILE_ATTRIBUTE_ values
+	fileAttributeDirectory = "16"
+	fileAttributeArchive   = "32"
+
+	// Windows Security Descriptors (base64-encoded)
+	// SDDL: O:BAG:SYD:(A;OICI;FA;;;BA)(A;OICI;FA;;;SY)(A;;FA;;;BA)(A;OICIIO;GA;;;CO)(A;OICI;0x1200a9;;;BU)(A;CI;LC;;;BU)(A;CI;DC;;;BU)
+	// Owner: Built-in Administrators (BA)
+	// Group: Local System (SY)
+	// DACL:
+	//   - Allow OBJECT_INHERIT+CONTAINER_INHERIT Full Access to Built-in Administrators (BA)
+	//   - Allow OBJECT_INHERIT+CONTAINER_INHERIT Full Access to Local System (SY)
+	//   - Allow Full Access to Built-in Administrators (BA)
+	//   - Allow OBJECT_INHERIT+CONTAINER_INHERIT+INHERIT_ONLY Generic All to Creator Owner (CO)
+	//   - Allow OBJECT_INHERIT+CONTAINER_INHERIT Read/Execute permissions to Built-in Users (BU)
+	//   - Allow CONTAINER_INHERIT List Contents to Built-in Users (BU)
+	//   - Allow CONTAINER_INHERIT Delete Child to Built-in Users (BU)
+	winSecurityDescriptorDirectory = "AQAEgBQAAAAkAAAAAAAAADAAAAABAgAAAAAABSAAAAAgAgAAAQEAAAAAAAUSAAAAAgCoAAcAAAAAAxgA/wEfAAECAAAAAAAFIAAAACACAAAAAxQA/wEfAAEBAAAAAAAFEgAAAAAAGAD/AR8AAQIAAAAAAAUgAAAAIAIAAAALFAAAAAAQAQEAAAAAAAMAAAAAAAMYAKkAEgABAgAAAAAABSAAAAAhAgAAAAIYAAQAAAABAgAAAAAABSAAAAAhAgAAAAIYAAIAAAABAgAAAAAABSAAAAAhAgAA"
+
+	// SDDL: O:BAG:SYD:(A;;FA;;;BA)(A;;FA;;;SY)(A;;0x1200a9;;;BU)
+	// Owner: Built-in Administrators (BA)
+	// Group: Local System (SY)
+	// DACL:
+	//   - Allow Full Access to Built-in Administrators (BA)
+	//   - Allow Full Access to Local System (SY)
+	//   - Allow Read/Execute permissions to Built-in Users (BU)
+	winSecurityDescriptorFile = "AQAEgBQAAAAkAAAAAAAAADAAAAABAgAAAAAABSAAAAAgAgAAAQEAAAAAAAUSAAAAAgBMAAMAAAAAABgA/wEfAAECAAAAAAAFIAAAACACAAAAABQA/wEfAAEBAAAAAAAFEgAAAAAAGACpABIAAQIAAAAAAAUgAAAAIQIAAA=="
 )
 
 // ExtractRootfsOptions is consumed by ExtractRootfs() which allows users to
@@ -112,6 +144,7 @@ type containerImageRef struct {
 	unsetAnnotations      []string
 	setAnnotations        []string
 	createdAnnotation     types.OptionalBool
+	os                    string
 }
 
 type blobLayerInfo struct {
@@ -1084,6 +1117,7 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, _ *types.SystemC
 		diffBeingAltered := i.compression != archive.Uncompressed
 		diffBeingAltered = diffBeingAltered || i.layerModTime != nil || i.layerLatestModTime != nil
 		diffBeingAltered = diffBeingAltered || len(layerExclusions) != 0
+		diffBeingAltered = diffBeingAltered || i.os == "windows"
 		if diffBeingAltered {
 			destHasher = digest.Canonical.Digester()
 			multiWriter = io.MultiWriter(counter, destHasher.Hash())
@@ -1099,11 +1133,13 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, _ *types.SystemC
 			return nil, fmt.Errorf("compressing %s: %w", what, err)
 		}
 		writer := io.MultiWriter(writeCloser, srcHasher.Hash())
-
 		// Use specified timestamps in the layer, if we're doing that for history
 		// entries.
 		nestedWriteCloser := ioutils.NewWriteCloserWrapper(writer, writeCloser.Close)
-		writeCloser = makeFilteredLayerWriteCloser(nestedWriteCloser, i.layerModTime, i.layerLatestModTime, layerExclusions)
+		writeCloser, err = makeFilteredLayerWriteCloser(nestedWriteCloser, i.layerModTime, i.layerLatestModTime, layerExclusions, i.os == "windows")
+		if err != nil {
+			return nil, fmt.Errorf("creating filter write closer %s: %w", what, err)
+		}
 		writer = writeCloser
 		// Okay, copy from the raw diff through the filter, compressor, and counter and
 		// digesters.
@@ -1373,9 +1409,9 @@ func (i *containerImageRef) makeExtraImageContentDiff(includeFooter bool, timest
 // no later than layerLatestModTime (if a value is provided for it).
 // This implies that if both values are provided, the archive's timestamps will
 // be set to the earlier of the two values.
-func makeFilteredLayerWriteCloser(wc io.WriteCloser, layerModTime, layerLatestModTime *time.Time, exclusions []copier.ConditionalRemovePath) io.WriteCloser {
-	if layerModTime == nil && layerLatestModTime == nil && len(exclusions) == 0 {
-		return wc
+func makeFilteredLayerWriteCloser(wc io.WriteCloser, layerModTime, layerLatestModTime *time.Time, exclusions []copier.ConditionalRemovePath, windows bool) (io.WriteCloser, error) {
+	if layerModTime == nil && layerLatestModTime == nil && len(exclusions) == 0 && !windows {
+		return wc, nil
 	}
 	exclusionsMap := make(map[string]copier.ConditionalRemovePath)
 	for _, exclusionSpec := range exclusions {
@@ -1385,19 +1421,22 @@ func makeFilteredLayerWriteCloser(wc io.WriteCloser, layerModTime, layerLatestMo
 		}
 		exclusionsMap[pathSpec] = exclusionSpec
 	}
+	var initialized bool
 	wc = newTarFilterer(wc, func(hdr *tar.Header) (skip, replaceContents bool, replacementContents io.Reader) {
-		// Changing a zeroed field to a non-zero field can affect the
-		// format that the library uses for writing the header, so only
-		// change fields that are already set to avoid changing the
-		// format (and as a result, changing the length) of the header
-		// that we write.
 		modTime := hdr.ModTime
-		nameSpec := strings.Trim(path.Clean(hdr.Name), "/")
-		if conditions, ok := exclusionsMap[nameSpec]; ok {
-			if (conditions.ModTime == nil || conditions.ModTime.Equal(modTime)) &&
-				(conditions.Owner == nil || (conditions.Owner.UID == hdr.Uid && conditions.Owner.GID == hdr.Gid)) &&
-				(conditions.Mode == nil || (*conditions.Mode&os.ModePerm == os.FileMode(hdr.Mode)&os.ModePerm)) {
-				return true, false, nil
+		if layerModTime != nil || layerLatestModTime != nil || len(exclusions) != 0 {
+			// Changing a zeroed field to a non-zero field can affect the
+			// format that the library uses for writing the header, so only
+			// change fields that are already set to avoid changing the
+			// format (and as a result, changing the length) of the header
+			// that we write.
+			nameSpec := strings.Trim(path.Clean(hdr.Name), "/")
+			if conditions, ok := exclusionsMap[nameSpec]; ok {
+				if (conditions.ModTime == nil || conditions.ModTime.Equal(modTime)) &&
+					(conditions.Owner == nil || (conditions.Owner.UID == hdr.Uid && conditions.Owner.GID == hdr.Gid)) &&
+					(conditions.Mode == nil || (*conditions.Mode&os.ModePerm == os.FileMode(hdr.Mode)&os.ModePerm)) {
+					return true, false, nil
+				}
 			}
 		}
 		if layerModTime != nil {
@@ -1415,9 +1454,70 @@ func makeFilteredLayerWriteCloser(wc io.WriteCloser, layerModTime, layerLatestMo
 		if !hdr.ChangeTime.IsZero() {
 			hdr.ChangeTime = modTime
 		}
+		if windows {
+			isDir := hdr.Typeflag == tar.TypeDir
+			if initialized {
+				hdr.Name = path.Join("Files", hdr.Name)
+				if isDir {
+					hdr.Name += "/"
+				}
+				if hdr.Linkname != "" {
+					hdr.Linkname = path.Join("Files", hdr.Linkname)
+					if isDir {
+						hdr.Linkname += "/"
+					}
+				}
+			}
+			// ensure all header fields are set in a way that is expected for Windows images
+			if hdr.PAXRecords == nil {
+				hdr.PAXRecords = map[string]string{}
+			}
+			hdr.Format = tar.FormatPAX
+			if isDir {
+				hdr.Mode |= syscall.S_IFDIR
+				hdr.PAXRecords[keyFileAttr] = fileAttributeDirectory
+				hdr.PAXRecords[keySDRaw] = winSecurityDescriptorDirectory
+			} else if hdr.Typeflag == tar.TypeReg {
+				hdr.Mode |= syscall.S_IFREG
+				hdr.PAXRecords[keyFileAttr] = fileAttributeArchive
+				hdr.PAXRecords[keySDRaw] = winSecurityDescriptorFile
+			}
+			if !hdr.ModTime.IsZero() {
+				hdr.PAXRecords[keyCreationTime] = fmt.Sprintf("%d.%09d", hdr.ModTime.Unix(), hdr.ModTime.Nanosecond())
+			}
+		}
 		return false, false, nil
 	})
-	return wc
+	if windows {
+		// prep the archive by writing the Files/ and Hives/ directories to the writer.
+		// This fulfills a requirement of Windows images
+		winTarWriter := tar.NewWriter(wc)
+		now := time.Now()
+		h := &tar.Header{
+			Name:     "Hives/",
+			Typeflag: tar.TypeDir,
+			ModTime:  now,
+			Mode:     0o755,
+		}
+		if err := winTarWriter.WriteHeader(h); err != nil {
+			return nil, err
+		}
+		h = &tar.Header{
+			Name:     "Files/",
+			Typeflag: tar.TypeDir,
+			ModTime:  now,
+			Mode:     0o755,
+		}
+		if err := winTarWriter.WriteHeader(h); err != nil {
+			return nil, err
+		}
+		// As we plan to continue to add to the archive, Flush() needs to be used, rather than Close().
+		if err := winTarWriter.Flush(); err != nil {
+			return nil, err
+		}
+	}
+	initialized = true
+	return wc, nil
 }
 
 // makeLinkedLayerInfos calculates the size and digest information for a layer
@@ -1475,7 +1575,10 @@ func (b *Builder) makeLinkedLayerInfos(layers []LinkedLayer, layerType string, l
 
 			digester := digest.Canonical.Digester()
 			sizeCountedFile := ioutils.NewWriteCounter(io.MultiWriter(digester.Hash(), f))
-			wc := makeFilteredLayerWriteCloser(ioutils.NopWriteCloser(sizeCountedFile), layerModTime, layerLatestModTime, nil)
+			wc, err := makeFilteredLayerWriteCloser(ioutils.NopWriteCloser(sizeCountedFile), layerModTime, layerLatestModTime, nil, false)
+			if err != nil {
+				return err
+			}
 			_, copyErr := io.Copy(wc, rc)
 			wcErr := wc.Close()
 			if err := rc.Close(); err != nil {
@@ -1677,6 +1780,7 @@ func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageR
 		layerMountTargets:     layerMountTargets,
 		layerPullUps:          layerPullUps,
 		createdAnnotation:     options.CreatedAnnotation,
+		os:                    b.OCIv1.OS,
 	}
 	if ref.created != nil {
 		for i := range ref.preEmptyLayers {


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
    Add basic functionality to build Windows images
    
    Enables committing a Windows base image as the final layer.
    This gives the possibility of building a Windows container image on a
    Linux build system. Only COPY and ADD are in scope. This allows the
    workflow of cross compiling Windows binaries on Linux, and copying them
    into a Windows container image for use on Windows systems.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->


Fixes #4010

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

