### PR TITLE
[release-1.43] ignore ErrLayerUnknown in cache lookup

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -2318,6 +2318,9 @@ func (s *StageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 		if image.TopLayer != "" {
 			imageTopLayer, err = s.executor.store.Layer(image.TopLayer)
 			if err != nil {
+				if errors.Is(err, storage.ErrLayerUnknown) {
+					continue
+				}
 				return "", fmt.Errorf("getting top layer info: %w", err)
 			}
 			// Figure out which layer from this image we should


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Description from #6688:

In podman CI I commonly see a flake where build fails with: checking if cached image exists from a previous build: getting top layer info: layer not known

This commit fixes it by simply ignoring the error, if the layer was removed between listing and looking up then this is fine and we can just continue looking for more layers.

#### How to verify it

#### Which issue(s) this PR fixes:

Originally fixed #5674

#### Special notes for your reviewer:

Cherry-picked from #6688 

#### Does this PR introduce a user-facing change?

```release-note
None
```