### PR TITLE
[release-1.41] convert some tests to use cached images instead of fedora-minimal

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3007,7 +3007,7 @@ _EOF
 }
 
 @test "bud and test inherit-labels" {
-  base=registry.fedoraproject.org/fedora-minimal
+  base=quay.io/libpod/testimage:20221018
   _prefetch $base
   _prefetch alpine
   run_buildah --version
@@ -3015,37 +3015,37 @@ _EOF
   buildah_version=${output_fields[2]}
   run_buildah build $WITH_POLICY_JSON -t exp -f $BUDFILES/base-with-labels/Containerfile
 
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "license"}}' exp
-  expect_output "MIT" "license must be MIT from fedora base image"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' exp
-  expect_output "fedora-minimal" "name must be fedora from base image"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_by"}}' exp
+  expect_output "test/system/build-testimage" "created_by was supposed to be test/system/build-testimage, not replaced during the build"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_at"}}' exp
+  expect_output "2022-10-18T16:28:08Z" "created_at was supposed to be 2022-10-18T16:28:08Z, not replaced during the build"
 
-  run_buildah build $WITH_POLICY_JSON --inherit-labels=false --label name=world -t exp -f $BUDFILES/base-with-labels/Containerfile
+  run_buildah build $WITH_POLICY_JSON --inherit-labels=false --label created_by=world -t exp -f $BUDFILES/base-with-labels/Containerfile
   # no labels should be inherited from base image, only the buildah version label
-  # and `hello=world` which we just added using cli flag
-  want_output='map["io.buildah.version":"'$buildah_version'" "name":"world"]'
+  # and `created_by=world` which we just added using cli flag
+  want_output='map["created_by":"world" "io.buildah.version":"'$buildah_version'"]'
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' exp
   expect_output "$want_output"
 
   # Try building another file with multiple layers
   run_buildah build $WITH_POLICY_JSON --iidfile ${TEST_SCRATCH_DIR}/id1 --layers -t exp -f $BUDFILES/base-with-labels/Containerfile.layer
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "license"}}' exp
-  expect_output "MIT" "license must be MIT from fedora base image"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' exp
-  expect_output "world" "name must be world from Containerfile"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_by"}}' exp
+  expect_output "world" "created_by was supposed to be world, replacing the value from the base image"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_at"}}' exp
+  expect_output "2022-10-18T16:28:08Z" "created_at was supposed to be inherited from the base image"
 
   # Now build same file with  --inherit-labels=false and verify if we are not using the cache again.
   run_buildah build $WITH_POLICY_JSON --layers --inherit-labels=false --iidfile ${TEST_SCRATCH_DIR}/inherit_false_1 -t exp -f $BUDFILES/base-with-labels/Containerfile.layer
   # Should not contain `Using cache` at all since
   assert "$output" !~ "Using cache"
-  want_output='map["io.buildah.version":"'$buildah_version'" "name":"world"]'
+  want_output='map["created_by":"world" "io.buildah.version":"'$buildah_version'"]'
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' exp
   expect_output "$want_output"
 
   run_buildah build $WITH_POLICY_JSON --layers --inherit-labels=false --iidfile ${TEST_SCRATCH_DIR}/inherit_false_2 -t exp -f $BUDFILES/base-with-labels/Containerfile.layer
   # Should contain `Using cache`
   expect_output --substring " Using cache"
-  want_output='map["io.buildah.version":"'$buildah_version'" "name":"world"]'
+  want_output='map["created_by":"world" "io.buildah.version":"'$buildah_version'"]'
   run_buildah inspect --format '{{printf "%q" .Docker.Config.Labels}}' exp
   expect_output "$want_output"
   assert "$(cat ${TEST_SCRATCH_DIR}/inherit_false_1)" = "$(cat ${TEST_SCRATCH_DIR}/inherit_false_2)" "expected image ids to not change"
@@ -3053,10 +3053,10 @@ _EOF
   # Now build same file with  --inherit-labels=true and verify if using the cache
   run_buildah build $WITH_POLICY_JSON --iidfile ${TEST_SCRATCH_DIR}/id2 --layers --inherit-labels=true -t exp -f $BUDFILES/base-with-labels/Containerfile.layer
   expect_output --substring " Using cache"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "license"}}' exp
-  expect_output "MIT" "license must be MIT from fedora base image"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' exp
-  expect_output "world" "name must be world from Containerfile"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_at"}}' exp
+  expect_output "2022-10-18T16:28:08Z" "created_at was supposed to inherited from the base image"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_by"}}' exp
+  expect_output "world" "created_by was supposed to set during the build, replacing the valud from the base image"
   # Final image id should be exactly same as the one image which was built in the past.
   assert "$(cat ${TEST_SCRATCH_DIR}/id1)" = "$(cat ${TEST_SCRATCH_DIR}/id2)" "expected image ids to not change"
 

--- a/tests/bud/base-with-labels/Containerfile
+++ b/tests/bud/base-with-labels/Containerfile
@@ -1,2 +1,2 @@
-FROM registry.fedoraproject.org/fedora-minimal
+FROM quay.io/libpod/testimage:20221018
 RUN echo hello

--- a/tests/bud/base-with-labels/Containerfile.layer
+++ b/tests/bud/base-with-labels/Containerfile.layer
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal
-LABEL name world
+FROM quay.io/libpod/testimage:20221018
+LABEL created_by world
 RUN echo world
 RUN echo hello

--- a/tests/bud/base-with-labels/Containerfile2
+++ b/tests/bud/base-with-labels/Containerfile2
@@ -1,3 +1,3 @@
-FROM registry.fedoraproject.org/fedora-minimal
+FROM quay.io/libpod/testimage:20221018
 RUN echo hello
 RUN echo world

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -82,18 +82,18 @@ function check_matrix() {
 }
 
 @test "config --unsetlabel" {
-  base=registry.fedoraproject.org/fedora-minimal
+  base=quay.io/libpod/testimage:20221018
   _prefetch $base
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON $base
   cid=$output
-  run_buildah commit $WITH_POLICY_JSON $cid with-name-label
-  run_buildah config --unsetlabel name $cid
-  run_buildah commit $WITH_POLICY_JSON $cid without-name-label
+  run_buildah commit $WITH_POLICY_JSON $cid with-created_by-label
+  run_buildah config --unsetlabel created_by $cid
+  run_buildah commit $WITH_POLICY_JSON $cid without-created_by-label
 
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' with-name-label
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_by"}}' with-created_by-label
   assert "$output" != "" "label should be set in base image"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' without-name-label
-  assert "$output" == "" "name label should be removed"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_by"}}' without-created_by-label
+  assert "$output" == "" "created_by label should be removed"
 }
 
 @test "config --unsetannotation" {


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

A couple of tests make assumptions about which labels the "fedora-minimal:latest" image will have set in it, and those assumptions are no longer true.  Switch them to using one of our pre-cached test images.

#### How to verify it

Updated integration tests!

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```