### PR TITLE
Use cached images instead of fedoraproject.org

### DIFF
--- a/tests/blobcache.bats
+++ b/tests/blobcache.bats
@@ -71,7 +71,7 @@ function _check_matches() {
 	run_buildah login --tls-verify=false --authfile ${TEST_SCRATCH_DIR}/test.auth --username testuser --password testpassword localhost:${REGISTRY_PORT}
 	outputdir=${TEST_SCRATCH_DIR}/outputdir
 	mkdir -p ${outputdir}
-	podman run --rm --mount type=bind,src=${TEST_SCRATCH_DIR}/test.auth,target=/test.auth,Z --mount type=bind,src=${outputdir},target=/output,Z --net host quay.io/skopeo/stable copy --preserve-digests --authfile=/test.auth --tls-verify=false docker://registry.fedoraproject.org/fedora-minimal dir:/output
+	podman run --rm --mount type=bind,src=${TEST_SCRATCH_DIR}/test.auth,target=/test.auth,Z --mount type=bind,src=${outputdir},target=/output,Z --net host quay.io/skopeo/stable copy --preserve-digests --authfile=/test.auth --tls-verify=false docker://quay.io/libpod/alpine:3.10.2 dir:/output
 	run_buildah rmi --all -f
 	run_buildah pull --blob-cache=${blobcachedir} dir:${outputdir}
 	run_buildah images -a --format '{{.ID}}'

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -142,7 +142,7 @@ _EOF
 }
 
 @test "bud and test --inherit-annotations" {
-  base=registry.fedoraproject.org/fedora-minimal
+  base=quay.io/libpod/testimage:20241011
   _prefetch $base
   target=exp
 
@@ -191,7 +191,7 @@ _EOF
 }
 
 @test "bud and test --inherit-annotations with --layers" {
-  base=registry.fedoraproject.org/fedora-minimal
+  base=quay.io/libpod/testimage:20241011
   _prefetch $base
   target=exp
 
@@ -2989,7 +2989,7 @@ _EOF
 }
 
 @test "bud and test --unsetlabel" {
-  base=registry.fedoraproject.org/fedora-minimal
+  base=quay.io/libpod/testimage:20241011
   _prefetch $base
   target=exp
 
@@ -3019,7 +3019,7 @@ _EOF
 }
 
 @test "bud and test --unsetannotation" {
-  base=registry.fedoraproject.org/fedora-minimal
+  base=quay.io/libpod/testimage:20241011
   _prefetch $base
   target=exp
 
@@ -3049,7 +3049,7 @@ _EOF
 }
 
 @test "bud and test --unsetannotation with --layers" {
-  base=registry.fedoraproject.org/fedora-minimal
+  base=quay.io/libpod/testimage:20241011
   _prefetch $base
   target=exp
 
@@ -3090,7 +3090,7 @@ _EOF
 }
 
 @test "bud and test --unsetannotation with only base image" {
-  base=registry.fedoraproject.org/fedora-minimal
+  base=quay.io/libpod/testimage:20241011
   _prefetch $base
   target=exp
 
@@ -3117,7 +3117,7 @@ _EOF
 }
 
 @test "bud and test inherit-labels" {
-  base=registry.fedoraproject.org/fedora-minimal
+  base=quay.io/libpod/testimage:20241011
   _prefetch $base
   _prefetch alpine
   run_buildah --version
@@ -3125,37 +3125,37 @@ _EOF
   buildah_version=${output_fields[2]}
   run_buildah build $WITH_POLICY_JSON -t exp -f $BUDFILES/base-with-labels/Containerfile
 
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "license"}}' exp
-  expect_output "MIT" "license must be MIT from fedora base image"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' exp
-  expect_output "fedora-minimal" "name must be fedora from base image"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_at"}}' exp
+  expect_output "2024-10-11T12:26:00Z" "created_at must be inherited from base image"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_by"}}' exp
+  expect_output "test/system/build-testimage" "created_by must be inherited from base image"
 
-  run_buildah build $WITH_POLICY_JSON --inherit-labels=false --label name=world -t exp -f $BUDFILES/base-with-labels/Containerfile
+  run_buildah build $WITH_POLICY_JSON --inherit-labels=false --label created_by=world -t exp -f $BUDFILES/base-with-labels/Containerfile
   # no labels should be inherited from base image, only the buildah version label
