### PR TITLE
tests: add link to coreutils bug workaround

### DIFF
--- a/tests/chroot.bats
+++ b/tests/chroot.bats
@@ -178,6 +178,10 @@ load helpers
   # https://github.com/podman-container-tools/buildah/issues/6967
   # chown -R is not safe against concurent removal, it will exit 1 when
   # it happens but still walks all files so we can ignore the error here.
+  # Bug: https://bugs.gnu.org/81444
+  # Only once the fix landed in our test distro images coreutils version this workaround can be removed.
+  # Because this is a flake as simple remove and test is not enough to confirm. Please actually verify
+  # it using the reproducer on the issue to ensure the flake is not added back.
   chown -R 1:1 ${TEST_SCRATCH_DIR}/chroot/merged/run ${TEST_SCRATCH_DIR}/chroot/merged/var/lib/containers || true
   mount --bind ${TEST_SCRATCH_DIR} ${TEST_SCRATCH_DIR}/chroot/merged/${TEST_SCRATCH_DIR}
   mkdir -p ${TEST_SCRATCH_DIR}/chroot/merged/usr/local/bin


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

#### What this PR does / why we need it:

I reported the issue to coreutils, based on the conversation there it is likely that this is going to get fixed. But of course this will likely take a long time until the fixes lands in our actual test images as I do not think any release will rebase coreutils.

Just some more context so someone will know when they can remove this.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

