### PR TITLE
imagebuildah: default RUN --mount type to bind for cache checksums

### DIFF
--- a/imagebuildah/util.go
+++ b/imagebuildah/util.go
@@ -10,6 +10,7 @@ import (
 
 	digest "github.com/opencontainers/go-digest"
 	"go.podman.io/buildah"
+	"go.podman.io/buildah/define"
 )
 
 type mountInfo struct {
@@ -19,12 +20,14 @@ type mountInfo struct {
 }
 
 // Consumes mount flag in format of `--mount=type=bind,src=/path,from=image` and
-// return mountInfo with values, otherwise values are empty if keys are not present in the option.
+// return mountInfo with values. Source and From are empty if not present in the
+// option; Type defaults to "bind" if not present, matching the default used
+// when the mount is actually set up (see internal/volumes.getMounts).
 func getFromAndSourceKeysFromMountFlag(mount string) mountInfo {
 	tokens := strings.Split(strings.TrimPrefix(mount, "--mount="), ",")
 	source := ""
 	from := ""
-	mountType := ""
+	mountType := define.TypeBind
 	for _, option := range tokens {
 		if optionSplit := strings.Split(option, "="); len(optionSplit) == 2 {
 			if optionSplit[0] == "src" || optionSplit[0] == "source" {

--- a/imagebuildah/util_test.go
+++ b/imagebuildah/util_test.go
@@ -10,7 +10,51 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"go.podman.io/buildah/define"
 )
+
+func TestGetFromAndSourceKeysFromMountFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		mount    string
+		expected mountInfo
+	}{
+		{
+			name:     "type omitted defaults to bind",
+			mount:    "--mount=src=/foo,target=/bar",
+			expected: mountInfo{Type: define.TypeBind, Source: "/foo"},
+		},
+		{
+			name:     "explicit bind type",
+			mount:    "--mount=type=bind,src=/foo,target=/bar",
+			expected: mountInfo{Type: "bind", Source: "/foo"},
+		},
+		{
+			name:     "cache type is not treated as bind",
+			mount:    "--mount=type=cache,target=/bar",
+			expected: mountInfo{Type: "cache"},
+		},
+		{
+			name:     "tmpfs type is not treated as bind",
+			mount:    "--mount=type=tmpfs,target=/bar",
+			expected: mountInfo{Type: "tmpfs"},
+		},
+		{
+			name:     "from without type defaults to bind",
+			mount:    "--mount=from=builder,src=/foo,target=/bar",
+			expected: mountInfo{Type: define.TypeBind, Source: "/foo", From: "builder"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, getFromAndSourceKeysFromMountFlag(tt.mount))
+		})
+	}
+}
 
 func TestGeneratePathChecksum(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

`getFromAndSourceKeysFromMountFlag()` parses a `RUN --mount=...` flag to decide whether `getCreatedBy()` should checksum the mounted content for the build-cache fingerprint. When a Dockerfile omits `type=` (the normal, idiomatic way to write a bind mount, since bind is the implicit default per the Dockerfile/BuildKit mount syntax), this parser left `Type` empty instead of defaulting it to `"bind"` — unlike buildah's other mount parser, the one that actually sets mounts up (`internal/volumes/volumes.go`'s `getMounts()`, which does default `mountType := define.TypeBind`).

Because of that, `getCreatedBy()`'s `if mountInfo.Type != "bind" { continue }` check skipped checksumming the mounted content for any implicit-bind mount — whether sourced from the build context, another build stage, an image, or an additional build context. Two builds with identical Dockerfile text but different mounted file content ended up with an identical cache key, so the second build silently reused the first build's cached layer instead of picking up the new content.

The fix defaults the parsed mount type to `define.TypeBind`, matching the default already used by the real mount-setup parser. `type=cache` and `type=tmpfs` mounts remain correctly excluded from checksumming — that's intentional, since persisting regardless of build content is their whole purpose.

#### How to verify it

1. Create a build context with a file, e.g. `data.txt` containing `foo`.
2. Build a Dockerfile that uses an implicit bind mount (no `type=`):
   ```
   FROM alpine
   RUN --mount=src=data.txt,target=/tmp/data.txt cat /tmp/data.txt
   ```
   using `buildah build --layers .` — it prints `foo`.
3. Change `data.txt` to contain `bar`, then rebuild the same Dockerfile with `--layers` again.
4. **Before this fix**: the second build reuses the cached layer and still prints `foo`, even though the mounted file changed. **After this fix**: the cache is correctly invalidated and the second build prints `bar`.

A unit test was also added, `TestGetFromAndSourceKeysFromMountFlag` in `imagebuildah/util_test.go`, which fails without this fix (asserts `Type` defaults to `"bind"` when `type=` is omitted) and passes with it:
```
go test -run TestGetFromAndSourceKeysFromMountFlag ./imagebuildah/...
```

#### Which issue(s) this PR fixes:

Fixes podman-container-tools/podman#29126

#### Special notes for your reviewer:

This bug was reported against podman (originally containers/podman#29126, now podman-container-tools/podman#29126 after the org transfer), but root-caused to buildah — `podman build` vendors buildah's `imagebuildah` package. There is no separate buildah-side issue tracking this; per CONTRIBUTING.md, a PR alone is sufficient as long as its description includes what an issue report would (repro steps + root cause), which this PR provides above.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a build-cache bug where `RUN --mount` flags that omit `type=` (an implicit bind mount) were not checksummed for cache invalidation, causing builds to silently reuse a stale cached layer when only the mounted file's content changed.
```