### PR TITLE
seccomp: reject --security-opt seccomp=profile when support is unavailable

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -325,6 +325,9 @@ func parseSecurityOpts(securityOpts []string, commonOpts *define.CommonBuildOpti
 		case "apparmor":
 			commonOpts.ApparmorProfile = con[1]
 		case "seccomp":
+			if !supportsSeccomp && con[1] != "unconfined" {
+				return fmt.Errorf("seccomp profile %q requested, but seccomp support is not enabled in this build", con[1])
+			}
 			commonOpts.SeccompProfilePath = con[1]
 		case "mask":
 			commonOpts.Masks = append(commonOpts.Masks, strings.Split(con[1], ":")...)
@@ -343,7 +346,7 @@ func parseSecurityOpts(securityOpts []string, commonOpts *define.CommonBuildOpti
 		}
 	}
 
-	if commonOpts.SeccompProfilePath == "" {
+	if supportsSeccomp && commonOpts.SeccompProfilePath == "" {
 		if err := fileutils.Exists(SeccompOverridePath); err == nil {
 			commonOpts.SeccompProfilePath = SeccompOverridePath
 		} else {

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -41,12 +41,16 @@ func TestCommonBuildOptionsSeccompFromConfig(t *testing.T) {
 
 	defaultOptions := new(define.CommonBuildOptions)
 	require.NoError(t, parseSecurityOpts(nil, defaultOptions))
+	if !supportsSeccomp {
+		assert.Empty(t, defaultOptions.SeccompProfilePath)
+	}
 
 	tests := []struct {
-		name            string
-		containersConf  string
-		securityOpts    []string
-		expectedProfile string
+		name                         string
+		containersConf               string
+		securityOpts                 []string
+		expectedProfile              string
+		expectErrorWithoutSeccompTag bool
 	}{
 		{
 			name:            "configured unconfined",
@@ -54,10 +58,17 @@ func TestCommonBuildOptionsSeccompFromConfig(t *testing.T) {
 			expectedProfile: "unconfined",
 		},
 		{
-			name:            "command line overrides config",
-			containersConf:  "[containers]\nseccomp_profile = \"unconfined\"\n",
-			securityOpts:    []string{"seccomp=/tmp/custom-seccomp.json"},
-			expectedProfile: "/tmp/custom-seccomp.json",
+			name:                         "command line overrides config",
+			containersConf:               "[containers]\nseccomp_profile = \"unconfined\"\n",
+			securityOpts:                 []string{"seccomp=/tmp/custom-seccomp.json"},
+			expectedProfile:              "/tmp/custom-seccomp.json",
+			expectErrorWithoutSeccompTag: true,
+		},
+		{
+			name:                         "configured custom profile",
+			containersConf:               "[containers]\nseccomp_profile = \"/tmp/custom-seccomp.json\"\n",
+			expectedProfile:              "/tmp/custom-seccomp.json",
+			expectErrorWithoutSeccompTag: true,
 		},
 		{
 			name:            "no configured profile",
@@ -74,6 +85,10 @@ func TestCommonBuildOptionsSeccompFromConfig(t *testing.T) {
 
 			fs := newCommonBuildOptionsFlagSet(t, test.securityOpts)
 			commonOpts, err := CommonBuildOptionsFromFlagSet(fs, fs.Lookup)
+			if test.expectErrorWithoutSeccompTag && !supportsSeccomp {
+				require.ErrorContains(t, err, "seccomp support is not enabled in this build")
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedProfile, commonOpts.SeccompProfilePath)
 		})

--- a/pkg/parse/seccomp_supported.go
+++ b/pkg/parse/seccomp_supported.go
@@ -1,0 +1,5 @@
+//go:build seccomp && linux
+
+package parse
+
+const supportsSeccomp = true

--- a/pkg/parse/seccomp_unsupported.go
+++ b/pkg/parse/seccomp_unsupported.go
@@ -1,0 +1,5 @@
+//go:build !seccomp || !linux
+
+package parse
+
+const supportsSeccomp = false

--- a/seccomp_unsupported.go
+++ b/seccomp_unsupported.go
@@ -3,10 +3,15 @@
 package buildah
 
 import (
+	"fmt"
+
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func setupSeccomp(spec *specs.Spec, seccompProfilePath string) error {
+	if seccompProfilePath != "" && seccompProfilePath != "unconfined" {
+		return fmt.Errorf("seccomp profile %q requested, but seccomp support is not enabled in this build", seccompProfilePath)
+	}
 	if spec.Linux != nil {
 		// runtime-tools may have supplied us with a default filter
 		spec.Linux.Seccomp = nil

--- a/seccomp_unsupported_test.go
+++ b/seccomp_unsupported_test.go
@@ -1,0 +1,36 @@
+//go:build !seccomp || !linux
+
+package buildah
+
+import (
+	"testing"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupSeccompUnsupported(t *testing.T) {
+	tests := []struct {
+		name        string
+		profilePath string
+		expectError bool
+	}{
+		{name: "default", profilePath: ""},
+		{name: "unconfined", profilePath: "unconfined"},
+		{name: "explicit profile", profilePath: "/tmp/seccomp.json", expectError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec := &specs.Spec{Linux: &specs.Linux{Seccomp: &specs.LinuxSeccomp{}}}
+			err := setupSeccomp(spec, test.profilePath)
+			if test.expectError {
+				require.ErrorContains(t, err, "seccomp support is not enabled in this build")
+				return
+			}
+			require.NoError(t, err)
+			assert.Nil(t, spec.Linux.Seccomp)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

Ensures that Buildah doesn't silently ignore the explicitly specified seccomp policies when the software was built without the seccomp support.

#### How to verify it

See:
- #6959 

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

Fixes #6959 

#### Special notes for your reviewer:

Let me know if this implementation fits the core idea.
I had a look in the existing implementation and tried to adapt my solution.

There is no problem if this isn't considered something that needs fixing.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Reject explicit seccomp profiles when Buildah is not built with seccomp support.
```

