### PR TITLE
[release-1.44] fix opaque whiteout pull error regression

### DIFF
--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -243,6 +243,16 @@ func after(cmd *cobra.Command) error {
 }
 
 func main() {
+	// Not a NOP, see https://github.com/podman-container-tools/buildah/issues/6903.
+	// This is a work around for a bug in the storage library as it does not properly
+	// init IsRootless() there and calls it only in the new chroot without a mounted
+	// /proc making it fail.
+	// Because IsRootless() uses a cache we just need to call it once here to avoid
+	// this problem.
+	// The proper storage fix was done for main here:
+	// https://github.com/podman-container-tools/container-libs/pull/908
+	_ = unshare.IsRootless()
+
 	if buildah.InitReexec() {
 		return
 	}


### PR DESCRIPTION






#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


 /kind bug


#### What this PR does / why we need it:

Buildah 1.44 has a new regression that was caused by me removing a bunch of init() code out of buildah, see commit ce7811fde1.

The bug is actual a storage library issue but because a fix there needs a full vendor dance to get released instead we do this alternative fix for just the buildah 1.44 branch.

#### How to verify it

#### Which issue(s) this PR fixes:

Fixes: #6903

#### Special notes for your reviewer:

The proper fix for storage is here https://github.com/podman-container-tools/container-libs/pull/908
As such I have not submitted this for for buildah@main as we will consume the storage fix on the next upgrade there and have no need for this then.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a regression that could make image pulls fail in a user namespace when using opaque whiteouts
```

