### PR TITLE
Makefile: add some missing dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,15 +150,7 @@ validate: all install.tools lint-entrypoint
 
 .PHONY: lint-entrypoint
 lint-entrypoint: internal/mkcw/embed/entrypoint_amd64.gz
-	@tmp=$$(mktemp) ; \
-	zcat internal/mkcw/embed/entrypoint_amd64.gz > "$$tmp" ; \
-	if readelf -S "$$tmp" | grep -qE '\.go\.|gopclntab'; then \
-		echo "FAIL: entrypoint_amd64.gz was built using Go fallback path" ; \
-		rm -f "$$tmp" ; \
-		exit 1 ; \
-	fi ; \
-	echo "OK: entrypoint_amd64.gz was built using native assembler" ; \
-	rm -f "$$tmp"
+	$(GO) run tests/validate/was-not-go-compiled.go internal/mkcw/embed/entrypoint_amd64.gz
 
 .PHONY: install.tools
 install.tools:

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ bin/imgtype: $(SOURCES)
 bin/copy: $(SOURCES)
 	$(GO_BUILD) $(BUILDAH_LDFLAGS) -o $@ $(BUILDFLAGS) ./tests/copy/copy.go
 
-bin/tutorial: $(SOURCES)
+bin/tutorial: $(SOURCES) internal/mkcw/embed/entrypoint_amd64.gz
 	$(GO_BUILD) $(BUILDAH_LDFLAGS) -o $@ $(BUILDFLAGS) ./tests/tutorial/tutorial.go
 
 bin/inet: tests/inet/inet.go
@@ -143,13 +143,13 @@ codespell:
 	codespell -w
 
 .PHONY: validate
-validate: install.tools lint-entrypoint
+validate: all install.tools lint-entrypoint
 	./tests/validate/whitespace.sh
 	./hack/xref-helpmsgs-manpages
 	./tests/validate/pr-should-include-tests
 
 .PHONY: lint-entrypoint
-lint-entrypoint:
+lint-entrypoint: internal/mkcw/embed/entrypoint_amd64.gz
 	@tmp=$$(mktemp) ; \
 	zcat internal/mkcw/embed/entrypoint_amd64.gz > "$$tmp" ; \
 	if readelf -S "$$tmp" | grep -qE '\.go\.|gopclntab'; then \
@@ -165,7 +165,7 @@ install.tools:
 	$(MAKE) -C tests/tools
 
 .PHONY: install
-install:
+install: bin/buildah
 	install -d -m 755 $(DESTDIR)/$(BINDIR)
 	install -m 755 bin/buildah $(DESTDIR)/$(BINDIR)/buildah
 	$(MAKE) -C docs install
@@ -182,11 +182,11 @@ install.completions:
 	install -m 644 contrib/completions/bash/buildah $(DESTDIR)/$(BASHINSTALLDIR)/buildah
 
 .PHONY: test-conformance
-test-conformance: tests/conformance/testdata/mount-targets/true
+test-conformance: tests/conformance/testdata/mount-targets/true internal/mkcw/embed/entrypoint_amd64.gz
 	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover -timeout 60m ./tests/conformance
 
 .PHONY: test-integration
-test-integration: install.tools
+test-integration: all install.tools
 	cd tests; ./test_runner.sh
 
 tests/testreport/testreport: tests/testreport/testreport.go
@@ -196,7 +196,7 @@ tests/conformance/testdata/mount-targets/true: tests/conformance/testdata/mount-
 	$(GO_BUILD) $(GO_LDFLAGS) "-linkmode external -extldflags -static" -o tests/conformance/testdata/mount-targets/true tests/conformance/testdata/mount-targets/true.go
 
 .PHONY: test-unit
-test-unit: tests/testreport/testreport
+test-unit: tests/testreport/testreport internal/mkcw/embed/entrypoint_amd64.gz
 	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover $(RACEFLAGS) $(shell $(GO) list ./... | grep -v vendor | grep -v tests | grep -v cmd | grep -v chroot | grep -v copier) -timeout 45m
 	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)"        $(RACEFLAGS) ./chroot ./copier -timeout 60m
 	tmp=$(shell mktemp -d) ; \
