### PR TITLE
docs: correct buildah pull --policy value to ifnewer

### DIFF
--- a/docs/buildah-pull.1.md
+++ b/docs/buildah-pull.1.md
@@ -70,14 +70,14 @@ and can also be found by running `go tool dist list`.
 
 **NOTE:** The `--platform` option may not be used in combination with the `--arch`, `--os`, or `--variant` options.
 
-**--policy**=**always**|**missing**|**never**|**newer**
+**--policy**=**always**|**missing**|**never**|**ifnewer**
 
 Pull image policy. The default is **missing**.
 
 - **always**: Always pull the image and throw an error if the pull fails.
 - **missing**: Pull the image only if it could not be found in the local containers storage.  Throw an error if no image could be found and the pull fails.
 - **never**: Never pull the image but use the one from the local containers storage.  Throw an error if no image could be found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+- **ifnewer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
 
 **--quiet**, **-q**
 


### PR DESCRIPTION
## Summary
- Update `docs/buildah-pull.1.md` so `--policy` documents `ifnewer` instead of `newer`.
- Matches the CLI help text and `define.PolicyMap` accepted values.

Fixes #6992

## Test plan
- [x] Confirmed `pull.go` flag help lists `ifnewer`
- [ ] Optional: `buildah pull --policy ifnewer ...` succeeds; `--policy newer` still errors