### PR TITLE
Fix commit validation workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,10 +16,25 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Workaround limitation/bug in commit-message-checker-with-regex (action below) where
+      # it breaks if there are "too many" commits in the PR.
+      # Ref: https://github.com/tim-actions/commit-message-checker-with-regex/issues/7
+
+      - name: Reduce commit data
+        run: >
+          echo '${{ steps.get-pr-commits.outputs.commits }}' | \
+              jq --monochrome-output --compact-output '[.[] | {"sha": .sha, "commit":{ "message": .commit.message }}]' \
+              > filtered-commits.json
+
+      - name: Load filtered commit data into output
+        id: 'get-pr-commit-messages'
+        run: >
+          echo "commit-messages=$(cat filtered-commits.json)" >> $GITHUB_OUTPUT
+
       - if: contains(github.head_ref, 'renovate/') != true
         name: check subject line length
         uses: tim-actions/commit-message-checker-with-regex@094fc16ff83d04e2ec73edb5eaf6aa267db33791 # v0.3.2
         with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          commits: ${{ steps.get-pr-commit-messages.outputs.commit-messages }}
           pattern: '^.{0,72}(\n.*)*$'
           error: 'Subject too long (max 72)'


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Fix commit title-length checking workflow bug.  Also, skip running this check for PR's **NOT** targeting the `main` branch.  These are typically renovate and/or release-branches that often have extended commit titles w/ additional context details.

#### How to verify it

The workflow will fail on this PR when the very long 'DO NOT MERGE:...' commit is included.  But the workflow will pass when that commit is removed.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

