### PR TITLE
[release-1.24] CI: force use of registry:2 instead of registry:latest

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,6 +19,9 @@ env:
     CIRRUS_CLONE_DEPTH: 50
     # Unless set by in_podman.sh, default to operating outside of a podman container
     IN_PODMAN: 'false'
+    # Override the default in older VM images, which was registry:latest, which is
+    # now registry 3.x
+    REGISTRY_FQIN: 'docker.io/library/registry:2'
 
     ####
     #### Cache-image names to test with

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -177,6 +177,7 @@ conformance_task:
 
     gce_instance:
         image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
+        cpu: 4
 
     timeout_in: 25m
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Set REGISTRY_FQIN in the CI configuration to "registry:2" so that the default, "registry:latest", won't be set up before our tests, as it expects its configuration to be done differently.

#### How to verify it

Smoke test should pass now.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```