### PR TITLE
copier: add PutOptions.Timestamp for timestamp override

### DIFF
--- a/add.go
+++ b/add.go
@@ -103,7 +103,7 @@ type AddAndCopyOptions struct {
 	// the source paths for source locations which include such a
 	// component.
 	Parents bool
-	// Timestamp is a timestamp to override on all content as it is being read.
+	// Timestamp, if set, overrides timestamps on all added or copied content.
 	Timestamp *time.Time
 	// Link, when set to true, creates an independent layer containing the copied content
 	// that sits on top of existing layers. This layer can be cached and reused
@@ -655,6 +655,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 						ChownFiles:    nil,
 						ChmodFiles:    nil,
 						IgnoreDevices: userns.RunningInUserNS(),
+						Timestamp:     options.Timestamp,
 					}
 					putErr = copier.Put(putRoot, putDir, putOptions, io.TeeReader(pipeReader, hasher))
 				}
@@ -822,6 +823,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 						ChownFiles:      nil,
 						ChmodFiles:      nil,
 						IgnoreDevices:   userns.RunningInUserNS(),
+						Timestamp:       options.Timestamp,
 					}
 					putErr = copier.Put(putRoot, putDir, putOptions, io.TeeReader(pipeReader, hasher))
 				}

--- a/copier/copier.go
+++ b/copier/copier.go
@@ -461,6 +461,7 @@ type PutOptions struct {
 	NoOverwriteDirNonDir bool              // instead of quietly overwriting directories with non-directories, return an error
 	NoOverwriteNonDirDir bool              // instead of quietly overwriting non-directories with directories, return an error
 	Rename               map[string]string // rename items with the specified names, or under the specified names
+	Timestamp            *time.Time        // override timestamps on all extracted content
 }
 
 // Put extracts an archive from the bulkReader at the specified directory.
@@ -1938,6 +1939,14 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 		}
 	}
 	directoryModes := make(map[string]os.FileMode)
