### PR TITLE
feat: add generic Containerfile template processing

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -263,6 +263,9 @@ type BuildOptions struct {
 	DropCapabilities []string
 	// CommonBuildOpts is *required*.
 	CommonBuildOpts *CommonBuildOptions
+	// TemplateOpts configures template preprocessing for Containerfile/Dockerfile files
+	// with specific suffixes (e.g., .in, .tmpl). See TemplateOptions for details.
+	TemplateOpts *TemplateOptions
 	// CPPFlags are additional arguments to pass to the C Preprocessor (cpp).
 	CPPFlags []string
 	// DefaultMountsFilePath is the file path holding the mounts to be mounted for RUN

--- a/define/types.go
+++ b/define/types.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -367,4 +368,227 @@ func stdinToDirectory(dir string) error {
 		}
 	}
 	return nil
+}
+
+// TemplateProcessorOptions configures how files with a specific suffix are processed.
+// Exactly one of UseBuiltinCpp or Cmd must be effectively configured:
+//   - If UseBuiltinCpp is true, the built-in C preprocessor (cpp) is used.
+//   - If UseBuiltinCpp is false, Cmd must specify an external command.
+type TemplateProcessorOptions struct {
+	// Cmd specifies the external command and its arguments to execute.
+	// The command receives the template content on stdin and must output
+	// the processed result to stdout. This field is ignored when UseBuiltinCpp is true.
+	Cmd []string
+
+	// UseBuiltinCpp indicates whether to use the built-in C preprocessor (cpp).
+	// When true, Cmd is ignored. Default is false, except when a template
+	// specification uses the special "cpp" command name (e.g., "in=cpp").
+	UseBuiltinCpp bool
+
+	// IgnoreStderr controls stderr output from the preprocessor command.
+	// When true, stderr is hidden unless the command exits with a non-zero code.
+	// When false, stderr is always logged as a warning.
+	IgnoreStderr bool
+
+	// ChdirCtxDir changes the working directory to the build context directory
+	// before executing the preprocessor command. The build context path is also
+	// always available via the BUILDAH_CTXDIR environment variable.
+	ChdirCtxDir bool
+}
+
+// TemplateLookupPolicy defines when to search for template files
+// versus regular Containerfile/Dockerfile files.
+type TemplateLookupPolicy int
+
+const (
+	// TemplateLookupNever disables template file lookup entirely.
+	// Only regular Containerfile/Dockerfile files are considered.
+	TemplateLookupNever TemplateLookupPolicy = iota
+
+	// TemplateLookupFirst searches for template files (e.g., Containerfile.in)
+	// before falling back to regular Containerfile/Dockerfile.
+	TemplateLookupFirst
+
+	// TemplateLookupLast searches for regular Containerfile/Dockerfile first,
+	// then falls back to template files if no regular file is found.
+	TemplateLookupLast
+)
+
+// TemplateOptions holds the complete template processing configuration.
+// The LookupPolicy determines when templates are considered, while SuffixOrder
+// and Preprocessors define which suffixes are supported and how they are processed.
+//
+// SuffixOrder and Preprocessors must be kept consistent: each suffix in SuffixOrder
+// must have a corresponding entry in Preprocessors, and vice versa.
+// The SanityCheck() method verifies this consistency.
+type TemplateOptions struct {
+	// LookupPolicy controls when template files are considered during discovery.
+	// See TemplateLookupPolicy for details.
+	LookupPolicy TemplateLookupPolicy
+
+	// SuffixOrder defines the sequence of suffixes to attempt when looking for
+	// template files. Suffixes are tried in order until a matching file is found.
+	// Example: []string{"in", "tmpl", "j2"}
+	SuffixOrder []string
+
+	// Preprocessors maps filename suffixes to their respective processing configurations.
+	// Each suffix listed in SuffixOrder must have an entry in this map.
+	Preprocessors map[string]*TemplateProcessorOptions
+}
+
+const (
+	// useDefaultCppHandling enables built-in .in file processing by default.
+	useDefaultCppHandling = true
+
+	// defaultCppSuffix is the filename suffix processed by the built-in C preprocessor.
+	defaultCppSuffix = "in"
+)
+
+// EmptyTemplateOptions returns a TemplateOptions with no preconfigured suffixes
+// and TemplateLookupNever as the default policy.
+func EmptyTemplateOptions() *TemplateOptions {
+	rv := &TemplateOptions{
+		LookupPolicy:  TemplateLookupNever,
+		SuffixOrder:   make([]string, 0),
+		Preprocessors: make(map[string]*TemplateProcessorOptions, 0),
+	}
+	return rv
+}
+
+// NewTemplateOptionsWithCapacity creates a TemplateOptions with pre-allocated capacity.
+// The capacity hint is used for internal slices and maps. If useDefaultCppHandling is true,
+// an additional slot is reserved for the default "in" suffix.
+//
+// The returned options include the default "in" suffix configured to use the built-in
+// C preprocessor.
+func NewTemplateOptionsWithCapacity(capacity int) *TemplateOptions {
+	if capacity < 0 {
+		capacity = 0
+	}
+
+	// reserve space for default "*.in" handling
+	if useDefaultCppHandling {
+		capacity++
+	}
+
+	rv := &TemplateOptions{
+		LookupPolicy:  TemplateLookupNever,
+		SuffixOrder:   make([]string, 0, capacity),
+		Preprocessors: make(map[string]*TemplateProcessorOptions, capacity),
+	}
+
+	// default "*.in" handling
+	if useDefaultCppHandling {
+		cppOpts := NewTemplateProcessorOptions()
+		cppOpts.UseBuiltinCpp = true
+		rv.SuffixOrder = append(rv.SuffixOrder, defaultCppSuffix)
+		rv.Preprocessors[defaultCppSuffix] = cppOpts
+	}
+
+	return rv
+}
+
+// NewTemplateOptions returns a TemplateOptions with default configuration.
+// If default C preprocessor handling is enabled, the returned options include
+// the default "in" suffix; otherwise, it returns an empty configuration.
+func NewTemplateOptions() *TemplateOptions {
+	if useDefaultCppHandling {
+		return NewTemplateOptionsWithCapacity(0)
+	}
+	return EmptyTemplateOptions()
+}
+
+// DeleteSuffix removes a suffix and its associated processor from the configuration.
+// If the suffix is empty, the call is ignored.
+func (t *TemplateOptions) DeleteSuffix(suffix string) {
+	if suffix == "" {
+		// ignore empty suffix
+		return
+	}
+
+	delete(t.Preprocessors, suffix)
+	t.SuffixOrder = slices.DeleteFunc(
+		t.SuffixOrder,
+		func(s string) bool { return s == suffix },
+	)
+}
+
+// AddSuffix adds or replaces a suffix processor. If procOpts is nil, the suffix is deleted.
+// Empty suffixes are ignored. The suffix is appended to SuffixOrder if not already present.
+func (t *TemplateOptions) AddSuffix(suffix string, procOpts *TemplateProcessorOptions) {
+	if suffix == "" {
+		// ignore empty suffix
+		return
+	}
+
+	if procOpts == nil {
+		// handle implicit suffix deletion
+		t.DeleteSuffix(suffix)
+		return
+	}
+
+	t.Preprocessors[suffix] = procOpts
+	if !slices.Contains(t.SuffixOrder, suffix) {
+		t.SuffixOrder = append(t.SuffixOrder, suffix)
+	}
+}
+
+// SanityCheck validates the consistency of TemplateOptions.
+// It ensures that:
+//   - SuffixOrder contains no empty or duplicate entries
+//   - Every suffix in SuffixOrder has a corresponding entry in Preprocessors
+//     and vice versa
+//   - For non-builtin processors, Cmd is non-empty and Cmd[0] is non-empty
+//   - No processor configuration is nil
+//
+// Returns an error describing the first inconsistency found.
+func (t *TemplateOptions) SanityCheck() error {
+	suffixes := make(map[string]bool, len(t.SuffixOrder))
+	for _, suffix := range t.SuffixOrder {
+		if suffix == "" {
+			return errors.New("empty suffix in `TemplateOptions.SuffixOrder`")
+		}
+
+		if _, seen := suffixes[suffix]; seen {
+			return fmt.Errorf("non-unique suffix %s in `TemplateOptions.SuffixOrder`", suffix)
+		}
+		suffixes[suffix] = true
+
+		if _, seen := t.Preprocessors[suffix]; !seen {
+			return fmt.Errorf("suffix %s presents only in `TemplateOptions.SuffixOrder`", suffix)
+		}
+	}
+
+	for suffix, opts := range t.Preprocessors {
+		if suffix == "" {
+			return errors.New("empty suffix in `TemplateOptions.Preprocessors`")
+		}
+
+		if _, seen := suffixes[suffix]; !seen {
+			return fmt.Errorf("suffix %s presents only in `TemplateOptions.Preprocessors`", suffix)
+		}
+
+		if opts == nil {
+			return fmt.Errorf("`TemplateOptions.Preprocessors[%s]` is nil", suffix)
+		}
+		if opts.UseBuiltinCpp {
+			continue
+		}
+
+		if len(opts.Cmd) == 0 {
+			return fmt.Errorf("empty `TemplateOptions.Preprocessors[%s].Cmd[]`", suffix)
+		}
+		if opts.Cmd[0] == "" {
+			return fmt.Errorf("empty `TemplateOptions.Preprocessors[%s].Cmd[0]`", suffix)
+		}
+	}
+
+	return nil
+}
+
+// NewTemplateProcessorOptions returns a new TemplateProcessorOptions with default values.
+// Note: When UseBuiltinCpp is false, the Cmd field must be set by the caller.
+func NewTemplateProcessorOptions() *TemplateProcessorOptions {
+	rv := &TemplateProcessorOptions{}
+	return rv
 }

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -18,6 +18,8 @@ The build context directory can be specified as the http(s) URL of an archive, g
 
 If no context directory is specified, then Buildah will assume the current working directory as build context, which should contain a Containerfile.
 
