### PR TITLE
Group global commands in global help output

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -55,7 +55,8 @@ func createCommand(addCopy string, desc string, short string, opts *addCopyResul
 		Example: `buildah ` + addCopy + ` containerID '/myapp/app.conf'
   buildah ` + addCopy + ` containerID 'app.conf' '/myapp/app.conf'
   buildah ` + addCopy + ` containerID 'app.conf' 'drop-in.conf' '/myapp/app.conf.d/'`,
-		Args: cobra.MinimumNArgs(1),
+		Args:    cobra.MinimumNArgs(1),
+		GroupID: groupContainers,
 	}
 }
 
@@ -106,8 +107,8 @@ func addcopyInit() {
 	var (
 		addDescription  = "\n  Adds the contents of a file, URL, or directory to a container's working\n  directory.  If a local file appears to be an archive, its contents are\n  extracted and added instead of the archive file itself."
 		copyDescription = "\n  Copies the contents of a file, URL, or directory into a container's working\n  directory."
-		shortAdd        = "Add content to the container"
-		shortCopy       = "Copy content into the container"
+		shortAdd        = "Add content to a working container"
+		shortCopy       = "Copy content into a working container"
 		addOpts         addCopyResults
 		copyOpts        addCopyResults
 	)

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -87,6 +87,7 @@ func commitInit() {
 		Example: `buildah commit containerID
   buildah commit containerID newImageName
   buildah commit containerID docker://localhost:5000/imageId`,
+		GroupID: groupContainers,
 	}
 	commitCommand.SetUsageTemplate(UsageTemplate())
 	commitListFlagSet(commitCommand, &opts)

--- a/cmd/buildah/config.go
+++ b/cmd/buildah/config.go
@@ -54,12 +54,12 @@ type configResults struct {
 
 func configInit() {
 	var (
-		configDescription = "\n  Modifies the configuration values which will be saved to the image."
+		configDescription = "\n  Modifies the configuration values which will be committed to an image."
 		opts              configResults
 	)
 	configCommand := &cobra.Command{
 		Use:   "config",
-		Short: "Update image configuration settings",
+		Short: "Update image configuration settings in a working container",
 		Long:  configDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return configCmd(cmd, args, opts)
@@ -67,6 +67,7 @@ func configInit() {
 		Example: `buildah config --author='Jane Austen' --workingdir='/etc/mycontainers' containerID
   buildah config --entrypoint '[ "/entrypoint.sh", "dev" ]' containerID
   buildah config --env foo=bar --env PATH=$PATH containerID`,
+		GroupID: groupContainers,
 	}
 	configCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/containers.go
+++ b/cmd/buildah/containers.go
@@ -80,6 +80,7 @@ func containersInit() {
 		Example: `buildah containers
   buildah containers --format "{{.ContainerID}} {{.ContainerName}}"
   buildah containers -q --noheading --notruncate`,
+		GroupID: groupContainers,
 	}
 	containersCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -58,6 +58,7 @@ func fromInit() {
 		Example: `buildah from --pull imagename
   buildah from docker-daemon:imagename:imagetag
   buildah from --name "myimagename" myregistry/myrepository/imagename:imagetag`,
+		GroupID: groupContainers,
 	}
 	fromCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -86,6 +86,7 @@ func imagesInit() {
 		Example: `buildah images --all
   buildah images [imageName]
   buildah images --format '{{.ID}} {{.Name}} {{.Size}} {{.CreatedAtRaw}}'`,
+		GroupID: groupImages,
 	}
 	imagesCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/info.go
+++ b/cmd/buildah/info.go
@@ -33,6 +33,7 @@ func infoInit() {
 		},
 		Args:    cobra.NoArgs,
 		Example: `buildah info`,
+		GroupID: groupSystem,
 	}
 	infoCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/login.go
+++ b/cmd/buildah/login.go
@@ -35,6 +35,7 @@ func loginInit() {
 			return loginCmd(cmd, args, &opts)
 		},
 		Example: `buildah login quay.io`,
+		GroupID: groupRegistries,
 	}
 	loginCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/logout.go
+++ b/cmd/buildah/logout.go
@@ -26,6 +26,7 @@ func logoutInit() {
 			return logoutCmd(cmd, args, &opts)
 		},
 		Example: `buildah logout quay.io`,
+		GroupID: groupRegistries,
 	}
 	logoutCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -23,6 +23,21 @@ import (
 	"go.podman.io/storage/pkg/unshare"
 )
 
+const (
+	// command group IDs
+	groupImages     = "images"
+	groupContainers = "containers"
+	groupRegistries = "registries"
+	groupSystem     = "system"
+)
+
+var commandGroups = []*cobra.Group{
+	{ID: groupImages, Title: "Image Commands:"},
+	{ID: groupContainers, Title: "Container Commands:"},
+	{ID: groupRegistries, Title: "Registry Commands:"},
+	{ID: groupSystem, Title: "System Commands:"},
+}
+
 type globalFlags struct {
 	Debug                      bool
 	LogLevel                   string
@@ -122,6 +137,7 @@ func mainInit() {
 	if err := rootCmd.PersistentFlags().MarkHidden("memory-profile"); err != nil {
 		logrus.Fatalf("unable to mark memory-profile flag as hidden: %v", err)
 	}
+	rootCmd.AddGroup(commandGroups...)
 }
 
 func initConfig() {

--- a/cmd/buildah/mkcw.go
+++ b/cmd/buildah/mkcw.go
@@ -69,6 +69,7 @@ func mkcwInit() {
 		},
 		Example: `buildah mkcw localhost/repository:typical localhost/repository:cw`,
 		Args:    cobra.ExactArgs(2),
+		GroupID: groupImages,
 	}
 	mkcwCommand.SetUsageTemplate(UsageTemplate())
 	rootCmd.AddCommand(mkcwCommand)

--- a/cmd/buildah/mount.go
+++ b/cmd/buildah/mount.go
@@ -46,6 +46,7 @@ func mountInit() {
   buildah unshare
   buildah mount containerID
 `,
+		GroupID: groupContainers,
 	}
 	mountCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/prune.go
+++ b/cmd/buildah/prune.go
@@ -32,6 +32,7 @@ Cleanup intermediate images as well as build and mount cache.`
 		},
 		Example: `buildah prune
   buildah prune --force`,
+		GroupID: groupSystem,
 	}
 	pruneCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -51,6 +51,7 @@ func pullInit() {
 		Example: `buildah pull imagename
   buildah pull docker-daemon:imagename:imagetag
   buildah pull myregistry/myrepository/imagename:imagetag`,
+		GroupID: groupImages,
 	}
 	pullCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -74,6 +74,7 @@ func pushInit() {
 		Example: `buildah push imageID docker://registry.example.com/repository:tag
   buildah push imageID docker-daemon:image:tagi
   buildah push imageID oci:/path/to/layout:image:tag`,
+		GroupID: groupImages,
 	}
 	pushCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/rename.go
+++ b/cmd/buildah/rename.go
@@ -8,15 +8,16 @@ import (
 )
 
 var (
-	renameDescription = "\n  Renames a local container."
+	renameDescription = "\n  Renames a working container."
 	renameCommand     = &cobra.Command{
 		Use:   "rename",
-		Short: "Rename a container",
+		Short: "Rename a working container",
 		Long:  renameDescription,
 		RunE:  renameCmd,
 		Example: `buildah rename containerName NewName
   buildah rename containerID NewName`,
-		Args: cobra.ExactArgs(2),
+		Args:    cobra.ExactArgs(2),
+		GroupID: groupContainers,
 	}
 )
 

--- a/cmd/buildah/rm.go
+++ b/cmd/buildah/rm.go
@@ -30,6 +30,7 @@ func rmInit() {
 		Example: `buildah rm containerID
   buildah rm containerID1 containerID2 containerID3
   buildah rm --all`,
+		GroupID: groupContainers,
 	}
 	rmCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -33,6 +33,7 @@ func rmiInit() {
 		Example: `buildah rmi imageID
   buildah rmi --all --force
   buildah rmi imageID1 imageID2 imageID3`,
+		GroupID: groupImages,
 	}
 	rmiCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -51,7 +51,7 @@ func runInit() {
 
 	runCommand := &cobra.Command{
 		Use:   "run",
-		Short: "Run a command inside of the container",
+		Short: "Run a command inside of a working container",
 		Long:  runDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.NameSpaceResults = &namespaceResults
@@ -60,6 +60,7 @@ func runInit() {
 		Example: `buildah run containerID -- ps -auxw
   buildah run --terminal containerID /bin/bash
   buildah run --volume /path/on/host:/path/in/container:ro,z containerID /bin/sh`,
+		GroupID: groupContainers,
 	}
 	runCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/tag.go
+++ b/cmd/buildah/tag.go
@@ -18,7 +18,8 @@ var (
 
 		Example: `buildah tag imageName firstNewName
   buildah tag imageName firstNewName SecondNewName`,
-		Args: cobra.MinimumNArgs(2),
+		Args:    cobra.MinimumNArgs(2),
+		GroupID: groupImages,
 	}
 )
 

--- a/cmd/buildah/umount.go
+++ b/cmd/buildah/umount.go
@@ -13,12 +13,13 @@ func umountInit() {
 	umountCommand := &cobra.Command{
 		Use:     "umount",
 		Aliases: []string{"unmount"},
-		Short:   "Unmount the root file system of the specified working containers",
+		Short:   "Unmount the root file system of one or more working containers",
 		Long:    "Unmounts the root file system of the specified working containers.",
 		RunE:    umountCmd,
 		Example: `buildah umount containerID
   buildah umount containerID1 containerID2 containerID3
   buildah umount --all`,
+		GroupID: groupContainers,
 	}
 	umountCommand.SetUsageTemplate(UsageTemplate())
 

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -26,6 +26,7 @@ var (
 		Example: `buildah unshare id
   buildah unshare cat /proc/self/uid_map
   buildah unshare buildah-script.sh`,
+		GroupID: groupSystem,
 	}
 	unshareMounts []string
 )

--- a/cmd/buildah/version.go
+++ b/cmd/buildah/version.go
@@ -50,6 +50,7 @@ func versionInit() {
 		},
 		Args:    cobra.NoArgs,
 		Example: `buildah version`,
+		GroupID: groupSystem,
 	}
 	versionCommand.SetUsageTemplate(UsageTemplate())
 

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -185,13 +185,15 @@ sub tool_help {
     while (my $line = <$fh>) {
         # Cobra is blessedly consistent in its output:
         #    Usage: ...
-        #    Available Commands:
+        #    [Group .Title] (ours always match "\w+\s+Commands:")
+        #       ....
+        #    Additional Commands:
         #       ....
         #    Flags:
         #       ....
         #
         # Start by identifying the section we're in...
-        if ($line =~ /^Available\s+(Commands):/) {
+        if ($line =~ /^\w+\s+(Commands):/) {
             $section = lc $1;
         }
         elsif ($line =~ /^(Flags):/) {

--- a/tests/help.bats
+++ b/tests/help.bats
@@ -6,7 +6,7 @@ load helpers
 # return that list.
 function buildah_commands() {
     run_buildah help "$@" |\
-        awk '/^Available Commands:/{ok=1;next}/^Flags:/{ok=0}ok { print $1 }' |\
+        awk '/^[A-Z][a-z]+ Commands:/{ok=1;next}/^Flags:/{ok=0}ok { print $1 }' |\
         grep .
 }
 
@@ -47,7 +47,6 @@ function check_help() {
         fi
 
         count=$(expr $count + 1)
-
     done
 
     run_buildah "$@" --help
@@ -87,7 +86,6 @@ function check_help() {
     # the old command parser and cobra.
     assert "$count" -gt 0 \
            "Internal error: no commands found in 'buildah help list"
-
 }
 
 @test "buildah help - basic tests" {


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Group the grab bag of top-level commands, in an attempt to make the help output more helpful.

#### How to verify it

Manual inspection.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I'm not strongly tied to the categories.

#### Does this PR introduce a user-facing change?

```release-note
Commands are now grouped in the output of `buildah --help`.
```