### PR TITLE
Add a test where a default ARG value is a quoted string

### DIFF
--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -3728,6 +3728,13 @@ var internalTestCases = []testCase{
 		dockerfile:        "Dockerfile.mount",
 		dockerUseBuildKit: true,
 	},
+
+	{
+		name:              "quoted and inherited arg",
+		dockerfile:        "Dockerfile.quoted-arg",
+		fsSkip:            []string{"(dir):arg-expansion.txt:mtime"},
+		dockerUseBuildKit: true,
+	},
 }
 
 func TestCommit(t *testing.T) {

--- a/tests/conformance/testdata/Dockerfile.quoted-arg
+++ b/tests/conformance/testdata/Dockerfile.quoted-arg
@@ -1,0 +1,12 @@
+FROM quay.io/libpod/centos:7 AS lower
+
+ARG quoted="words with quotes"
+ARG expanded=$quoted
+
+RUN printf "%q\n" lower: $quoted >> /arg-expansion.txt
+RUN printf "%q\n" lower: $expanded >> /arg-expansion.txt
+
+FROM lower AS upper
+
+RUN printf "%q\n" upper: $quoted >> /arg-expansion.txt
+RUN printf "%q\n" upper: $expanded >> /arg-expansion.txt


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Add a test reproducer from #6648.

#### How to verify it

New conformance test!

#### Which issue(s) this PR fixes:

Verifies that #6648 was fixed by #6663.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
In multi-stage builds, default ARG values inherited from a base stage by a later stage should now handle quoting consistently.
```