+Containerfiles with specific filename suffixes can be preprocessed as templates before building. By default, files ending with ".in" suffix are preprocessed using the C Preprocessor (cpp(1)). This feature can be extended to support custom template processors for different filename suffixes using the **--template** option.
+
 Containerfiles ending with a ".in" suffix will be preprocessed via cpp(1).  This can be useful to decompose Containerfiles into several reusable parts that can be used via CPP's **#include** directive.  Notice, a Containerfile.in file can still be used by other tools when manually preprocessing them via `cpp -E`. Any comments ( Lines beginning with `#` ) in included Containerfile(s) that are not preprocess commands, will be printed as warnings during builds.
 
 When the URL is an archive, the contents of the URL is downloaded to a temporary location and extracted before execution.
@@ -222,6 +224,7 @@ Thus, compressing the data before sending it is irrelevant to Buildah.
 
 Set additional flags to pass to the C Preprocessor cpp(1).
 Containerfiles ending with a ".in" suffix will be preprocessed via cpp(1). This option can be used to pass additional flags to cpp.
+When using custom template processors (via **--template** option), the **--cpp-flag** option only applies to templates processed with the built-in C preprocessor.
 Note: You can also set default CPPFLAGS by setting the BUILDAH\_CPPFLAGS
 environment variable (e.g., `export BUILDAH_CPPFLAGS="-DDEBUG"`).
 
@@ -1193,6 +1196,48 @@ Set the target build stage to build.  When building a Containerfile with multipl
 can be used to specify an intermediate build stage by name as the final stage for the resulting image.
 Commands after the target stage will be skipped.
 
+**--template** *templateSpec*
+
+Define template preprocessor for "Containerfile.\*" or "Dockerfile.\*" files. This option can be specified multiple times.
+
+The *templateSpec* format is: `suffix=cmd[,opts]` where:
+
+- `suffix`: Filename suffix (e.g., "in", "tmpl", "j2")
+- `cmd`: Command to process the template:
+  - `-`: Remove handling for this suffix (e.g. `in=-` to disable default .in processing)
+  - `cpp`: Use built-in C preprocessor (same as default .in handling)
+  - Any other command name or path to custom processor
+- `opts`: Optional comma-separated options:
+  - `ignore_stderr`: Hide stderr output unless command fails
+  - `chdir_ctxdir`: Change working directory to build context before processing
+
+For complex commands with arguments, use JSON array format: `suffix=["cmd","arg1","arg2"][,opts]`
+
+**Note:** The build context directory is always available to template preprocessors via the `BUILDAH_CTXDIR` environment variable, regardless of the `chdir_ctxdir` setting. This allows preprocessors to locate files relative to the build context even when running with a different working directory.
+
+Multiple template specifications can also be provided via the BUILDAH\_TEMPLATE environment variable as a semicolon-separated list or JSON array.
+
+Examples:
+
+- `--template in=cpp`: Use C preprocessor for .in files (default)
+- `--template in=-`: Disable .in file processing
+- `--template j2=jinja2`: Use `jinja2` command for .j2 files
+- `--template tmpl=m4,chdir_ctxdir`: Use `m4` command for .tmpl files, change to context directory
+- `--template macro=["python3","-m","mymodule"],ignore_stderr`: Use Python module with stderr hidden
+
+**--template-lookup** *policy*
+
+Template filename lookup policy. If not specified, the default is **never**.
+
+- **never**: Use templates only if filename is specified explicitly (e.g. via **--file**).
+
+- **first**: Try template files first, then fall back to regular Containerfile/Dockerfile.
+
+- **last**: Try regular Containerfile/Dockerfile first, then fall back to template files.
+
+Note: You can also override the default policy by setting the BUILDAH\_TEMPLATE\_LOOKUP
+environment variable.  `export BUILDAH_TEMPLATE_LOOKUP=first`
+
 **--timestamp** *seconds*
 
 Set the "created" timestamp for the built image to this number of seconds since
