### PR TITLE
[release-1.37] use a precached image for the "config --unsetlabel" test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,7 +31,7 @@ env:
     IMAGE_PROJECT: "libpod-218412"
     FEDORA_NAME: "fedora-42"
     PRIOR_FEDORA_NAME: "fedora-41"
-    UBUNTU_NAME: "ubuntu-2204"
+    DEBIAN_NAME: "debian-13"
 
     IMAGE_SUFFIX: "c20250910t092246z-f42f41d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -82,18 +82,18 @@ function check_matrix() {
 }
 
 @test "config --unsetlabel" {
-  base=registry.fedoraproject.org/fedora-minimal
+  base=quay.io/libpod/testimage:20221018
   _prefetch $base
   run_buildah from --quiet --pull=false $WITH_POLICY_JSON $base
   cid=$output
-  run_buildah commit $WITH_POLICY_JSON $cid with-name-label
-  run_buildah config --unsetlabel name $cid
-  run_buildah commit $WITH_POLICY_JSON $cid without-name-label
+  run_buildah commit $WITH_POLICY_JSON $cid with-created_by-label
+  run_buildah config --unsetlabel created_by $cid
+  run_buildah commit $WITH_POLICY_JSON $cid without-created_by-label
 
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' with-name-label
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_by"}}' with-created_by-label
   assert "$output" != "" "label should be set in base image"
-  run_buildah inspect --format '{{ index .Docker.Config.Labels "name"}}' without-name-label
-  assert "$output" == "" "name label should be removed"
+  run_buildah inspect --format '{{ index .Docker.Config.Labels "created_by"}}' without-created_by-label
+  assert "$output" == "" "created_by label should be removed"
 }
 
 @test "config set empty entrypoint doesn't wipe cmd" {


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

The brand new version of the base image used in the test for "config --unsetlabel" no longer includes the label that the test assumed it always would.  Switch to using a known image.

#### How to verify it

Updated integration test!

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```