### PR TITLE
tests: Adapt tests to run on architectures other than amd64

### DIFF
--- a/tests/blobcache.bats
+++ b/tests/blobcache.bats
@@ -102,8 +102,8 @@ function _check_matches() {
 	blobcachedir=${TEST_SCRATCH_DIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah from --quiet --blob-cache=${blobcachedir} $WITH_POLICY_JSON registry.k8s.io/pause
-	ctr="$output"
+	run_buildah from --quiet --cidfile ${TEST_SCRATCH_DIR}/cid --blob-cache=${blobcachedir} $WITH_POLICY_JSON registry.k8s.io/pause
+	ctr="$(< ${TEST_SCRATCH_DIR}/cid)"
 	run_buildah add ${ctr} $BUDFILES/add-file/file /
 	# Commit the image without using the blob cache, using compression so that uncompressed blobs
 	# in the cache which we inherited from our base image won't be matched.
@@ -131,8 +131,8 @@ function _check_matches() {
 	blobcachedir=${TEST_SCRATCH_DIR}/cache
 	mkdir -p ${blobcachedir}
 	# Pull an image using a fresh directory for the blob cache.
-	run_buildah from --quiet --blob-cache=${blobcachedir} $WITH_POLICY_JSON registry.k8s.io/pause
-	ctr="$output"
+	run_buildah from --quiet --cidfile ${TEST_SCRATCH_DIR}/cid --blob-cache=${blobcachedir} $WITH_POLICY_JSON registry.k8s.io/pause
+	ctr="$(< ${TEST_SCRATCH_DIR}/cid)"
 	run_buildah add ${ctr} $BUDFILES/add-file/file /
 	# Commit the image using the blob cache.
 	ls -l ${blobcachedir}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2351,6 +2351,9 @@ _EOF
 }
 
 @test "bud-multistage-copy-final-slash" {
+  # This test requires a statically linked busybox which is not
+  # the case for quay.io/libpod/busybox on ppc64le & s390x
+  skip_unless_arch amd64 arm64
   _prefetch busybox
   target=foo
   run_buildah build $WITH_POLICY_JSON -t ${target} $BUDFILES/dest-final-slash
@@ -7953,6 +7956,8 @@ _EOF
 }
 
 @test "bud with ADD with git repository source" {
+  # quay.io/hummingbird/git is only available on these arches:
+  skip_unless_arch amd64 arm64
   _prefetch quay.io/hummingbird/git # any image with git preinstalled would do
 
   local repodir=${TEST_SCRATCH_DIR}/repository
@@ -9023,6 +9028,9 @@ _EOF
 }
 
 @test "bud with exec-form RUN instruction" {
+  # This test requires a statically linked busybox which is not
+  # the case for quay.io/libpod/busybox on ppc64le & s390x
+  skip_unless_arch amd64 arm64
   baseimage=busybox
   _prefetch $baseimage
   local contextdir=${TEST_SCRATCH_DIR}/context

--- a/tests/bud/base-with-arg/Containerfile
+++ b/tests/bud/base-with-arg/Containerfile
@@ -16,5 +16,11 @@ ENV BUILT_FOR=arm/v7
 FROM build AS platform-arm/v6
 ENV BUILT_FOR=arm/v6
 
+FROM build AS platform-ppc64le
+ENV BUILT_FOR=ppc64le
+
+FROM build AS platform-s390x
+ENV BUILT_FOR=s390x
+
 FROM platform-${TARGETARCH} AS final
 RUN echo "This is built for ${BUILT_FOR}"

--- a/tests/byid.bats
+++ b/tests/byid.bats
@@ -65,9 +65,9 @@ load helpers
     mkdir -p $TARGET $TARGET-truncated
 
     # Pull down the image, if we have to.
-    run_buildah from --quiet --pull=false $WITH_POLICY_JSON $image
-    expect_output "${image##*/}-working-container"  # image, w/o registry prefix
-    run_buildah rm $output
+    run_buildah from --quiet --cidfile ${TEST_SCRATCH_DIR}/cid --pull=false $WITH_POLICY_JSON $image
+    cid="$(< ${TEST_SCRATCH_DIR}/cid)"
+    run_buildah rm $cid
 
     # Get the image's ID.
     run_buildah images -q $image

--- a/tests/containers_conf.bats
+++ b/tests/containers_conf.bats
@@ -83,7 +83,14 @@ load helpers
     run_buildah from --quiet $WITH_POLICY_JSON alpine
     cid="$output"
     run_buildah --log-level=error run $cid sh -c 'df /dev/shm | awk '\''/shm/{print $4}'\'''
-    expect_output "200"
+    # On architectures with 64k page size (e.g. ppc64le), the
+    # kernel rounds shm sizes up to the nearest page boundary.
+    pagesize="$(getconf PAGESIZE)"
+    expected=200
+    if [ "$pagesize" -eq 65536 ]; then
+        expected=256
+    fi
+    expect_output "$expected"
 }
 
 @test "containers.conf custom runtime" {

--- a/tests/digest.bats
+++ b/tests/digest.bats
@@ -5,8 +5,8 @@ load helpers
 fromreftest() {
   local img=$1
 
-  run_buildah from --quiet --pull $WITH_POLICY_JSON $img
-  cid=$output
+  run_buildah from --quiet --cidfile ${TEST_SCRATCH_DIR}/cid --pull $WITH_POLICY_JSON $img
+  cid="$(< ${TEST_SCRATCH_DIR}/cid)"
 
   # If image includes '_v2sN', verify that image is schema version N
   local expected_schemaversion=$(expr "$img" : '.*_v2s\([0-9]\)')

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -754,6 +754,24 @@ function skip_if_no_unshare() {
 }
 
 ######################
+#  skip_unless_arch  #
+######################
+function skip_unless_arch() {
+  local goarch
+  goarch="$(go env GOARCH 2>/dev/null)"
+
+  [ -z "$goarch" ] && return 0
+
+  for arch in "$@"; do
+    if [ "$arch" = "$goarch" ]; then
+      return 0
+    fi
+  done
+
+  skip "test requires one of these architectures: $* (current: $goarch)"
+}
+
+######################
 #  start_git_daemon  #
 ######################
 function start_git_daemon() {

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -93,6 +93,8 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 }
 
 @test "manifest-add-one" {
+    # This test must be run on amd64 to get an error when pulling an image from a different platform
+    skip_unless_arch amd64
     run_buildah manifest create foo
     run_buildah manifest add --arch=arm64 foo ${IMAGE_LIST_INSTANCE}
     run_buildah manifest inspect foo

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -258,26 +258,26 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
 
 @test "manifest-from-tag" {
     run_buildah from $WITH_POLICY_JSON --name test-container ${IMAGE_LIST}
-    run_buildah inspect --format ''{{.OCIv1.Architecture}}' ${IMAGE_LIST}
-    expect_output --substring $(go env GOARCH)
-    run_buildah inspect --format ''{{.OCIv1.Architecture}}' test-container
-    expect_output --substring $(go env GOARCH)
+    run_buildah inspect --format '{{.OCIv1.Architecture}}' ${IMAGE_LIST#docker://}
+    expect_output --substring amd64
+    run_buildah inspect --format '{{.OCIv1.Architecture}}' test-container
+    expect_output --substring amd64
 }
 
 @test "manifest-from-digest" {
     run_buildah from $WITH_POLICY_JSON --name test-container ${IMAGE_LIST_DIGEST}
-    run_buildah inspect --format ''{{.OCIv1.Architecture}}' ${IMAGE_LIST_DIGEST}
-    expect_output --substring $(go env GOARCH)
-    run_buildah inspect --format ''{{.OCIv1.Architecture}}' test-container
-    expect_output --substring $(go env GOARCH)
+    run_buildah inspect --format '{{.OCIv1.Architecture}}' ${IMAGE_LIST_DIGEST#docker://}
+    expect_output --substring amd64
+    run_buildah inspect --format '{{.OCIv1.Architecture}}' test-container
+    expect_output --substring amd64
 }
 
 @test "manifest-from-instance" {
     run_buildah from $WITH_POLICY_JSON --name test-container ${IMAGE_LIST_INSTANCE}
-    run_buildah inspect --format ''{{.OCIv1.Architecture}}' ${IMAGE_LIST_INSTANCE}
-    expect_output --substring arm64
-    run_buildah inspect --format ''{{.OCIv1.Architecture}}' test-container
-    expect_output --substring arm64
+    run_buildah inspect --format '{{.OCIv1.Architecture}}' ${IMAGE_LIST_INSTANCE#docker://}
+    expect_output --substring amd64
+    run_buildah inspect --format '{{.OCIv1.Architecture}}' test-container
+    expect_output --substring amd64
 }
 
 @test "manifest-no-matching-instance" {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -571,8 +571,8 @@ function configure_and_check_user() {
 	# This image is known to include a volume, but not include the mountpoint
 	# in the image.
 	_prefetch quay.io/libpod/registry:volume_omitted
-	run_buildah from --quiet --pull=ifmissing $WITH_POLICY_JSON quay.io/libpod/registry:volume_omitted
-	cid=$output
+	run_buildah from --quiet --cidfile ${TEST_SCRATCH_DIR}/cid --pull=ifmissing $WITH_POLICY_JSON quay.io/libpod/registry:volume_omitted
+	cid="$(< ${TEST_SCRATCH_DIR}/cid)"
 	run_buildah mount $cid
 	mnt=$output
 	# By default, the mountpoint should not be there.

--- a/tests/ssh.bats
+++ b/tests/ssh.bats
@@ -14,6 +14,8 @@ function teardown(){
 }
 
 @test "bud with ssh key" {
+  # quay.io/hummingbird/git is only available on these arches:
+  skip_unless_arch amd64 arm64
   _prefetch quay.io/hummingbird/git
 
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir1
@@ -31,7 +33,9 @@ function teardown(){
 }
 
 @test "bud with ssh key secret accessed on second RUN" {
- _prefetch quay.io/hummingbird/git
+  # quay.io/hummingbird/git is only available on these arches:
+  skip_unless_arch amd64 arm64
+  _prefetch quay.io/hummingbird/git
 
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir1
   mkdir -p ${mytmpdir}
@@ -43,6 +47,8 @@ function teardown(){
 }
 
 @test "bud with containerfile ssh options" {
+  # quay.io/hummingbird/git is only available on these arches:
+  skip_unless_arch amd64 arm64
   _prefetch quay.io/hummingbird/git
 
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir1
@@ -57,6 +63,8 @@ function teardown(){
 }
 
 @test "bud with ssh sock" {
+  # quay.io/hummingbird/git is only available on these arches:
+  skip_unless_arch amd64 arm64
   _prefetch quay.io/hummingbird/git
 
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir1


### PR DESCRIPTION
Adapt tests to run on architectures other than amd64. 

Some images - `quay.io/hummingbird/git` are available for certain architectures and others like `quay.io/libpod/busybox` require a statically compiled busybox.  Introduce `skip_unless_arch helper` function and skip some tests if we're not running on arm64 and/or amd64 so we can run the testsuite on other architectures. 

Otherwise tests fail on:
- aarch64: http://openqa-assets.opensuse.org/tests/5705837/file/buildah-buildah-root.tap.txt
- ppc64le: https://openqa-assets.opensuse.org/tests/5705116/file/buildah-buildah-root.tap.txt

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

We need it to be able to run the testsuite on architectures other than amd64.

#### How to verify it

openQA links will follow.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The alternative to this PR is to change these images:

- The `k8s.gcr.io/pause` image is only available for amd64.
- The `quay.io/hummingbird/git` image is only available for amd64 & arm64.

#### Does this PR introduce a user-facing change?

```release-note
None
```