@@ -1612,6 +1657,40 @@ buildah images --filter "label=io.buildah.stage.base=golang:1.21"
 
   Note: supported compression formats are 'xz', 'bzip2', 'gzip' and 'identity' (no compression).
 
+### Using Template Processing
+
+#### Process Containerfile.in with C preprocessor (default behavior)
+
+```sh
+buildah build -f Containerfile.in .
+```
+
+#### Use custom template processor for .j2 files
+
+```sh
+buildah build --template-lookup first --template j2=jinja2 .
+```
+
+#### Use m4 processor for .m4 files with context directory change
+
+```sh
+buildah build --template m4=m4,chdir_ctxdir .
+```
+
+#### Disable default .in processing and use custom processor
+
+```sh
+buildah build --template in=- --template tmpl=myprocessor .
+```
+
+#### Use environment variable to configure templates
+
+```sh
+export BUILDAH_TEMPLATE="in=- ; j2=jinja2,ignore_stderr"
+export BUILDAH_TEMPLATE_LOOKUP="first"
+buildah build .
+```
+
 ### Using Build Time Variables
 
 #### Replace the value set for the HTTP_PROXY environment variable within the Containerfile.
@@ -1632,8 +1711,30 @@ If there are registries in the `allowedRegistries` list, and the registry's
 name is not in the list, the pull attempt is denied.
 
 **TMPDIR**
+
 The TMPDIR environment variable allows the user to specify where temporary files
 are stored while pulling and pushing images.  Defaults to '/var/tmp'.
+
+**BUILDAH\_TEMPLATE**
+
+Defines template processors for Containerfile/Dockerfile templates. Can be set as:
+
+- Semicolon-separated list: `suffix1=cmd1,opts1;suffix2=cmd2,opts2`
+- JSON array of strings: `["suffix1=cmd1,opts1", "suffix2=cmd2,opts2"]`
+- JSON array of objects: `[{"suffix": "suffix1", "cmd": ["cmd1", "arg1"], "ignore_stderr": true}, ...]`
+
+Note: for semicolon-separated lists, whitespace around the delimiter and at the
+ends is ignored (e.g., `suffix1=cmd1 ; suffix2=cmd2` is valid).
+
+**BUILDAH\_TEMPLATE\_LOOKUP**
+
+Sets the default template lookup policy. Valid values: "never", "first", "last".
+Defaults to "never".
+
+**BUILDAH\_CPPFLAGS**
+
+Sets default flags for the C preprocessor when processing .in files.
+Example: `export BUILDAH_CPPFLAGS="-DDEBUG -I./includes"`
 
 ## Files
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -114,6 +114,14 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 		}
 	}
 
+	if options.TemplateOpts == nil {
+		options.TemplateOpts = define.NewTemplateOptions()
+	}
+	if err := options.TemplateOpts.SanityCheck(); err != nil {
+		options.TemplateOpts = define.EmptyTemplateOptions()
+		return "", nil, err
+	}
+
 	for _, dfile := range paths {
 		var data io.Reader
 
@@ -162,13 +170,25 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 			data = contents
 		}
 
