### PR TITLE
docs: fix pull --policy value from newer to ifnewer

### DIFF
--- a/docs/buildah-pull.1.md
+++ b/docs/buildah-pull.1.md
@@ -70,14 +70,14 @@ and can also be found by running `go tool dist list`.
 
 **NOTE:** The `--platform` option may not be used in combination with the `--arch`, `--os`, or `--variant` options.
 
-**--policy**=**always**|**missing**|**never**|**newer**
+**--policy**=**always**|**missing**|**never**|**ifnewer**
 
 Pull image policy. The default is **missing**.
 
 - **always**: Always pull the image and throw an error if the pull fails.
 - **missing**: Pull the image only if it could not be found in the local containers storage.  Throw an error if no image could be found and the pull fails.
 - **never**: Never pull the image but use the one from the local containers storage.  Throw an error if no image could be found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+- **ifnewer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
 
 **--quiet**, **-q**
 

--- a/docs/buildah-pull.1.md
+++ b/docs/buildah-pull.1.md
@@ -73,11 +73,12 @@ and can also be found by running `go tool dist list`.
 **--policy**=**always**|**missing**|**never**|**ifnewer**
 
 Pull image policy. The default is **missing**.
+These values match the pull policies used by **podman pull** (see **podman-pull(1)**); the policy that podman documents as **newer** is the same behavior as **ifnewer** here.
 
 - **always**: Always pull the image and throw an error if the pull fails.
 - **missing**: Pull the image only if it could not be found in the local containers storage.  Throw an error if no image could be found and the pull fails.
 - **never**: Never pull the image but use the one from the local containers storage.  Throw an error if no image could be found.
-- **ifnewer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+- **ifnewer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.  Equivalent to **podman pull --policy=newer**.
 
 **--quiet**, **-q**
 


### PR DESCRIPTION
## Summary

The `buildah pull` man page documented `--policy=newer`, but the CLI only accepts `ifnewer` via `define.PolicyMap` (see `cmd/buildah/pull.go` and `define/pull.go`). Using `--policy newer` fails with:

```
Error: unsupported pull policy "newer"
```

Update `docs/buildah-pull.1.md` so the documented values match the CLI: `always`, `missing`, `never`, and `ifnewer`.

Note: `buildah from` / `buildah build` `--pull` docs that mention `newer` are intentionally left unchanged; those commands parse both `newer` and `ifnewer` via `parse.PullPolicyFromOptions`.

Fixes #6992

## Test plan

- [x] Confirmed CLI help: `--policy string   missing, always, ifnewer, or never.`
- [x] Confirmed `define.PolicyMap` keys are only `missing`, `always`, `never`, `ifnewer`
- [x] Man page now documents `ifnewer` consistently in the flag synopsis and bullet list