### PR TITLE
build: accept "FROM containers-storage:" prefixes again

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -997,7 +997,7 @@ func (s *stageExecutor) sanitizeFrom(from, tmpdir string) (newFrom string, err e
 		return "", fmt.Errorf("parsing image name %q: %w", from, err)
 	}
 	// TODO: drop this part and just return an error... someday
-	return sanitize.ImageName(transportName, restOfImageName, s.executor.contextDir, tmpdir)
+	return sanitize.ImageName(s.executor.store, transportName, restOfImageName, s.executor.contextDir, tmpdir)
 }
 
 // prepare creates a working container based on the specified image, or if one

--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -18,6 +18,8 @@ import (
 	ociLayoutTransport "go.podman.io/image/v5/oci/layout"
 	openshiftTransport "go.podman.io/image/v5/openshift"
 	"go.podman.io/image/v5/pkg/compression"
+	storageTransport "go.podman.io/image/v5/storage"
+	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/archive"
 	"go.podman.io/storage/pkg/chrootarchive"
 )
@@ -183,7 +185,7 @@ func writeToDirectory(root string, hdr *tar.Header, content io.Reader) error {
 // relative to "contextDir", it will create a copy of the original image, under
 // "tmpdir", which contains no symbolic links.  It it returns a parseable
 // reference to the image which should be used.
-func ImageName(transportName, restOfImageName, contextDir, tmpdir string) (newFrom string, err error) {
+func ImageName(store storage.Store, transportName, restOfImageName, contextDir, tmpdir string) (newFrom string, err error) {
 	seenEntries := make(map[string]struct{})
 	// we're going to try to create a temporary directory or file, but if
 	// we fail, make sure that they get removed immediately
@@ -208,6 +210,11 @@ func ImageName(transportName, restOfImageName, contextDir, tmpdir string) (newFr
 	switch transportName {
 	case dockerTransport.Transport.Name(), "docker-daemon", openshiftTransport.Transport.Name(): // ok, these are all remote
 		return transportName + ":" + restOfImageName, nil
+	case storageTransport.Transport.Name(): // local, expected to already be there, but might not be in this store, so check on that
+		if _, err := storageTransport.Transport.ParseStoreReference(store, restOfImageName); err != nil {
+			return "", fmt.Errorf("looking for image %q in local storage: %w", restOfImageName, err)
+		}
+		return restOfImageName, nil
 	case dockerArchiveTransport.Transport.Name(), ociArchiveTransport.Transport.Name(): // these are, basically, tarballs
 		// these take the form path[:stuff]
 		transportRef := restOfImageName

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -24,6 +24,7 @@ import (
 	"go.podman.io/image/v5/signature"
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/transports/alltransports"
+	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/reexec"
 )
 
@@ -37,6 +38,18 @@ func TestMain(m *testing.M) {
 }
 
 func TestSanitizeImageName(t *testing.T) {
+	storageRoot, storageRunRoot := t.TempDir(), t.TempDir()
+	store, err := storage.GetStore(storage.StoreOptions{
+		GraphRoot:       storageRoot,
+		RunRoot:         storageRunRoot,
+		GraphDriverName: "vfs",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, err := store.Shutdown(false)
+		assert.NoError(t, err)
+	})
+
 	const badLinkTarget = "../../../../../../../../../../../etc/passwd"
 
 	// prepare to copy from the layout to other types of destinations
@@ -361,19 +374,19 @@ func TestSanitizeImageName(t *testing.T) {
 	// sanitize them all
 	goodLayoutRel, err := filepath.Rel(contextDir, goodLayout)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", goodLayout)
-	newGoodLayout, err := ImageName("oci", goodLayoutRel, contextDir, t.TempDir())
+	newGoodLayout, err := ImageName(store, "oci", goodLayoutRel, contextDir, t.TempDir())
 	require.NoError(t, err, "sanitizing good OCI layout")
 	goodDirRel, err := filepath.Rel(contextDir, goodDir)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", goodDir)
-	newGoodDir, err := ImageName("dir", goodDirRel, contextDir, t.TempDir())
+	newGoodDir, err := ImageName(store, "dir", goodDirRel, contextDir, t.TempDir())
 	require.NoError(t, err, "sanitizing good directory")
 	goodOCIArchiveRel, err := filepath.Rel(contextDir, goodOCIArchive)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", goodOCIArchive)
-	newGoodOCIArchive, err := ImageName("oci-archive", goodOCIArchiveRel, contextDir, t.TempDir())
+	newGoodOCIArchive, err := ImageName(store, "oci-archive", goodOCIArchiveRel, contextDir, t.TempDir())
 	require.NoError(t, err, "sanitizing good OCI archive")
 	goodDockerArchiveRel, err := filepath.Rel(contextDir, goodDockerArchive)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", goodDockerArchive)
-	newGoodDockerArchive, err := ImageName("docker-archive", goodDockerArchiveRel, contextDir, t.TempDir())
+	newGoodDockerArchive, err := ImageName(store, "docker-archive", goodDockerArchiveRel, contextDir, t.TempDir())
 	require.NoError(t, err, "sanitizing good docker archive")
 
 	// make sure the sanitized versions can all be read without error
@@ -386,24 +399,24 @@ func TestSanitizeImageName(t *testing.T) {
 	badLayout := mutateDirectory(t, contextDir, goodLayout, filepath.Join(v1.ImageBlobsDir, blobDigest.Algorithm().String(), blobDigest.Encoded()))
 	badLayoutRel, err := filepath.Rel(contextDir, badLayout)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", badLayout)
-	_, err = ImageName("oci", badLayoutRel, contextDir, t.TempDir())
+	_, err = ImageName(store, "oci", badLayoutRel, contextDir, t.TempDir())
 	require.ErrorIs(t, err, os.ErrNotExist, "sanitizing bad OCI layout")
 
 	badDir := mutateDirectory(t, contextDir, goodDir, blobDigest.Encoded())
 	badDirRel, err := filepath.Rel(contextDir, badDir)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", badDir)
-	_, err = ImageName("dir", badDirRel, contextDir, t.TempDir())
+	_, err = ImageName(store, "dir", badDirRel, contextDir, t.TempDir())
 	require.ErrorIs(t, err, os.ErrNotExist, "sanitizing bad directory")
 
 	badOCIArchive := mutateArchive(t, contextDir, goodOCIArchive, filepath.Join(v1.ImageBlobsDir, blobDigest.Algorithm().String(), blobDigest.Encoded()))
 	badOCIArchiveRel, err := filepath.Rel(contextDir, badOCIArchive)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", badOCIArchive)
-	_, err = ImageName("oci-archive", badOCIArchiveRel, contextDir, t.TempDir())
+	_, err = ImageName(store, "oci-archive", badOCIArchiveRel, contextDir, t.TempDir())
 	require.ErrorContains(t, err, "invalid symbolic link", "sanitizing bad oci archive")
 
 	badDockerArchive := mutateArchive(t, contextDir, goodDockerArchive, diffDigest.Encoded()+".tar")
 	badDockerArchiveRel, err := filepath.Rel(contextDir, badDockerArchive)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", badDockerArchive)
-	_, err = ImageName("docker-archive", badDockerArchiveRel, contextDir, t.TempDir())
+	_, err = ImageName(store, "docker-archive", badDockerArchiveRel, contextDir, t.TempDir())
 	require.ErrorContains(t, err, "invalid symbolic link", "sanitizing bad docker archive")
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -9589,6 +9589,22 @@ EOF
   diff "${out_path}.a" "${out_path}.b"
 }
 
+@test "build-explicitly-from-storage" {
+  _prefetch busybox
+  run_buildah inspect --type=image --format '{{.FromImageID}}' busybox
+  local iid="${output}"
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir -p "${contextdir}"
+  cat > "${contextdir}"/Containerfile <<- _EOF
+  ARG BASE=containers-storage:busybox
+  FROM \$BASE
+  RUN date | tee /root/date.txt
+_EOF
+  for base in containers-storage:docker.io/library/busybox containers-storage:docker.io/busybox containers-storage:busybox containers-storage:${iid}; do
+    run_buildah build --build-arg BASE="${base}" "${contextdir}"
+  done
+}
+
 @test "build-with-run-image-mount" {
   _prefetch busybox
   local contextdir=${TEST_SCRATCH_DIR}/context


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The change in #5975 that tightened up what we would accept as a base image spec didn't expect builds to explicitly be specifying "containers-storage:" in image references, and yet, they sometimes do.

#### How to verify it

New test!

#### Which issue(s) this PR fixes:

Fixes #6979

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Restores the ability to explicitly specify "containers-storage:" when specifying base images for `buildah build`.
```