-		// pre-process Dockerfiles with ".in" suffix
-		if strings.HasSuffix(dfile, ".in") {
-			pData, err := preprocessContainerfileContents(logger, dfile, data, options.ContextDirectory, options.CPPFlags)
-			if err != nil {
-				return "", nil, err
+		lastSep := strings.LastIndexAny(dfile, "/\\")
+		dfileBase := dfile
+		if lastSep >= 0 {
+			dfileBase = dfile[lastSep+1:]
+		}
+		if (dfileBase != "") && strings.ContainsRune(dfileBase, '.') {
+			for _, suffix := range options.TemplateOpts.SuffixOrder {
+				if !strings.HasSuffix(dfileBase, "."+suffix) {
+					continue
+				}
+
+				templateProc := options.TemplateOpts.Preprocessors[suffix]
+				pData, err := preprocessContainerfileContents(&options, logger, dfile, data, templateProc)
+				if err != nil {
+					return "", nil, err
+				}
+				data = pData
+				break
 			}
-			data = pData
 		}
 
 		dockerfiles = append(dockerfiles, data)
@@ -491,14 +511,42 @@ func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logr
 	return exec.Build(ctx, stages)
 }
 
-// preprocessContainerfileContents runs CPP(1) in preprocess-only mode on the input
-// dockerfile content and will use ctxDir as the base include path.
-func preprocessContainerfileContents(logger *logrus.Logger, containerfile string, r io.Reader, ctxDir string, cppFlags []string) (stdout io.Reader, err error) {
-	cppCommand := "cpp"
-	cppPath, err := exec.LookPath(cppCommand)
+const templateEnvContextDir = "BUILDAH_CTXDIR"
+
+var templateLogSeparator = strings.Repeat("-", 40)
+
+func preprocessContainerfileContents(buildOptions *define.BuildOptions, logger *logrus.Logger, fileName string, fileData io.Reader, templateProcessor *define.TemplateProcessorOptions) (io.Reader, error) {
+	var cmdName string
+	var cmdArgs []string
+
+	if templateProcessor.UseBuiltinCpp {
+		// run CPP(1) in preprocess-only mode on the input dockerfile content and use ContextDirectory as the base include path.
+
+		cmdName = "cpp"
+		cmdArgs = []string{"-E", "-iquote", buildOptions.ContextDirectory, "-traditional", "-undef", "-"}
+
+		if flags, ok := os.LookupEnv("BUILDAH_CPPFLAGS"); ok {
+			args, err := shellwords.Parse(flags)
+			if err != nil {
+				return nil, fmt.Errorf("parsing BUILDAH_CPPFLAGS %q: %v", flags, err)
+			}
+			cmdArgs = append(cmdArgs, args...)
+		}
+
+		cmdArgs = append(cmdArgs, buildOptions.CPPFlags...)
+	} else {
+		cmdName = templateProcessor.Cmd[0]
+		cmdArgs = templateProcessor.Cmd[1:]
+	}
+
+	cmdPath, err := exec.LookPath(cmdName)
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
-			err = fmt.Errorf("%v: .in support requires %s to be installed", err, cppCommand)
+			if templateProcessor.UseBuiltinCpp {
+				err = fmt.Errorf("error: %s support requires %s to be installed", fileName, cmdName)
+			} else {
+				err = fmt.Errorf("%v: missing command for template processing: %q", err, cmdName)
+			}
 		}
 		return nil, err
 	}
@@ -506,31 +554,68 @@ func preprocessContainerfileContents(logger *logrus.Logger, containerfile string
 	stdoutBuffer := bytes.Buffer{}
 	stderrBuffer := bytes.Buffer{}
 
-	cppArgs := []string{"-E", "-iquote", ctxDir, "-traditional", "-undef", "-"}
-	if flags, ok := os.LookupEnv("BUILDAH_CPPFLAGS"); ok {
-		args, err := shellwords.Parse(flags)
-		if err != nil {
-			return nil, fmt.Errorf("parsing BUILDAH_CPPFLAGS %q: %v", flags, err)
-		}
-		cppArgs = append(cppArgs, args...)
-	}
-	cppArgs = append(cppArgs, cppFlags...)
-	cmd := exec.Command(cppPath, cppArgs...)
-	cmd.Stdin = r
+	cmd := exec.Command(cmdPath, cmdArgs...)
+	cmd.Stdin = fileData
 	cmd.Stdout = &stdoutBuffer
 	cmd.Stderr = &stderrBuffer
 
+	if templateProcessor.ChdirCtxDir {
+		cmd.Dir = buildOptions.ContextDirectory
+	}
+
+	// propagate ContextDirectory into environment
+	{
+		ctxDirPrefix := templateEnvContextDir + "="
+		ctxDirValue := ctxDirPrefix + buildOptions.ContextDirectory
+
+		cmdEnv := cmd.Environ()
+		cmdEnv = slices.DeleteFunc(
+			cmdEnv,
+			func(s string) bool { return strings.HasPrefix(s, ctxDirPrefix) },
+		)
+		cmdEnv = append(cmdEnv, ctxDirValue)
+		cmd.Env = cmdEnv
+	}
+
 	if err = cmd.Start(); err != nil {
-		return nil, fmt.Errorf("preprocessing %s: %w", containerfile, err)
+		return nil, fmt.Errorf("preprocessing %s: %w", fileName, err)
 	}
-	if err = cmd.Wait(); err != nil {
-		if stderrBuffer.Len() != 0 {
-			logger.Warnf("Ignoring %s\n", stderrBuffer.String())
-		}
-		if stdoutBuffer.Len() == 0 {
-			return nil, fmt.Errorf("preprocessing %s: preprocessor produced no output: %w", containerfile, err)
-		}
+	err = cmd.Wait()
+
+	missingOutput := (stdoutBuffer.Len() == 0)
+	showStderr := ((err != nil) || !templateProcessor.IgnoreStderr) && (stderrBuffer.Len() != 0)
+	wantLog := (err != nil) || missingOutput || showStderr
+
+	if wantLog {
+		logger.Warn(templateLogSeparator)
+		logger.Warnf("preprocessing: %s", fileName)
+		logger.Warnf("command: %q (%q)", cmdName, cmdPath)
 	}
+	if err != nil {
+		logger.Warnf("error: %v", err)
+	}
+	if missingOutput {
+		logger.Warn("command produced no output")
+	}
+	if showStderr {
+		logger.Warnf("command error output:\n%s\n", stderrBuffer.String())
+	}
+	if wantLog {
+		logger.Warn(templateLogSeparator)
+	}
+
+	if err != nil {
+		// allow CPP(1) to exit with non-zero code if output is present
+		if templateProcessor.UseBuiltinCpp && !missingOutput {
+			return &stdoutBuffer, nil
+		}
+
+		return nil, fmt.Errorf("preprocessing %s: error: %w", fileName, err)
+	}
+	if missingOutput {
+		return nil, fmt.Errorf("preprocessing %s: empty output", fileName)
+	}
+
 	return &stdoutBuffer, nil
 }
 

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -128,6 +128,14 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		}
 	}
 
