### PR TITLE
golangci-lint: enable nilnesserr, modernize and more govet checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,3 +27,8 @@ linters:
       checks:
         - all
         - -QF1008 # https://staticcheck.dev/docs/checks/#QF1008 Omit embedded fields from selector expression.
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+        - shadow

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ formatters:
 
 linters:
   enable:
+    - nilnesserr
     - nolintlint
     - revive
     - unconvert

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ formatters:
 
 linters:
   enable:
+    - modernize
     - nilnesserr
     - nolintlint
     - revive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,3 +32,7 @@ linters:
       disable:
         - fieldalignment
         - shadow
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/add.go
+++ b/add.go
@@ -636,8 +636,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 				}()
 			}
 
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				b.ContentDigester.Start("")
 				hashCloser := b.ContentDigester.Hash()
 				hasher := io.Writer(hashCloser)
@@ -661,8 +660,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 				}
 				hashCloser.Close()
 				pipeReader.Close()
-				wg.Done()
-			}()
+			})
 			wg.Wait()
 			if getErr != nil {
 				getErr = fmt.Errorf("reading %q: %w", src, getErr)
@@ -739,8 +737,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 				latestTimestamp = st.ModTime
 			}
 			pipeReader, pipeWriter := io.Pipe()
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				renamedItems := 0
 				writer := io.WriteCloser(pipeWriter)
 				if renameTarget != "" {
@@ -796,10 +793,8 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 				if renameTarget != "" && renamedItems > 1 {
 					renameErr = fmt.Errorf("internal error: renamed %d items when we expected to only rename 1", renamedItems)
 				}
-				wg.Done()
-			}()
-			wg.Add(1)
-			go func() {
+			})
+			wg.Go(func() {
 				if st.IsDir {
 					b.ContentDigester.Start("dir")
 				} else {
@@ -829,8 +824,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 				}
 				hashCloser.Close()
 				pipeReader.Close()
-				wg.Done()
-			}()
+			})
 
 			wg.Wait()
 			if getErr != nil {

--- a/bind/mount.go
+++ b/bind/mount.go
@@ -254,9 +254,6 @@ func UnmountMountpoints(mountpoint string, mountpointsToRemove []string) error {
 	// find the top of the tree we're unmounting
 	top := getMountByPoint(mountpoint)
 	if top == nil {
-		if err != nil {
-			return fmt.Errorf("%q is not mounted: %w", mountpoint, err)
-		}
 		return nil
 	}
 	// add all of the mounts that are hanging off of it

--- a/chroot/run_common.go
+++ b/chroot/run_common.go
@@ -146,12 +146,10 @@ func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reade
 	}
 
 	logrus.Debugf("Running %#v in %#v", cmd.Cmd, cmd)
-	confwg.Add(1)
-	go func() {
+	confwg.Go(func() {
 		_, conferr = io.Copy(pwriter, bytes.NewReader(config))
 		pwriter.Close()
-		confwg.Done()
-	}()
+	})
 	cmd.ExtraFiles = append([]*os.File{preader}, cmd.ExtraFiles...)
 	err = cmd.Run()
 	confwg.Wait()
@@ -541,12 +539,10 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 	}
 
 	logrus.Debugf("Running %#v in %#v", cmd.Cmd, cmd)
-	confwg.Add(1)
-	go func() {
+	confwg.Go(func() {
 		_, conferr = io.Copy(pwriter, bytes.NewReader(config))
 		pwriter.Close()
-		confwg.Done()
-	}()
+	})
 	err = cmd.Run()
 	confwg.Wait()
 	signal.Stop(interrupted)

--- a/convertcw.go
+++ b/convertcw.go
@@ -140,9 +140,6 @@ func CWConvertImage(ctx context.Context, systemContext *types.SystemContext, sto
 		}
 	}()
 	sourceInfo := GetBuildInfo(source)
