### PR TITLE
tests: fix "chroot with overlay root" flake

### DIFF
--- a/tests/chroot.bats
+++ b/tests/chroot.bats
@@ -175,7 +175,10 @@ load helpers
   chmod 755 ${TEST_SCRATCH_DIR}/chroot/merged/run/containers/storage
   mkdir -p ${TEST_SCRATCH_DIR}/chroot/merged/var/lib/containers/storage
   chmod 755 ${TEST_SCRATCH_DIR}/chroot/merged/var/lib/containers/storage
-  chown -R 1:1 ${TEST_SCRATCH_DIR}/chroot/merged/run ${TEST_SCRATCH_DIR}/chroot/merged/var/lib/containers
+  # https://github.com/podman-container-tools/buildah/issues/6967
+  # chown -R is not safe against concurent removal, it will exit 1 when
+  # it happens but still walks all files so we can ignore the error here.
+  chown -R 1:1 ${TEST_SCRATCH_DIR}/chroot/merged/run ${TEST_SCRATCH_DIR}/chroot/merged/var/lib/containers || true
   mount --bind ${TEST_SCRATCH_DIR} ${TEST_SCRATCH_DIR}/chroot/merged/${TEST_SCRATCH_DIR}
   mkdir -p ${TEST_SCRATCH_DIR}/chroot/merged/usr/local/bin
   chmod 755 ${TEST_SCRATCH_DIR}/chroot/merged/usr/local/bin


### PR DESCRIPTION



<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


#### What this PR does / why we need it:

I have seen this fail twice on onf of my PRs. The problems is chown -R is currently not safe against concurrent removal of files and will report ENOENT errors which make it exit 1 and fail the test. However since it actually still chown's all files even when it fails we can ignore the failure here.

In the test context in particular thew problem is we have the full / as lower dir so any host file removals in /var/lib/containers can make this fail. Because the blob info cache uses a global path of var/lib/containers/cache/blob-info-cache-v1.sqlite regardless of the per test root/runroot and sqlite transactions will create and remove the blob-info-cache-v1.sqlite-journal many times we have a good chance to hit the race.

So we see failures like this:
chown: changing ownership of '/tmp/buildah_tests.vrbqgx/chroot/merged/var/lib/containers/cache/blob-info-cache-v1.sqlite-journal

The linked issues also shows a standalone coreutils reproducer to prove this is a problem there.

#### How to verify it

#### Which issue(s) this PR fixes:

Fixes: #6967

#### Special notes for your reviewer:

I plan to submit a bug report against coreutils and hopefully fix this properly there but this will take more time and it would take a long time until a new coreutils would land in our CI images anyway so this here seems the simplest to fix this for now and repduce some flakes.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

