### PR TITLE
tests: remove cgroupsv1 checks and simplify cgroupsv2 conditionals

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6484,21 +6484,9 @@ _EOF
   local flag_accepted_rx="level=debug.*msg=.child process in init"
   if [ -n "$(command -v runc)" ]; then
     found_runtime=y
-    if is_cgroupsv2; then
-      # The result with cgroup v2 depends on the version of runc.
-      run_buildah '?' bud --runtime=runc --runtime-flag=debug \
-                        -q -t alpine-bud-runc $WITH_POLICY_JSON --file ${mytmpdir}/Containerfile .
-      if [ "$status" -eq 0 ]; then
-        expect_output --substring "$flag_accepted_rx"
-      else
-        # If it fails, this is because this version of runc doesn't support cgroup v2.
-        expect_output --substring "this version of runc doesn't work on cgroups v2" "should fail by unsupportability for cgroupv2"
-      fi
-    else
-      run_buildah build --runtime=runc --runtime-flag=debug \
-                      -q -t alpine-bud-runc $WITH_POLICY_JSON --file ${mytmpdir}/Containerfile .
-      expect_output --substring "$flag_accepted_rx"
-    fi
+    run_buildah build --runtime=runc --runtime-flag=debug \
+                    -q -t alpine-bud-runc $WITH_POLICY_JSON --file ${mytmpdir}/Containerfile .
+    expect_output --substring "$flag_accepted_rx"
 
   fi
 
