### PR TITLE
Fix `COPY/ADD --from=` with `ARG` in stage scope

### DIFF
--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -763,12 +763,12 @@ func baseImages(dockerfilenames []string, dockerfilecontents [][]byte, from stri
 						}
 						base := child.Next.Value
 						if base != "" && base != buildah.BaseImageFakeName && !internalUtil.SetHas(nicknames, base) {
+							builtinArgs := argsMapToSlice(stage.Builder.BuiltinArgDefaults)
 							headingArgs := argsMapToSlice(stage.Builder.HeadingArgs)
 							userArgs := argsMapToSlice(stage.Builder.Args)
-							// append heading args so if --build-arg key=value is not
-							// specified but default value is set in Containerfile
-							// via `ARG key=value` so default value can be used.
-							userArgs = append(headingArgs, userArgs...)
+							// ProcessWord uses first match; put highest priority first so
+							// --build-arg overrides header ARG overrides builtin.
+							userArgs = slices.Concat(userArgs, headingArgs, builtinArgs)
 							baseWithArg, err := imagebuilder.ProcessWord(base, userArgs)
 							if err != nil {
 								return nil, fmt.Errorf("while replacing arg variables with values for format %q: %w", base, err)

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -879,6 +879,7 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 	// not they can skip certain steps near the end of their stages.
 	for stageIndex, stage := range stages {
 		dependencyMap[stage.Name] = &stageDependencyInfo{Name: stage.Name, Position: stage.Position}
+		stageLocalScopeArgs := make(map[string]string)
 		node := stage.Node // first line
 		for node != nil {  // each line
 			for _, child := range node.Children { // tokens on this line, though we only care about the first
@@ -902,10 +903,11 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 							builtinArgs := argsMapToSlice(stage.Builder.BuiltinArgDefaults)
 							headingArgs := argsMapToSlice(stage.Builder.HeadingArgs)
 							userArgs := argsMapToSlice(stage.Builder.Args)
+							localScopeArgs := argsMapToSlice(stageLocalScopeArgs)
 							// append heading args so if --build-arg key=value is not
 							// specified but default value is set in Containerfile
 							// via `ARG key=value` so default value can be used.
-							userArgs = slices.Concat(builtinArgs, userArgs, headingArgs)
+							userArgs = slices.Concat(builtinArgs, userArgs, headingArgs, localScopeArgs)
 							baseWithArg, err := imagebuilder.ProcessWord(base, userArgs)
 							if err != nil {
 								return "", nil, fmt.Errorf("while replacing arg variables with values for format %q: %w", base, err)
@@ -936,7 +938,8 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 							builtinArgs := argsMapToSlice(stage.Builder.BuiltinArgDefaults)
 							headingArgs := argsMapToSlice(stage.Builder.HeadingArgs)
 							userArgs := argsMapToSlice(stage.Builder.Args)
-							userArgs = slices.Concat(builtinArgs, userArgs, headingArgs)
+							localScopeArgs := argsMapToSlice(stageLocalScopeArgs)
+							userArgs = slices.Concat(builtinArgs, userArgs, headingArgs, localScopeArgs)
 							afterResolved, err := imagebuilder.ProcessWord(after, userArgs)
 							if err != nil {
 								return "", nil, fmt.Errorf("while replacing arg variables with values for --after=%q: %w", after, err)
@@ -975,13 +978,17 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 							builtinArgs := argsMapToSlice(stage.Builder.BuiltinArgDefaults)
 							headingArgs := argsMapToSlice(stage.Builder.HeadingArgs)
 							userArgs := argsMapToSlice(stage.Builder.Args)
+							localScopeArgs := argsMapToSlice(stageLocalScopeArgs)
 							// append heading args so if --build-arg key=value is not
 							// specified but default value is set in Containerfile
 							// via `ARG key=value` so default value can be used.
-							userArgs = slices.Concat(builtinArgs, userArgs, headingArgs)
+							userArgs = slices.Concat(builtinArgs, userArgs, headingArgs, localScopeArgs)
 							baseWithArg, err := imagebuilder.ProcessWord(stageName, userArgs)
 							if err != nil {
 								return "", nil, fmt.Errorf("while replacing arg variables with values for format %q: %w", stageName, err)
+							}
+							if baseWithArg != "" {
+								b.rootfsMap[baseWithArg] = struct{}{}
 							}
 							logrus.Debugf("stage %d name: %q resolves to %q", stageIndex, stageName, baseWithArg)
 							stageName = baseWithArg
@@ -999,6 +1006,18 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 									currentStageInfo.Needs = append(currentStageInfo.Needs, stageName)
 								}
 							}
+						}
+					}
+				case "ARG":
+					arg := child.Next
+					if arg != nil {
+						argName, argValue, hasValue := strings.Cut(arg.Value, "=")
+						if hasValue && argName != "" {
+							argValue, err := imagebuilder.ProcessWord(argValue, argsMapToSlice(stage.Builder.BuiltinArgDefaults))
+							if err != nil {
+								return "", nil, fmt.Errorf("while replacing arg variables with values for format %q: %w", arg.Value, err)
+							}
+							stageLocalScopeArgs[argName] = argValue
 						}
 					}
 				case "RUN":

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -401,12 +401,12 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		for node != nil { // tokens on this line, though we only care about the first
 			switch strings.ToUpper(node.Value) { // first token - instruction
 			case "ARG":
-				arg := node.Next
-				if arg != nil {
-					// We have to be careful here - it's either an argument
-					// and value, or just an argument, since they can be
-					// separated by either "=" or whitespace.
+				for arg := node.Next; arg != nil; arg = arg.Next {
+					// Each token is name=value or name (multiple ARGs in one instruction, see imagebuilder PR #210)
 					argName, argValue, hasValue := strings.Cut(arg.Value, "=")
+					if argName == "" {
+						continue
+					}
 					if !foundFirstStage {
 						if hasValue {
 							globalArgs[argName] = argValue
@@ -748,32 +748,32 @@ func (b *executor) warnOnUnsetBuildArgs(stages imagebuilder.Stages, dependencyMa
 			for _, child := range node.Children {
 				switch strings.ToUpper(child.Value) {
 				case "ARG":
-					argName := child.Next.Value
-					if strings.Contains(argName, "=") {
-						res := strings.Split(argName, "=")
-						if res[1] != "" {
-							argFound[res[0]] = struct{}{}
+					for arg := child.Next; arg != nil; arg = arg.Next {
+						argToken := arg.Value
+						argName, argValue, hasEqual := strings.Cut(argToken, "=")
+						if argName == "" {
+							continue
 						}
-					}
-					argHasValue := true
-					if !strings.Contains(argName, "=") {
-						argHasValue = internalUtil.SetHas(argFound, argName)
-					}
-					if _, ok := args[argName]; !argHasValue && !ok {
-						shouldWarn := true
-						if stageDependencyInfo, ok := dependencyMap[stage.Name]; ok {
-							if !stageDependencyInfo.NeededByTarget && b.skipUnusedStages != types.OptionalBoolFalse {
+						if hasEqual && argValue != "" {
+							argFound[argName] = struct{}{}
+						}
+						argHasValue := internalUtil.SetHas(argFound, argName)
+						if _, ok := args[argName]; !argHasValue && !ok {
+							shouldWarn := true
+							if stageDependencyInfo, ok := dependencyMap[stage.Name]; ok {
+								if !stageDependencyInfo.NeededByTarget && b.skipUnusedStages != types.OptionalBoolFalse {
+									shouldWarn = false
+								}
+							}
+							if _, isBuiltIn := builtinAllowedBuildArgs[argName]; isBuiltIn {
 								shouldWarn = false
 							}
-						}
-						if _, isBuiltIn := builtinAllowedBuildArgs[argName]; isBuiltIn {
-							shouldWarn = false
-						}
-						if _, isGlobalArg := b.globalArgs[argName]; isGlobalArg {
-							shouldWarn = false
-						}
-						if shouldWarn {
-							b.logger.Warnf("missing %q build argument. Try adding %q to the command line", argName, fmt.Sprintf("--build-arg %s=<VALUE>", argName))
+							if _, isGlobalArg := b.globalArgs[argName]; isGlobalArg {
+								shouldWarn = false
+							}
+							if shouldWarn {
+								b.logger.Warnf("missing %q build argument. Try adding %q to the command line", argName, fmt.Sprintf("--build-arg %s=<VALUE>", argName))
+							}
 						}
 					}
 				default:
@@ -1002,8 +1002,7 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 						}
 					}
 				case "ARG":
-					arg := child.Next
-					if arg != nil {
+					for arg := child.Next; arg != nil; arg = arg.Next {
 						argName, argValue, hasValue := strings.Cut(arg.Value, "=")
 						if hasValue && argName != "" {
 							argValue, err := imagebuilder.ProcessWord(argValue, argsMapToSlice(stage.Builder.BuiltinArgDefaults))

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -904,10 +904,9 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 							headingArgs := argsMapToSlice(stage.Builder.HeadingArgs)
 							userArgs := argsMapToSlice(stage.Builder.Args)
 							localScopeArgs := argsMapToSlice(stageLocalScopeArgs)
-							// append heading args so if --build-arg key=value is not
-							// specified but default value is set in Containerfile
-							// via `ARG key=value` so default value can be used.
-							userArgs = slices.Concat(builtinArgs, userArgs, headingArgs, localScopeArgs)
+							// ProcessWord uses first match; put highest priority first so
+							// --build-arg overrides stage ARG overrides header ARG overrides builtin.
+							userArgs = slices.Concat(userArgs, localScopeArgs, headingArgs, builtinArgs)
 							baseWithArg, err := imagebuilder.ProcessWord(base, userArgs)
 							if err != nil {
 								return "", nil, fmt.Errorf("while replacing arg variables with values for format %q: %w", base, err)
@@ -939,7 +938,9 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 							headingArgs := argsMapToSlice(stage.Builder.HeadingArgs)
 							userArgs := argsMapToSlice(stage.Builder.Args)
 							localScopeArgs := argsMapToSlice(stageLocalScopeArgs)
-							userArgs = slices.Concat(builtinArgs, userArgs, headingArgs, localScopeArgs)
+							// ProcessWord uses first match; put highest priority first so
+							// --build-arg overrides stage ARG overrides header ARG overrides builtin.
+							userArgs = slices.Concat(userArgs, localScopeArgs, headingArgs, builtinArgs)
 							afterResolved, err := imagebuilder.ProcessWord(after, userArgs)
 							if err != nil {
 								return "", nil, fmt.Errorf("while replacing arg variables with values for --after=%q: %w", after, err)
@@ -964,25 +965,17 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 				case "ADD", "COPY":
 					for _, flag := range child.Flags { // flags for this instruction
 						if after, ok := strings.CutPrefix(flag, "--from="); ok {
-							// TODO: this didn't undergo variable and
-							// arg expansion, so if the previous stage
-							// was named using argument values, we might
-							// not record the right value here.
-							rootfs := after
-							b.rootfsMap[rootfs] = struct{}{}
-							logrus.Debugf("rootfs needed for COPY in stage %d: %q", stageIndex, rootfs)
 							// Populate dependency tree and check
 							// if following ADD or COPY needs any other
 							// stage.
-							stageName := rootfs
+							stageName := after
 							builtinArgs := argsMapToSlice(stage.Builder.BuiltinArgDefaults)
 							headingArgs := argsMapToSlice(stage.Builder.HeadingArgs)
 							userArgs := argsMapToSlice(stage.Builder.Args)
 							localScopeArgs := argsMapToSlice(stageLocalScopeArgs)
-							// append heading args so if --build-arg key=value is not
-							// specified but default value is set in Containerfile
-							// via `ARG key=value` so default value can be used.
-							userArgs = slices.Concat(builtinArgs, userArgs, headingArgs, localScopeArgs)
+							// ProcessWord uses first match; put highest priority first so
+							// --build-arg overrides stage ARG overrides header ARG overrides builtin.
+							userArgs = slices.Concat(userArgs, localScopeArgs, headingArgs, builtinArgs)
 							baseWithArg, err := imagebuilder.ProcessWord(stageName, userArgs)
 							if err != nil {
 								return "", nil, fmt.Errorf("while replacing arg variables with values for format %q: %w", stageName, err)

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4460,14 +4460,21 @@ _EOF
     "copy-from-arg::/from.txt:a"
     "copy-from-arg:SRC=b:/from.txt:b"
     "stage-overrides-header-copy-from::/from.txt:b"
+    "multiple-args-stage-overrides-one::/out.txt:9 1"
+    "multiple-args-stage-only::/out.txt:1 2"
+    "multiple-args-one-step::/out.txt:0 1"
+    "multiple-args-one-step:bar=88:/out.txt:0 88"
+    "multiple-args-one-step:foo=99 bar=88:/out.txt:99 88"
+    "arg-mixed-defaults::/out.txt:set"
+    "arg-mixed-defaults:a=given:/out.txt:given set"
   )
   for c in "${cases[@]}"; do
     IFS=: read -r cf_suffix build_arg path expected <<< "$c"
-    build_arg_safe=$(echo "${build_arg//=/-}" | tr '[:upper:]' '[:lower:]')
+    build_arg_safe=$(echo "${build_arg//=/-}" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
     imgname=arg-scope-$(safename)-${cf_suffix}-${build_arg_safe:-none}
     build_args=""
     if [[ -n "$build_arg" ]]; then
-      build_args="--build-arg $build_arg"
+      for arg in $build_arg; do build_args="$build_args --build-arg $arg"; done
     fi
 
     run_buildah build $WITH_POLICY_JSON $build_args -t ${imgname} -f ${ctx}/Containerfile.${cf_suffix} ${ctx}

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4449,6 +4449,39 @@ _EOF
   assert "$output" =~ "build:dev"
 }
 
+@test "bud ARG scope: table of scope combinations" {
+  _prefetch alpine busybox
+  local ctx=$BUDFILES/arg-scope
+  # containerfile_suffix | build_arg (or empty) | path | expected_substring
+  local cases=(
+    "from-arg::/base.txt:alpine"
+    "from-arg:BASE=busybox:/base.txt:busybox"
+    "stage-overrides-header::/foo.txt:stage"
+    "copy-from-arg::/from.txt:a"
+    "copy-from-arg:SRC=b:/from.txt:b"
+    "stage-overrides-header-copy-from::/from.txt:b"
+  )
+  for c in "${cases[@]}"; do
+    IFS=: read -r cf_suffix build_arg path expected <<< "$c"
+    build_arg_safe=$(echo "${build_arg//=/-}" | tr '[:upper:]' '[:lower:]')
+    imgname=arg-scope-$(safename)-${cf_suffix}-${build_arg_safe:-none}
+    build_args=""
+    if [[ -n "$build_arg" ]]; then
+      build_args="--build-arg $build_arg"
+    fi
+
+    run_buildah build $WITH_POLICY_JSON $build_args -t ${imgname} -f ${ctx}/Containerfile.${cf_suffix} ${ctx}
+
+    run_buildah from $WITH_POLICY_JSON ${imgname}
+    ctr=$(echo "$output" | tail -1)
+    run_buildah mount ${ctr}
+    mnt=$output
+    run cat ${mnt}${path}
+    expect_output --substring "$expected" "case: \"$c\""
+    run_buildah unmount ${ctr}
+  done
+}
+
 @test "bud-with-healthcheck" {
   _prefetch alpine
   target=alpine-image

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4429,6 +4429,26 @@ _EOF
   run_buildah build $WITH_POLICY_JSON -t source -f $BUDFILES/multi-stage-builds/Dockerfile.arg_in_copy
 }
 
+@test "bud COPY --from= with ARG in stage scope" {
+  _prefetch busybox
+
+  imgname=copy-from-stage-scoped-arg-$(safename)
+  ctrname=copy-from-stage-scoped-arg-ctr-$(safename)
+  run_buildah build $WITH_POLICY_JSON -t ${imgname} -f $BUDFILES/copy-from-stage-scoped-arg/Containerfile $BUDFILES/copy-from-stage-scoped-arg
+  run_buildah from --name ${ctrname} ${imgname}
+  run_buildah run ${ctrname} cat /variant
+  assert "$output" =~ "build:staging"
+
+  imgname_multi=copy-from-stage-scoped-arg-multi-$(safename)
+  ctrname_multi=copy-from-stage-scoped-arg-multi-ctr-$(safename)
+  run_buildah build $WITH_POLICY_JSON -t ${imgname_multi} -f $BUDFILES/copy-from-stage-scoped-arg/Containerfile.multi-copy-arg-override $BUDFILES/copy-from-stage-scoped-arg
+  run_buildah from --name ${ctrname_multi} ${imgname_multi}
+  run_buildah run ${ctrname_multi} cat /variant_first
+  assert "$output" =~ "build:staging"
+  run_buildah run ${ctrname_multi} cat /variant_second
+  assert "$output" =~ "build:dev"
+}
+
 @test "bud-with-healthcheck" {
   _prefetch alpine
   target=alpine-image
@@ -8551,7 +8571,7 @@ EOF
   _prefetch alpine
   local contextdir=${TEST_SCRATCH_DIR}/bud/link-diffid-nocache
   mkdir -p $contextdir
-  
+
   cat > $contextdir/Dockerfile << EOF
 FROM alpine
 RUN echo "before link layer" > /before.txt
@@ -8560,18 +8580,18 @@ RUN echo "after link layer" > /after.txt
 RUN ls -l /test.txt
 RUN cat /test.txt
 EOF
-  
+
   echo "test content" > $contextdir/test.txt
-  
+
   run_buildah build --no-cache --layers $WITH_POLICY_JSON -t oci:${TEST_SCRATCH_DIR}/oci-layout1 $contextdir
-  
+
   run_buildah build --no-cache --layers $WITH_POLICY_JSON -t oci:${TEST_SCRATCH_DIR}/oci-layout2 $contextdir
-  
+
   diffid1=$(oci_image_diff_id ${TEST_SCRATCH_DIR}/oci-layout1 2)
   diffid2=$(oci_image_diff_id ${TEST_SCRATCH_DIR}/oci-layout2 2)
   echo $diffid1
   echo $diffid2
-  
+
   assert "$diffid1" = "$diffid2" "COPY --link should produce identical diffIDs with --no-cache"
 }
 
@@ -8579,9 +8599,9 @@ EOF
   _prefetch alpine busybox
   local contextdir=${TEST_SCRATCH_DIR}/bud/link-diffid-bases
   mkdir -p $contextdir
-  
+
   echo "shared content" > $contextdir/shared.txt
-  
+
   cat > $contextdir/Containerfile.alpine << EOF
 FROM alpine
 RUN echo "alpine setup" > /setup.txt
@@ -8589,7 +8609,7 @@ COPY --link shared.txt /shared.txt
 RUN echo "alpine complete" > /complete.txt
 RUN cat /shared.txt
 EOF
-  
+
   cat > $contextdir/Containerfile.busybox << EOF
 FROM busybox
 RUN echo "busybox setup" > /setup.txt
@@ -8597,14 +8617,14 @@ COPY --link shared.txt /shared.txt
 RUN echo "busybox complete" > /complete.txt
 RUN cat /shared.txt
 EOF
-  
+
   run_buildah build --no-cache --layers $WITH_POLICY_JSON -f $contextdir/Containerfile.alpine -t oci:${TEST_SCRATCH_DIR}/oci-layout-alpine $contextdir
-  
+
   run_buildah build --no-cache --layers $WITH_POLICY_JSON -f $contextdir/Containerfile.busybox -t oci:${TEST_SCRATCH_DIR}/oci-layout-busybox $contextdir
-  
+
   diffid_alpine=$(oci_image_diff_id ${TEST_SCRATCH_DIR}/oci-layout-alpine 2)
   diffid_busybox=$(oci_image_diff_id ${TEST_SCRATCH_DIR}/oci-layout-busybox 2)
-  
+
   assert "$diffid_alpine" = "$diffid_busybox" "COPY --link should produce identical diffIDs regardless of base image"
 }
 
@@ -8612,11 +8632,11 @@ EOF
   _prefetch alpine
   local contextdir=${TEST_SCRATCH_DIR}/bud/link-diffid-multi
   mkdir -p $contextdir/subdir
-  
+
   echo "file1" > $contextdir/file1.txt
   echo "file2" > $contextdir/file2.txt
   echo "subfile" > $contextdir/subdir/sub.txt
-  
+
   cat > $contextdir/Dockerfile << EOF
 FROM alpine
 RUN echo "setup" > /setup.txt
@@ -8625,16 +8645,16 @@ ADD --link subdir /subdir
 RUN echo "complete" > /complete.txt
 RUN ls -l /files/
 EOF
-  
+
   run_buildah build --no-cache --layers $WITH_POLICY_JSON -t oci:${TEST_SCRATCH_DIR}/oci-layout-multi1 $contextdir
-  
+
   run_buildah build --no-cache --layers $WITH_POLICY_JSON -t oci:${TEST_SCRATCH_DIR}/oci-layout-multi2 $contextdir
-  
+
   copy_diffid1=$(oci_image_diff_id ${TEST_SCRATCH_DIR}/oci-layout-multi1 2)
   copy_diffid2=$(oci_image_diff_id ${TEST_SCRATCH_DIR}/oci-layout-multi2 2)
   add_diffid1=$(oci_image_diff_id ${TEST_SCRATCH_DIR}/oci-layout-multi1 3)
   add_diffid2=$(oci_image_diff_id ${TEST_SCRATCH_DIR}/oci-layout-multi2 3)
-  
+
   assert "$copy_diffid1" = "$copy_diffid2" "COPY --link with multiple files should have consistent diffID"
   assert "$add_diffid1" = "$add_diffid2" "ADD --link should have consistent diffID"
 }
@@ -8643,12 +8663,12 @@ EOF
   _prefetch alpine
   local contextdir=${TEST_SCRATCH_DIR}/bud/link-diffid-glob
   mkdir -p $contextdir
-  
+
   echo "test1" > $contextdir/test1.txt
   echo "test2" > $contextdir/test2.txt
   echo "json1" > $contextdir/data1.json
   echo "json2" > $contextdir/data2.json
-  
+
   cat > $contextdir/Dockerfile << EOF
 FROM alpine
 COPY --link test*.txt /tests/
@@ -8657,16 +8677,16 @@ RUN echo "globbing complete" > /complete.txt
 RUN ls -l /tests/
 RUN ls -l /data/
 EOF
-  
+
   run_buildah build --no-cache --layers $WITH_POLICY_JSON -t oci:${TEST_SCRATCH_DIR}/oci-glob-1 $contextdir
-  
+
   run_buildah build --no-cache --layers $WITH_POLICY_JSON -t oci:${TEST_SCRATCH_DIR}/oci-glob-2 $contextdir
-  
+
   glob_txt_diffid1=$(oci_image_diff_id ${TEST_SCRATCH_DIR}/oci-glob-1 1)
   glob_txt_diffid2=$(oci_image_diff_id ${TEST_SCRATCH_DIR}/oci-glob-2 1)
   glob_json_diffid1=$(oci_image_diff_id ${TEST_SCRATCH_DIR}/oci-glob-1 2)
   glob_json_diffid2=$(oci_image_diff_id ${TEST_SCRATCH_DIR}/oci-glob-2 2)
-  
+
   assert "$glob_txt_diffid1" = "$glob_txt_diffid2" "COPY --link with glob *.txt should have consistent diffID"
   assert "$glob_json_diffid1" = "$glob_json_diffid2" "COPY --link with glob *.json should have consistent diffID"
 }
@@ -8675,25 +8695,25 @@ EOF
   _prefetch alpine
   local contextdir=${TEST_SCRATCH_DIR}/bud/link-cache
   mkdir -p $contextdir
-  
+
   echo "test content" > $contextdir/testfile.txt
-  
+
   cat > $contextdir/Dockerfile << EOF
 FROM alpine
 COPY --link testfile.txt /testfile.txt
 RUN echo "build complete" > /complete.txt
 RUN cat /testfile.txt
 EOF
-  
+
   # First build
   run_buildah build --layers $WITH_POLICY_JSON -t link-cache1 $contextdir
-  
+
   run_buildah build --layers $WITH_POLICY_JSON -t link-cache2 $contextdir
   assert "$output" =~ "Using cache"
-  
+
   # Modify content
   echo "modified content" > $contextdir/testfile.txt
-  
+
   run_buildah build --layers $WITH_POLICY_JSON -t link-cache3 $contextdir
   assert "$output" !~ "STEP 2/3: COPY --link testfile.txt /testfile.txt"$'\n'".*Using cache"
 }
@@ -8702,15 +8722,15 @@ EOF
   _prefetch alpine
   local contextdir=${TEST_SCRATCH_DIR}/bud/link-perms
   mkdir -p $contextdir
-  
+
   echo "test content" > $contextdir/testfile.txt
-  
+
   cat > $contextdir/Dockerfile << EOF
 FROM alpine
 COPY --link --chmod=755 --chown=1000:1000 testfile.txt /testfile.txt
 RUN stat -c '%u:%g %a' /testfile.txt
 EOF
-  
+
   run_buildah build --layers $WITH_POLICY_JSON -t link-perms $contextdir
   expect_output --substring "1000:1000 755"
 }
@@ -8719,10 +8739,10 @@ EOF
   _prefetch alpine
   local contextdir=${TEST_SCRATCH_DIR}/bud/link-multistage
   mkdir -p $contextdir
-  
+
   echo "stage1 content" > $contextdir/stage1.txt
   echo "stage2 content" > $contextdir/stage2.txt
-  
+
   cat > $contextdir/Dockerfile << EOF
 FROM alpine AS stage1
 ADD --link stage1.txt /stage1.txt
@@ -8736,12 +8756,12 @@ RUN echo "stage2 complete" > /complete.txt
 RUN cat /stage2.txt
 
 EOF
-  
+
   run_buildah build --layers $WITH_POLICY_JSON -t link-multistage1 $contextdir
-  
+
   run_buildah build --layers $WITH_POLICY_JSON -t link-multistage2 $contextdir
   assert "$output" =~ "Using cache"
-  
+
   run_buildah from --name test-ctr link-multistage2
   run_buildah run test-ctr cat /from-stage1.txt
   expect_output "stage1 content"
@@ -8779,12 +8799,12 @@ EOF
   _prefetch alpine
   local contextdir=${TEST_SCRATCH_DIR}/bud/link-ignore
   mkdir -p $contextdir
-  
+
   echo "included" > $contextdir/included.txt
   echo "excluded" > $contextdir/excluded.txt
-  
+
   echo "excluded.txt" > $contextdir/.dockerignore
-  
+
   cat > $contextdir/Dockerfile << EOF
 FROM alpine
 RUN echo "Starting" > /start.txt
@@ -8792,7 +8812,7 @@ COPY --link *.txt /files/
 RUN echo "Ending" > /end.txt
 RUN ls -l /files/
 EOF
-  
+
   run_buildah build --layers $WITH_POLICY_JSON -t link-ignore $contextdir
   expect_output --substring "included.txt"
   assert "$output" !~ "excluded.txt"

--- a/tests/bud/arg-scope/Containerfile.arg-mixed-defaults
+++ b/tests/bud/arg-scope/Containerfile.arg-mixed-defaults
@@ -1,0 +1,3 @@
+FROM alpine
+ARG a b=set
+RUN echo "$a" "$b" > /out.txt

--- a/tests/bud/arg-scope/Containerfile.copy-from-arg
+++ b/tests/bud/arg-scope/Containerfile.copy-from-arg
@@ -1,4 +1,4 @@
-ARG SRC=a
+ARG SRC=a DST=b
 FROM busybox AS a
 RUN echo a > /from.txt
 FROM alpine AS b

--- a/tests/bud/arg-scope/Containerfile.copy-from-arg
+++ b/tests/bud/arg-scope/Containerfile.copy-from-arg
@@ -1,0 +1,8 @@
+ARG SRC=a
+FROM busybox AS a
+RUN echo a > /from.txt
+FROM alpine AS b
+RUN echo b > /from.txt
+FROM scratch
+ARG SRC
+COPY --from=$SRC /from.txt /

--- a/tests/bud/arg-scope/Containerfile.from-arg
+++ b/tests/bud/arg-scope/Containerfile.from-arg
@@ -1,0 +1,4 @@
+ARG BASE=alpine
+FROM $BASE
+ARG BASE
+RUN echo $BASE > /base.txt

--- a/tests/bud/arg-scope/Containerfile.from-arg
+++ b/tests/bud/arg-scope/Containerfile.from-arg
@@ -1,4 +1,4 @@
-ARG BASE=alpine
+ARG BASE=alpine BUSY=busybox
 FROM $BASE
 ARG BASE
 RUN echo $BASE > /base.txt

--- a/tests/bud/arg-scope/Containerfile.multiple-args-one-step
+++ b/tests/bud/arg-scope/Containerfile.multiple-args-one-step
@@ -1,0 +1,3 @@
+FROM alpine
+ARG foo=0 bar=1
+RUN echo $foo $bar > /out.txt

--- a/tests/bud/arg-scope/Containerfile.multiple-args-stage-only
+++ b/tests/bud/arg-scope/Containerfile.multiple-args-stage-only
@@ -1,0 +1,3 @@
+FROM alpine
+ARG x=1 y=2
+RUN echo $x $y > /out.txt

--- a/tests/bud/arg-scope/Containerfile.multiple-args-stage-overrides-one
+++ b/tests/bud/arg-scope/Containerfile.multiple-args-stage-overrides-one
@@ -1,0 +1,5 @@
+ARG foo=0 bar=1
+FROM alpine
+ARG foo=9
+ARG bar
+RUN echo $foo $bar > /out.txt

--- a/tests/bud/arg-scope/Containerfile.stage-overrides-header
+++ b/tests/bud/arg-scope/Containerfile.stage-overrides-header
@@ -1,0 +1,4 @@
+ARG FOO=header
+FROM busybox
+ARG FOO=stage
+RUN echo $FOO > /foo.txt

--- a/tests/bud/arg-scope/Containerfile.stage-overrides-header-copy-from
+++ b/tests/bud/arg-scope/Containerfile.stage-overrides-header-copy-from
@@ -1,0 +1,8 @@
+ARG SRC=a
+FROM busybox AS a
+RUN echo a > /from.txt
+FROM alpine AS b
+RUN echo b > /from.txt
+FROM scratch
+ARG SRC=b
+COPY --from=$SRC /from.txt /

--- a/tests/bud/copy-from-stage-scoped-arg/Containerfile
+++ b/tests/bud/copy-from-stage-scoped-arg/Containerfile
@@ -1,0 +1,12 @@
+FROM docker.io/library/busybox:latest AS build
+RUN echo "build" >> /variant
+
+FROM build AS dev
+RUN echo "build:dev" >> /variant
+
+FROM build AS staging
+RUN echo "build:staging" >> /variant
+
+FROM docker.io/library/busybox:latest
+ARG VARIANT="staging"
+COPY --from="${VARIANT}" /variant /variant

--- a/tests/bud/copy-from-stage-scoped-arg/Containerfile.multi-copy-arg-override
+++ b/tests/bud/copy-from-stage-scoped-arg/Containerfile.multi-copy-arg-override
@@ -1,0 +1,14 @@
+FROM docker.io/library/busybox:latest AS build
+RUN echo "build" > /variant
+
+FROM build AS dev
+RUN echo "build:dev" >> /variant
+
+FROM build AS staging
+RUN echo "build:staging" >> /variant
+
+FROM docker.io/library/busybox:latest
+ARG VARIANT="staging"
+COPY --from="${VARIANT}" /variant /variant_first
+ARG VARIANT="dev"
+COPY --from="${VARIANT}" /variant /variant_second

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -3780,6 +3780,27 @@ var internalTestCases = []testCase{
 		}, "\n"),
 		fsSkip: []string{"(dir):foo.txt:mtime"},
 	},
+
+	{
+		name: "multiple ARGs in single instruction",
+		dockerfileContents: strings.Join([]string{
+			"FROM mirror.gcr.io/alpine",
+			"ARG foo=0 bar=1",
+			"RUN echo $foo $bar > /out.txt",
+		}, "\n"),
+		fsSkip: []string{"(dir):out.txt:mtime"},
+	},
+
+	{
+		name: "multiple ARGs in single instruction with build-arg override",
+		dockerfileContents: strings.Join([]string{
+			"FROM mirror.gcr.io/alpine",
+			"ARG foo=0 bar=1",
+			"RUN echo $foo $bar > /out.txt",
+		}, "\n"),
+		buildArgs: map[string]string{"foo": "9", "bar": "8"},
+		fsSkip:    []string{"(dir):out.txt:mtime"},
+	},
 }
 
 func TestCommit(t *testing.T) {

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -3748,6 +3748,38 @@ var internalTestCases = []testCase{
 		fsSkip:            []string{"(dir):arg-expansion.txt:mtime"},
 		dockerUseBuildKit: true,
 	},
+
+	{
+		name: "build-arg overrides header arg for FROM",
+		dockerfileContents: strings.Join([]string{
+			"ARG BASE=mirror.gcr.io/alpine",
+			"FROM $BASE",
+			"RUN echo $BASE > /base.txt",
+		}, "\n"),
+		buildArgs: map[string]string{"BASE": "mirror.gcr.io/busybox"},
+		fsSkip:    []string{"(dir):base.txt:mtime"},
+	},
+
+	{
+		name: "header arg default for FROM when no build-arg",
+		dockerfileContents: strings.Join([]string{
+			"ARG BASE=mirror.gcr.io/alpine",
+			"FROM $BASE",
+			"RUN echo $BASE > /base.txt",
+		}, "\n"),
+		fsSkip: []string{"(dir):base.txt:mtime"},
+	},
+
+	{
+		name: "stage arg overrides header arg in same stage",
+		dockerfileContents: strings.Join([]string{
+			"ARG FOO=header",
+			"FROM mirror.gcr.io/busybox",
+			"ARG FOO=stage",
+			"RUN echo $FOO > /foo.txt",
+		}, "\n"),
+		fsSkip: []string{"(dir):foo.txt:mtime"},
+	},
 }
 
 func TestCommit(t *testing.T) {


### PR DESCRIPTION
Fixes: https://github.com/containers/buildah/issues/6719

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> 
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes `COPY/ADD --from=` when the source stage is defined via a stage scoped `ARG`, ensuring correct source resolution.
```

