### PR TITLE
tests/helpers.bash: when determining the OCI runtime, use temporary storage

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5583,8 +5583,10 @@ EOM
   expect_output "$buildah_version"
 }
 
-@test "run check --from with arg" {
+@test "bud run check --from with arg" {
   skip_if_no_runtime
+
+  find_oci_runtime
 
   ${OCI} --version
   _prefetch alpine busybox
@@ -7853,6 +7855,8 @@ _EOF
 
   run_buildah build --group-add $id $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}
   expect_output --substring "$id"
+
+  find_oci_runtime
 
   if is_rootless && has_supplemental_groups && ! [[ $OCI =~ runc ]]; then
      run_buildah build --group-add keep-groups $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -15,7 +15,6 @@ PASSWD_BINARY=${PASSWD_BINARY:-$TEST_SOURCES/../bin/passwd}
 GRPCNOOP_BINARY=${GRPCNOOP_BINARY:-$TEST_SOURCES/../bin/grpcnoop}
 STORAGE_DRIVER=${STORAGE_DRIVER:-vfs}
 PATH=$(dirname ${BASH_SOURCE})/../bin:${PATH}
-OCI=${BUILDAH_RUNTIME:-$(${BUILDAH_BINARY} info --format '{{.host.OCIRuntime}}' || command -v runc || command -v crun)}
 # Default timeout for a buildah command.
 BUILDAH_TIMEOUT=${BUILDAH_TIMEOUT:-300}
 
@@ -60,6 +59,9 @@ function setup_tests() {
     # me: "but it's a local file path, not a repository name!"
     # buildah/podman: "i dont care. no caps anywhere!"
     TEST_SCRATCH_DIR=$(mktemp -d --dry-run --tmpdir=${BATS_TMPDIR:-${TMPDIR:-/tmp}} buildah_tests.XXXXXX | tr A-Z a-z)
+    if test -z "${TEST_SCRATCH_DIR}" ; then
+        die error creating temporary directory
+    fi
     mkdir --mode=0700 $TEST_SCRATCH_DIR
 
     mkdir -p ${TEST_SCRATCH_DIR}/{root,runroot,sigstore,registries.d}
@@ -105,21 +107,18 @@ function starthttpd() { # directoryspecs [working-directory-or-"" [certfile, key
     go build -o serve ${TEST_SOURCES}/serve/serve.go
     portfile=$(mktemp)
     if test -z "${portfile}"; then
-        echo error creating temporary file
-        exit 1
+        die error creating temporary file
     fi
     pidfile=$(mktemp)
     if test -z "${pidfile}"; then
-        echo error creating temporary file
-        exit 1
+        die error creating temporary file
     fi
     sh -c "./serve \"${1:-${BATS_TMPDIR}}\" 0 \"${portfile}\" \"${3}\" \"${4}\" ${pidfile} &"
     waited=0
     while ! test -s ${pidfile} ; do
         sleep 0.1
         if test $((++waited)) -ge 300 ; then
-            echo test http server did not write pid file within timeout
-            exit 1
+            die test http server did not write pid file within timeout
         fi
     done
     HTTP_SERVER_PID=$(< ${pidfile})
@@ -128,8 +127,7 @@ function starthttpd() { # directoryspecs [working-directory-or-"" [certfile, key
     while ! test -s ${portfile} ; do
         sleep 0.1
         if test $((++waited)) -ge 300 ; then
-            echo test http server did not start listening within timeout
-            exit 1
+            die test http server did not start listening within timeout
         fi
     done
     HTTP_SERVER_PORT=$(< ${portfile})
@@ -439,6 +437,14 @@ function run_buildah() {
     done
 }
 
+######################
+#  find_oci_runtime  #  Sets $OCI to the command for the OCI runtime, for invoking it directly
+######################
+function find_oci_runtime() {
+    run_buildah info --format '{{.host.OCIRuntime}}'
+    OCI="$output"
+}
+
 #########
 #  die  #  Abort with helpful message
 #########
@@ -662,6 +668,8 @@ function skip_if_rootless() {
 #  skip_if_no_runtime  #  'buildah run' can't work without a runtime
 ########################
 function skip_if_no_runtime() {
+    find_oci_runtime
+
     if type -p "${OCI}" &> /dev/null; then
         return
     fi
@@ -765,8 +773,7 @@ function start_git_daemon() {
   while ! test -s ${TEST_SCRATCH_DIR}/git-daemon/pid ; do
     sleep 0.1
     if test $((++waited)) -ge 300 ; then
-      echo test git server did not write pid file within timeout
-      exit 1
+      die test git server did not write pid file within timeout
     fi
   done
   GITPORT=$(< ${TEST_SCRATCH_DIR}/git-daemon/port)

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -6,6 +6,9 @@ load helpers
 	skip_if_no_runtime
 
 	_prefetch alpine
+
+	find_oci_runtime
+
 	${OCI} --version
 	createrandom ${TEST_SCRATCH_DIR}/randomfile
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
@@ -262,6 +265,8 @@ function configure_and_check_user() {
 	run_buildah run $cid id -G
 	expect_output --substring "$id"
 
+	find_oci_runtime
+
 	if is_rootless && has_supplemental_groups && ! [[ $OCI =~ runc ]]; then
 	   run_buildah from --group-add keep-groups --quiet --pull=false $WITH_POLICY_JSON alpine
 	   cid=$output
@@ -276,6 +281,9 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	_prefetch alpine
+
+	find_oci_runtime
+
 	${OCI} --version
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
@@ -289,6 +297,9 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 
 	_prefetch alpine
+
+	find_oci_runtime
+
 	${OCI} --version
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
 	cid=$output
@@ -316,6 +327,9 @@ function configure_and_check_user() {
 			zflag=z
 		fi
 	fi
+
+	find_oci_runtime
+
 	${OCI} --version
 	_prefetch alpine
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
@@ -345,6 +359,9 @@ function configure_and_check_user() {
 			zflag=z
 		fi
 	fi
+
+	find_oci_runtime
+
 	${OCI} --version
 	_prefetch alpine
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
@@ -422,6 +439,9 @@ function configure_and_check_user() {
 			zflag=,z
 		fi
 	fi
+
+	find_oci_runtime
+
 	${OCI} --version
 	_prefetch alpine
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
@@ -487,6 +507,8 @@ function configure_and_check_user() {
 @test "run symlinks" {
 	skip_if_no_runtime
 
+	find_oci_runtime
+
 	${OCI} --version
 	_prefetch alpine
 	run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
@@ -499,6 +521,8 @@ function configure_and_check_user() {
 
 @test "run --cap-add/--cap-drop" {
 	skip_if_no_runtime
+
+	find_oci_runtime
 
 	${OCI} --version
 	_prefetch alpine
@@ -669,6 +693,8 @@ function configure_and_check_user() {
 	skip_if_no_runtime
 	skip_if_in_container
 
+	find_oci_runtime
+
 	${OCI} --version
         # We use ubuntu image because it has no /etc/hosts file. This
         # allows the fake_host test below to be an equality check,
@@ -774,6 +800,8 @@ function configure_and_check_user() {
 @test "run check /etc/resolv.conf" {
         skip_if_rootless_environment
 	skip_if_no_runtime
+
+	find_oci_runtime
 
 	${OCI} --version
 	_prefetch alpine


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Wait until we have a per-test default storage location set up before attempting to determine which OCI runtime we're using, so that we don't trigger an error message if the system-wide defaults would cause one to be printed.

#### How to verify it

Manually running a test using `bats` as an unprivileged user should no longer print
```bash
Error: mkdir /run/containers/storage: permission denied
WARN[0000] failed to shutdown storage: "mkdir /run/containers/storage: permission denied" 
```
error messages on systems where the system-wide settings haven't been updated to match the expectations of newer versions of go.podman.io/common.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

