### PR TITLE
Do not load config files in re-exec process

### DIFF
--- a/chroot/run_common.go
+++ b/chroot/run_common.go
@@ -35,8 +35,6 @@ const (
 	runUsingChrootCommand = "buildah-chroot-runtime"
 	// runUsingChrootExec is a command we use as a key for reexec
 	runUsingChrootExecCommand = "buildah-chroot-exec"
-	// containersConfEnv is an environment variable that we need to pass down except for the command itself
-	containersConfEnv = "CONTAINERS_CONF"
 )
 
 func init() {
@@ -133,9 +131,6 @@ func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reade
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdin, stdout, stderr
 	cmd.Dir = "/"
 	cmd.Env = []string{fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel())}
-	if _, ok := os.LookupEnv(containersConfEnv); ok {
-		cmd.Env = append(cmd.Env, containersConfEnv+"="+os.Getenv(containersConfEnv))
-	}
 
 	interrupted := make(chan os.Signal, 100)
 	cmd.Hook = func(int) error {
@@ -521,9 +516,6 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdin, stdout, stderr
 	cmd.Dir = "/"
 	cmd.Env = []string{fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel())}
-	if _, ok := os.LookupEnv(containersConfEnv); ok {
-		cmd.Env = append(cmd.Env, containersConfEnv+"="+os.Getenv(containersConfEnv))
-	}
 	if ctty != nil {
 		cmd.Setsid = true
 		cmd.Ctty = ctty

--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -102,7 +102,7 @@ func applyFlagVars(flags *pflag.FlagSet, opts *addCopyResults) {
 	flags.StringVar(&opts.timestamp, "timestamp", "", "set timestamps on new content to `seconds` after the epoch")
 }
 
-func init() {
+func addcopyInit() {
 	var (
 		addDescription  = "\n  Adds the contents of a file, URL, or directory to a container's working\n  directory.  If a local file appears to be an archive, its contents are\n  extracted and added instead of the archive file itself."
 		copyDescription = "\n  Copies the contents of a file, URL, or directory into a container's working\n  directory."

--- a/cmd/buildah/build.go
+++ b/cmd/buildah/build.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
+func buildInit() {
 	buildDescription := `
   Builds an OCI image using instructions in one or more Containerfiles.
 

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -72,7 +72,7 @@ type commitInputOptions struct {
 	metadataFile       string
 }
 
-func init() {
+func commitInit() {
 	var (
 		opts              commitInputOptions
 		commitDescription = "\n  Writes a new image using the container's read-write layer and, if it is based\n  on an image, the layers of that image."

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -52,7 +52,7 @@ type configResults struct {
 	unsetAnnotations         []string
 }
 
-func init() {
+func configInit() {
 	var (
 		configDescription = "\n  Modifies the configuration values which will be saved to the image."
 		opts              configResults

--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -63,7 +63,7 @@ type containersResults struct {
 	quiet      bool
 }
 
-func init() {
+func containersInit() {
 	var (
 		containersDescription = "\n  Lists containers which appear to be " + define.Package + " working containers, their\n  names and IDs, and the names and IDs of the images from which they were\n  initialized."
 		opts                  containersResults

--- a/cmd/buildah/dumpbolt.go
+++ b/cmd/buildah/dumpbolt.go
@@ -69,6 +69,6 @@ func dumpBoltCmd(_ *cobra.Command, args []string) error {
 	})
 }
 
-func init() {
+func dumpboltInit() {
 	rootCmd.AddCommand(dumpBoltCommand)
 }

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -36,7 +36,7 @@ type fromReply struct {
 
 var suffix string
 
-func init() {
+func fromInit() {
 	var (
 		fromDescription = "\n  Creates a new working container, either from scratch or using a specified\n  image as a starting point."
 		opts            fromReply

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -71,7 +71,7 @@ var imagesHeader = map[string]string{
 	"History":   "HISTORY",
 }
 
-func init() {
+func imagesInit() {
 	var (
 		opts              imageResults
 		imagesDescription = "\n  Lists locally stored images."

--- a/cmd/buildah/info.go
+++ b/cmd/buildah/info.go
@@ -19,7 +19,7 @@ type infoResults struct {
 	format string
 }
 
-func init() {
+func infoInit() {
 	var (
 		infoDescription = "\n  Display information about the host and current storage statistics which are useful when reporting issues."
 		opts            infoResults

--- a/cmd/buildah/inspect.go
+++ b/cmd/buildah/inspect.go
@@ -26,7 +26,7 @@ type inspectResults struct {
 	inspectType string
 }
 
-func init() {
+func inspectInit() {
 	var (
 		opts               inspectResults
 		inspectDescription = "\n  Inspects a build container's or built image's configuration."

--- a/cmd/buildah/login.go
+++ b/cmd/buildah/login.go
@@ -16,7 +16,7 @@ type loginReply struct {
 	tlsVerify bool
 }
 
-func init() {
+func loginInit() {
 	var (
 		opts = loginReply{
 			loginOpts: auth.LoginOptions{

--- a/cmd/buildah/logout.go
+++ b/cmd/buildah/logout.go
@@ -10,7 +10,7 @@ import (
 	"go.podman.io/common/pkg/auth"
 )
 
-func init() {
+func logoutInit() {
 	var (
 		opts = auth.LogoutOptions{
 			Stdout:             os.Stdout,

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -66,7 +66,7 @@ var (
 	defaultContainerConfig *config.Config
 )
 
-func init() {
+func mainInit() {
 	var defaultStoreDriverOptions []string
 	storageOptions, err := storage.DefaultStoreOptions()
 	if err != nil {
@@ -230,6 +230,37 @@ func main() {
 	if buildah.InitReexec() {
 		return
 	}
+
+	mainInit()
+
+	addcopyInit()
+	buildInit()
+	commitInit()
+	configInit()
+	containersInit()
+	dumpboltInit()
+	fromInit()
+	imagesInit()
+	infoInit()
+	inspectInit()
+	loginInit()
+	logoutInit()
+	manifestInit()
+	mkcwInit()
+	mountInit()
+	pruneInit()
+	pullInit()
+	pushInit()
+	renameInit()
+	rmiInit()
+	rmInit()
+	rpcInit()
+	runInit()
+	sourceInit()
+	tagInit()
+	umountInit()
+	unshareInit()
+	versionInit()
 
 	// Hard code TMPDIR functions to use $TMPDIR or /var/tmp
 	os.Setenv("TMPDIR", parse.GetTempDir())

--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -61,7 +61,7 @@ type manifestInspectOpts struct {
 	tlsVerify bool
 }
 
-func init() {
+func manifestInit() {
 	var (
 		manifestDescription         = "\n  Creates, modifies, and pushes manifest lists and image indexes."
 		manifestCreateDescription   = "\n  Creates manifest lists and image indexes."

--- a/cmd/buildah/mkcw.go
+++ b/cmd/buildah/mkcw.go
@@ -37,7 +37,7 @@ func mkcwCmd(c *cobra.Command, args []string, options buildah.CWConvertImageOpti
 	return err
 }
 
-func init() {
+func mkcwInit() {
 	var teeType string
 	var addFile []string
 	var options buildah.CWConvertImageOptions

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -19,7 +19,7 @@ type mountOptions struct {
 	json bool
 }
 
-func init() {
+func mountInit() {
 	var (
 		mountDescription = `buildah mount
   mounts a working container's root filesystem for manipulation.

--- a/cmd/buildah/prune.go
+++ b/cmd/buildah/prune.go
@@ -17,7 +17,7 @@ type pruneOptions struct {
 	all   bool
 }
 
-func init() {
+func pruneInit() {
 	var (
 		pruneDescription = `
 Cleanup intermediate images as well as build and mount cache.`

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -32,7 +32,7 @@ type pullOptions struct {
 	retryDelay       string
 }
 
-func init() {
+func pullInit() {
 	var (
 		opts pullOptions
 

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -49,7 +49,7 @@ type pushOptions struct {
 	addCompression         []string
 }
 
-func init() {
+func pushInit() {
 	var (
 		opts            pushOptions
 		pushDescription = fmt.Sprintf(`

--- a/cmd/buildah/rename.go
+++ b/cmd/buildah/rename.go
@@ -20,7 +20,7 @@ var (
 	}
 )
 
-func init() {
+func renameInit() {
 	renameCommand.SetUsageTemplate(UsageTemplate())
 	rootCmd.AddCommand(renameCommand)
 }

--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -14,7 +14,7 @@ type rmResults struct {
 	all bool
 }
 
-func init() {
+func rmInit() {
 	var (
 		rmDescription = "\n  Removes one or more working containers, unmounting them if necessary."
 		opts          rmResults

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -18,7 +18,7 @@ type rmiOptions struct {
 	force bool
 }
 
-func init() {
+func rmiInit() {
 	var (
 		rmiDescription = "\n  Removes one or more locally stored images."
 		opts           rmiOptions

--- a/cmd/buildah/rpc.go
+++ b/cmd/buildah/rpc.go
@@ -84,7 +84,7 @@ func rpcCmd(c *cobra.Command, args []string) error {
 	return cmd.Run()
 }
 
-func init() {
+func rpcInit() {
 	var rpcOptions struct {
 		envVar     string
 		listenPath string

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -41,7 +41,7 @@ type runInputOptions struct {
 	*buildahcli.NameSpaceResults
 }
 
-func init() {
+func runInit() {
 	var (
 		runDescription = "\n  Runs a specified command using the container's root filesystem as a root\n  filesystem, using configuration settings inherited from the container's\n  image or as specified using previous calls to the config command."
 		opts           runInputOptions

--- a/cmd/buildah/source.go
+++ b/cmd/buildah/source.go
@@ -91,7 +91,7 @@ var (
 	}
 )
 
-func init() {
+func sourceInit() {
 	// buildah source
 	sourceCommand.SetUsageTemplate(UsageTemplate())
 	rootCmd.AddCommand(sourceCommand)

--- a/cmd/buildah/tag.go
+++ b/cmd/buildah/tag.go
@@ -51,7 +51,7 @@ func tagCmd(c *cobra.Command, args []string) error {
 	return nil
 }
 
-func init() {
+func tagInit() {
 	tagCommand.SetUsageTemplate(UsageTemplate())
 	rootCmd.AddCommand(tagCommand)
 }

--- a/cmd/buildah/umount.go
+++ b/cmd/buildah/umount.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
+func umountInit() {
 	umountCommand := &cobra.Command{
 		Use:     "umount",
 		Aliases: []string{"unmount"},

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -30,7 +30,7 @@ var (
 	unshareMounts []string
 )
 
-func init() {
+func unshareInit() {
 	unshareCommand.SetUsageTemplate(UsageTemplate())
 	flags := unshareCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/buildah/unshare_unsupported.go
+++ b/cmd/buildah/unshare_unsupported.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
+func unshareInit() {
 	unshareCommand := cobra.Command{
 		Use:    "unshare",
 		Hidden: true,

--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -41,7 +41,7 @@ type versionOptions struct {
 	json bool
 }
 
-func init() {
+func versionInit() {
 	var opts versionOptions
 
 	// cli command to print out the version info of buildah

--- a/run_common.go
+++ b/run_common.go
@@ -478,15 +478,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 
 	logrus.Debugf("config = %v", string(specbytes))
 
-	// Decide which runtime to use.
 	runtime := options.Runtime
-	if runtime == "" {
-		runtime = util.Runtime()
-	}
-	localRuntime := util.FindLocalRuntime(runtime)
-	if localRuntime != "" {
-		runtime = localRuntime
-	}
 
 	// Default to just passing down our stdio.
 	getCreateStdio := func() (io.ReadCloser, io.WriteCloser, io.WriteCloser) {
@@ -1165,6 +1157,17 @@ func runUsingRuntimeMain() {
 func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options RunOptions, configureNetwork bool, networkString string,
 	moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName, buildContainerName, hostsFile, resolvFile string,
 ) (err error) {
+	// Decide which runtime to use in case it was empty.
+	ociRuntime := options.Runtime
+	if ociRuntime == "" {
+		ociRuntime = util.Runtime()
+	}
+	localRuntime := util.FindLocalRuntime(ociRuntime)
+	if localRuntime != "" {
+		ociRuntime = localRuntime
+	}
+	options.Runtime = ociRuntime
+
 	// Lock the caller to a single OS-level thread.
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

It fixes storage.conf parsing errors with my storage.conf rework in https://github.com/containers/buildah/pull/6708

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

