### PR TITLE
manifest create: add --amend and --replace for non-list images

### DIFF
--- a/docs/buildah-manifest-create.1.md
+++ b/docs/buildah-manifest-create.1.md
@@ -31,13 +31,21 @@ image from such a list will be added to the newly-created list or index.
 
 **--amend**
 
-If a manifest list named *listNameOrIndexName* already exists, modify the
-preexisting list instead of exiting with an error.  The contents of
-*listNameOrIndexName* are not modified if no *imageName*s are given.
+Instead of exiting with an error when *listNameOrIndexName* already exists,
+amend the existing image. When *listNameOrIndexName* is a manifest list, the
+contents of *listNameOrIndexName* are not modified unless *imageName*s are
+given. When *listNameOrIndexName* is a regular image, that image is converted
+into a manifest list with the original image as its first entry.
 
 **--annotation** *annotation=value*
 
 Set an annotation on the newly-created image index.
+
+**--replace**
+
+If an image named *listNameOrIndexName* already exists, remove the name from the
+existing image before creating the new manifest list.  This option cannot be
+used together with **--amend**.
 
 **--tls-verify** *bool-value*
 

--- a/docs/buildah-manifest-create.1.md
+++ b/docs/buildah-manifest-create.1.md
@@ -33,7 +33,7 @@ image from such a list will be added to the newly-created list or index.
 
 Instead of exiting with an error when *listNameOrIndexName* already exists,
 amend the existing image. When *listNameOrIndexName* is a manifest list, the
-contents of *listNameOrIndexName* are not modified unless *imageName*s are
+contents of *listNameOrIndexName* are not modified unless *imageNames* are
 given. When *listNameOrIndexName* is a regular image, that image is converted
 into a manifest list with the original image as its first entry.
 


### PR DESCRIPTION
Extend `manifest create` to handle name conflicts with non-list images:
- --amend: convert a non-list image into a manifest list with the original image as its first entry.
- --replace: remove the name from the existing image before creating a new manifest list.

Closes: #6639

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

/kind feature

#### Special notes for your reviewer:

Some of the original `manifest create --amend` logic did not make total sense to me and has been omitted. I suspect there could be tricky edge cases I haven't considered that may warrant some of that debug logging.

#### Does this PR introduce a user-facing change?
Yes.
```release-note
manifest create: add --replace
manifest create: update --amend to convert non-list images
```