-  # and `hello=world` which we just added using cli flag
-  want_output='map["io.buildah.version":"'$buildah_version'" "name":"world"]'
+  # and `created_by=world` which we just added using cli flag
+  want_output='map["created_by":"world" "io.buildah.version":"'$buildah_version'"]'
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' exp
   expect_output "$want_output"
 
   # Try building another file with multiple layers
   run_buildah build $WITH_POLICY_JSON --iidfile ${TEST_SCRATCH_DIR}/id1 --layers -t exp -f $BUDFILES/base-with-labels/Containerfile.layer
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "license"}}' exp
-  expect_output "MIT" "license must be MIT from fedora base image"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' exp
-  expect_output "world" "name must be world from Containerfile"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_at"}}' exp
+  expect_output "2024-10-11T12:26:00Z" "created_at must be inherited from base image"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_by"}}' exp
+  expect_output "world" "created_by must be world from Containerfile"
 
   # Now build same file with  --inherit-labels=false and verify if we are not using the cache again.
   run_buildah build $WITH_POLICY_JSON --layers --inherit-labels=false --iidfile ${TEST_SCRATCH_DIR}/inherit_false_1 -t exp -f $BUDFILES/base-with-labels/Containerfile.layer
   # Should not contain `Using cache` at all since
   assert "$output" !~ "Using cache"
-  want_output='map["io.buildah.version":"'$buildah_version'" "name":"world"]'
+  want_output='map["created_by":"world" "io.buildah.version":"'$buildah_version'"]'
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' exp
   expect_output "$want_output"
 
   run_buildah build $WITH_POLICY_JSON --layers --inherit-labels=false --iidfile ${TEST_SCRATCH_DIR}/inherit_false_2 -t exp -f $BUDFILES/base-with-labels/Containerfile.layer
   # Should contain `Using cache`
   expect_output --substring " Using cache"
-  want_output='map["io.buildah.version":"'$buildah_version'" "name":"world"]'
+  want_output='map["created_by":"world" "io.buildah.version":"'$buildah_version'"]'
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' exp
   expect_output "$want_output"
   assert "$(cat ${TEST_SCRATCH_DIR}/inherit_false_1)" = "$(cat ${TEST_SCRATCH_DIR}/inherit_false_2)" "expected image ids to not change"
@@ -3163,10 +3163,10 @@ _EOF
   # Now build same file with  --inherit-labels=true and verify if using the cache
   run_buildah build $WITH_POLICY_JSON --iidfile ${TEST_SCRATCH_DIR}/id2 --layers --inherit-labels=true -t exp -f $BUDFILES/base-with-labels/Containerfile.layer
   expect_output --substring " Using cache"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "license"}}' exp
-  expect_output "MIT" "license must be MIT from fedora base image"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' exp
-  expect_output "world" "name must be world from Containerfile"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_at"}}' exp
+  expect_output "2024-10-11T12:26:00Z" "created_at must be inherited from base image"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_by"}}' exp
+  expect_output "world" "created_by must be world from Containerfile"
   # Final image id should be exactly same as the one image which was built in the past.
   assert "$(cat ${TEST_SCRATCH_DIR}/id1)" = "$(cat ${TEST_SCRATCH_DIR}/id2)" "expected image ids to not change"
 
@@ -3178,13 +3178,13 @@ _EOF
 
   # Now build same file with  --inherit-labels=true and verify if target stage inherits labels from the base stage.
   run_buildah build $WITH_POLICY_JSON --iidfile ${TEST_SCRATCH_DIR}/id3 --layers --inherit-labels=true -t exp -f $BUDFILES/base-with-labels/Containerfile.multi-stage
-  want_output='map["io.buildah.version":"'$buildah_version'" "name":"world"]'
+  want_output='map["created_by":"world" "io.buildah.version":"'$buildah_version'"]'
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' exp
   expect_output "$want_output"
 
   # Rebuild again with layers should not build image again at all.
   run_buildah build $WITH_POLICY_JSON --iidfile ${TEST_SCRATCH_DIR}/id4 --layers --inherit-labels=true -t exp -f $BUDFILES/base-with-labels/Containerfile.multi-stage
-  want_output='map["io.buildah.version":"'$buildah_version'" "name":"world"]'
+  want_output='map["created_by":"world" "io.buildah.version":"'$buildah_version'"]'
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' exp
   expect_output "$want_output"
   assert "$(cat ${TEST_SCRATCH_DIR}/id3)" = "$(cat ${TEST_SCRATCH_DIR}/id4)" "expected image ids to not change"

--- a/tests/bud/base-with-labels/Containerfile
+++ b/tests/bud/base-with-labels/Containerfile
@@ -1,2 +1,2 @@
-FROM registry.fedoraproject.org/fedora-minimal
+FROM quay.io/libpod/testimage:20241011
 RUN echo hello

--- a/tests/bud/base-with-labels/Containerfile.layer
+++ b/tests/bud/base-with-labels/Containerfile.layer
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal
-LABEL name world
+FROM quay.io/libpod/testimage:20241011
+LABEL created_by world
 RUN echo world
 RUN echo hello

--- a/tests/bud/base-with-labels/Containerfile.multi-stage
+++ b/tests/bud/base-with-labels/Containerfile.multi-stage
@@ -1,5 +1,5 @@
 FROM alpine as one
-LABEL name world
+LABEL created_by world
 
 FROM one
 RUN echo world

--- a/tests/bud/base-with-labels/Containerfile2
+++ b/tests/bud/base-with-labels/Containerfile2
@@ -1,3 +1,3 @@
-FROM registry.fedoraproject.org/fedora-minimal
+FROM quay.io/libpod/testimage:20241011
 RUN echo hello
 RUN echo world

