### PR TITLE
Makefile: add install.nobuild target to install ONLY.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,11 +165,14 @@ install.go-md2man:
 install.golangci-lint:
 	$(MAKE) -C tests/tools build/golangci-lint
 
-.PHONY: install
-install: bin/buildah
+.PHONY: install.nobuild
+install.nobuild:
 	install -d -m 755 $(DESTDIR)/$(BINDIR)
 	install -m 755 bin/buildah $(DESTDIR)/$(BINDIR)/buildah
 	$(MAKE) -C docs install
+
+.PHONY: install
+install: bin/buildah install.nobuild
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
Current behaviour is `make install` builds binary as well as installs it. This stays the same. But in scenario when one just want to install and not compile, there was no option but to patch source.

Adding new target accomodates such scenario.
Idea from @lsm5 https://github.com/podman-container-tools/skopeo/pull/2172#issuecomment-1838559541
