### PR TITLE
tests: use jq to validate images --json structure

### DIFF
--- a/tests/images.bats
+++ b/tests/images.bats
@@ -111,14 +111,17 @@ load helpers
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
 
   for img in '' alpine busybox; do
-      # e.g. [ { "id": "xx", ... },{ "id": "yy", ... } ]
-      # We check for the presence of some keys, but not (yet) their values.
-      # FIXME: once we can rely on 'jq' tool being present, improve this test!
       run_buildah images --json $img
-      expect_output --from="${lines[0]}" "[" "first line of JSON output: array"
-      for key in id names digest createdat size readonly history; do
-          expect_output --substring "\"$key\": "
-      done
+      run jq -re 'length > 0 and
+        all(.[]; has("id")
+             and has("names")
+             and has("digest")
+             and has("createdat")
+             and has("size")
+             and has("readonly")
+             and has("history"))' <<<"$output"
+      expect_output "true"
+      assert "$status" -eq 0 "status from jq for $img"
   done
 }
 


### PR DESCRIPTION
Use jq to validate images --json structure.  We have other tests using jq and we can leverage it here.

#### What type of PR is this?

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake

/kind other

#### What this PR does / why we need it:

#### How to verify it

https://openqa-assets.opensuse.org/tests/5733722/file/buildah-buildah-root.tap.txt

#### Which issue(s) this PR fixes:

`None`

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

