### PR TITLE
imagebuildah.stageExecutor.Run(): pull images for transient mounts

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -811,7 +811,7 @@ func (s *stageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 			args = []string{full}
 		}
 	}
-	stageMountPoints, err := s.runStageMountPoints(run.Mounts)
+	stageMountPoints, err := s.runStageMountPoints(slices.Concat(run.Mounts, s.executor.transientRunMounts))
 	if err != nil {
 		return err
 	}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -9190,6 +9190,17 @@ EOF
   diff "${out_path}.a" "${out_path}.b"
 }
 
+@test "build-with-run-image-mount" {
+  _prefetch busybox
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir -p "${contextdir}"
+  cat > "${contextdir}"/Containerfile << _EOF
+  FROM busybox
+  RUN cat /alpine/etc/os-release | tee /alpine.os-release
+_EOF
+  run_buildah build --mount=type=bind,from=alpine,target=/alpine "${contextdir}"
+}
+
 @test "bud with FROM --after" {
   # This tests the 'FROM --after' workflow, i.e. that:
   # - --after is enough to pull in the builder stage as a dep


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `buildah build` is passed a `--mount` option that references an image in its "from" value, instead of pulling the image, as we do when the `--mount` option is included in the Dockerfile, we would return an error.  Correct the difference in behavior.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This does nothing for a similar error when `buildah run` is given a `--mount` flag which references an image which hasn't been pulled.  I'm not sure about that.

#### Does this PR introduce a user-facing change?

```release-note
The `--mount` option to `buildah build` no longer fails with an error at RUN instructions if the value for the `--mount` option references an image as its "from" value, and the image has not previously been pulled.
```