### PR TITLE
fix issue_pr_lock.yml workflow and do not run cronjobs at midnight

### DIFF
--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -1,7 +1,7 @@
 ---
 
 # See also:
-# https://github.com/containers/podman/blob/main/.github/workflows/issue_pr_lock.yml
+# https://github.com/podman-container-tools/podman/blob/main/.github/workflows/issue_pr_lock.yml
 
 on:
   schedule:
@@ -14,7 +14,7 @@ on:
 jobs:
   # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
   closed_issue_discussion_lock:
-    uses: containers/podman/.github/workflows/issue_pr_lock.yml@main
+    uses: podman-container-tools/podman/.github/workflows/issue_pr_lock.yml@main
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/issue_pr_lock.yml
+++ b/.github/workflows/issue_pr_lock.yml
@@ -5,7 +5,9 @@
 
 on:
   schedule:
-    - cron:  '0 0 * * *'
+    # Do not run at the top of the hour to avoid github action job limits that will drop jobs sometimes.
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule
+    - cron:  '22 1 * * *'
   # Debug: Allow triggering job manually in github-actions WebUI
   workflow_dispatch: {}
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v10
+    - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'A friendly reminder that this issue had no activity for 30 days.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,9 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: "0 0 * * *"
+  # Do not run at the top of the hour to avoid github action job limits that will drop jobs sometimes.
+  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule
+  - cron: "32 1 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION


#### What type of PR is this?


#### What this PR does / why we need it:

see commits

It will make issue_pr_lock.yml work again.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

same cron change in podman https://github.com/podman-container-tools/podman/pull/29221

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

