### PR TITLE
docs: fix typo in --dns-option flag reference in buildah-run.1.md

### DIFF
--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -190,7 +190,7 @@ Sets the configuration for the network namespace for the container.
 
 Valid _mode_ values are:
 
-- **none**: no networking. Invalid if using **--dns**, **--dns-opt**, or **--dns-search**;
+- **none**: no networking. Invalid if the builder is configured with **--dns**, **--dns-option**, or **--dns-search**;
 - **host**: use the host network stack. Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure;
 - **ns:**_path_: path to a network namespace to join;
 - **private**: create a new namespace for the container (default)


### PR DESCRIPTION
Fixes the incorrect flag name `--dns-opt` to `--dns-option` in the `buildah-run.1.md` documentation, as the CLI flag is `--dns-option` and `--dns-opt` does not exist. Closes #6954.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._