### PR TITLE
copier: add MkdirOptions.MakeParents

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"go.podman.io/image/v5/pkg/compression"
+	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/archive"
 	"go.podman.io/storage/pkg/fileutils"
 	"go.podman.io/storage/pkg/idtools"
@@ -481,10 +482,11 @@ func Put(root string, directory string, options PutOptions, bulkReader io.Reader
 
 // MkdirOptions controls parts of Mkdir()'s behavior.
 type MkdirOptions struct {
-	UIDMap, GIDMap []idtools.IDMap // map from containerIDs to hostIDs when creating directories
-	ModTimeNew     *time.Time      // set mtime and atime of newly-created directories
-	ChownNew       *idtools.IDPair // set ownership of newly-created directories
-	ChmodNew       *os.FileMode    // set permissions on newly-created directories
+	UIDMap, GIDMap []idtools.IDMap    // map from containerIDs to hostIDs when creating directories
+	MakeParents    types.OptionalBool // create parent directories as needed, default is true
+	ModTimeNew     *time.Time         // set mtime and atime of newly-created directories
+	ChownNew       *idtools.IDPair    // set ownership of newly-created directories
+	ChmodNew       *os.FileMode       // set permissions on newly-created directories
 }
 
 // Mkdir ensures that the specified directory exists.  Any directories which
@@ -2196,7 +2198,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 }
 
 func copierHandlerMkdir(req request, idMappings *idtools.IDMappings) (*response, func() error, error) {
-	errorResponse := func(fmtspec string, args ...any) (*response, func() error, error) { //nolint:unparam
+	errorResponse := func(fmtspec string, args ...any) (*response, func() error, error) {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Mkdir: mkdirResponse{}}, nil, nil
 	}
 	dirUID, dirGID := 0, 0
@@ -2226,10 +2228,19 @@ func copierHandlerMkdir(req request, idMappings *idtools.IDMappings) (*response,
 		return errorResponse("copier: mkdir: error computing path of %q relative to %q: %v", directory, req.Root, err)
 	}
 
-	subdir := ""
+	var subdirs []string
+	if req.MkdirOptions.MakeParents == types.OptionalBoolFalse {
+		subdirs = []string{rel}
+	} else {
+		subdir := ""
+		for component := range strings.SplitSeq(rel, string(os.PathSeparator)) {
+			subdir = filepath.Join(subdir, component)
+			subdirs = append(subdirs, subdir)
+		}
+	}
+
 	var created []string
-	for component := range strings.SplitSeq(rel, string(os.PathSeparator)) {
-		subdir = filepath.Join(subdir, component)
+	for _, subdir := range subdirs {
 		path := filepath.Join(req.Root, subdir)
 		if err := os.Mkdir(path, 0o700); err == nil {
 			if err = chown(path, dirUID, dirGID); err != nil {

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/idtools"
 	"go.podman.io/storage/pkg/reexec"
 )
@@ -1649,9 +1650,11 @@ func TestMkdirNoChroot(t *testing.T) {
 
 func testMkdir(t *testing.T) {
 	type testCase struct {
-		name   string
-		create string
-		expect []string
+		name        string
+		create      string
+		makeParents types.OptionalBool
+		fail        bool
+		expect      []string
 	}
 	testArchives := []struct {
 		name      string
@@ -1738,6 +1741,35 @@ func testMkdir(t *testing.T) {
 					create: "/../intermediate/../final",
 					expect: []string{"final"},
 				},
+				{
+					name:        "basic-no-make-parents",
+					create:      "subdir-d",
+					makeParents: types.OptionalBoolFalse,
+					expect:      []string{"subdir-d"},
+				},
+				{
+					name:        "subdir-no-make-parents",
+					create:      "subdir-d/subdir-e/subdir-f",
+					makeParents: types.OptionalBoolFalse,
+					fail:        true,
+				},
+				{
+					name:        "subdir-make-parents-true",
+					create:      "subdir-d/subdir-e/subdir-f",
+					makeParents: types.OptionalBoolTrue,
+					expect:      []string{"subdir-d", "subdir-d/subdir-e", "subdir-d/subdir-e/subdir-f"},
+				},
+				{
+					name:        "nested-no-make-parents-parents-exist",
+					create:      "subdir-a/subdir-b/subdir-d",
+					makeParents: types.OptionalBoolFalse,
+					expect:      []string{"subdir-a/subdir-b/subdir-d"},
+				},
+				{
+					name:        "existing-no-make-parents",
+					create:      "subdir-a",
+					makeParents: types.OptionalBoolFalse,
+				},
 			},
 		},
 	}
@@ -1748,7 +1780,10 @@ func testMkdir(t *testing.T) {
 					dir, err := makeContextFromArchive(t, makeArchive(testArchives[i].headers, nil), "")
 					require.NoErrorf(t, err, "error creating context from archive %q, topdir=%q", testArchives[i].name, "")
 					root := dir
-					options := MkdirOptions{ChownNew: &idtools.IDPair{UID: os.Getuid(), GID: os.Getgid()}}
+					options := MkdirOptions{
+						ChownNew:    &idtools.IDPair{UID: os.Getuid(), GID: os.Getgid()},
+						MakeParents: testCase.makeParents,
+					}
 					var beforeNames, afterNames []string
 					err = filepath.WalkDir(dir, func(path string, _ fs.DirEntry, err error) error {
 						if err != nil {
@@ -1763,6 +1798,10 @@ func testMkdir(t *testing.T) {
 					})
 					require.NoErrorf(t, err, "error walking directory to catalog pre-Mkdir contents: %v", err)
 					err = Mkdir(root, testCase.create, options)
+					if testCase.fail {
+						require.Errorf(t, err, "expected error creating directory %q under %q with Mkdir", testCase.create, root)
+						return
+					}
 					require.NoErrorf(t, err, "error creating directory %q under %q with Mkdir: %v", testCase.create, root, err)
 					err = filepath.WalkDir(dir, func(path string, _ fs.DirEntry, err error) error {
 						if err != nil {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:
Add `MakeParents` option to `copier.MkdirOptions` so that `copier.Mkdir()` can optionally skip creating parent directories. When `MakeParents` is explicitly set to false, only the final directory is created and the call fails if parent directories don't exist. Default behavior is unchanged.

#### How to verify it
Run the copier mkdir tests:
`go test -v -run TestMkdir ./copier`
  
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->
Fixes #6781
<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

