### PR TITLE
copier: add RemoveOptions.AllowNotFound

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -516,7 +516,8 @@ func Mkdir(root string, directory string, options MkdirOptions) error {
 
 // RemoveOptions controls parts of Remove()'s behavior.
 type RemoveOptions struct {
-	All bool // if Directory is a directory, remove its contents as well
+	All           bool // if Directory is a directory, remove its contents as well
+	AllowNotFound bool // don't return an error if the item is already not present
 }
 
 // Remove removes the specified directory or item, traversing any intermediate
@@ -2274,6 +2275,9 @@ func copierHandlerRemove(req request) *response {
 		err = os.RemoveAll(resolvedTarget)
 	} else {
 		err = os.Remove(resolvedTarget)
+		if req.RemoveOptions.AllowNotFound && errors.Is(err, os.ErrNotExist) {
+			err = nil
+		}
 	}
 	if err != nil {
 		return errorResponse("copier: remove %q: %v", req.Directory, err)

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -1842,11 +1842,12 @@ func TestRemoveNoChroot(t *testing.T) {
 
 func testRemove(t *testing.T) {
 	type testCase struct {
-		name    string
-		remove  string
-		all     bool
-		fail    bool
-		removed []string
+		name          string
+		remove        string
+		all           bool
+		allowNotFound bool
+		fail          bool
+		removed       []string
 	}
 	testArchives := []struct {
 		name      string
@@ -1875,16 +1876,49 @@ func testRemove(t *testing.T) {
 					removed: []string{"subdir-a/file-a"},
 				},
 				{
+					name:          "file-allow-not-found",
+					remove:        "subdir-a/file-a",
+					allowNotFound: true,
+					removed:       []string{"subdir-a/file-a"},
+				},
+				{
 					name:    "file-all",
 					remove:  "subdir-a/file-a",
 					all:     true,
 					removed: []string{"subdir-a/file-a"},
 				},
 				{
+					name:   "missing-file",
+					remove: "subdir-a/file-missing",
+					fail:   true,
+				},
+				{
+					name:          "missing-file-allow-not-found",
+					remove:        "subdir-a/file-missing",
+					allowNotFound: true,
+				},
+				{
+					name:   "missing-file-all",
+					remove: "subdir-a/file-missing",
+					all:    true,
+				},
+				{
+					name:          "missing-directory-allow-not-found",
+					remove:        "subdir-a/subdir-missing",
+					allowNotFound: true,
+				},
+				{
 					name:   "subdir",
 					remove: "subdir-a/subdir-b",
 					all:    false,
 					fail:   true,
+				},
+				{
+					name:          "subdir-allow-not-found",
+					remove:        "subdir-a/subdir-b",
+					allowNotFound: true,
+					all:           false,
+					fail:          true,
 				},
 				{
 					name:   "subdir-all",
@@ -1963,7 +1997,7 @@ func testRemove(t *testing.T) {
 					dir, err := makeContextFromArchive(t, makeArchive(testArchives[i].headers, nil), "")
 					require.NoErrorf(t, err, "error creating context from archive %q, topdir=%q", testArchives[i].name, "")
 					root := dir
-					options := RemoveOptions{All: testCase.all}
+					options := RemoveOptions{All: testCase.all, AllowNotFound: testCase.allowNotFound}
 					beforeNames := make(map[string]struct{})
 					err = filepath.WalkDir(dir, func(path string, _ fs.DirEntry, err error) error {
 						if err != nil {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:
Add `AllowNotFound` option to `copier.RemoveOptions` so that `copier.Remove()` can silently ignore missing targets when requested. Default behavior is unchanged.

#### How to verify it
Run the copier remove tests:
go test -v -run TestRemove ./copier

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->
Fixes #6780
<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
`AllowNotFound` only applies to the `os.Remove` path. `os.RemoveAll` already returns nil for non-existent targets, so no additional handling is needed there.
  
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

