### PR TITLE
Builder.getSecretMount(): don't leak an fd

### DIFF
--- a/run_common.go
+++ b/run_common.go
@@ -1852,6 +1852,7 @@ func (b *Builder) getSecretMount(tokens []string, secrets map[string]define.Secr
 		if err != nil {
 			return secretMountOrEnv{}, err
 		}
+		tmpFile.Close()
 		defer func() {
 			if retErr != nil {
 				os.Remove(tmpFile.Name())


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Close the handle to a newly-created temporary file, since we reopen it to write to it almost immediately.

#### How to verify it

Shouldn't generate any "file already closed" errors while mounting secrets as environment variables.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Spotted while reviewing #6285

#### Does this PR introduce a user-facing change?

```release-note
None
```