### PR TITLE
ci: make the automation release renovate managed

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,7 @@
    https://docs.renovatebot.com/configuration-options/
 
    Monitoring Dashboard:
-   https://app.renovatebot.com/dashboard#github/containers
+   https://developer.mend.io/github/podman-container-tools
 
    Note: The Renovate bot will create/manage it's business on
          branches named 'renovate/*'.  Otherwise, and by
@@ -38,8 +38,8 @@
 
   // Re-use predefined sets of configuration options to DRY
   "extends": [
-    // https://github.com/containers/automation/blob/main/renovate/defaults.json5
-    "github>containers/automation//renovate/defaults.json5"
+    // https://github.com/podman-container-tools/automation/blob/main/renovate/defaults.json5
+    "github>podman-container-tools/automation//renovate/defaults.json5"
   ],
 
   /*************************************************

--- a/.github/workflows/lima.yml
+++ b/.github/workflows/lima.yml
@@ -28,7 +28,7 @@ env:
   # CI automation repo release for the VM image downloads in ci.sh.
   # ENV is managed by renovate, do not change the name without
   # updating the renovate config in the automation repo.
-  AUTOMATION_RELEASE: 20260616t073924z
+  AUTOMATION_RELEASE: 20260707t092805z
 
 jobs:
   lima:

--- a/.github/workflows/lima.yml
+++ b/.github/workflows/lima.yml
@@ -24,6 +24,12 @@ on:
 
 permissions: {}
 
+env:
+  # CI automation repo release for the VM image downloads in ci.sh.
+  # ENV is managed by renovate, do not change the name without
+  # updating the renovate config in the automation repo.
+  AUTOMATION_RELEASE: 20260616t073924z
+
 jobs:
   lima:
     name: lima # main name is set by who spawns this job

--- a/hack/ci/ci.sh
+++ b/hack/ci/ci.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" && pwd )
 
 source "$SCRIPT_DIR/lib.sh"
 
-AUTOMATION_RELEASE="${AUTOMATION_RELEASE:-20260616t073924z}" # TODO should be renovate managed
+AUTOMATION_RELEASE="${AUTOMATION_RELEASE:-$(get_automation_release)}"
 LIMA_VM_NAME=buildah-ci
 
 REPO_DIR="$SCRIPT_DIR/../.."

--- a/hack/ci/lib.sh
+++ b/hack/ci/lib.sh
@@ -68,3 +68,10 @@ function validate_priv() {
             ;;
     esac
 }
+
+
+# Reads and prints the AUTOMATION_RELEASE value from the workflow file.
+# Used for local runs where ci.sh is not triggered by gh actions.
+function get_automation_release() {
+    sed -En 's/.*AUTOMATION_RELEASE:\s(.*)/\1/p' .github/workflows/lima.yml
+}

--- a/tests/conformance/testdata/heredoc/Dockerfile.heredoc_copy
+++ b/tests/conformance/testdata/heredoc/Dockerfile.heredoc_copy
@@ -1,4 +1,4 @@
-# syntax=mirror.gcr.io/docker/dockerfile:1.3-labs
+# syntax=mirror.gcr.io/docker/dockerfile:1.25-labs
 FROM mirror.gcr.io/busybox as one
 RUN echo helloworld > image_file
 FROM mirror.gcr.io/busybox


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?



#### What this PR does / why we need it:


Put the variable in the workflow file like the renovate config expects,
see https://github.com/podman-container-tools/automation/pull/29

To ensure the local runs keep working we need a fall back to parse the
file manually.

Same as the podman change for this which is known to work:
https://github.com/podman-container-tools/podman/commit/8e74c1efd88e39d462e1f4411dc741e5cd9739bb
https://github.com/podman-container-tools/podman/pull/29186

Also manually update the image id for now while at it to safe one CI run.


#### How to verify it

see the change in podman

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

