### PR TITLE
fix: replace dead len > 2 guard with len != 2 in addSysctl

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -833,7 +833,7 @@ func setupNamespaces(_ *logrus.Logger, g *generate.Generator, namespaceOptions d
 	addSysctl := func(prefixes []string) error {
 		for _, sysctl := range defaultContainerConfig.Sysctls() {
 			splitn := strings.SplitN(sysctl, "=", 2)
-			if len(splitn) > 2 {
+			if len(splitn) != 2 {
 				return fmt.Errorf("sysctl %q defined in containers.conf must be formatted name=value", sysctl)
 			}
 			for _, prefix := range prefixes {


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

`strings.SplitN(s, "=", 2)` returns at most 2 elements, so `len(splitn) > 2` in `addSysctl` is dead code that never fires. When a sysctl in `containers.conf` has no `=`, `splitn` has length 1 and `splitn[1]` panics instead of hitting the error return right below.

Changing `> 2` to `!= 2` kills the dead code and catches the bad input.

#### How to verify it

```
# ~/.config/containers/containers.conf
[containers]
default_sysctls = ["net.core.rmem_max"]
```

Before: `buildah run` panics with `index out of range [1] with length 1`
After: returns `sysctl "net.core.rmem_max" defined in containers.conf must be formatted name=value`

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```