### PR TITLE
Fix panic in --secret flag parsing when key has no value

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -1319,20 +1319,23 @@ func Secrets(secrets []string) (map[string]define.Secret, error) {
 		tokens := strings.Split(secret, ",")
 		var id, src, typ string
 		for _, val := range tokens {
-			kv := strings.SplitN(val, "=", 2)
-			switch kv[0] {
+			key, value, ok := strings.Cut(val, "=")
+			if !ok {
+				return nil, errInvalidSecretSyntax
+			}
+			switch key {
 			case "id":
-				id = kv[1]
+				id = value
 			case "src":
-				src = kv[1]
+				src = value
 			case "env":
-				src = kv[1]
+				src = value
 				typ = "env"
 			case "type":
-				if kv[1] != "file" && kv[1] != "env" {
+				if value != "file" && value != "env" {
 					return nil, errors.New("invalid secret type, must be file or env")
 				}
-				typ = kv[1]
+				typ = value
 			default:
 				return nil, errInvalidSecretSyntax
 			}

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -2,6 +2,7 @@ package parse //nolint:revive,nolintlint
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"testing"
 
@@ -296,6 +297,64 @@ func TestGetBuildOutput(t *testing.T) {
 			result, err := GetBuildOutput(testCase.input)
 			require.NoErrorf(t, err, "expected to be able to parse %q", testCase.input)
 			assert.Equal(t, testCase.output, result)
+		})
+	}
+}
+
+func TestSecrets(t *testing.T) {
+	errorTests := []struct {
+		name  string
+		input string
+	}{
+		{"bare-src-no-equals", "id=,src"},
+		{"bare-id-no-equals", "id"},
+		{"known-key-without-value", "id=mysecret,src"},
+		{"empty-id", "id="},
+		{"unknown-key", "id=mysecret,bogus=x"},
+	}
+	for _, tc := range errorTests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Secrets([]string{tc.input})
+			assert.Error(t, err, "expected error for input %q", tc.input)
+		})
+	}
+
+	tmpfile, err := os.CreateTemp(t.TempDir(), "secret")
+	require.NoError(t, err)
+	_, err = tmpfile.WriteString("supersecret")
+	require.NoError(t, err)
+	tmpfile.Close()
+
+	t.Setenv("TEST_SECRET_ENV", "envsecret")
+
+	validFile := tmpfile.Name()
+
+	successTests := []struct {
+		name     string
+		input    string
+		expected define.Secret
+	}{
+		{
+			"id-and-file-src",
+			"id=mysecret,src=" + validFile,
+			define.Secret{ID: "mysecret", Source: validFile, SourceType: "file"},
+		},
+		{
+			"id-and-env",
+			"id=TEST_SECRET_ENV,env=TEST_SECRET_ENV",
+			define.Secret{ID: "TEST_SECRET_ENV", Source: "TEST_SECRET_ENV", SourceType: "env"},
+		},
+		{
+			"id-only-env-fallback",
+			"id=TEST_SECRET_ENV",
+			define.Secret{ID: "TEST_SECRET_ENV", Source: "TEST_SECRET_ENV", SourceType: "env"},
+		},
+	}
+	for _, tc := range successTests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := Secrets([]string{tc.input})
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result[tc.expected.ID])
 		})
 	}
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -7074,6 +7074,20 @@ _EOF
   expect_output --substring "ENVDATA"
 }
 
+@test "bud with malformed --secret flag should fail not panic" {
+  run_buildah 125 build --secret=id=,src $WITH_POLICY_JSON -f $BUDFILES/run-mounts/Dockerfile.secret $BUDFILES/run-mounts
+  expect_output --substring "incorrect secret flag format"
+
+  run_buildah 125 build --secret=id=mysecret,src $WITH_POLICY_JSON -f $BUDFILES/run-mounts/Dockerfile.secret $BUDFILES/run-mounts
+  expect_output --substring "incorrect secret flag format"
+
+  run_buildah 125 build --secret=src $WITH_POLICY_JSON -f $BUDFILES/run-mounts/Dockerfile.secret $BUDFILES/run-mounts
+  expect_output --substring "incorrect secret flag format"
+
+  run_buildah 125 build --secret=id $WITH_POLICY_JSON -f $BUDFILES/run-mounts/Dockerfile.secret $BUDFILES/run-mounts
+  expect_output --substring "incorrect secret flag format"
+}
+
 @test "bud-multiple-platform-values" {
   skip "FIXME: #4396 - this test is broken, and is failing gating tests"
   outputlist=testlist


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/28394

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> 
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

