### PR TITLE
build: commit an empty layer instead of a layer with nothing in it

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -105,6 +105,9 @@ type CommitOptions struct {
 	// EmptyLayer tells the builder to omit the diff for the working
 	// container.
 	EmptyLayer bool
+	// EmptyLayerIfEmptyDiff tells the builder to omit the diff for the
+	// working container if it doesn't contain anything.
+	EmptyLayerIfEmptyDiff bool
 	// OmitLayerHistoryEntry tells the builder to omit the diff for the
 	// working container and to not add an entry in the commit history.  By
 	// default, the rest of the image's history is preserved, subject to

--- a/image.go
+++ b/image.go
@@ -126,6 +126,7 @@ type containerImageRef struct {
 	confidentialWorkload  ConfidentialWorkloadOptions
 	omitHistory           bool
 	emptyLayer            bool
+	emptyLayerIfEmptyDiff bool
 	omitLayerHistoryEntry bool
 	idMappingOptions      *define.IDMappingOptions
 	parent                string
@@ -1184,6 +1185,18 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, _ *types.SystemC
 		if err = os.Rename(filepath.Join(path, "layer"), finalBlobName); err != nil {
 			return nil, fmt.Errorf("storing %s to file while renaming %q to %q: %w", what, filepath.Join(path, "layer"), finalBlobName, err)
 		}
+		// If the layer blob is just a block of zeroes of a size that could
+		// plausibly be an empty diff (i.e., if it's several megabytes,
+		// don't bother, because it's highly unlikely), suppress it.
+		if i.emptyLayerIfEmptyDiff && layerID == i.layerID {
+			switch size {
+			case 0, 512, 1024, 2048:
+				if srcHasher.Digest() == digest.Canonical.FromBytes(make([]byte, size)) {
+					i.emptyLayer = true
+					continue
+				}
+			}
+		}
 		mb.addLayer(destHasher.Digest(), size, srcHasher.Digest())
 	}
 
@@ -1764,6 +1777,7 @@ func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageR
 		confidentialWorkload:  options.ConfidentialWorkloadOptions,
 		omitHistory:           options.OmitHistory || forceOmitHistory,
 		emptyLayer:            (options.EmptyLayer || options.OmitLayerHistoryEntry) && !options.Squash && !options.ConfidentialWorkloadOptions.Convert,
+		emptyLayerIfEmptyDiff: options.EmptyLayerIfEmptyDiff && !options.Squash && !options.ConfidentialWorkloadOptions.Convert,
 		omitLayerHistoryEntry: options.OmitLayerHistoryEntry && !options.Squash && !options.ConfidentialWorkloadOptions.Convert,
 		idMappingOptions:      &b.IDMappingOptions,
 		parent:                parent,

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1415,9 +1415,13 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 			// to make some changes to just the config blob.  Whichever
 			// is the case, we need to commit() to create a new image.
 			logCommit(s.output, -1)
-			// No base image means there's nothing to put in a
-			// layer, so don't create one.
-			emptyLayer := (s.builder.FromImageID == "")
+			// Default to only creating a layer blob if there's
+			// something to put in it.  No base image means there's
+			// nothing to put in a layer.
+			var emptyLayer types.OptionalBool
+			if s.builder.FromImageID == "" {
+				emptyLayer = types.OptionalBoolTrue
+			}
 			createdBy, err := s.getCreatedBy(nil, "", lastStage)
 			if err != nil {
 				return "", nil, false, fmt.Errorf("unable to get createdBy for the node: %w", err)
@@ -1594,7 +1598,11 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 				if err != nil {
 					return "", nil, false, fmt.Errorf("unable to get createdBy for the node: %w", err)
 				}
-				imgID, commitResults, err = s.commit(ctx, createdBy, !executedLayerStep, s.output, s.executor.squash, lastStage && lastInstruction)
+				var emptyLayer types.OptionalBool
+				if !executedLayerStep {
+					emptyLayer = types.OptionalBoolTrue
+				}
+				imgID, commitResults, err = s.commit(ctx, createdBy, emptyLayer, s.output, s.executor.squash, lastStage && lastInstruction)
 				if err != nil {
 					return "", nil, false, fmt.Errorf("committing container for step %+v: %w", *step, err)
 				}
@@ -1832,7 +1840,8 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 			// because at this point we want to save history for
 			// layers even if its a squashed build so that they
 			// can be part of the build cache.
-			imgID, commitResults, err = s.commit(ctx, createdBy, !s.stepRequiresLayer(step), commitName, false, lastStage && lastInstruction)
+			emptyLayer := types.NewOptionalBool(!s.stepRequiresLayer(step))
+			imgID, commitResults, err = s.commit(ctx, createdBy, emptyLayer, commitName, false, lastStage && lastInstruction)
 			if err != nil {
 				return "", nil, false, fmt.Errorf("committing container for step %+v: %w", *step, err)
 			}
@@ -1872,7 +1881,8 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 				// version of the image if that's what we're after,
 				// or a normal one if we need to scan the image while
 				// committing it.
-				imgID, commitResults, err = s.commit(ctx, createdBy, !s.stepRequiresLayer(step), commitName, s.executor.squash || s.executor.confidentialWorkload.Convert, lastStage && lastInstruction)
+				emptyLayer := types.NewOptionalBool(!s.stepRequiresLayer(step))
+				imgID, commitResults, err = s.commit(ctx, createdBy, emptyLayer, commitName, s.executor.squash || s.executor.confidentialWorkload.Convert, lastStage && lastInstruction)
 				if err != nil {
 					return "", nil, false, fmt.Errorf("committing final squash step %+v: %w", *step, err)
 				}
@@ -2573,7 +2583,7 @@ func (s *stageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 // commit writes the container's contents to an image, using a passed-in tag as
 // the name if there is one, generating a unique ID-based one otherwise.
 // or commit via any custom exporter if specified.
-func (s *stageExecutor) commit(ctx context.Context, createdBy string, emptyLayer bool, output string, squash, finalInstruction bool) (string, *buildah.CommitResults, error) {
+func (s *stageExecutor) commit(ctx context.Context, createdBy string, emptyLayer types.OptionalBool, output string, squash, finalInstruction bool) (string, *buildah.CommitResults, error) {
 	ib := s.stage.Builder
 	var imageRef types.ImageReference
 	if output != "" {
@@ -2707,7 +2717,8 @@ func (s *stageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 		SystemContext:         s.systemContext,
 		Squash:                squash,
 		OmitHistory:           s.executor.commonBuildOptions.OmitHistory,
-		EmptyLayer:            emptyLayer,
+		EmptyLayer:            emptyLayer == types.OptionalBoolTrue,
+		EmptyLayerIfEmptyDiff: emptyLayer == types.OptionalBoolUndefined,
 		OmitLayerHistoryEntry: s.hasLink,
 		BlobDirectory:         s.executor.blobDirectory,
 		SignBy:                s.executor.signBy,

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -884,6 +884,75 @@ _EOF
   expect_output --substring "Cache burst add diff"
 }
 
+@test "bud build without multiple layers, with and without layer-creating instructions" {
+  local base=busybox
+  _prefetch $base
+
+  contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir -p ${contextdir}
+  createrandom ${contextdir}/randomfile
+
+  # count the number of layers in the base image
+  run_buildah inspect --type=image --format "{{ len .Docker.RootFS.DiffIDs }}" $base
+  local baselayers="$output"
+  local baselayersplusone=$(( ${baselayers} + 1 ))
+  run_buildah inspect --type=image --format "{{ len .Docker.History }}" $base
+  local basehistory="$output"
+
+  for instruction in \
+    "ADD randomfile /" \
+    "ARG A=B" \
+    "COPY randomfile /" \
+    "ENTRYPOINT /bin/bash" \
+    "ENV A=B C=D" \
+    "EXPOSE 85" \
+    "HEALTHCHECK CMD /bin/pwd" \
+    "LABEL A=B C=D" \
+    "MAINTAINER who knows" \
+    "RUN pwd" \
+    "USER 1:2" \
+    "VOLUME /pants" \
+    "WORKDIR /pants" \
+    ; do
+    cat > ${contextdir}/Dockerfile << _EOF
+FROM $base
+$instruction
+_EOF
+    # build an image based on $base with one instruction added"
+    run_buildah build $WITH_POLICY_JSON --iidfile ${TEST_SCRATCH_DIR}/iid.txt ${contextdir}
+    # expect one new history entry
+    run_buildah inspect --type=image --format "{{ len .Docker.History }}" $(< ${TEST_SCRATCH_DIR}/iid.txt)
+    local derivedhistory="$output"
+    assert $derivedhistory -eq $(( ${basehistory} + 1 )) "expected one new history entry in derived image"
+    # count the number of layers in the newly-built image
+    run_buildah inspect --type=image --format "{{ len .Docker.RootFS.DiffIDs }}" $(< ${TEST_SCRATCH_DIR}/iid.txt)
+    local derivedlayers="$output"
+    # expectations vary based on what that instruction was
+    case "$instruction" in
+      # if it's ADD, COPY, or RUN, accept either the same set of layers, or one more layer added,
+      # but not with a digest that matches a turns-out-to-be-empty layer
+      ADD*|COPY*|RUN*)
+        if test ${baselayersplusone} -eq ${derivedlayers} ; then
+          run_buildah inspect --type=image --format "{{ index .Docker.RootFS.DiffIDs $baselayers }}" $(< ${TEST_SCRATCH_DIR}/iid.txt)
+          local lastdiffid="$output"
+          # sha256sum([0]{})
+          assert lastdiffid != sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+          # sha256sum([1024]{})
+          assert lastdiffid != sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef
+          # sha512sum([0]{})
+          assert lastdiffid != sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
+          # sha512sum([1024]{})
+          assert lastdiffid != sha512:8efb4f73c5655351c444eb109230c556d39e2c7624e9c11abc9e3fb4b9b9254218cc5085b454a9698d085cfa92198491f07a723be4574adc70617b73eb0b6461
+        else
+          assert ${baselayers} -eq ${derivedlayers} "should have omitted turned-out-empty layer"
+        fi
+        ;;
+      # every other instruction -> no new layer
+      *) assert ${baselayers} -eq ${derivedlayers} "should not have added new layers for $instruction" ;;
+    esac
+  done
+}
+
 @test "bud build with heredoc content" {
   _prefetch alpine
   run_buildah build -t heredoc $WITH_POLICY_JSON -f $BUDFILES/heredoc/Containerfile .


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When `buildah build`ing an image in single-layer mode, if the generated diff has nothing in it, omit the blob and set the EmptyLayer field in the final history entry, which would otherwise correspond to it.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

Fixes #6860

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Images built by `buildah build` without `--layers=true` will no longer add a layer with no contents to the output image if there were no changes to the working container's root filesystem during the build.
```