### PR TITLE
Add /assign command GitHub Action

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,41 @@
+name: Assign Command
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  assign:
+    # Only run on issue comments (not PR comments)
+    if: "!github.event.issue.pull_request && contains(github.event.comment.body, '/assign')"
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Self-assign if unassigned
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          # Check if issue has any assignees
+          ASSIGNEES=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json assignees -q '.assignees | length')
+
+          if [ "$ASSIGNEES" -eq 0 ]; then
+            # Use API directly to assign (works for any GitHub user, not just collaborators)
+            if gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/assignees" -X POST -f "assignees[]=${COMMENTER}" --silent; then
+              echo "Successfully assigned @${COMMENTER} to issue #${ISSUE_NUMBER}"
+            else
+              echo "Failed to assign @${COMMENTER} to issue #${ISSUE_NUMBER}"
+              exit 1
+            fi
+          else
+            # Add commenter as an additional assignee
+            if gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/assignees" -X POST -f "assignees[]=${COMMENTER}" --silent; then
+              echo "Successfully added @${COMMENTER} as an additional assignee to issue #${ISSUE_NUMBER}"
+            else
+              echo "Failed to add @${COMMENTER} as an additional assignee to issue #${ISSUE_NUMBER}"
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
Enable community members to self-assign issues by commenting /assign. This workflow uses the GitHub API to assign any user, not just collaborators.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

