### PR TITLE
test: Fix the typo in bud test

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -303,12 +303,12 @@ EOF
       ;;
     --label=A=B)
       # Should have had the requested label set.
-      run jq -r '.OCIv1.config.Labels.["A"]' <<< "$output"
+      run jq -r '.OCIv1.config.Labels["A"]' <<< "$output"
       assert ${status} == 0
       assert "${output}" == B
       # Go back and check the base, as a control.
       run_buildah inspect -t image ${baseiid}
-      run jq '.OCIv1.config.Labels.["A"]' <<< "$output"
+      run jq '.OCIv1.config.Labels["A"]' <<< "$output"
       assert ${status} == 0
       assert "${output}" == null
       ;;


### PR DESCRIPTION
The command for get buildah inspect results from jq have typo in test "bud with no instructions but with CLI flags that require a new image be written". Fix it in this commit.

#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Fix a typo in the bud.bats

#### How to verify it

Run test "bud with no instructions but with CLI flags that require a new image be written"

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```None

```

