### PR TITLE
[release-1.42] Run: don't try to encode SystemContext with json

### DIFF
--- a/run.go
+++ b/run.go
@@ -175,7 +175,7 @@ type RunOptions struct {
 	// unmounted if Run() returned an error
 	ExternalImageMounts []string
 	// System context of current build
-	SystemContext *types.SystemContext
+	SystemContext *types.SystemContext `json:"-"`
 	// CgroupManager to use for running OCI containers
 	CgroupManager string
 	// CDIConfigDir is the location of CDI configuration files, if the files in


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Don't expect to be able to encode a `SystemContext` as JSON, because it will trigger an encoding error if fields which can't be encoded are set.

#### How to verify it

podman has a "podman build - basic test" test that should be fixed by this.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Cherry-picked from #6650

#### Does this PR introduce a user-facing change?

```release-note
None
```