### PR TITLE
imagebuildah: avoid empty layer in single-layer build path

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1412,6 +1412,7 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 		logImageID(imgID)
 	}
 
+	executedLayerStep := false
 	for i, node := range children {
 		logRusage()
 		moreInstructions := i < len(children)-1
@@ -1521,6 +1522,9 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 		// instruction.
 		if !s.executor.layers {
 			s.didExecute = true
+			if s.stepRequiresLayer(step) {
+				executedLayerStep = true
+			}
 			err := ib.Run(step, s, noRunsRemaining)
 			if err != nil {
 				logrus.Debugf("Error building at step %+v: %v", *step, err)
@@ -1555,7 +1559,7 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 				if err != nil {
 					return "", nil, false, fmt.Errorf("unable to get createdBy for the node: %w", err)
 				}
-				imgID, commitResults, err = s.commit(ctx, createdBy, false, s.output, s.executor.squash, lastStage && lastInstruction)
+				imgID, commitResults, err = s.commit(ctx, createdBy, !executedLayerStep, s.output, s.executor.squash, lastStage && lastInstruction)
 				if err != nil {
 					return "", nil, false, fmt.Errorf("committing container for step %+v: %w", *step, err)
 				}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -141,6 +141,20 @@ _EOF
   expect_output "0" "layer should not exist"
 }
 
+@test "no empty layer for metadata-only instructions without --layers" {
+  _prefetch alpine
+  imgname="img-$(safename)"
+
+  # Get the base image layer count
+  run_buildah inspect -f '{{len .Docker.RootFS.DiffIDs}}' alpine
+  base_layers="$output"
+
+  # Build without --layers (single-layer mode) with only metadata instructions
+  run_buildah build --layers=false -t $imgname -f $BUDFILES/metadata-only/Containerfile
+  run_buildah inspect -f '{{len .Docker.RootFS.DiffIDs}}' $imgname
+  expect_output "$base_layers" "metadata-only instructions should not add a layer"
+}
+
 @test "bud and test --inherit-annotations" {
   base=quay.io/libpod/testimage:20241011
   _prefetch $base

--- a/tests/bud/metadata-only/Containerfile
+++ b/tests/bud/metadata-only/Containerfile
@@ -1,0 +1,5 @@
+FROM alpine
+LABEL testlabel=testvalue
+ENV TESTVAR=testvalue
+USER nobody
+CMD ["/bin/sh"]


### PR DESCRIPTION
In the single-layer build path (i.e. with `--layers=false`), the final commit always created a layer even when only metadata instructions were executed after `FROM`.

Fix this by tracking if any instruction actually created data so we can avoid creating a layer in that case.

Noticed this when looking at images passed through chunkah, where one can specify the number of layers N to output; the resulting image would have a total of N+1 layers because it's often the case that you want to add metadata after the `FROM oci-archive:...`.

[Assisted-by](https://gist.github.com/jlebon/dd287bd01218a59bb41d000c9e7d3897): Claude Opus 4.6

/kind bug

```release-note
Stop creating an empty layer when using `--layers=false` and adding metadata only (e.g. `LABEL`).
```

