### PR TITLE
Add RunOptions.ValidExitCodes and --valid-exit-codes flag

### DIFF
--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -20,24 +20,25 @@ import (
 )
 
 type runInputOptions struct {
-	addHistory   bool
-	capAdd       []string
-	capDrop      []string
-	cdiConfigDir string
-	contextDir   string
-	devices      []string
-	env          []string
-	hostname     string
-	isolation    string
-	mounts       []string
-	runtime      string
-	runtimeFlag  []string
-	noHostname   bool
-	noHosts      bool
-	noPivot      bool
-	terminal     bool
-	volumes      []string
-	workingDir   string
+	addHistory     bool
+	capAdd         []string
+	capDrop        []string
+	cdiConfigDir   string
+	contextDir     string
+	devices        []string
+	env            []string
+	hostname       string
+	isolation      string
+	mounts         []string
+	runtime        string
+	runtimeFlag    []string
+	noHostname     bool
+	noHosts        bool
+	noPivot        bool
+	terminal       bool
+	validExitCodes []int32
+	volumes        []string
+	workingDir     string
 	*buildahcli.NameSpaceResults
 }
 
@@ -83,6 +84,7 @@ func runInit() {
 	flags.BoolVar(&opts.noHosts, "no-hosts", false, "do not override the /etc/hosts file within the container")
 	flags.BoolVar(&opts.noPivot, "no-pivot", false, "do not use pivot root to jail process inside rootfs")
 	flags.BoolVarP(&opts.terminal, "terminal", "t", false, "allocate a pseudo-TTY in the container")
+	flags.Int32SliceVar(&opts.validExitCodes, "valid-exit-codes", []int32{0}, "list of exit codes to consider successful (default [0])")
 	flags.StringArrayVarP(&opts.volumes, "volume", "v", []string{}, "bind mount a host location into the container while running the command")
 	flags.StringArrayVar(&opts.mounts, "mount", []string{}, "attach a filesystem mount to the container (default [])")
 	flags.StringVar(&opts.workingDir, "workingdir", "", "temporarily set working directory for command (default to container's workingdir)")
@@ -174,6 +176,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 		WorkingDir:       iopts.workingDir,
 		DeviceSpecs:      iopts.devices,
 		CDIConfigDir:     iopts.cdiConfigDir,
+		ValidExitCodes:   iopts.validExitCodes,
 	}
 
 	if c.Flag("terminal").Changed {

--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -301,6 +301,11 @@ that the UTS namespace in which `buildah` itself is being run should be reused,
 or it can be the path to a UTS namespace which is already in use by another
 process.
 
+**--valid-exit-codes** *exitcode[,exitcode,...]*
+
+Specifies a comma-separated list of exit codes that should be considered
+successful.  Defaults to **0**.
+
 **--volume**, **-v** *source*:*destination*:*options*
 
 Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Buildah
@@ -410,6 +415,8 @@ buildah run --volume /path/on/host:/path/in/container:ro,z containerID sh
 buildah run -v /path/on/host:/path/in/container:z,U containerID sh
 
 buildah run --mount type=bind,src=/tmp/on:host,dst=/in:container,ro containerID sh
+
+buildah run --valid-exit-codes 0,1 containerID grep pattern /etc/hosts
 
 ## SEE ALSO
 buildah(1), buildah-from(1), buildah-config(1), namespaces(7), pid\_namespaces(7), crun(1), runc(8), containers.conf(5)

--- a/run.go
+++ b/run.go
@@ -189,6 +189,9 @@ type RunOptions struct {
 	// made to contents of those changes when the container is subsequently
 	// committed.
 	CompatBuiltinVolumes types.OptionalBool
+	// ValidExitCodes is a list of exit codes which should be considered
+	// successful. If empty, only exit code 0 is considered success.
+	ValidExitCodes []int32
 }
 
 // RunMountArtifacts are the artifacts created when using a run mount.

--- a/run_common.go
+++ b/run_common.go
@@ -2227,3 +2227,31 @@ func (b *Builder) createMountTargets(spec *specs.Spec) ([]copier.ConditionalRemo
 	// to clear them out itself now instead of waiting until commit-time
 	return remove, nil
 }
+
+func checkExitCodeError(err error, validExitCodes []int32) error {
+	if len(validExitCodes) == 0 {
+		return err
+	}
+	exitCode, ok := exitCodeFromError(err)
+	if !ok {
+		return err
+	}
+	if slices.Contains(validExitCodes, exitCode) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("exit status %d is not in the valid exit codes list", exitCode)
+}
+
+func exitCodeFromError(err error) (int32, bool) {
+	if err == nil {
+		return 0, true
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return int32(ee.ExitCode()), true
+	}
+	return 0, false
+}

--- a/run_common_test.go
+++ b/run_common_test.go
@@ -1,9 +1,12 @@
 package buildah
 
 import (
+	"errors"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMapContainerNameToHostname(t *testing.T) {
@@ -26,6 +29,41 @@ func TestMapContainerNameToHostname(t *testing.T) {
 		t.Run(cases[i][0], func(t *testing.T) {
 			sanitized := mapContainerNameToHostname(cases[i][0])
 			assert.Equalf(t, cases[i][1], sanitized, "mapping container name %q to a valid hostname", cases[i][0])
+		})
+	}
+}
+
+func TestCheckExitCodeError(t *testing.T) {
+	exitErr := exec.Command("false").Run()
+	require.Error(t, exitErr)
+	var ee *exec.ExitError
+	require.True(t, errors.As(exitErr, &ee))
+	require.Equal(t, 1, ee.ExitCode())
+
+	for _, tc := range []struct {
+		name           string
+		err            error
+		validExitCodes []int32
+		expectNil      bool
+	}{
+		{"nil error, nil codes", nil, nil, true},
+		{"nil error, code 0 listed", nil, []int32{0}, true},
+		{"nil error, code 0 not listed", nil, []int32{1}, false},
+		{"exit error, nil codes", exitErr, nil, false},
+		{"exit error, empty codes", exitErr, []int32{}, false},
+		{"exit error, matching code", exitErr, []int32{1}, true},
+		{"exit error, matching with others", exitErr, []int32{0, 1, 2}, true},
+		{"exit error, non-matching code", exitErr, []int32{2}, false},
+		{"regular error, nil codes", errors.New("test"), nil, false},
+		{"regular error, with codes", errors.New("test"), []int32{1}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := checkExitCodeError(tc.err, tc.validExitCodes)
+			if tc.expectNil {
+				assert.NoError(t, result)
+			} else {
+				assert.Error(t, result)
+			}
 		})
 	}
 }

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -357,7 +357,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	default:
 		err = errors.New("don't know how to run this command")
 	}