+	templateOpts, err := parse.TemplateOptions(c)
+	if err != nil {
+		return options, nil, nil, err
+	}
+	if err := templateOpts.SanityCheck(); err != nil {
+		return options, nil, nil, err
+	}
+
 	containerfiles := getContainerfiles(iopts.File)
 	format, err := GetFormat(iopts.Format)
 	if err != nil {
@@ -170,7 +178,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 
 	if len(containerfiles) == 0 {
 		// Try to find the Containerfile/Dockerfile within the contextDir
-		containerfile, err := util.DiscoverContainerfile(contextDir)
+		containerfile, err := util.DiscoverContainerfileEx(contextDir, templateOpts.LookupPolicy, templateOpts.SuffixOrder)
 		if err != nil {
 			return options, nil, nil, err
 		}
@@ -456,6 +464,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		StageLabels:             iopts.StageLabels,
 		SystemContext:           systemContext,
 		Target:                  iopts.Target,
+		TemplateOpts:            templateOpts,
 		Timestamp:               timestamp,
 		TransientMounts:         iopts.Volumes,
 		TransientRunMounts:      iopts.TransientRunMounts,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -118,6 +118,8 @@ type BudResults struct {
 	Tag                 []string
 	BuildOutputs        []string
 	Target              string
+	TemplateLookup      string
+	TemplateSpec        []string
 	TLSVerify           bool
 	Jobs                int
 	LogRusage           bool
@@ -333,6 +335,8 @@ newer:   only pull base and SBOM scanner images when newer images exist on the r
 	fs.StringArrayVarP(&flags.Tag, "tag", "t", []string{}, "tagged `name` to apply to the built image")
 	fs.StringArrayVarP(&flags.BuildOutputs, "output", "o", nil, "output destination (format: type=local,dest=path)")
 	fs.StringVar(&flags.Target, "target", "", "set the target build stage to build")
+	fs.StringArrayVar(&flags.TemplateSpec, "template", nil, "define template preprocessor for \"Dockerfile.*\". (format: suffix=cmd[,opts])")
+	fs.StringVar(&flags.TemplateLookup, "template-lookup", DefaultTemplateLookupPolicy(), "set template lookup policy.")
 	fs.Int64Var(&flags.Timestamp, "timestamp", 0, "set new timestamps in image info and layer to `seconds` after the epoch, defaults to current times")
 	fs.BoolVar(&flags.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	fs.String("variant", "", "override the `variant` of the specified image")
@@ -395,6 +399,8 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["source-date-epoch"] = commonComp.AutocompleteNone
 	flagCompletion["tag"] = commonComp.AutocompleteNone
 	flagCompletion["target"] = commonComp.AutocompleteNone
+	flagCompletion["template"] = commonComp.AutocompleteNone
+	flagCompletion["template-lookup"] = commonComp.AutocompleteNone
 	flagCompletion["timestamp"] = commonComp.AutocompleteNone
 	flagCompletion["unsetenv"] = commonComp.AutocompleteNone
 	flagCompletion["unsetlabel"] = commonComp.AutocompleteNone
@@ -534,6 +540,15 @@ func DefaultHistory() bool {
 		return true
 	}
 	return false
+}
+
+// DefaultTemplateLookupPolicy returns the default template lookup policy setting
+func DefaultTemplateLookupPolicy() string {
+	templateLookup := os.Getenv("BUILDAH_TEMPLATE_LOOKUP")
+	if templateLookup != "" {
+		return templateLookup
+	}
+	return "never"
 }
 
 func VerifyFlagsArgsOrder(args []string) error {

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -5,6 +5,7 @@ package parse //nolint:revive,nolintlint
 // would be useful to projects vendoring buildah
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -39,6 +40,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/fileutils"
 	"go.podman.io/storage/pkg/idtools"
+	"go.podman.io/storage/pkg/regexp"
 	"go.podman.io/storage/pkg/unshare"
 	storageTypes "go.podman.io/storage/types"
 	"golang.org/x/term"
@@ -1433,4 +1435,409 @@ func ContainerIgnoreFile(contextDir, path string, containerFiles []string) ([]st
 		return excludes, "", nil
 	}
 	return excludes, path, err
+}
+
+const (
+	templateListDelimChar = ';'
+	templateListDelim     = string(templateListDelimChar)
+
+	templateFileNameSuffix         = `[[:word:]-]+(?:\.[[:word:]-]+)*`
+	templateCommandName            = `[[:word:]/.-]+` // allows paths like /usr/bin/cpp or ./myproc
+	templateCommandOption          = `[[:word:]-]+`
+	templateCommandOptionDelimChar = ','
+	templateCommandOptionDelim     = string(templateCommandOptionDelimChar)
+	templateCommandOptions         = templateCommandOption + `(?:` + templateCommandOptionDelim + templateCommandOption + `)*`
+
+	templateMatchNameFileNameSuffix = `suffix`
+	templateMatchNameCommandName    = `cmd`
+	templateMatchNameCommandOptions = `opts`
+
+	templateNamedMatchFileNameSuffix = `\.?(?P<` + templateMatchNameFileNameSuffix + `>` + templateFileNameSuffix + `)`
+	templateNamedCommandName         = `(?P<` + templateMatchNameCommandName + `>` + templateCommandName + `)`
+	templateNamedMatchCommandOptions = `(?:` + templateCommandOptionDelim + `(?P<` + templateMatchNameCommandOptions + `>` + templateCommandOptions + `))?`
+)
+
+var (
+	templateRegexFileNameSuffix = regexp.Delayed(`^\.?` + templateFileNameSuffix + `$`)
+	templateRegexCommandOptions = regexp.Delayed(`^` + templateCommandOptions + `$`)
+
+	templateRegexPlainSpec = regexp.Delayed(`^` + templateNamedMatchFileNameSuffix + `=` + templateNamedCommandName + templateNamedMatchCommandOptions + `$`)
+)
+
+// TemplateNormalizeSuffix verifies and normalizes a template filename suffix.
+// It removes a leading dot if present and validates the suffix against the
+// allowed character set (letters, digits, underscore, hyphen, dot).
+func TemplateNormalizeSuffix(value string) (string, error) {
+	if !templateRegexFileNameSuffix.MatchString(value) {
+		return "", fmt.Errorf("incorrect template filename suffix value %q", value)
+	}
+
+	return strings.TrimPrefix(value, "."), nil
+}
+
+// TemplateLookupPolicyFromString converts a string to TemplateLookupPolicy.
+// Valid values are "never", "first", "last" (case-insensitive).
+func TemplateLookupPolicyFromString(value string) (define.TemplateLookupPolicy, error) {
+	switch strings.ToLower(value) {
+	case "never":
+		return define.TemplateLookupNever, nil
+	case "first":
+		return define.TemplateLookupFirst, nil
+	case "last":
+		return define.TemplateLookupLast, nil
+	default:
+		return 0, fmt.Errorf("unrecognized template lookup policy value %q", value)
+	}
+}
+
+// TemplateProcessorOptionsApplyFromString applies comma-separated options to
+// TemplateProcessorOptions.
+//
+// Currently supported options: "ignore_stderr", "chdir_ctxdir".
+func TemplateProcessorOptionsApplyFromString(procOptions *define.TemplateProcessorOptions, cmdOptions string) error {
+	if cmdOptions == "" {
+		return nil
+	}
+
+	if !templateRegexCommandOptions.MatchString(cmdOptions) {
+		return fmt.Errorf("incorrect template command options value %q", cmdOptions)
+	}
+
+	opts := strings.Split(cmdOptions, templateCommandOptionDelim)
+	for _, opt := range opts {
+		switch opt {
+		case "ignore_stderr":
+			procOptions.IgnoreStderr = true
+		case "chdir_ctxdir":
+			procOptions.ChdirCtxDir = true
+		default:
+			return fmt.Errorf("unknown template command option value %q", opt)
+		}
+	}
+
+	return nil
+}
+
+func templateProcessorOptionErrorEmpty() (string, *define.TemplateProcessorOptions, error) {
+	return "", nil, errors.New("empty template processor value")
+}
+
+func templateProcessorOptionErrorIncorrect(value string) (string, *define.TemplateProcessorOptions, error) {
+	return "", nil, fmt.Errorf("incorrect template processor value %q", value)
+}
+
+// parseTemplateProcessorOptionJSON parses JSON format: suffix=["cmd","arg"][,opts]
+//
+// Example: "tmpl=["python3","-m","jinja"],ignore_stderr"
+func parseTemplateProcessorOptionJSON(value string) (string, *define.TemplateProcessorOptions, error) {
+	if value == "" {
+		return templateProcessorOptionErrorEmpty()
+	}
+
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 {
+		return templateProcessorOptionErrorIncorrect(value)
+	}
+
+	suffix := parts[0]
+	if suffix == "" {
+		return templateProcessorOptionErrorIncorrect(value)
+	}
+	suffix, err := TemplateNormalizeSuffix(suffix)
+	if err != nil {
+		return templateProcessorOptionErrorIncorrect(value)
+	}
+
+	cmdWithOpts := parts[1]
+	if cmdWithOpts == "" {
+		return templateProcessorOptionErrorIncorrect(value)
+	}
+	if cmdWithOpts[0] != '[' {
+		return templateProcessorOptionErrorIncorrect(value)
+	}
+
+	runeClosingBracket := strings.LastIndexFunc(cmdWithOpts,
+		func(r rune) bool { return r == ']' },
+	)
+	if runeClosingBracket < 0 {
+		return templateProcessorOptionErrorIncorrect(value)
+	}
+
+	cmd := cmdWithOpts[:runeClosingBracket+1]
+
+	var cmdArgs []string
+	err = json.Unmarshal([]byte(cmd), &cmdArgs)
+	if err != nil {
+		return templateProcessorOptionErrorIncorrect(value)
+	}
+	if len(cmdArgs) == 0 {
+		return templateProcessorOptionErrorIncorrect(value)
+	}
+	if cmdArgs[0] == "" {
+		return templateProcessorOptionErrorIncorrect(value)
+	}
+
+	procOpts := define.NewTemplateProcessorOptions()
+	procOpts.Cmd = cmdArgs
+
+	opts := cmdWithOpts[runeClosingBracket+1:]
+	if opts != "" {
+		if opts[0] != templateCommandOptionDelimChar {
+			return templateProcessorOptionErrorIncorrect(value)
+		}
+		opts = opts[1:] // trim leading delimiter
+		if opts == "" {
+			return templateProcessorOptionErrorIncorrect(value)
+		}
+	}
+	if err := TemplateProcessorOptionsApplyFromString(procOpts, opts); err != nil {
+		return suffix, nil, err
+	}
+
+	return suffix, procOpts, nil
+}
+
+// parseTemplateProcessorOptionPlain parses simple format: suffix=cmd[,opts]
+//
+// Example: "in=cpp" or "tmpl=m4,chdir_ctxdir"
+//
+// Special cases:
+//   - cmd = "-" removes handling for this suffix
+//   - cmd = "cpp" enables built-in C preprocessor
+func parseTemplateProcessorOptionPlain(value string) (string, *define.TemplateProcessorOptions, error) {
+	if value == "" {
+		return templateProcessorOptionErrorEmpty()
+	}
+
+	match := templateRegexPlainSpec.FindStringSubmatch(value)
+	if len(match) == 0 {
+		return templateProcessorOptionErrorIncorrect(value)
+	}
+
+	suffix := match[templateRegexPlainSpec.SubexpIndex(templateMatchNameFileNameSuffix)]
+	cmd := match[templateRegexPlainSpec.SubexpIndex(templateMatchNameCommandName)]
+
+	// handle usage like "in=-" and treat it as "remove handling of *.in files"
+	if cmd == "-" {
+		return suffix, nil, nil
+	}
+
+	procOpts := define.NewTemplateProcessorOptions()
+
+	// handle usage like "cmacro=cpp" and treat it as "use builtin cpp handler for *.cmacro files"
+	if strings.ToLower(cmd) == "cpp" {
+		procOpts.UseBuiltinCpp = true
+	} else {
+		procOpts.Cmd = make([]string, 1)
+		procOpts.Cmd[0] = cmd
+	}
+
+	optsIndex := templateRegexPlainSpec.SubexpIndex(templateMatchNameCommandOptions)
+	if optsIndex >= 0 {
+		optsValue := match[optsIndex]
+		if err := TemplateProcessorOptionsApplyFromString(procOpts, optsValue); err != nil {
+			return suffix, nil, err
+		}
+	}
+
+	return suffix, procOpts, nil
+}
+
+func parseTemplateProcessorOption(value string) (string, *define.TemplateProcessorOptions, error) {
+	if value == "" {
+		return templateProcessorOptionErrorEmpty()
+	}
+
+	suffix, procOpts, err := parseTemplateProcessorOptionJSON(value)
+	if err == nil {
+		return suffix, procOpts, nil
+	}
+
+	suffix, procOpts, err = parseTemplateProcessorOptionPlain(value)
+	if err == nil {
+		return suffix, procOpts, nil
+	}
+
+	return templateProcessorOptionErrorIncorrect(value)
+}
+
+// templateProcessorOptionsPlainJSON is used to unmarshal JSON array of objects
+// from the BUILDAH_TEMPLATE environment variable.
+type templateProcessorOptionsPlainJSON struct {
+	Suffix string   `json:"suffix"`
+	Cmd    []string `json:"cmd,omitempty"`
+
+	// sync fields with:
+	// - type `TemplateProcessorOptions` in `define/types.go`
+	// - func `TemplateProcessorOptionsApplyFromString`
+	// NB: "UseBuiltinCpp" is handled separately.
+
+	UseBuiltinCpp bool `json:"builtin_cpp,omitempty"`
+	IgnoreStderr  bool `json:"ignore_stderr,omitempty"`
+	ChdirCtxDir   bool `json:"chdir_ctxdir,omitempty"`
+}
+
+// templateOptionsFromPlainJSONStructArray parses JSON array of objects format:
+// [{"suffix":"in","builtin_cpp":true},{"suffix":"tmpl","cmd":["m4"],"ignore_stderr":true}]
+func templateOptionsFromPlainJSONStructArray(value string) (*define.TemplateOptions, error) {
+	var err error
+
+	var args []templateProcessorOptionsPlainJSON
+	err = json.Unmarshal([]byte(value), &args)
+	if err != nil {
+		return nil, err
+	}
+	if len(args) == 0 {
+		return nil, errors.New("empty JSON array")
+	}
+
+	templateOpts := define.NewTemplateOptionsWithCapacity(len(args))
+
+	for _, arg := range args {
+		suffix, err := TemplateNormalizeSuffix(arg.Suffix)
+		if err != nil {
+			return nil, fmt.Errorf("incorrect suffix %q", arg.Suffix)
+		}
+
+		if !arg.UseBuiltinCpp && (arg.Cmd == nil) {
+			templateOpts.DeleteSuffix(suffix)
+			continue
+		}
+
+		procOpts := define.NewTemplateProcessorOptions()
+		procOpts.IgnoreStderr = arg.IgnoreStderr
+		procOpts.ChdirCtxDir = arg.ChdirCtxDir
+
+		if arg.UseBuiltinCpp {
+			procOpts.UseBuiltinCpp = arg.UseBuiltinCpp
+		} else {
+			procOpts.Cmd = arg.Cmd
+		}
+
+		templateOpts.AddSuffix(suffix, procOpts)
+	}
+
+	return templateOpts, nil
+}
+
+// templateOptionsFromJSONStringArray parses JSON array of strings format:
+// ["in=cpp", "tmpl=m4,ignore_stderr"]
+func templateOptionsFromJSONStringArray(value string) (*define.TemplateOptions, error) {
+	var err error
+
+	var args []string
+	err = json.Unmarshal([]byte(value), &args)
+	if err != nil {
+		return nil, err
+	}
+	if len(args) == 0 {
+		return nil, errors.New("empty JSON array")
+	}
+
+	templateOpts := define.NewTemplateOptionsWithCapacity(len(args))
+
+	for _, arg := range args {
+		suffix, procOpts, err := parseTemplateProcessorOptionPlain(arg)
+		if err != nil {
+			return nil, err
+		}
+
+		// if procOpts is nil then templateOpts.DeleteSuffix(suffix) is applied
+		templateOpts.AddSuffix(suffix, procOpts)
+	}
+
+	return templateOpts, nil
+}
+
+// templateOptionsFromList parses semicolon-separated list format:
+// "in=cpp;tmpl=m4,ignore_stderr"
+func templateOptionsFromList(value string) (*define.TemplateOptions, error) {
+	args := strings.Split(value, templateListDelim)
+
+	templateOpts := define.NewTemplateOptionsWithCapacity(len(args))
+
+	for _, arg := range args {
+		arg = strings.TrimSpace(arg)
+
+		suffix, procOpts, err := parseTemplateProcessorOptionPlain(arg)
+		if err != nil {
+			return nil, err
+		}
+
+		// if procOpts is nil then templateOpts.DeleteSuffix(suffix) is applied
+		templateOpts.AddSuffix(suffix, procOpts)
+	}
+
+	return templateOpts, nil
+}
+
+// TemplateOptionsFromEnv parses the BUILDAH_TEMPLATE environment variable
+// and returns the corresponding TemplateOptions.
+func TemplateOptionsFromEnv() (*define.TemplateOptions, error) {
+	templateEnv := os.Getenv("BUILDAH_TEMPLATE")
+	if templateEnv == "" {
+		return nil, nil
+	}
+
+	// JSON-encoded array
+	if templateEnv[0] == '[' {
+		templateOpts, err := templateOptionsFromPlainJSONStructArray(templateEnv)
+		if err == nil {
+			return templateOpts, nil
+		}
+		templateOpts, err = templateOptionsFromJSONStringArray(templateEnv)
+		if err == nil {
+			return templateOpts, nil
+		}
+		return nil, fmt.Errorf("env $BUILDAH_TEMPLATE: unrecognized value %q", templateEnv)
+	}
+
+	templateOpts, err := templateOptionsFromList(templateEnv)
+	if err == nil {
+		return templateOpts, nil
+	}
+
+	return nil, fmt.Errorf("unrecognized $BUILDAH_TEMPLATE value %q", templateEnv)
+}
+
+// TemplateOptions parses "--template" and "--template-lookup" options.
+func TemplateOptions(c *cobra.Command) (*define.TemplateOptions, error) {
+	return TemplateOptionsFromFlagSet(c.Flags())
+}
+
+// TemplateOptionsFromFlagSet parses "--template" and "--template-lookup" options.
+func TemplateOptionsFromFlagSet(flags *pflag.FlagSet) (*define.TemplateOptions, error) {
+	templateOpts, err := TemplateOptionsFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	if templateOpts == nil {
+		templateOpts = define.NewTemplateOptions()
+	}
+
+	policyValue, _ := flags.GetString("template-lookup")
+	if policyValue != "" {
+		policy, err := TemplateLookupPolicyFromString(policyValue)
+		if err != nil {
+			return nil, err
+		}
+		templateOpts.LookupPolicy = policy
+	}
+
+	templateProcessors, _ := flags.GetStringArray("template")
+	if len(templateProcessors) == 0 {
+		return templateOpts, nil
+	}
+
+	for _, templateProc := range templateProcessors {
+		suffix, procOpts, err := parseTemplateProcessorOption(templateProc)
+		if err != nil {
+			return nil, err
+		}
+
+		// if procOpts is nil then templateOpts.DeleteSuffix(suffix) is applied
+		templateOpts.AddSuffix(suffix, procOpts)
+	}
+
+	return templateOpts, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,11 +1,13 @@
 package util //nolint:revive,nolintlint
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/pkg/parse"
 )
 
@@ -40,43 +42,101 @@ func MirrorToTempFileIfPathIsDescriptor(file string) (string, bool) {
 	return tmpfile.Name(), true
 }
 
-// DiscoverContainerfile tries to find a Containerfile or a Dockerfile within the provided `path`.
-func DiscoverContainerfile(path string) (foundCtrFile string, err error) {
+// filename search order
+var containerFileNames = []string{
+	"Containerfile",
+	"Dockerfile",
+}
+
+func discoverTemplateContainerfile(path string, suffix string) (string, error) {
+	var filePath string
+	var file os.FileInfo
+	var err error
+
+	for _, name := range containerFileNames {
+		if suffix != "" {
+			filePath = filepath.Join(path, name+"."+suffix)
+		} else {
+			filePath = filepath.Join(path, name)
+		}
+
+		file, err = os.Stat(filePath)
+		if err != nil {
+			continue
+		}
+
+		// The file exists, now verify the correct mode
+		if mode := file.Mode(); mode.IsRegular() {
+			return filePath, nil
+		}
+	}
+
+	return "", errors.New("cannot find Containerfile")
+}
+
+func discoverContainerfile(path string) (string, error) {
+	return discoverTemplateContainerfile(path, "")
+}
+
+// DiscoverContainerfileEx searches for a Containerfile or Dockerfile at the given path.
+// When path is a directory, it searches for regular container definition files
+// ("Containerfile", "Dockerfile") and optionally for template files
+// ("Containerfile.suffix", "Dockerfile.suffix") according to the templateLookupPolicy.
+//
+// The templateSuffixOrder defines the list of suffixes to try when searching for
+// template files. The templateLookupPolicy controls whether to try template files
+// before (TemplateLookupFirst), after (TemplateLookupLast), or not at all (TemplateLookupNever).
+//
+// If path is a regular file, it is returned directly without further searching.
+func DiscoverContainerfileEx(path string, templateLookupPolicy define.TemplateLookupPolicy, templateSuffixOrder []string) (string, error) {
 	// Test for existence of the file
 	target, err := os.Stat(path)
 	if err != nil {
-		return "", fmt.Errorf("discovering Containerfile: %w", err)
+		return "", fmt.Errorf("discovering Containerfile: %v", err)
 	}
 
 	switch mode := target.Mode(); {
 	case mode.IsDir():
 		// If the path is a real directory, we assume a Containerfile or a Dockerfile within it
-		ctrfile := filepath.Join(path, "Containerfile")
 
-		// Test for existence of the Containerfile file
-		file, err := os.Stat(ctrfile)
-		if err != nil {
-			// See if we have a Dockerfile within it
-			ctrfile = filepath.Join(path, "Dockerfile")
-
-			// Test for existence of the Dockerfile file
-			file, err = os.Stat(ctrfile)
-			if err != nil {
-				return "", fmt.Errorf("cannot find Containerfile or Dockerfile in context directory: %w", err)
+		if templateLookupPolicy == define.TemplateLookupFirst {
+			for _, suffix := range templateSuffixOrder {
+				filePath, err := discoverTemplateContainerfile(path, suffix)
+				if err == nil {
+					return filePath, nil
+				}
 			}
 		}
 
-		// The file exists, now verify the correct mode
-		if mode := file.Mode(); mode.IsRegular() {
-			foundCtrFile = ctrfile
-		} else {
-			return "", fmt.Errorf("assumed Containerfile %q is not a file", ctrfile)
+		filePath, err := discoverContainerfile(path)
+		if err == nil {
+			return filePath, nil
 		}
+
+		if templateLookupPolicy == define.TemplateLookupLast {
+			for _, suffix := range templateSuffixOrder {
+				filePath, err := discoverTemplateContainerfile(path, suffix)
+				if err == nil {
+					return filePath, nil
+				}
+			}
+		}
+
+		missingNames := strings.Join(containerFileNames, " or ")
+		if len(containerFileNames) > 1 {
+			missingNames = "either " + missingNames
+		}
+		return "", fmt.Errorf("cannot find %s in context directory", missingNames)
 
 	case mode.IsRegular():
 		// If the context dir is a file, we assume this as Containerfile
-		foundCtrFile = path
+		return path, nil
 	}
 
-	return foundCtrFile, nil
+	return "", fmt.Errorf("path is not a file or directory: %s", path)
+}
+
+// DiscoverContainerfile tries to find a Containerfile or a Dockerfile within the provided `path`.
+func DiscoverContainerfile(path string) (string, error) {
+	return DiscoverContainerfileEx(path, define.TemplateLookupNever, nil)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add support for preprocessing Containerfile/Dockerfile files with configurable suffixes and preprocessors. Files with registered suffixes (e.g., .in, .tmpl) are processed by either the built-in C preprocessor (cpp) or external commands before the build.

CLI changes:

- Add `--template` flag for `suffix=preprocessor[,options]` specifications
- Add `--template-lookup` flag to control search order (`first`/`last`/`never`)

Environment variables:

- `BUILDAH_TEMPLATE`: configure templates via semicolon-separated list or JSON
- `BUILDAH_TEMPLATE_LOOKUP`: set default lookup policy

Template options:

- `ignore_stderr`: suppress stderr output unless command fails
- `chdir_ctxdir`: change working directory to build context

The build context directory is always exposed to preprocessors via the `BUILDAH_CTXDIR` environment variable.

This enables features like:
- Decomposing Containerfiles using CPP(1) `#include` directives (.in files)
- Using custom template engines (jinja2, m4, etc.) for dynamic Containerfile generation
- Conditional builds based on environment variables or external configuration

#### How to verify it

1. Default .in file processing with built-in cpp:

```sh
buildah build -f Containerfile.in .
```

2. Custom template processor with lookup policy:

```sh
buildah build --template j2=jinja2 --template-lookup=first .
```

3. Using environment variables:

```sh
export BUILDAH_TEMPLATE="in=- ; j2=jinja2,ignore_stderr"
export BUILDAH_TEMPLATE_LOOKUP="last"
buildah build .
```

4. JSON configuration:

```sh
export BUILDAH_TEMPLATE='[{"suffix":"in","builtin_cpp":true},{"suffix":"tmpl","cmd":["m4"],"ignore_stderr":true}]'
buildah build .
```

5. Remote git repository with file discovery:

```sh
buildah build --template-lookup=first https://github.com/rockdrilla/fork.PodmanHello_in.git
```

Note: the mentioned repository is a fork of [PodmanHello](https://github.com/containers/PodmanHello.git) with `Containerfile` renamed to `Containerfile.in` to demonstrate template processing.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I was unable to run the full test suite locally due to rootless/rootful Podman setup issues on my development machine. The code has been manually tested with various scenarios, but I'd appreciate guidance from maintainers on adding automated tests for this feature.

The implementation includes:

- Backward compatible: existing behavior unchanged when no template options specified

- Flexible configuration: supports CLI flags, environment variables, and multiple formats

- Comprehensive documentation: man page updated with examples

#### Does this PR introduce a user-facing change?

```release-note
Add support for Containerfile/Dockerfile template preprocessing:
- New `--template` flag to define suffix-based preprocessors
- New `--template-lookup` flag to control template search order
- New `BUILDAH_TEMPLATE` environment variable for template configuration
- New `BUILDAH_TEMPLATE_LOOKUP` environment variable for default lookup policy
- Template preprocessors receive build context via `BUILDAH_CTXDIR` environment variable
- Support for built-in C preprocessor (cpp) and custom external commands
- Options: `ignore_stderr` and `chdir_ctxdir` for template preprocessing
```