### PR TITLE
chroot: error out on --network != host when $BUILDAH_ISOLATION

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -331,7 +331,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		}
 	}
 
-	if c.Flag("network").Changed && c.Flag("isolation").Changed {
+	if c.Flag("network").Changed {
 		if isolation == define.IsolationChroot {
 			if ns := namespaceOptions.Find(string(specs.NetworkNamespace)); ns != nil {
 				if !ns.Host {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -569,6 +569,9 @@ _EOF
 
   run_buildah 125 build --network=none --isolation=chroot $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
   expect_output --substring "cannot set --network other than host with --isolation chroot"
+
+  BUILDAH_ISOLATION=chroot run_buildah 125 build --network=none $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
+  expect_output --substring "cannot set --network other than host with --isolation chroot"
 }
 
 @test "bud with .dockerignore #1" {
@@ -5769,6 +5772,7 @@ EOF
 }
 
 @test "bud with network options" {
+  skip_if_chroot
   _prefetch alpine
   target=alpine-image
 
@@ -6533,6 +6537,7 @@ _EOF
 
 @test "bud with --no-hostname" {
   skip_if_no_runtime
+  skip_if_chroot
 
   _prefetch alpine
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Error out if someone tries to mix the --network CLI flag, with a value other than "host", with chroot isolation configured by setting $BUILDAH_ISOLATION to "chroot", as we have been doing for cases where it's done using the "--isolation" option, instead of just ignoring it as we did previously.

#### How to verify it

Updated integration test!

#### Which issue(s) this PR fixes:

Fixes #6696 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Attempting to use the `--network` option with a value other than "host" when "BUILDAH_ISOLATION" is set to "chroot" in the environment now produces an error, as it would with `--isolation=chroot`.
```