-	return err
+	return checkExitCodeError(err, options.ValidExitCodes)
 }
 
 func addCommonOptsToSpec(commonOpts *define.CommonBuildOptions, g *generate.Generator) error {

--- a/run_linux.go
+++ b/run_linux.go
@@ -594,7 +594,7 @@ rootless=%d
 	default:
 		err = errors.New("don't know how to run this command")
 	}
-	return err
+	return checkExitCodeError(err, options.ValidExitCodes)
 }
 
 func (b *Builder) setupOCIHooks(config *specs.Spec, hasVolumes bool) (map[string][]specs.Hook, error) {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1075,3 +1075,26 @@ _EOF
   echo "$output"
   assert "$output" !~ "caught reparented child process"
 }
+
+@test "run-valid-exit-codes" {
+  skip_if_no_runtime
+
+  _prefetch alpine
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON alpine
+  cid=$output
+
+  # Exit 1 fails by default
+  run_buildah 1 run $cid sh -c "exit 1"
+  expect_output --substring "exit status 1"
+
+  # Exit 1 succeeds with --valid-exit-codes 0,1
+  run_buildah run --valid-exit-codes 0,1 $cid sh -c "exit 1"
+
+  # Exit 2 still fails with --valid-exit-codes 0,1
+  run_buildah 2 run --valid-exit-codes 0,1 $cid sh -c "exit 2"
+  expect_output --substring "exit status 2"
+
+  # Exit 0 fails when not in the valid exit codes list
+  run_buildah 125 run --valid-exit-codes 1 $cid sh -c "exit 0"
+  expect_output --substring "not in the valid exit codes list"
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind feature

#### What this PR does / why we need it:
Adds a new field `RunOptions.ValidExitCodes` and a `--valid-exit-codes` CLI flag for `buildah run` that lets specific non-zero exit codes be treated as success, aligning with BuildKit's `Op_Exec.Meta.ValidExitCodes`.

#### How to verify it
```
go test -run TestCheckExitCodeError -v .
bats tests/run.bats -f "run-valid-exit-codes"
```
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

Fixes #6805
<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `--valid-exit-codes` flag for `buildah run` to accept specific non-zero exit codes as success.
```

