### PR TITLE
copier: drain tar stream to prevent broken pipe errors

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -2181,6 +2181,15 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 		if err != io.EOF {
 			return fmt.Errorf("reading tar stream: expected EOF: %w", err)
 		}
+		// Drain any remaining data from bulkReader to prevent broken pipe errors.
+		// tar.Reader returns EOF after reading the standard tar EOF marker
+		// (two 512-byte blocks of nulls), but the tar file may have additional
+		// trailing null bytes. If we don't read them, the subprocess exits before
+		// the sender finishes writing to the pipe, causing EPIPE/broken pipe.
+		// See: https://github.com/containers/buildah/issues/6573
+		if _, err := io.Copy(io.Discard, bulkReader); err != nil {
+			logrus.Debugf("error draining remaining data from tar stream: %v", err)
+		}
 		return nil
 	}
 	return &response{Error: "", Put: putResponse{}}, cb, nil


### PR DESCRIPTION
Fix race condition where tar.Reader returns EOF after reading the standard EOF marker (two 512-byte null blocks) but before consuming trailing null bytes that many tar implementations add. This caused the copier subprocess to exit early, resulting in EPIPE errors when the sender tried to write remaining data.

Fixes: https://github.com/containers/buildah/issues/6573

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed broken pipe errors when uploading tar archives with trailing null bytes (#6573)
```