@@ -219,7 +219,7 @@ vendor:
 	if test -n "$(strip $(shell $(GO) env GOTOOLCHAIN))"; then go mod edit -toolchain none ; fi
 
 .PHONY: lint
-lint: install.tools
+lint: install.tools internal/mkcw/embed/entrypoint_amd64.gz
 	./tests/tools/build/golangci-lint run $(LINTFLAGS)
 	./tests/tools/build/golangci-lint run --tests=false $(LINTFLAGS)
 
@@ -232,11 +232,3 @@ fmt: install.tools
 .PHONY: rpm
 rpm:  ## Build rpm packages
 	$(MAKE) -C rpm
-
-# Remember that rpms install exec to /usr/bin/buildah while a `make install`
-# installs them to /usr/local/bin/buildah which is likely before. Always use
-# a full path to test installed buildah or you risk to call another executable.
-.PHONY: rpm-install
-rpm-install: package  ## Install rpm packages
-	$(call err_if_empty,PKG_MANAGER) -y install rpm/RPMS/*/*.rpm
-	/usr/bin/buildah version

--- a/tests/copy/copy.go
+++ b/tests/copy/copy.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/containers/buildah"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -21,6 +20,7 @@ import (
 	"go.podman.io/image/v5/transports/alltransports"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage"
+	"go.podman.io/storage/pkg/reexec"
 	"go.podman.io/storage/pkg/unshare"
 )
 
@@ -33,7 +33,7 @@ func main() {
 	var manifestFormat string
 	compressionLevel := -1
 
-	if buildah.InitReexec() {
+	if reexec.Init() {
 		return
 	}
 

--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/docker"
 	"github.com/containers/buildah/util"
@@ -19,11 +18,12 @@ import (
 	"go.podman.io/image/v5/transports/alltransports"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage"
+	"go.podman.io/storage/pkg/reexec"
 	"go.podman.io/storage/pkg/unshare"
 )
 
 func main() {
-	if buildah.InitReexec() {
+	if reexec.Init() {
 		return
 	}
 	unshare.MaybeReexecUsingUserNamespace(false)

--- a/tests/rpc/noop/noop.go
+++ b/tests/rpc/noop/noop.go
@@ -9,18 +9,18 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
 	noop "github.com/containers/buildah/internal/rpc/noop/pb"
 	"github.com/containers/buildah/pkg/cli"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"go.podman.io/storage/pkg/reexec"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
-	if buildah.InitReexec() {
+	if reexec.Init() {
 		return
 	}
 

--- a/tests/validate/was-not-go-compiled.go
+++ b/tests/validate/was-not-go-compiled.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"debug/elf"
+	"io"
+	"log"
+	"os"
+	"strings"
+)
+
+func main() {
+	for _, arg := range os.Args[1:] {
+		compressed, err := os.ReadFile(arg)
+		if err != nil {
+			log.Fatal("reading: ", err)
+		}
+		reader, err := gzip.NewReader(bytes.NewReader(compressed))
+		if err != nil {
+			log.Fatal("decompressing: ", err, " in ", arg)
+		}
+		contents, err := io.ReadAll(reader)
+		if err != nil {
+			log.Fatal("decompressing: ", err, " in ", arg)
+		}
+		elfFile, err := elf.NewFile(bytes.NewReader(contents))
+		if err != nil {
+			log.Fatal("parsing: ", err, " in ", arg)
+		}
+		for _, section := range elfFile.Sections {
+			if strings.Contains(section.Name, ".go") || strings.Contains(section.Name, "gopclntab") {
+				log.Fatal("found section ", section.Name, " in ", arg, ", appears to have been unintentionally cross-rebuilt with Go")
+			}
+		}
+		log.Print(arg, ": OK - appears to have been built using native assembler")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Running `make clean` before assorted targets would cause make to fail unexpectedly when building those targets due to missing target dependencies; add them.  Drop a dependency from the "copy" and "imgtype" test helpers instead of adding it to the Makefile.

Drop the "rpm-install" target, which appears to be unused, as it depends on a "package" dependency which isn't defined in the Makefile.

Rework the lint-entrypoint target to parse the file in Go, to make it easier to catch errors while it's doing its work.

#### How to verify it
Run `make clean` before any other targets.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```