### PR TITLE
Fix 32-bit build failure due to `statFlagMap` using int keys

### DIFF
--- a/chroot/run_linux.go
+++ b/chroot/run_linux.go
@@ -75,7 +75,7 @@ var (
 		unix.MS_SYNCHRONOUS:  "MS_SYNCHRONOUS",
 		unix.MS_UNBINDABLE:   "MS_UNBINDABLE",
 	}
-	statFlagMap = map[int]string{
+	statFlagMap = map[uintptr]string{
 		unix.ST_MANDLOCK:    "ST_MANDLOCK",
 		unix.ST_NOATIME:     "ST_NOATIME",
 		unix.ST_NODEV:       "ST_NODEV",
@@ -107,9 +107,9 @@ func statFlagNames(flags uintptr) []string {
 	var names []string
 	flags = flags & ^uintptr(0x20) // mask off ST_VALID
 	for flag, name := range statFlagMap {
-		if int(flags)&flag == flag {
+		if flags&flag == flag {
 			names = append(names, name)
-			flags = flags &^ (uintptr(flag))
+			flags = flags &^ flag
 		}
 	}
 	if flags != 0 { // got some unknown leftovers

--- a/chroot/run_linux_test.go
+++ b/chroot/run_linux_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestStatFlagNames(t *testing.T) {
 	var names []string
-	var flags int
+	var flags uintptr
 	for flag := range statFlagMap {
 		flags |= flag
 		names = append(names, statFlagMap[flag])
-		assert.Equal(t, []string{statFlagMap[flag]}, statFlagNames(uintptr(flag)))
+		assert.Equal(t, []string{statFlagMap[flag]}, statFlagNames(flag))
 	}
 	slices.Sort(names)
-	assert.Equal(t, names, statFlagNames(uintptr(flags)))
+	assert.Equal(t, names, statFlagNames(flags))
 }
 
 func TestMountFlagNames(t *testing.T) {


### PR DESCRIPTION
Change `statFlagMap` from `map[int]string` to `map[uintptr]string` and remove int/uintptr casts in `statFlagNames()`, matching `mountFlagMap`. On 32-bit architectures, `unix.MS_NOUSER` (0x80000000) overflows signed int.

Regression from PR #6129.

Fixes this podman cross build failure:
```
# go.podman.io/buildah/chroot
Error: vendor/go.podman.io/buildah/chroot/run_linux.go:63:3: cannot use unix.MS_NOUSER (untyped int constant 2147483648) as int value in map literal (overflows)
make: *** [Makefile:512: bin/podman.cross.linux.arm] Error 1
Error: Process completed with exit code 2.
```
Link: https://github.com/podman-container-tools/podman/actions/runs/30037831733/job/89310129440?pr=29242


<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

