### PR TITLE
tree: replace various nested append calls with slices.Concat

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -852,7 +852,7 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 							// append heading args so if --build-arg key=value is not
 							// specified but default value is set in Containerfile
 							// via `ARG key=value` so default value can be used.
-							userArgs = append(builtinArgs, append(userArgs, headingArgs...)...)
+							userArgs = slices.Concat(builtinArgs, userArgs, headingArgs)
 							baseWithArg, err := imagebuilder.ProcessWord(base, userArgs)
 							if err != nil {
 								return "", nil, fmt.Errorf("while replacing arg variables with values for format %q: %w", base, err)
@@ -883,7 +883,7 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 							builtinArgs := argsMapToSlice(stage.Builder.BuiltinArgDefaults)
 							headingArgs := argsMapToSlice(stage.Builder.HeadingArgs)
 							userArgs := argsMapToSlice(stage.Builder.Args)
-							userArgs = append(builtinArgs, append(userArgs, headingArgs...)...)
+							userArgs = slices.Concat(builtinArgs, userArgs, headingArgs)
 							afterResolved, err := imagebuilder.ProcessWord(after, userArgs)
 							if err != nil {
 								return "", nil, fmt.Errorf("while replacing arg variables with values for --after=%q: %w", after, err)
@@ -925,7 +925,7 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 							// append heading args so if --build-arg key=value is not
 							// specified but default value is set in Containerfile
 							// via `ARG key=value` so default value can be used.
-							userArgs = append(builtinArgs, append(userArgs, headingArgs...)...)
+							userArgs = slices.Concat(builtinArgs, userArgs, headingArgs)
 							baseWithArg, err := imagebuilder.ProcessWord(stageName, userArgs)
 							if err != nil {
 								return "", nil, fmt.Errorf("while replacing arg variables with values for format %q: %w", stageName, err)

--- a/run_common.go
+++ b/run_common.go
@@ -1421,7 +1421,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 	}
 	mountArtifacts.RunOverlayDirs = append(mountArtifacts.RunOverlayDirs, overlayDirs...)
 
-	allMounts := util.SortMounts(append(append(append(append(append(volumes, builtins...), runMounts...), subscriptionMounts...), bindFileMounts...), specMounts...))
+	allMounts := util.SortMounts(slices.Concat(volumes, builtins, runMounts, subscriptionMounts, bindFileMounts, specMounts))
 
 	// Add them all, in the preferred order, except where they conflict with something that was previously added.
 	for _, mount := range allMounts {

--- a/run_linux.go
+++ b/run_linux.go
@@ -285,7 +285,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		}
 		devices = append(devices, device...)
 	}
-	devices = append(append(devices, options.Devices...), b.Devices...)
+	devices = slices.Concat(devices, options.Devices, b.Devices)
 
 	// Mount devices, if any, and if we're rootless attempt to work around not
 	// being able to create device nodes by bind-mounting them from the host, like podman does.


### PR DESCRIPTION
As suggested in #6654, slices.Concat is much cleaner for this.

#### What type of PR is this?

/kind cleanup

#### Does this PR introduce a user-facing change?

```release-note
None
```

