### PR TITLE
[release-1.42] fix(build): make --tag oci-archive:xxx.tar work with simple images

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -8074,6 +8074,17 @@ _EOF
   diff "${outpath}.b" "${outpath}.c"
 }
 
+@test "build-with-timestamp-applies-to-oci-archive-with-base" {
+  local outpath="${TEST_SCRATCH_DIR}/timestamp-oci.tar"
+
+  run_buildah build -f <(echo 'FROM busybox') --tag=oci-archive:${outpath}.a --timestamp 0
+  sleep 1.1 # sleep at least 1 second, so that timestamps are incremented
+  run_buildah build -f <(echo 'FROM busybox') --tag=oci-archive:${outpath}.b --timestamp 0
+
+  # should be the same
+  diff "${outpath}.a" "${outpath}.b"
+}
+
 @test "bud-source-date-epoch-arg" {
   _prefetch busybox
   local timestamp=60


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This allows `buildah build -f <(echo 'FROM busybox') --tag=oci-archive:out.tar` to succeed without error.

#### How to verify it

bats test added.

#### Which issue(s) this PR fixes:

FIxes #6280 

#### Special notes for your reviewer:

Cherry-picked from #6284.

#### Does this PR introduce a user-facing change?

```release-note
None
```