-	if err != nil {
-		return "", nil, "", fmt.Errorf("retrieving info about source image: %w", err)
-	}
 	sourceImageID := sourceInfo.FromImageID
 	sourceSize, err := store.ImageSize(sourceImageID)
 	if err != nil {

--- a/copier/copier.go
+++ b/copier/copier.go
@@ -837,20 +837,16 @@ func copierWithSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req reques
 	stdoutRead = nil
 	var wg sync.WaitGroup
 	var readError, writeError error
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		_, writeError = io.Copy(bulkWriter, bulkWriterRead)
 		bulkWriterRead.Close()
 		bulkWriterRead = nil
-		wg.Done()
-	}()
-	wg.Add(1)
-	go func() {
+	})
+	wg.Go(func() {
 		_, readError = io.Copy(bulkReaderWrite, bulkReader)
 		bulkReaderWrite.Close()
 		bulkReaderWrite = nil
-		wg.Done()
-	}()
+	})
 	wg.Wait()
 	cmdToWaitFor = nil
 	if err = cmd.Wait(); err != nil {

--- a/copier/copier.go
+++ b/copier/copier.go
@@ -1359,8 +1359,6 @@ func checkLinks(item string, req request, info os.FileInfo) (string, os.FileInfo
 }
 
 func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMatcher, idMappings *idtools.IDMappings) (*response, func() error, error) {
-	statRequest := req
-	statRequest.Request = requestStat
 	statResponse := copierHandlerStat(req, pm, idMappings)
 	errorResponse := func(fmtspec string, args ...any) (*response, func() error, error) {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Stat: statResponse.Stat, Get: getResponse{}}, nil, nil

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -798,12 +798,10 @@ func testGetSingle(t *testing.T) {
 						pipeReader, pipeWriter := io.Pipe()
 						var getErr error
 						var wg sync.WaitGroup
-						wg.Add(1)
-						go func() {
+						wg.Go(func() {
 							getErr = Get(root, topdir, getOptions, []string{name}, pipeWriter)
 							pipeWriter.Close()
-							wg.Done()
-						}()
+						})
 						tr := tar.NewReader(pipeReader)
 						hdr, err := tr.Next()
 						for err == nil {
@@ -823,12 +821,10 @@ func testGetSingle(t *testing.T) {
 											getOptions.StripSetgidBit = stripSetgidBit
 											getOptions.StripStickyBit = stripStickyBit
 											pipeReader, pipeWriter := io.Pipe()
-											wg.Add(1)
-											go func() {
+											wg.Go(func() {
 												getErr = Get(root, topdir, getOptions, []string{name}, pipeWriter)
 												pipeWriter.Close()
-												wg.Done()
-											}()
+											})
 											tr := tar.NewReader(pipeReader)
 											hdr, err := tr.Next()
 											for err == nil {
@@ -1605,12 +1601,10 @@ func testGetMultiple(t *testing.T) {
 					pipeReader, pipeWriter := io.Pipe()
 					var getErr error
 					var wg sync.WaitGroup
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
+					wg.Go(func() {
 						getErr = Get(root, topdir, getOptions, []string{testCase.pattern}, pipeWriter)
 						pipeWriter.Close()
-					}()
+					})
 					tr := tar.NewReader(pipeReader)
 					hdr, err := tr.Next()
 					actualContents := []string{}
@@ -3096,13 +3090,11 @@ func testChmod(t *testing.T) {
 
 			pipeReader, pipeWriter := io.Pipe()
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				opts := GetOptions{Chmod: v.chmod, ChmodDirs: v.chmodDirs, ChmodFiles: v.chmodFiles}
 				err = Get(testDir, "", opts, []string{name}, pipeWriter)
 				pipeWriter.Close()
-				wg.Done()
-			}()
+			})
 			tr := tar.NewReader(pipeReader)
 			hdr, tarErr := tr.Next()
 			for tarErr == nil {

--- a/digester.go
+++ b/digester.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -100,8 +101,7 @@ func newTarFilterer(writeCloser io.WriteCloser, filter func(hdr *tar.Header) (sk
 	filterer := &tarFilterer{
 		pipeWriter: pipeWriter,
 	}
-	filterer.wg.Add(1)
-	go func() {
+	filterer.wg.Go(func() {
 		filterer.closedLock.Lock()
 		closed := filterer.closed
 		filterer.closedLock.Unlock()
@@ -161,8 +161,7 @@ func newTarFilterer(writeCloser io.WriteCloser, filter func(hdr *tar.Header) (sk
 		} else {
 			pipeReader.Close()
 		}
-		filterer.wg.Done()
-	}()
+	})
 	return filterer
 }
 
@@ -270,17 +269,17 @@ func (c *CompositeDigester) Digest() (string, digest.Digest) {
 	case 1:
 		return c.digesters[0].ContentType(), c.digesters[0].Digest()
 	default:
-		content := ""
+		var content strings.Builder
 		for i, digester := range c.digesters {
 			if i > 0 {
-				content += ","
+				content.WriteString(",")
 			}
 			contentType := digester.ContentType()
 			if contentType != "" {
 				contentType += ":"
 			}
-			content += contentType + digester.Digest().Encoded()
+			content.WriteString(contentType + digester.Digest().Encoded())
 		}
-		return "multi", digest.Canonical.FromString(content)
+		return "multi", digest.Canonical.FromString(content.String())
 	}
 }

--- a/digester_test.go
+++ b/digester_test.go
@@ -280,8 +280,7 @@ func TestTarFilterer(t *testing.T) {
 			output := make(map[string]string)
 			pipeReader, pipeWriter := io.Pipe()
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				tr := tar.NewReader(pipeReader)
 				hdr, err := tr.Next()
 				for err == nil {
@@ -295,8 +294,7 @@ func TestTarFilterer(t *testing.T) {
 				}
 				require.Equal(t, io.EOF, err, "unexpected error ended our tarstream read")
 				pipeReader.Close()
-				wg.Done()
-			}()
+			})
 			filterer := newTarFilterer(pipeWriter, test.filter)
 			_, err := io.Copy(filterer, &buffer)
 			require.Nil(t, err, "unexpected error copying archive through filter to reader")

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -600,15 +600,16 @@ func (b *executor) buildStage(ctx context.Context, cleanupStages map[int]*stageE
 		// processed like regular steps, and if no modification is done to
 		// layers, its easier to reuse cached layers.
 		if len(b.labels) > 0 {
-			labelLine := "LABEL"
+			var labelLine strings.Builder
+			labelLine.WriteString("LABEL")
 			for _, labelSpec := range b.labels {
 				key, value, _ := strings.Cut(labelSpec, "=")
 				// check only for an empty key since docker allows empty values
 				if key != "" {
-					labelLine += fmt.Sprintf(" %q=%q", key, value)
+					fmt.Fprintf(&labelLine, " %q=%q", key, value)
 				}
 			}
-			appendInstructions = slices.Concat(appendInstructions, []string{labelLine})
+			appendInstructions = slices.Concat(appendInstructions, []string{labelLine.String()})
 		}
 	}
 
@@ -616,16 +617,17 @@ func (b *executor) buildStage(ctx context.Context, cleanupStages map[int]*stageE
 	// at the beginning of the stage so that they affect subsequent RUN instructions and
 	// factor into the image history.
 	if len(b.envs) > 0 {
-		envLine := "ENV"
+		var envLine strings.Builder
+		envLine.WriteString("ENV")
 		for _, envSpec := range b.envs {
 			key, value, hasValue := strings.Cut(envSpec, "=")
 			if hasValue {
-				envLine += fmt.Sprintf(" %q=%q", key, value)
+				fmt.Fprintf(&envLine, " %q=%q", key, value)
 			} else {
 				return "", nil, false, fmt.Errorf("BUG: unresolved environment variable: %q", key)
 			}
 		}
-		prependInstructions = slices.Concat([]string{envLine}, prependInstructions)
+		prependInstructions = slices.Concat([]string{envLine.String()}, prependInstructions)
 	}
 
 	// Create stage labels for all stage images including final stage

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -361,8 +361,7 @@ func joinExcludePatternWithCopySource(srcNorm, excl string) string {
 	if srcNorm == "." {
 		return excl
 	}
-	if strings.HasPrefix(excl, "!") {
-		rest := strings.TrimPrefix(excl, "!")
+	if rest, ok := strings.CutPrefix(excl, "!"); ok {
 		if rest == "" {
 			return excl
 		}
@@ -840,11 +839,12 @@ func (s *stageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 				args = []string{run.Files[0].Data}
 			}
 		} else {
-			full := args[0]
+			var full strings.Builder
+			full.WriteString(args[0])
 			for _, file := range run.Files {
-				full += file.Data + "\n" + file.Name
+				full.WriteString(file.Data + "\n" + file.Name)
 			}
-			args = []string{full}
+			args = []string{full.String()}
 		}
 	}
 	stageMountPoints, err := s.runStageMountPoints(slices.Concat(run.Mounts, s.executor.transientRunMounts))
@@ -2045,7 +2045,7 @@ func (s *stageExecutor) getCreatedBy(node *parser.Node, addedContentSummary stri
 	case "RUN":
 		shArg := ""
 		buildArgs := s.getBuildArgsResolvedForRun()
-		appendCheckSum := ""
+		var appendCheckSum strings.Builder
 		for _, flag := range node.Flags {
 			var err error
 			mountOptionSource := ""
@@ -2108,7 +2108,7 @@ func (s *stageExecutor) getCreatedBy(node *parser.Node, addedContentSummary stri
 			}
 			if mountCheckSum != "" {
 				// add a separator to appendCheckSum
-				appendCheckSum += ":" + mountCheckSum
+				appendCheckSum.WriteString(":" + mountCheckSum)
 			}
 		}
 		if len(node.Original) > 4 {
@@ -2126,7 +2126,7 @@ func (s *stageExecutor) getCreatedBy(node *parser.Node, addedContentSummary stri
 		if buildArgs != "" {
 			result = result + "|" + strconv.Itoa(len(strings.Split(buildArgs, " "))) + " " + buildArgs + " "
 		}
-		result = result + "/bin/sh -c " + shArg + heredoc + appendCheckSum + labelsAndAnnotations
+		result = result + "/bin/sh -c " + shArg + heredoc + appendCheckSum.String() + labelsAndAnnotations
 		return result, nil
 	case "ADD", "COPY":
 		destination := node
@@ -2804,9 +2804,9 @@ func (s *stageExecutor) EnsureContainerPathAs(path, user string, mode *os.FileMo
 // flag set differently should be reflected in its result.  Some build settings
 // only take affect at the final step, so only note those when they're applied.
 func (s *stageExecutor) buildMetadata(isLastStep bool, isAddOrCopy bool) string {
-	unsetLabels := ""
+	var unsetLabels strings.Builder
 	inheritLabels := ""
-	unsetAnnotations := ""
+	var unsetAnnotations strings.Builder
 	inheritAnnotations := ""
 	newAnnotations := ""
 	layerMutations := ""
@@ -2817,12 +2817,12 @@ func (s *stageExecutor) buildMetadata(isLastStep bool, isAddOrCopy bool) string 
 	}
 	// If --unsetlabel was used to clear a label, make a note of it.
 	for _, label := range s.executor.unsetLabels {
-		unsetLabels += "|unsetLabel=" + label
+		unsetLabels.WriteString("|unsetLabel=" + label)
 	}
 	if isLastStep {
 		// If --unsetannotation was used to clear an annotation, make a note of it.
 		for _, annotation := range s.executor.unsetAnnotations {
-			unsetAnnotations += "|unsetAnnotation=" + annotation
+			unsetAnnotations.WriteString("|unsetAnnotation=" + annotation)
 		}
 		// If --inherit-annotation was manually set to false then we cleared the inherited annotations.
 		if s.executor.inheritAnnotations == types.OptionalBoolFalse {
@@ -2855,7 +2855,7 @@ func (s *stageExecutor) buildMetadata(isLastStep bool, isAddOrCopy bool) string 
 	}
 
 	if isAddOrCopy {
-		return unsetLabels + " " + inheritLabels + " " + unsetAnnotations + " " + inheritAnnotations + " " + layerMutations + " " + newAnnotations
+		return unsetLabels.String() + " " + inheritLabels + " " + unsetAnnotations.String() + " " + inheritAnnotations + " " + layerMutations + " " + newAnnotations
 	}
-	return unsetLabels + inheritLabels + unsetAnnotations + inheritAnnotations + layerMutations + newAnnotations
+	return unsetLabels.String() + inheritLabels + unsetAnnotations.String() + inheritAnnotations + layerMutations + newAnnotations
 }

--- a/internal/mkcw/archive.go
+++ b/internal/mkcw/archive.go
@@ -552,8 +552,7 @@ func slop(size int64, slop string) int64 {
 		if factor == "" {
 			continue
 		}
-		if strings.HasSuffix(factor, "%") {
-			percentage := strings.TrimSuffix(factor, "%")
+		if percentage, ok := strings.CutSuffix(factor, "%"); ok {
 			percent, err := strconv.ParseInt(percentage, 10, 8)
 			if err != nil {
 				logrus.Warnf("parsing percentage %q: %v", factor, err)

--- a/internal/volumes/volumes.go
+++ b/internal/volumes/volumes.go
@@ -107,9 +107,9 @@ func convertToOverlay(m specs.Mount, store storage.Store, mountLabel, tmpDir str
 		}
 		if mountedOverlay.Type != define.TypeBind {
 			if err2 := overlay.RemoveTemp(overlayDir); err2 != nil {
-				return specs.Mount{}, "", fmt.Errorf("cleaning up after failing to set up overlay: %v, while setting up overlay for %q: %w", err2, destination, err)
+				return specs.Mount{}, "", fmt.Errorf("cleaning up after failing to set up overlay for %q: %w", destination, err2)
 			}
-			return specs.Mount{}, "", fmt.Errorf("setting up overlay for %q at %q: %w", mountedOverlay.Source, destination, err)
+			return specs.Mount{}, "", fmt.Errorf("setting up overlay for %q at %q, incorrect mount type: %q (expected \"bind\")", mountedOverlay.Source, destination, mountedOverlay.Type)
 		}
 		mountThisInstead = mountedOverlay
 		mountThisInstead.Source = filepath.Join(mountedOverlay.Source, sourceBase)

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -594,8 +594,8 @@ func LookupEnvVarReferences(specs, environ []string) []string {
 			result = append(result, environ...)
 		} else {
 			prefix := key + "="
-			if strings.HasSuffix(key, "*") {
-				prefix = strings.TrimSuffix(key, "*")
+			if before, ok := strings.CutSuffix(key, "*"); ok {
+				prefix = before
 			}
 
 			for _, spec := range environ {

--- a/pkg/sshagent/sshagent.go
+++ b/pkg/sshagent/sshagent.go
@@ -114,15 +114,13 @@ func (a *AgentServer) Serve(processLabel string) (string, error) {
 					continue
 				}
 			}
-			a.wg.Add(1)
-			go func() {
+			a.wg.Go(func() {
 				// agent.ServeAgent will only ever return with error,
 				err := agent.ServeAgent(a.agent, c)
 				if err != io.EOF {
 					logrus.Errorf("error serving agent: %v", err)
 				}
-				a.wg.Done()
-			}()
+			})
 			// the only way to get agent.ServeAgent is to close the connection it's serving on
 			// TODO: ideally we should use some sort of forwarding mechanism for output instead of manually closing connection.
 			go func() {

--- a/run_common.go
+++ b/run_common.go
@@ -591,19 +591,17 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 	if err != nil {
 		return 1, fmt.Errorf("parsing pid %s as a number: %w", string(pidValue), err)
 	}
-	var stopped uint32
+	var stopped atomic.Uint32
 	var reaping sync.WaitGroup
-	reaping.Add(1)
-	go func() {
-		defer reaping.Done()
+	reaping.Go(func() {
 		var err error
 		_, err = unix.Wait4(pid, &wstatus, 0, nil)
 		if err != nil {
 			wstatus = 0
 			options.Logger.Errorf("error waiting for container child process %d: %v\n", pid, err)
 		}
-		atomic.StoreUint32(&stopped, 1)
-	}()
+		stopped.Store(1)
+	})
 
 	if configureNetwork {
 		if _, err := containerCreateW.Write([]byte{1}); err != nil {
@@ -638,11 +636,11 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 		return 1, fmt.Errorf("from %s starting container: %w", runtime, err)
 	}
 	defer func() {
-		if atomic.LoadUint32(&stopped) == 0 {
+		if stopped.Load() == 0 {
 			if err := kill("").Run(); err != nil {
 				options.Logger.Infof("error from %s stopping container: %v", runtime, err)
 			}
-			atomic.StoreUint32(&stopped, 1)
+			stopped.Store(1)
 		}
 	}()
 
@@ -665,7 +663,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 		stat.Stderr = os.Stderr
 		stateOutput, err := stat.Output()
 		if err != nil {
-			if atomic.LoadUint32(&stopped) != 0 {
+			if stopped.Load() != 0 {
 				// container exited
 				break
 			}
@@ -678,20 +676,20 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 		case specs.StateCreating, specs.StateCreated, specs.StateRunning:
 			// all fine
 		case specs.StateStopped:
-			atomic.StoreUint32(&stopped, 1)
+			stopped.Store(1)
 		default:
 			return 1, fmt.Errorf("container status unexpectedly changed to %q", state.Status)
 		}
-		if atomic.LoadUint32(&stopped) != 0 {
+		if stopped.Load() != 0 {
 			break
 		}
 		select {
 		case <-finishedCopy:
-			atomic.StoreUint32(&stopped, 1)
+			stopped.Store(1)
 		case <-time.After(time.Until(now.Add(100 * time.Millisecond))):
 			continue
 		}
-		if atomic.LoadUint32(&stopped) != 0 {
+		if stopped.Load() != 0 {
 			break
 		}
 	}
@@ -1190,14 +1188,12 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 	if err != nil {
 		return fmt.Errorf("creating configuration pipe: %w", err)
 	}
-	confwg.Add(1)
-	go func() {
+	confwg.Go(func() {
 		_, conferr = io.Copy(pwriter, bytes.NewReader(config))
 		if conferr != nil {
 			conferr = fmt.Errorf("while copying configuration down pipe to child process: %w", conferr)
 		}
-		confwg.Done()
-	}()
+	})
 
 	// create network configuration pipes
 	var containerCreateR, containerCreateW fileCloser

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -233,26 +233,22 @@ func testConformanceInternal(t *testing.T, dateStamp string, testIndex int, muta
 	pipeReader, pipeWriter := io.Pipe()
 	var getErr, putErr error
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		if test.contextDir != "" {
 			getErr = copier.Get("", testDataDir, copier.GetOptions{}, []string{test.contextDir}, pipeWriter)
 		} else if test.dockerfile != "" {
 			getErr = copier.Get("", testDataDir, copier.GetOptions{}, []string{test.dockerfile}, pipeWriter)
 		}
 		pipeWriter.Close()
-		wg.Done()
-	}()
-	wg.Add(1)
-	go func() {
+	})
+	wg.Go(func() {
 		if test.contextDir != "" || test.dockerfile != "" {
 			putErr = copier.Put("", contextDir, copier.PutOptions{}, pipeReader)
 		} else {
 			putErr = os.Mkdir(contextDir, 0o755)
 		}
 		pipeReader.Close()
-		wg.Done()
-	}()
+	})
 	wg.Wait()
 	assert.NoErrorf(t, getErr, "error reading build info from %q", filepath.Join("testdata", test.dockerfile))
 	assert.NoErrorf(t, putErr, "error writing build info to %q", contextDir)

--- a/util.go
+++ b/util.go
@@ -157,18 +157,14 @@ func extractWithTar(root, src, dest string) error {
 
 	pipeReader, pipeWriter := io.Pipe()
 
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		getErr = copier.Get(root, src, copier.GetOptions{}, []string{"."}, pipeWriter)
 		pipeWriter.Close()
-		wg.Done()
-	}()
-	wg.Add(1)
-	go func() {
+	})
+	wg.Go(func() {
 		putErr = copier.Put(dest, dest, copier.PutOptions{}, pipeReader)
 		pipeReader.Close()
-		wg.Done()
-	}()
+	})
 	wg.Wait()
 
 	if getErr != nil {


### PR DESCRIPTION

#### What type of PR is this?


#### What this PR does / why we need it:

Enable more checks that catch issues and fix some of them. In this case
things reported by nilness and unusedwrite.
I enabled all checks except fieldalignment and shadow as they produce a
lot of warnings that are not real issues.

see https://golangci-lint.run/docs/linters/configuration/#govet

---

golangci-lint: show all issues at once

By default golangci-lint does not show all error which makes it look
like there is not that much to fix, however in just shows a maximum of
50 issues per linter and a maximum of 3 issues with the same text.

It is much better to see all at once locally to know how much work it is
to fix a new linter.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