@@ -6646,7 +6634,6 @@ _EOF
 
 @test "bud with --cpu-period and --cpu-quota" {
   skip_if_chroot
-  skip_if_rootless_and_cgroupv1
   skip_if_rootless_environment
   skip_if_no_runtime
 
@@ -6655,17 +6642,10 @@ _EOF
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir
   mkdir -p ${mytmpdir}
 
-  if is_cgroupsv2; then
-    cat > $mytmpdir/Containerfile << _EOF
+  cat > $mytmpdir/Containerfile << _EOF
 from alpine
 run cat /sys/fs/cgroup/\$(awk -F: '{print \$NF}' /proc/self/cgroup)/cpu.max
 _EOF
-  else
-    cat > $mytmpdir/Containerfile << _EOF
-from alpine
-run echo "\$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us) \$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)"
-_EOF
-  fi
 
   run_buildah build --cpu-period=1234 --cpu-quota=5678 -t testcpu \
                   $WITH_POLICY_JSON --file ${mytmpdir}/Containerfile .
@@ -6673,7 +6653,6 @@ _EOF
 }
 
 @test "bud check mount /sys/fs/cgroup" {
-  skip_if_rootless_and_cgroupv1
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir
   mkdir -p ${mytmpdir}
 
@@ -6689,7 +6668,6 @@ _EOF
 @test "bud with --cpu-shares, checked" {
   skip_if_chroot
   skip_if_rootless_environment
-  skip_if_rootless_and_cgroupv1
   skip_if_no_runtime
 
   _prefetch alpine
@@ -6697,21 +6675,14 @@ _EOF
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir
   mkdir -p ${mytmpdir}
 
-  for shares in 2 200 2000 12345 20000 200000 ; do
-  if is_cgroupsv2; then
-    cat > $mytmpdir/Containerfile << _EOF
+  cat > $mytmpdir/Containerfile << _EOF
 FROM alpine
 RUN printf "weight " && cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpu.weight
 _EOF
-      local converted="$(convert_v1_shares_to_v2_weight ${shares})"
-      local expect="(weight ${converted##* }|weight ${converted%% *})"
-    else
-      cat > $mytmpdir/Containerfile << _EOF
-FROM alpine
-RUN printf "weight " && cat /sys/fs/cgroup/cpu/cpu.shares
-_EOF
-      local expect="weight ${shares}"
-    fi
+
+  for shares in 2 200 2000 12345 20000 200000 ; do
+    local converted="$(convert_v1_shares_to_v2_weight ${shares})"
+    local expect="(weight ${converted##* }|weight ${converted%% *})"
 
     echo requesting "${shares}" shares
     run_buildah build --cpu-shares=${shares} -t testcpu \
@@ -6723,7 +6694,6 @@ _EOF
 
 @test "bud with --cpuset-cpus" {
   skip_if_chroot
-  skip_if_rootless_and_cgroupv1
   skip_if_rootless_environment
   skip_if_no_runtime
 
@@ -6732,17 +6702,10 @@ _EOF
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir
   mkdir -p ${mytmpdir}
 
-  if is_cgroupsv2; then
-    cat > $mytmpdir/Containerfile << _EOF
+  cat > $mytmpdir/Containerfile << _EOF
 from alpine
 run printf "cpuset-cpus " && cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpuset.cpus
 _EOF
-  else
-    cat > $mytmpdir/Containerfile << _EOF
-from alpine
-run printf "cpuset-cpus " && cat /sys/fs/cgroup/cpuset/cpuset.cpus
-_EOF
-  fi
 
   run_buildah build --cpuset-cpus=0 -t testcpuset \
                   $WITH_POLICY_JSON --file ${mytmpdir}/Containerfile .
@@ -6751,7 +6714,6 @@ _EOF
 
 @test "bud with --cpuset-mems" {
   skip_if_chroot
-  skip_if_rootless_and_cgroupv1
   skip_if_rootless_environment
   skip_if_no_runtime
 
@@ -6760,17 +6722,10 @@ _EOF
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir
   mkdir -p ${mytmpdir}
 
-  if is_cgroupsv2; then
-    cat > $mytmpdir/Containerfile << _EOF
+  cat > $mytmpdir/Containerfile << _EOF
 from alpine
 run printf "cpuset-mems " && cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpuset.mems
 _EOF
-  else
-    cat > $mytmpdir/Containerfile << _EOF
-from alpine
-run printf "cpuset-mems " && cat /sys/fs/cgroup/cpuset/cpuset.mems
-_EOF
-  fi
 
   run_buildah build --cpuset-mems=0 -t testcpuset \
                   $WITH_POLICY_JSON --file ${mytmpdir}/Containerfile .
@@ -6810,7 +6765,6 @@ _EOF
 @test "bud with --memory and --memory-swap" {
   skip_if_chroot
   skip_if_no_runtime
-  skip_if_rootless_and_cgroupv1
   skip_if_rootless_environment
 
   _prefetch alpine
@@ -6818,27 +6772,16 @@ _EOF
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir
   mkdir -p ${mytmpdir}
 
-  local expect_swap=
-  if is_cgroupsv2; then
-    cat > $mytmpdir/Containerfile << _EOF
+  cat > $mytmpdir/Containerfile << _EOF
 from alpine
 run printf "memory-max=" && cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/memory.max
 run printf "memory-swap-result=" && cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/memory.swap.max
 _EOF
-    expect_swap=31457280
-  else
-    cat > $mytmpdir/Containerfile << _EOF
-from alpine
-run printf "memory-max=" && cat /sys/fs/cgroup/memory/memory.limit_in_bytes
-run printf "memory-swap-result=" && cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes
-_EOF
-    expect_swap=73400320
-  fi
 
   run_buildah build --memory=40m --memory-swap=70m -t testmemory \
                   $WITH_POLICY_JSON --file ${mytmpdir}/Containerfile .
   expect_output --from="${lines[2]}" "memory-max=41943040"
-  expect_output --from="${lines[4]}" "memory-swap-result=${expect_swap}"
+  expect_output --from="${lines[4]}" "memory-swap-result=31457280"
 }
 
 @test "bud with --shm-size" {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -6487,7 +6487,6 @@ _EOF
     run_buildah build --runtime=runc --runtime-flag=debug \
                     -q -t alpine-bud-runc $WITH_POLICY_JSON --file ${mytmpdir}/Containerfile .
     expect_output --substring "$flag_accepted_rx"
-
   fi
 
   if [ -n "$(command -v crun)" ]; then

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -173,116 +173,81 @@ load helpers
 @test "from cpu-period test" {
   skip_if_rootless_environment
   skip_if_chroot
-  skip_if_rootless_and_cgroupv1
   skip_if_no_runtime
 
   _prefetch alpine
   run_buildah from --quiet --cpu-period=5000 --pull $WITH_POLICY_JSON alpine
   cid=$output
-  if is_cgroupsv2; then
-    run_buildah run $cid /bin/sh -c "cut -d ' ' -f 2 /sys/fs/cgroup/\$(awk -F: '{print \$NF}' /proc/self/cgroup)/cpu.max"
-  else
-    run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_period_us
-  fi
+  run_buildah run $cid /bin/sh -c "cut -d ' ' -f 2 /sys/fs/cgroup/\$(awk -F: '{print \$NF}' /proc/self/cgroup)/cpu.max"
   expect_output "5000"
 }
 
 @test "from cpu-quota test" {
   skip_if_rootless_environment
   skip_if_chroot
-  skip_if_rootless_and_cgroupv1
   skip_if_no_runtime
 
   _prefetch alpine
   run_buildah from --quiet --cpu-quota=5000 --pull=false $WITH_POLICY_JSON alpine
   cid=$output
-  if is_cgroupsv2; then
-    run_buildah run $cid /bin/sh -c "cut -d ' ' -f 1 /sys/fs/cgroup/\$(awk -F: '{print \$NF}' /proc/self/cgroup)/cpu.max"
-  else
-    run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
-  fi
+  run_buildah run $cid /bin/sh -c "cut -d ' ' -f 1 /sys/fs/cgroup/\$(awk -F: '{print \$NF}' /proc/self/cgroup)/cpu.max"
   expect_output "5000"
 }
 
 @test "from cpu-shares test" {
   skip_if_rootless_environment
   skip_if_chroot
-  skip_if_rootless_and_cgroupv1
   skip_if_no_runtime
 
   _prefetch alpine
   for shares in 2 200 2000 12345 20000 200000 ; do
     run_buildah from --quiet --cpu-shares=${shares} --pull $WITH_POLICY_JSON alpine
     cid=$output
-    if is_cgroupsv2; then
-      local converted="$(convert_v1_shares_to_v2_weight ${shares})"
-      local expect="(weight ${converted##* }|weight ${converted%% *})"
-      run_buildah run $cid /bin/sh -c "echo -n 'weight '; cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpu.weight"
-      echo expected "${expect}"
-      expect_output --substring "${expect}"
-    else
-      run_buildah run $cid cat /sys/fs/cgroup/cpu/cpu.shares
-      expect_output "${shares}"
-    fi
+    local converted="$(convert_v1_shares_to_v2_weight ${shares})"
+    local expect="(weight ${converted##* }|weight ${converted%% *})"
+    run_buildah run $cid /bin/sh -c "echo -n 'weight '; cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpu.weight"
+    echo expected "${expect}"
+    expect_output --substring "${expect}"
   done
 }
 
 @test "from cpuset-cpus test" {
   skip_if_rootless_environment
   skip_if_chroot
-  skip_if_rootless_and_cgroupv1
   skip_if_no_runtime
 
   _prefetch alpine
   run_buildah from --quiet --cpuset-cpus=0 --pull=false $WITH_POLICY_JSON alpine
   cid=$output
-  if is_cgroupsv2; then
-    run_buildah run $cid /bin/sh -c "cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpuset.cpus"
-  else
-    run_buildah run $cid cat /sys/fs/cgroup/cpuset/cpuset.cpus
-  fi
+  run_buildah run $cid /bin/sh -c "cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpuset.cpus"
   expect_output "0"
 }
 
 @test "from cpuset-mems test" {
   skip_if_rootless_environment
   skip_if_chroot
-  skip_if_rootless_and_cgroupv1
   skip_if_no_runtime
 
   _prefetch alpine
   run_buildah from --quiet --cpuset-mems=0 --pull $WITH_POLICY_JSON alpine
   cid=$output
-  if is_cgroupsv2; then
-   run_buildah run $cid /bin/sh -c "cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpuset.mems"
-  else
-    run_buildah run $cid cat /sys/fs/cgroup/cpuset/cpuset.mems
-  fi
+  run_buildah run $cid /bin/sh -c "cat /sys/fs/cgroup/\$(awk -F : '{print \$NF}' /proc/self/cgroup)/cpuset.mems"
   expect_output "0"
 }
 
 @test "from memory test" {
   skip_if_rootless_environment
   skip_if_chroot
-  skip_if_rootless_and_cgroupv1
-
   _prefetch alpine
   run_buildah from --quiet --memory=40m --memory-swap=70m --pull=false $WITH_POLICY_JSON alpine
   cid=$output
 
-  # Life is much more complicated under cgroups v2
-  mpath='/sys/fs/cgroup/memory/memory.limit_in_bytes'
-  spath='/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes'
-  expect_sw=73400320
-  if is_cgroupsv2; then
-      mpath="/sys/fs/cgroup\$(awk -F: '{print \$3}' /proc/self/cgroup)/memory.max"
-      spath="/sys/fs/cgroup\$(awk -F: '{print \$3}' /proc/self/cgroup)/memory.swap.max"
-      expect_sw=31457280
-  fi
+  mpath="/sys/fs/cgroup\$(awk -F: '{print \$3}' /proc/self/cgroup)/memory.max"
+  spath="/sys/fs/cgroup\$(awk -F: '{print \$3}' /proc/self/cgroup)/memory.swap.max"
   run_buildah run $cid sh -c "cat $mpath"
   expect_output "41943040" "$mpath"
   run_buildah run $cid sh -c "cat $spath"
-  expect_output "$expect_sw" "$spath"
+  expect_output "31457280" "$spath"
 }
 
 @test "from volume test" {

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -657,16 +657,6 @@ function skip_if_rootless() {
     fi
 }
 
-##################################
-#  skip_if_rootless_and_cgroupv1 #
-##################################
-function skip_if_rootless_and_cgroupv1() {
-    if test "$BUILDAH_ISOLATION" = "rootless"; then
-        if ! is_cgroupsv2; then
-            skip "${1:-test does not work when \$BUILDAH_ISOLATION = rootless} and not cgroupv2"
-        fi
-    fi
-}
 
 ########################
 #  skip_if_no_runtime  #  'buildah run' can't work without a runtime
@@ -689,22 +679,6 @@ function skip_if_no_podman() {
     fi
 }
 
-##################
-#  is_cgroupsv2  #  Returns true if host system has cgroupsv2 enabled
-##################
-function is_cgroupsv2() {
-    local cgroupfs_t=$(stat -f -c %T /sys/fs/cgroup)
-    test "$cgroupfs_t" = "cgroup2fs"
-}
-
-#######################
-#  skip_if_cgroupsv2  #  Some tests don't work with cgroupsv2
-#######################
-function skip_if_cgroupsv2() {
-    if is_cgroupsv2; then
-        skip "${1:-test does not work with cgroups v2}"
-    fi
-}
 
 ##########################
 #  skip_if_in_container  #

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -908,14 +908,8 @@ _EOF
 
 	if [ -n "$(command -v runc)" ]; then
 		found_runtime=y
-		run_buildah '?' run --runtime=runc --runtime-flag=debug $cid true
-		if [ "$status" -eq 0 ]; then
-			assert "$output" != "" "Output from running 'true' with --runtime-flag=debug"
-		else
-			# runc fully supports cgroup v2 (unified mode) since v1.0.0-rc93.
-			# older runc doesn't work on cgroup v2.
-			expect_output --substring "this version of runc doesn't work on cgroups v2" "should fail by unsupportability for cgroupv2"
-		fi
+		run_buildah run --runtime=runc --runtime-flag=debug $cid true
+		assert "$output" != "" "Output from running 'true' with --runtime-flag=debug"
 	fi
 
 	if [ -n "$(command -v crun)" ]; then


### PR DESCRIPTION
Since cgroupsv1 support has been removed from buildah, all is_cgroupsv2 checks are always true and skip_if_rootless_and_cgroupv1 is always a no-op. Remove these helper functions and simplify tests to use only cgroupsv2 code paths. Also simplify runc runtime-flag tests to expect success instead of tolerating old runc versions that don't support cgroupsv2.

Fixes: RUN-4432

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:

Removes cgroupsv1 conditionals since we're now cgroupsv2 only.

#### How to verify it

Apart from manual review, I guess tests should barf on cgroups v1 systems.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->


None


#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

