### PR TITLE
[release-1.42] update test configuration for newer test helpers

### DIFF
--- a/tests/tmt/system.fmf
+++ b/tests/tmt/system.fmf
@@ -11,6 +11,9 @@ environment:
     TUTORIAL_BINARY: /usr/bin/buildah-tutorial
     DUMPSPEC_BINARY: /usr/bin/buildah-dumpspec
     PASSWD_BINARY: /usr/bin/buildah-passwd
+    GRPCNOOP_BINARY: /usr/bin/buildah-grpcnoop
+    WAIT_BINARY: /usr/bin/buildah-wait
+    CRASH_BINARY: /usr/bin/buildah-crash
     TMPDIR: /var/tmp
 
 adjust:


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

The testing farm configuration which runs the tests from packages doesn't direct them to use test helper binaries which are also in the package, and that's causing those tests to fail when they're run elsewhere.

#### How to verify it

After this is merged, testing farm tests in https://github.com/containers/buildah/pull/6763 might pass.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This patch was cherry-picked and trimmed from #6705.

#### Does this PR introduce a user-facing change?

```release-note
None
```