--- a/tests/bud/only-base/Containerfile
+++ b/tests/bud/only-base/Containerfile
@@ -1,1 +1,1 @@
-FROM registry.fedoraproject.org/fedora-minimal
+FROM quay.io/libpod/testimage:20241011

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -82,22 +82,22 @@ function check_matrix() {
 }
 
 @test "config --unsetlabel" {
-  base=registry.fedoraproject.org/fedora-minimal
+  base=quay.io/libpod/testimage:20241011
   _prefetch $base
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON $base
   cid=$output
-  run_buildah commit $WITH_POLICY_JSON $cid with-name-label
-  run_buildah config --unsetlabel name $cid
-  run_buildah commit $WITH_POLICY_JSON $cid without-name-label
+  run_buildah commit $WITH_POLICY_JSON $cid with-created-by-label
+  run_buildah config --unsetlabel created_by $cid
+  run_buildah commit $WITH_POLICY_JSON $cid without-created-by-label
 
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' with-name-label
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_by"}}' with-created-by-label
   assert "$output" != "" "label should be set in base image"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' without-name-label
-  assert "$output" == "" "name label should be removed"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_by"}}' without-created-by-label
+  assert "$output" == "" "created_by label should be removed"
 }
 
 @test "config --unsetannotation" {
-  base=registry.fedoraproject.org/fedora-minimal
+  base=quay.io/libpod/testimage:20241011
   _prefetch $base
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON $base
   cid=$output

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -22,9 +22,7 @@ docker pull mirror.gcr.io/golang
 docker pull mirror.gcr.io/alpine
 docker pull mirror.gcr.io/busybox
 docker pull quay.io/libpod/centos:7
-docker pull registry.fedoraproject.org/fedora-minimal:42-aarch64
-docker pull registry.fedoraproject.org/fedora-minimal:42-x86_64
-docker pull registry.fedoraproject.org/fedora-minimal
+docker pull quay.io/libpod/ubuntu:latest
 ```
 
 This test program is used as input in a few of the conformance tests:

--- a/tests/conformance/testdata/header-builtin/Dockerfile
+++ b/tests/conformance/testdata/header-builtin/Dockerfile
@@ -1,15 +1,14 @@
-# if TARGETARCH is defined, we'l pull the x86_64 image
-FROM registry.fedoraproject.org/fedora-minimal:42${TARGETARCH:+-x86_64} AS amd64
-# if TARGETARCH is defined, we'l pull the aarch64 image
-FROM registry.fedoraproject.org/fedora-minimal:42${TARGETARCH:+-aarch64} AS arm64
+# Pull architecture-specific ubuntu images from cached registry
+FROM --platform=linux/amd64 quay.io/libpod/ubuntu:latest AS amd64
+FROM --platform=linux/arm64 quay.io/libpod/ubuntu:latest AS arm64
 
 # run "file" against both shared libraries
-FROM registry.fedoraproject.org/fedora-minimal AS native
-COPY --from=amd64 /lib64/libc.so.6 /libc-amd64
-COPY --from=arm64 /lib64/libc.so.6 /libc-arm64
-RUN microdnf -y install file && microdnf -y clean all
+FROM quay.io/libpod/ubuntu:latest AS native
+COPY --from=amd64 /lib/x86_64-linux-gnu/libc.so.6 /libc-amd64
+COPY --from=arm64 /lib/aarch64-linux-gnu/libc.so.6 /libc-arm64
+RUN apt-get update && apt-get install -y file && apt-get clean
 RUN file /libc-* | tee /libc-types.txt && touch -d @0 /libc-types.txt
 
 # expect them to have different target architectures listed in their ELF headers
-FROM registry.fedoraproject.org/fedora-minimal
+FROM quay.io/libpod/ubuntu:latest
 COPY --from=native /libc-types.txt /

--- a/tests/registries.bats
+++ b/tests/registries.bats
@@ -28,5 +28,4 @@ load helpers
   # Test with pairs of short and fully-qualified names that should be the same image.
   registrypair busybox           docker.io/busybox
   registrypair busybox           docker.io/library/busybox
-  registrypair fedora-minimal:32 registry.fedoraproject.org/fedora-minimal:32
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:
Image replacements:                                                                                                                                                                                             
- `fedora-minimal` -> `testimage:20241011` (label tests in bud.bats, config.bats)                                                                                                                                
- `fedora-minimal` -> `alpine:3.10.2` (blobcache.bats)                                                                                                                                                           
- `fedora-minimal` -> `ubuntu:latest` (conformance test)                                                                                                                                                         
- Removed `fedora-minimal` registrypair from registries.bats (short-name resolution is still tested via busybox/docker.io pairs; adding a quay.io pair would require custom registries.conf) 

#### How to verify it
 Run the affected tests:`sudo bats tests/config.bats tests/bud.bats tests/registries.bats`

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #6492 
or
None
-->
Fixes #6492 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

