### PR TITLE
[release-1.41] Buildah to 1.41.8 for CVE-2025-47913

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Changelog
 
+## v1.41.8 (2026-01-06)
+
+    [release-1.41] Bump Go in tests/tools to 1.24
+    [release-1.41] CVE-2025-47913 x/crypto
+
 ## v1.41.7 (2025-12-11)
 
     [release-1.41] Bump runc to v1.3.4

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+- Changelog for v1.41.8 (2026-01-06)
+  * [release-1.41] Bump Go in tests/tools to 1.24
+  * [release-1.41] CVE-2025-47913 x/crypto
+
 - Changelog for v1.41.7 (2025-12-11)
   * [release-1.41] Bump runc to v1.3.4
 

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	// identify working containers.
 	Package = "buildah"
 	// Version for the Package. Also used by .packit.sh for Packit builds.
-	Version = "1.41.7"
+	Version = "1.41.8"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
In #6558, I neglected to add a commit to bump the version there. This PR does that, bumping Buildah to v1.41.8

This will complete the fixes for:

Fixes: https://issues.redhat.com/browse/RHEL-134777, https://issues.redhat.com/browse/RHEL-134792

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

