### PR TITLE
tests: Skip chroot overlay test if STORAGE_DRIVER is overlay

### DIFF
--- a/tests/chroot.bats
+++ b/tests/chroot.bats
@@ -120,6 +120,9 @@ load helpers
   if [ "$(id -u)" -ne 0 ]; then
     skip "expects to already be root"
   fi
+  if test "$STORAGE_DRIVER" = "overlay"; then
+    skip "skipping test because \$STORAGE_DRIVER = $STORAGE_DRIVER"
+  fi
   _prefetch docker.io/library/busybox
   cp -v ${TEST_SOURCES}/containers.conf ${TEST_SCRATCH_DIR}/containers.conf
   chmod ugo+r ${TEST_SCRATCH_DIR}/containers.conf


### PR DESCRIPTION
Skip chroot overlay test if `STORAGE_DRIVER` is overlay.

Otherwise the test fails like this:
https://openqa-assets.opensuse.org/tests/5554359/file/buildah-buildah-root.tap.txt

```
# Error: path "/var/tmp/storage-run-0" exists and it is not writeable only by the current user
```

In openSUSE we run the buildah tests as root & rootless, but test `overlay` as root and `vfs` as rootless.  This particular test fails because we're creating an overlay on top of another overlay which seems wrong.

#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

#### How to verify it

https://openqa-assets.opensuse.org/tests/5592678/file/buildah-buildah-root.tap.txt

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

