### PR TITLE
tests: some more storage.conf rewrite prep

### DIFF
--- a/tests/chroot.bats
+++ b/tests/chroot.bats
@@ -63,6 +63,7 @@ load helpers
   echo export XDG_CONFIG_HOME=$xdgconfighome >> ${TEST_SCRATCH_DIR}/script.sh
   echo export XDG_DATA_HOME=$xdgdatahome >> ${TEST_SCRATCH_DIR}/script.sh
   echo export CONTAINERS_CONF=${TEST_SCRATCH_DIR}/containers.conf >> ${TEST_SCRATCH_DIR}/script.sh
+  echo export CONTAINERS_STORAGE_CONF=/dev/null >> ${TEST_SCRATCH_DIR}/script.sh
   # give our would-be user ownership of that directory
   echo chown --recursive ${subid}:${subid} ${storagedir} >> ${TEST_SCRATCH_DIR}/script.sh
   # make newuidmap/newgidmap, invoked by unshare even for uid=0, happy
@@ -198,6 +199,7 @@ EOF
   set -x
   export _CONTAINERS_USERNS_CONFIGURED=done
   export CONTAINERS_CONF=${TEST_SCRATCH_DIR}/containers.conf
+  export CONTAINERS_STORAGE_CONF=/dev/null # needed to avoid file lookup permission errors under /root/...
   cat /proc/self/uid_map
   cat /proc/self/gid_map
   mount --make-shared /

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -289,10 +289,9 @@ func testConformanceInternal(t *testing.T, dateStamp string, testIndex int, muta
 
 	// initialize storage for buildah
 	options := storage.StoreOptions{
-		GraphDriverName:     os.Getenv("STORAGE_DRIVER"),
-		GraphRoot:           rootDir,
-		RunRoot:             runrootDir,
-		RootlessStoragePath: rootDir,
+		GraphDriverName: os.Getenv("STORAGE_DRIVER"),
+		GraphRoot:       rootDir,
+		RunRoot:         runrootDir,
 	}
 	store, err := storage.GetStore(options)
 	require.NoErrorf(t, err, "error creating buildah storage at %q", rootDir)
@@ -4090,10 +4089,9 @@ func TestCommit(t *testing.T) {
 
 	// initialize storage for buildah
 	options := storage.StoreOptions{
-		GraphDriverName:     os.Getenv("STORAGE_DRIVER"),
-		GraphRoot:           rootDir,
-		RunRoot:             runrootDir,
-		RootlessStoragePath: rootDir,
+		GraphDriverName: os.Getenv("STORAGE_DRIVER"),
+		GraphRoot:       rootDir,
+		RunRoot:         runrootDir,
 	}
 	store, err := storage.GetStore(options)
 	require.NoErrorf(t, err, "error creating buildah storage at %q", rootDir)


### PR DESCRIPTION


#### What this PR does / why we need it:

More preparation work for https://github.com/containers/container-libs/pull/680, I like to get them merged in advance so the container-libs PR will not break the vendor for others once it gets merged.
Commits were tested in https://github.com/containers/buildah/pull/6708 already.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