+	type directoryTimestamp struct {
+		directory    string
+		atime, mtime time.Time
+	}
+	// track directory timestamps so we can restore them after extraction
+	// because creating entries under a directory updates its mtime.
+	var directoryTimestamps []directoryTimestamp
+	timestamp := req.PutOptions.Timestamp
 	ensureDirectoryUnderRoot := func(directory string) error {
 		rel, err := convertToRelSubdirectory(req.Root, directory)
 		if err != nil {
@@ -1955,6 +1964,13 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				// later, but not if we already had an explicitly-provided mode
 				if _, ok := directoryModes[path]; !ok {
 					directoryModes[path] = defaultDirMode
+				}
+				if timestamp != nil {
+					directoryTimestamps = append(directoryTimestamps, directoryTimestamp{
+						directory: path,
+						atime:     timestamp.UTC(),
+						mtime:     timestamp.UTC(),
+					})
 				}
 			} else {
 				// FreeBSD can return EISDIR for "mkdir /":
@@ -2035,16 +2051,11 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 		}
 	}
 	cb := func() error {
-		type directoryAndTimes struct {
-			directory    string
-			atime, mtime time.Time
-		}
-		var directoriesAndTimes []directoryAndTimes
 		defer func() {
-			for i := range directoriesAndTimes {
-				directoryAndTimes := directoriesAndTimes[len(directoriesAndTimes)-i-1]
-				if err := lutimes(false, directoryAndTimes.directory, directoryAndTimes.atime, directoryAndTimes.mtime); err != nil {
-					logrus.Debugf("error setting access and modify timestamps on %q to %s and %s: %v", directoryAndTimes.directory, directoryAndTimes.atime, directoryAndTimes.mtime, err)
+			for i := range directoryTimestamps {
+				timestamps := directoryTimestamps[len(directoryTimestamps)-i-1]
+				if err := lutimes(false, timestamps.directory, timestamps.atime, timestamps.mtime); err != nil {
+					logrus.Debugf("error setting access and modify timestamps on %q to %s and %s: %v", timestamps.directory, timestamps.atime, timestamps.mtime, err)
 				}
 			}
 			for directory, mode := range directoryModes {
@@ -2215,15 +2226,12 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 					// either we removed it and retried, or it was a directory,
 					// in which case we want to just add the new stuff under it
 				}
-				// make a note of the directory's times.  we
-				// might create items under it, which will
-				// cause the mtime to change after we correct
-				// it, so we'll need to correct it again later
-				directoriesAndTimes = append(directoriesAndTimes, directoryAndTimes{
-					directory: path,
-					atime:     hdr.AccessTime,
-					mtime:     hdr.ModTime,
-				})
+				dt := directoryTimestamp{directory: path, atime: hdr.AccessTime, mtime: hdr.ModTime}
+				if timestamp != nil {
+					dt.atime = timestamp.UTC()
+					dt.mtime = dt.atime
+				}
+				directoryTimestamps = append(directoryTimestamps, dt)
 				// set the mode here unconditionally, in case the directory is in
 				// the archive more than once for whatever reason
 				directoryModes[path] = mode
@@ -2294,7 +2302,10 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				}
 			}
 			// set time
-			if hdr.AccessTime.IsZero() || hdr.AccessTime.Before(hdr.ModTime) {
+			if timestamp != nil {
+				hdr.AccessTime = timestamp.UTC()
+				hdr.ModTime = hdr.AccessTime
+			} else if hdr.AccessTime.IsZero() || hdr.AccessTime.Before(hdr.ModTime) {
 				hdr.AccessTime = hdr.ModTime
 			}
 			if err = lutimes(hdr.Typeflag == tar.TypeSymlink, path, hdr.AccessTime, hdr.ModTime); err != nil {

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -3148,3 +3148,62 @@ func testChmod(t *testing.T) {
 		})
 	}
 }
+
+func TestPutTimestampNoChroot(t *testing.T) {
+	couldChroot := canChroot
+	canChroot = false
+	defer func() { canChroot = couldChroot }()
+	testPutTimestamp(t)
+}
+
+func testPutTimestamp(t *testing.T) {
+	override := time.Unix(1600000000, 0)
+	originalTime := time.Unix(1500000000, 0)
+	uidMap := []idtools.IDMap{{HostID: os.Getuid(), ContainerID: 0, Size: 1}}
+	gidMap := []idtools.IDMap{{HostID: os.Getgid(), ContainerID: 0, Size: 1}}
+
+	t.Run("overrides-archive-entry-timestamps", func(t *testing.T) {
+		root := t.TempDir()
+		archive := makeArchive([]tar.Header{
+			{Name: "subdir/", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: originalTime},
+			{Name: "subdir/file.txt", Typeflag: tar.TypeReg, Size: 3, Mode: 0o644, ModTime: originalTime},
+		}, map[string][]byte{"subdir/file.txt": []byte("abc")})
+		err := Put(root, root, PutOptions{UIDMap: uidMap, GIDMap: gidMap, Timestamp: &override}, archive)
+		require.NoError(t, err)
+
+		for _, name := range []string{"subdir", "subdir/file.txt"} {
+			info, err := os.Lstat(filepath.Join(root, name))
+			require.NoError(t, err)
+			assert.Equal(t, override.Unix(), info.ModTime().Unix(), "%q should have overridden timestamp", name)
+		}
+	})
+
+	t.Run("overrides-created-directory-timestamps", func(t *testing.T) {
+		root := t.TempDir()
+		target := filepath.Join(root, "dest", "nested")
+		archive := makeArchive([]tar.Header{
+			{Name: "a/b/file.txt", Typeflag: tar.TypeReg, Size: 2, Mode: 0o644, ModTime: originalTime},
+		}, map[string][]byte{"a/b/file.txt": []byte("hi")})
+		err := Put(root, target, PutOptions{UIDMap: uidMap, GIDMap: gidMap, Timestamp: &override}, archive)
+		require.NoError(t, err)
+
+		for _, name := range []string{"dest", "dest/nested", "dest/nested/a", "dest/nested/a/b", "dest/nested/a/b/file.txt"} {
+			info, err := os.Lstat(filepath.Join(root, name))
+			require.NoError(t, err)
+			assert.Equal(t, override.Unix(), info.ModTime().Unix(), "%q should have overridden timestamp", name)
+		}
+	})
+
+	t.Run("preserves-original-without-override", func(t *testing.T) {
+		root := t.TempDir()
+		archive := makeArchive([]tar.Header{
+			{Name: "file.txt", Typeflag: tar.TypeReg, Size: 5, Mode: 0o644, ModTime: originalTime},
+		}, map[string][]byte{"file.txt": []byte("hello")})
+		err := Put(root, root, PutOptions{UIDMap: uidMap, GIDMap: gidMap}, archive)
+		require.NoError(t, err)
+
+		info, err := os.Lstat(filepath.Join(root, "file.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, originalTime.Unix(), info.ModTime().Unix())
+	})
+}

--- a/copier/copier_unix_test.go
+++ b/copier/copier_unix_test.go
@@ -160,6 +160,16 @@ func checkStatInfoOwnership(t *testing.T, result *StatForItem) {
 	require.EqualValues(t, 0, result.GID, "expected the owning group to be reported")
 }
 
+func TestPutTimestampChroot(t *testing.T) {
+	if uid != 0 {
+		t.Skip("chroot() requires root privileges, skipping")
+	}
+	couldChroot := canChroot
+	canChroot = true
+	defer func() { canChroot = couldChroot }()
+	testPutTimestamp(t)
+}
+
 func TestTarPutChroot(t *testing.T) {
 	if uid != 0 {
 		t.Skip("chroot() requires root privileges, skipping")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:
Add a Timestamp field to copier.PutOptions so callers can force a specific mtime on all content extracted by Put(). This is the write side counterpart to the existing GetOptions.Timestamp which covers the read side, aligning with BuildKit's FileActionCopy.Timestamp.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->
Fixes #6928

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

